### PR TITLE
Fixed header cache for unknown values

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -146,17 +146,22 @@ public class HttpParser
             {
                 HttpField field = new PreEncodedHttpField(HttpHeader.CONTENT_TYPE, type);
                 map.put(field.toString(), field);
+                map.put(field.toString().replace(": ", ":"), field);
 
                 for (String charset : new String[]{"utf-8", "iso-8859-1"})
                 {
                     PreEncodedHttpField field1 = new PreEncodedHttpField(HttpHeader.CONTENT_TYPE, type + ";charset=" + charset);
                     map.put(field1.toString(), field1);
+                    map.put(field1.toString().replace(": ", ":"), field1);
                     PreEncodedHttpField field2 = new PreEncodedHttpField(HttpHeader.CONTENT_TYPE, type + "; charset=" + charset);
                     map.put(field2.toString(), field2);
+                    map.put(field1.toString().replace(": ", ":"), field2);
                     PreEncodedHttpField field3 = new PreEncodedHttpField(HttpHeader.CONTENT_TYPE, type + ";charset=" + charset.toUpperCase(Locale.ENGLISH));
                     map.put(field3.toString(), field3);
+                    map.put(field1.toString().replace(": ", ":"), field3);
                     PreEncodedHttpField field4 = new PreEncodedHttpField(HttpHeader.CONTENT_TYPE, type + "; charset=" + charset.toUpperCase(Locale.ENGLISH));
                     map.put(field4.toString(), field4);
+                    map.put(field1.toString().replace(": ", ":"), field4);
                 }
             }
             return map;
@@ -167,7 +172,8 @@ public class HttpParser
             for (HttpHeader h : HttpHeader.values())
             {
                 HttpField httpField = new HttpField(h, UNMATCHED_VALUE);
-                map.put(httpField.toString(), httpField);
+                map.put(h + ": ", httpField);
+                map.put(h + ":", httpField);
             }
             return map;
         })

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -168,7 +168,6 @@ public class HttpParser
             {
                 HttpField httpField = new HttpField(h, UNMATCHED_VALUE);
                 map.put(h + ": ", httpField);
-                map.put(h + ":", httpField);
             }
             return map;
         })

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -146,22 +146,17 @@ public class HttpParser
             {
                 HttpField field = new PreEncodedHttpField(HttpHeader.CONTENT_TYPE, type);
                 map.put(field.toString(), field);
-                map.put(field.toString().replace(": ", ":"), field);
 
                 for (String charset : new String[]{"utf-8", "iso-8859-1"})
                 {
                     PreEncodedHttpField field1 = new PreEncodedHttpField(HttpHeader.CONTENT_TYPE, type + ";charset=" + charset);
                     map.put(field1.toString(), field1);
-                    map.put(field1.toString().replace(": ", ":"), field1);
                     PreEncodedHttpField field2 = new PreEncodedHttpField(HttpHeader.CONTENT_TYPE, type + "; charset=" + charset);
                     map.put(field2.toString(), field2);
-                    map.put(field1.toString().replace(": ", ":"), field2);
                     PreEncodedHttpField field3 = new PreEncodedHttpField(HttpHeader.CONTENT_TYPE, type + ";charset=" + charset.toUpperCase(Locale.ENGLISH));
                     map.put(field3.toString(), field3);
-                    map.put(field1.toString().replace(": ", ":"), field3);
                     PreEncodedHttpField field4 = new PreEncodedHttpField(HttpHeader.CONTENT_TYPE, type + "; charset=" + charset.toUpperCase(Locale.ENGLISH));
                     map.put(field4.toString(), field4);
-                    map.put(field1.toString().replace(": ", ":"), field4);
                 }
             }
             return map;

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpParserTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpParserTest.java
@@ -370,11 +370,6 @@ public class HttpParserTest
         assertThat(HttpParser.CACHE.getBest("Content-Type: unknown\n").toString(), is("Content-Type: \u0000"));
         assertThat(HttpParser.CACHE.getBest("content-type: unknown\r\n").toString(), is("Content-Type: \u0000"));
         assertThat(HttpParser.CACHE.getBest("content-type: unknown\n").toString(), is("Content-Type: \u0000"));
-
-        assertThat(HttpParser.CACHE.getBest("Content-Type:text/plain\r\n").toString(), is("Content-Type: \u0000"));
-        assertThat(HttpParser.CACHE.getBest("Content-Type:text/plain\n").toString(), is("Content-Type: \u0000"));
-        assertThat(HttpParser.CACHE.getBest("content-type:unknown\r\n").toString(), is("Content-Type: \u0000"));
-        assertThat(HttpParser.CACHE.getBest("content-type:unknown\n").toString(), is("Content-Type: \u0000"));
     }
 
     @ParameterizedTest

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpParserTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpParserTest.java
@@ -358,6 +358,24 @@ public class HttpParserTest
         assertEquals(1, _headers);
     }
 
+    @Test
+    public void testHeaderCache()
+    {
+        assertThat(HttpParser.CACHE.getBest("Content-Type: text/plain\r\n").toString(), is("Content-Type: text/plain"));
+        assertThat(HttpParser.CACHE.getBest("Content-Type: text/plain\n").toString(), is("Content-Type: text/plain"));
+        assertThat(HttpParser.CACHE.getBest("content-type: text/plain\r\n").toString(), is("Content-Type: text/plain"));
+        assertThat(HttpParser.CACHE.getBest("content-type: text/plain\n").toString(), is("Content-Type: text/plain"));
+        assertThat(HttpParser.CACHE.getBest("Content-Type:text/plain\r\n").toString(), is("Content-Type: text/plain"));
+        assertThat(HttpParser.CACHE.getBest("Content-Type:text/plain\n").toString(), is("Content-Type: text/plain"));
+
+        assertThat(HttpParser.CACHE.getBest("Content-Type: unknown\r\n").toString(), is("Content-Type: \u0000"));
+        assertThat(HttpParser.CACHE.getBest("Content-Type: unknown\n").toString(), is("Content-Type: \u0000"));
+        assertThat(HttpParser.CACHE.getBest("content-type: unknown\r\n").toString(), is("Content-Type: \u0000"));
+        assertThat(HttpParser.CACHE.getBest("content-type: unknown\n").toString(), is("Content-Type: \u0000"));
+        assertThat(HttpParser.CACHE.getBest("content-type:unknown\r\n").toString(), is("Content-Type: \u0000"));
+        assertThat(HttpParser.CACHE.getBest("content-type:unknown\n").toString(), is("Content-Type: \u0000"));
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {"\r\n", "\n"})
     public void testHeaderCacheNearMiss(String eoln)

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpParserTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpParserTest.java
@@ -365,13 +365,14 @@ public class HttpParserTest
         assertThat(HttpParser.CACHE.getBest("Content-Type: text/plain\n").toString(), is("Content-Type: text/plain"));
         assertThat(HttpParser.CACHE.getBest("content-type: text/plain\r\n").toString(), is("Content-Type: text/plain"));
         assertThat(HttpParser.CACHE.getBest("content-type: text/plain\n").toString(), is("Content-Type: text/plain"));
-        assertThat(HttpParser.CACHE.getBest("Content-Type:text/plain\r\n").toString(), is("Content-Type: text/plain"));
-        assertThat(HttpParser.CACHE.getBest("Content-Type:text/plain\n").toString(), is("Content-Type: text/plain"));
 
         assertThat(HttpParser.CACHE.getBest("Content-Type: unknown\r\n").toString(), is("Content-Type: \u0000"));
         assertThat(HttpParser.CACHE.getBest("Content-Type: unknown\n").toString(), is("Content-Type: \u0000"));
         assertThat(HttpParser.CACHE.getBest("content-type: unknown\r\n").toString(), is("Content-Type: \u0000"));
         assertThat(HttpParser.CACHE.getBest("content-type: unknown\n").toString(), is("Content-Type: \u0000"));
+
+        assertThat(HttpParser.CACHE.getBest("Content-Type:text/plain\r\n").toString(), is("Content-Type: \u0000"));
+        assertThat(HttpParser.CACHE.getBest("Content-Type:text/plain\n").toString(), is("Content-Type: \u0000"));
         assertThat(HttpParser.CACHE.getBest("content-type:unknown\r\n").toString(), is("Content-Type: \u0000"));
         assertThat(HttpParser.CACHE.getBest("content-type:unknown\n").toString(), is("Content-Type: \u0000"));
     }


### PR DESCRIPTION
Avoid adding the unknown marker into the CACHE index. Issue introduced in #11661 fixing #11659