### PR TITLE
jetty#11789 run list distinct on the generated resources list during startup

### DIFF
--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaData.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaData.java
@@ -485,7 +485,8 @@ public class MetaData
         resources.add(null); //always apply annotations with no resource first
         resources.addAll(_orderedContainerResources); //next all annotations from container path
         resources.addAll(_webInfClasses); //next everything from web-inf classes
-        resources.addAll(getWebInfResources(isOrdered())); //finally annotations (in order) from webinf path 
+        resources.addAll(getWebInfResources(isOrdered())); //finally annotations (in order) from webinf path
+        resources = resources.stream().distinct().collect(Collectors.toList()); // filter out possible duplicates
 
         for (Resource r : resources)
         {

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaData.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaData.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import jakarta.servlet.ServletContext;
 import org.eclipse.jetty.util.URIUtil;


### PR DESCRIPTION
Fixes the duplicate resource issue described in the ticket https://github.com/jetty/jetty.project/issues/11789