### PR TITLE
Issue #11776 - NPE protection in Request.getServerPort

### DIFF
--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpURITest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpURITest.java
@@ -1109,6 +1109,8 @@ public class HttpURITest
             Arguments.of("hTTps", "example.org", 443, "/", null, null, "https://example.org/"),
             Arguments.of("WS", "example.org", 8282, "/", null, null, "ws://example.org:8282/"),
             Arguments.of("wsS", "example.org", 8383, "/", null, null, "wss://example.org:8383/"),
+            // Undefined scheme
+            Arguments.of(null, "example.org", 8181, "/", null, null, "//example.org:8181/"),
             // Undefined Ports
             Arguments.of("http", "example.org", 0, "/", null, null, "http://example.org/"),
             Arguments.of("https", "example.org", -1, "/", null, null, "https://example.org/"),

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -486,9 +486,13 @@ public interface Request extends Attributes, Content.Source
             return authority.getPort();
 
         // Is there a scheme with a default port?
-        HttpScheme scheme = HttpScheme.CACHE.get(request.getHttpURI().getScheme());
-        if (scheme != null && scheme.getDefaultPort() > 0)
-            return scheme.getDefaultPort();
+        String rawScheme = uri.getScheme();
+        if (StringUtil.isNotBlank(rawScheme))
+        {
+            HttpScheme scheme = HttpScheme.CACHE.get(rawScheme);
+            if (scheme != null && scheme.getDefaultPort() > 0)
+                return scheme.getDefaultPort();
+        }
 
         // Is there a local port?
         SocketAddress local = request.getConnectionMetaData().getLocalSocketAddress();

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -486,13 +486,9 @@ public interface Request extends Attributes, Content.Source
             return authority.getPort();
 
         // Is there a scheme with a default port?
-        String rawScheme = uri.getScheme();
-        if (StringUtil.isNotBlank(rawScheme))
-        {
-            HttpScheme scheme = HttpScheme.CACHE.get(rawScheme);
-            if (scheme != null && scheme.getDefaultPort() > 0)
-                return scheme.getDefaultPort();
-        }
+        HttpScheme scheme = HttpScheme.CACHE.get(request.getHttpURI().getScheme());
+        if (scheme != null && scheme.getDefaultPort() > 0)
+            return scheme.getDefaultPort();
 
         // Is there a local port?
         SocketAddress local = request.getConnectionMetaData().getLocalSocketAddress();

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/AbstractTrie.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/AbstractTrie.java
@@ -63,7 +63,7 @@ abstract class AbstractTrie<V> implements Index.Mutable<V>
 
     public V get(String s)
     {
-        return get(s, 0, s.length());
+        return get(s, 0, s == null ? 0 : s.length());
     }
 
     public V get(ByteBuffer b)
@@ -73,7 +73,7 @@ abstract class AbstractTrie<V> implements Index.Mutable<V>
 
     public V getBest(String s)
     {
-        return getBest(s, 0, s.length());
+        return getBest(s, 0, s == null ? 0 : s.length());
     }
 
     public V getBest(byte[] b, int offset, int len)

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ArrayTernaryTrie.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ArrayTernaryTrie.java
@@ -260,12 +260,6 @@ class ArrayTernaryTrie<V> extends AbstractTrie<V>
     }
 
     @Override
-    public V getBest(String s)
-    {
-        return getBest(0, s, 0, s.length());
-    }
-
-    @Override
     public V getBest(String s, int offset, int length)
     {
         return getBest(0, s, offset, length);

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Index.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Index.java
@@ -29,7 +29,7 @@ public interface Index<V>
     /**
      * Get an exact match from a String key
      *
-     * @param s The key
+     * @param s The key, possibly null
      * @return the value for the string key
      */
     V get(String s);
@@ -45,7 +45,7 @@ public interface Index<V>
     /**
      * Get an exact match from a String key
      *
-     * @param s The key
+     * @param s The key, possibly null
      * @param offset The offset within the string of the key
      * @param len the length of the key
      * @return the value for the string / offset / length
@@ -65,7 +65,7 @@ public interface Index<V>
     /**
      * Check if there is an exact match from a String key
      *
-     * @param s The key
+     * @param s The key, possibly null
      * @return true if there is a match, false otherwise
      */
     default boolean contains(String s)
@@ -76,7 +76,7 @@ public interface Index<V>
     /**
      * Get the best match from key in a String.
      *
-     * @param s The string
+     * @param s The string, possibly null
      * @param offset The offset within the string of the key
      * @param len the length of the key
      * @return The value or null if not found
@@ -87,7 +87,7 @@ public interface Index<V>
      * Get the best match from key in a String, which may be
      * a prefix match or an exact match.
      *
-     * @param s The string
+     * @param s The string, possibly null
      * @return The value or null if not found
      */
     V getBest(String s);

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/TrieTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/TrieTest.java
@@ -415,6 +415,17 @@ public class TrieTest
     }
 
     @ParameterizedTest
+    @MethodSource("emptyImplementations")
+    public void testGetNullStringKey(AbstractTrie<Integer> trie) throws Exception
+    {
+        assertNull(trie.get((String)null));
+        assertNull(trie.get((String)null, 0, 0));
+        assertFalse(trie.contains(null));
+        assertNull(trie.getBest((String)null));
+        assertNull(trie.getBest((String)null, 0, 0));
+    }
+
+    @ParameterizedTest
     @MethodSource("implementations")
     public void testIsNotEmpty(AbstractTrie<Integer> trie) throws Exception
     {


### PR DESCRIPTION
If the HttpURI is scheme-less, the attempt to get the port can result in a NPE.

Fixes: #11776