### PR TITLE
Fixed JPMS declarations.

### DIFF
--- a/jetty-core/jetty-deploy/src/main/java/module-info.java
+++ b/jetty-core/jetty-deploy/src/main/java/module-info.java
@@ -15,7 +15,7 @@ module org.eclipse.jetty.deploy
 {
     requires java.xml;
     requires org.eclipse.jetty.xml;
-    requires org.eclipse.jetty.server;
+    requires transitive org.eclipse.jetty.server;
     requires org.slf4j;
 
     // Only required if using JMX.

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CookieCache.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CookieCache.java
@@ -21,8 +21,6 @@ import java.util.ListIterator;
 import java.util.Map;
 
 import org.eclipse.jetty.util.StringUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Cookie parser
@@ -31,9 +29,8 @@ import org.slf4j.LoggerFactory;
 @Deprecated (forRemoval = true)
 public class CookieCache implements CookieParser.Handler, ComplianceViolation.Listener
 {
-    protected static final Logger LOG = LoggerFactory.getLogger(CookieCache.class);
-    protected final List<String> _rawFields = new ArrayList<>();
-    protected List<HttpCookie> _cookieList;
+    private final List<String> _rawFields = new ArrayList<>();
+    private List<HttpCookie> _cookieList;
     private final CookieParser _parser;
     private List<ComplianceViolation.Event> _violations;
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CookieCutter.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CookieCutter.java
@@ -33,7 +33,7 @@ import static org.eclipse.jetty.http.CookieCompliance.Violation.SPECIAL_CHARS_IN
 @Deprecated
 public class CookieCutter implements CookieParser
 {
-    protected static final Logger LOG = LoggerFactory.getLogger(CookieCutter.class);
+    private static final Logger LOG = LoggerFactory.getLogger(CookieCutter.class);
 
     private final CookieParser.Handler _handler;
     private final CookieCompliance _complianceMode;

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -92,7 +92,7 @@ import static org.eclipse.jetty.http.HttpTokens.LINE_FEED;
  */
 public class HttpParser
 {
-    public static final Logger LOG = LoggerFactory.getLogger(HttpParser.class);
+    private static final Logger LOG = LoggerFactory.getLogger(HttpParser.class);
     public static final int INITIAL_URI_LENGTH = 256;
     private static final int MAX_CHUNK_LENGTH = Integer.MAX_VALUE / 16 - 16;
     private static final String UNMATCHED_VALUE = "\u0000";

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/RFC6265CookieParser.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/RFC6265CookieParser.java
@@ -16,8 +16,6 @@ package org.eclipse.jetty.http;
 import java.util.Locale;
 
 import org.eclipse.jetty.util.StringUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.eclipse.jetty.http.CookieCompliance.Violation.ATTRIBUTES;
 import static org.eclipse.jetty.http.CookieCompliance.Violation.ATTRIBUTE_VALUES;
@@ -34,8 +32,6 @@ import static org.eclipse.jetty.http.CookieCompliance.Violation.SPECIAL_CHARS_IN
  */
 public class RFC6265CookieParser implements CookieParser
 {
-    protected static final Logger LOG = LoggerFactory.getLogger(RFC6265CookieParser.class);
-
     private final CookieParser.Handler _handler;
     private final CookieCompliance _complianceMode;
     private final ComplianceViolation.Listener _complianceListener;

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/SelectorManager.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/SelectorManager.java
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
 public abstract class SelectorManager extends ContainerLifeCycle implements Dumpable
 {
     public static final int DEFAULT_CONNECT_TIMEOUT = 15000;
-    protected static final Logger LOG = LoggerFactory.getLogger(SelectorManager.class);
+    private static final Logger LOG = LoggerFactory.getLogger(SelectorManager.class);
 
     private final Executor executor;
     private final Scheduler scheduler;

--- a/jetty-core/jetty-plus/src/main/java/module-info.java
+++ b/jetty-core/jetty-plus/src/main/java/module-info.java
@@ -13,13 +13,13 @@
 
 module org.eclipse.jetty.plus
 {
-    requires org.eclipse.jetty.security;
+    requires transitive org.eclipse.jetty.security;
     requires org.eclipse.jetty.util;
     requires org.slf4j;
 
     requires transitive java.naming;
     // Only required if using DataSourceLoginService.
-    requires static java.sql;
+    requires static transitive java.sql;
 
     exports org.eclipse.jetty.plus.annotation;
     exports org.eclipse.jetty.plus.jndi;

--- a/jetty-core/jetty-security/src/main/java/module-info.java
+++ b/jetty-core/jetty-security/src/main/java/module-info.java
@@ -17,7 +17,7 @@ module org.eclipse.jetty.security
     requires transitive org.eclipse.jetty.util;
     requires transitive org.slf4j;
     requires static java.security.jgss;
-    requires static java.sql;
+    requires static transitive java.sql;
 
     exports org.eclipse.jetty.security;
     exports org.eclipse.jetty.security.authentication;

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConnectionTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConnectionTest.java
@@ -251,7 +251,7 @@ public class HttpConnectionTest
     @MethodSource("contentLengths")
     public void testHttp11MultipleContentLength(int[] clen) throws Exception
     {
-        HttpParser.LOG.info("badMessage: 400 Bad messages EXPECTED...");
+        LOG.info("badMessage: 400 Bad messages EXPECTED...");
         StringBuilder request = new StringBuilder();
         request.append("POST / HTTP/1.1\r\n");
         request.append("Host: local\r\n");
@@ -298,7 +298,7 @@ public class HttpConnectionTest
     @MethodSource("http11ContentLengthAndChunkedData")
     public void testHttp11ContentLengthAndChunk(int[] contentLengths) throws Exception
     {
-        HttpParser.LOG.info("badMessage: 400 Bad messages EXPECTED...");
+        LOG.info("badMessage: 400 Bad messages EXPECTED...");
 
         StringBuilder request = new StringBuilder();
         request.append("POST / HTTP/1.1\r\n");
@@ -405,7 +405,7 @@ public class HttpConnectionTest
     @MethodSource("http11TransferEncodingInvalidChunked")
     public void testHttp11TransferEncodingInvalidChunked(List<String> tokens) throws Exception
     {
-        HttpParser.LOG.info("badMessage: 400 Bad messages EXPECTED...");
+        LOG.info("badMessage: 400 Bad messages EXPECTED...");
         StringBuilder request = new StringBuilder();
         request.append("POST / HTTP/1.1\r\n");
         request.append("Host: local\r\n");

--- a/jetty-core/jetty-session/src/main/java/module-info.java
+++ b/jetty-core/jetty-session/src/main/java/module-info.java
@@ -18,7 +18,7 @@ module org.eclipse.jetty.session
     requires transitive org.slf4j;
 
     // Only required if using DatabaseAdaptor/JDBCSessionDataStore.
-    requires static java.sql;
+    requires static transitive java.sql;
     requires static java.naming;
 
     exports org.eclipse.jetty.session;

--- a/jetty-core/jetty-util/src/main/java/module-info.java
+++ b/jetty-core/jetty-util/src/main/java/module-info.java
@@ -14,7 +14,7 @@
 module org.eclipse.jetty.util
 {
     // Standard Jetty Logging now.
-    requires org.slf4j;
+    requires transitive org.slf4j;
 
     // Required by SSL code (for X509).
     requires transitive java.naming;

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8StringBuilder.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8StringBuilder.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  */
 public class Utf8StringBuilder implements CharsetStringBuilder
 {
-    protected static final Logger LOG = LoggerFactory.getLogger(Utf8StringBuilder.class);
+    private static final Logger LOG = LoggerFactory.getLogger(Utf8StringBuilder.class);
     public static final char REPLACEMENT = '�';
     private static final int UTF8_ACCEPT = 0;
     private static final int UTF8_REJECT = 12;

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/preventers/AWTLeakPreventer.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/preventers/AWTLeakPreventer.java
@@ -26,7 +26,6 @@ import java.awt.Toolkit;
  */
 public class AWTLeakPreventer extends AbstractLeakPreventer
 {
-
     @Override
     public void prevent(ClassLoader loader)
     {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/preventers/AbstractLeakPreventer.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/preventers/AbstractLeakPreventer.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AbstractLeakPreventer extends AbstractLifeCycle
 {
-    protected static final Logger LOG = LoggerFactory.getLogger(AbstractLeakPreventer.class);
+    static final Logger LOG = LoggerFactory.getLogger(AbstractLeakPreventer.class);
 
     public abstract void prevent(ClassLoader loader);
 

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/preventers/AppContextLeakPreventer.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/preventers/AppContextLeakPreventer.java
@@ -25,7 +25,6 @@ import javax.imageio.ImageIO;
  */
 public class AppContextLeakPreventer extends AbstractLeakPreventer
 {
-
     @Override
     public void prevent(ClassLoader loader)
     {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/preventers/DriverManagerLeakPreventer.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/preventers/DriverManagerLeakPreventer.java
@@ -24,7 +24,6 @@ import java.sql.DriverManager;
  */
 public class DriverManagerLeakPreventer extends AbstractLeakPreventer
 {
-
     @Override
     public void prevent(ClassLoader loader)
     {

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/ServerWebSocketContainer.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/ServerWebSocketContainer.java
@@ -322,7 +322,7 @@ public class ServerWebSocketContainer extends ContainerLifeCycle implements WebS
      * @see #upgrade(WebSocketCreator, Request, Response, Callback)
      */
     @Override
-    public boolean handle(Request request, Response response, Callback callback) throws WebSocketException
+    public boolean handle(Request request, Response response, Callback callback)
     {
         return mappings.upgrade(request, response, callback, configuration);
     }
@@ -346,7 +346,7 @@ public class ServerWebSocketContainer extends ContainerLifeCycle implements WebS
      * @throws WebSocketException there is an error during the upgrade
      * @see #handle(Request, Response, Callback)
      */
-    public boolean upgrade(WebSocketCreator creator, Request request, Response response, Callback callback) throws WebSocketException
+    public boolean upgrade(WebSocketCreator creator, Request request, Response response, Callback callback)
     {
         var coreCreator = newWebSocketCreator(creator);
         WebSocketNegotiator negotiator = WebSocketNegotiator.from(coreCreator, factory);

--- a/jetty-ee10/jetty-ee10-annotations/pom.xml
+++ b/jetty-ee10/jetty-ee10-annotations/pom.xml
@@ -45,21 +45,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>jakarta.enterprise</groupId>
-      <artifactId>jakarta.enterprise.cdi-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>jakarta.interceptor</groupId>
-      <artifactId>jakarta.interceptor-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>jakarta.transaction</groupId>
-      <artifactId>jakarta.transaction-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-slf4j-impl</artifactId>
       <scope>test</scope>

--- a/jetty-ee10/jetty-ee10-apache-jsp/src/main/java/module-info.java
+++ b/jetty-ee10/jetty-ee10-apache-jsp/src/main/java/module-info.java
@@ -14,9 +14,9 @@
 module org.eclipse.jetty.ee10.apache.jsp
 {
     requires java.xml;
-    requires  jakarta.servlet;
+    requires transitive jakarta.servlet;
     requires org.eclipse.jetty.util;
-    requires org.mortbay.apache.jasper;
+    requires transitive org.mortbay.apache.jasper;
     requires org.slf4j;
 
     exports org.eclipse.jetty.ee10.apache.jsp;

--- a/jetty-ee10/jetty-ee10-jndi/src/main/java/module-info.java
+++ b/jetty-ee10/jetty-ee10-jndi/src/main/java/module-info.java
@@ -19,7 +19,7 @@ module org.eclipse.jetty.ee10.jndi
     requires transitive java.naming;
 
     // Only required if using MailSessionReference.
-    requires static jakarta.mail;
+    requires static transitive jakarta.mail;
 
     exports org.eclipse.jetty.ee10.jndi.factories;
 }

--- a/jetty-ee10/jetty-ee10-plus/src/main/java/module-info.java
+++ b/jetty-ee10/jetty-ee10-plus/src/main/java/module-info.java
@@ -16,13 +16,13 @@ import org.eclipse.jetty.ee10.plus.webapp.PlusConfiguration;
 
 module org.eclipse.jetty.ee10.plus
 {
-    requires org.eclipse.jetty.plus;
+    requires transitive org.eclipse.jetty.plus;
     requires org.slf4j;
 
     requires transitive org.eclipse.jetty.ee10.webapp;
 
     // Only required if using Transaction.
-    requires static jakarta.transaction;
+    requires static transitive jakarta.transaction;
 
     exports org.eclipse.jetty.ee10.plus.jndi;
     exports org.eclipse.jetty.ee10.plus.webapp;

--- a/jetty-ee10/jetty-ee10-plus/src/main/java/org/eclipse/jetty/ee10/plus/jndi/Transaction.java
+++ b/jetty-ee10/jetty-ee10-plus/src/main/java/org/eclipse/jetty/ee10/plus/jndi/Transaction.java
@@ -16,8 +16,6 @@ package org.eclipse.jetty.ee10.plus.jndi;
 import javax.naming.NamingException;
 
 import jakarta.transaction.UserTransaction;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Transaction
@@ -26,8 +24,6 @@ import org.slf4j.LoggerFactory;
  */
 public class Transaction extends org.eclipse.jetty.plus.jndi.Transaction
 {
-    private static final Logger LOG = LoggerFactory.getLogger(Transaction.class);
-
     /**
      * @param scope the scope, usually an environment like ee9, ee10
      * @param userTransaction the UserTransaction

--- a/jetty-ee10/jetty-ee10-proxy/src/main/java/module-info.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/main/java/module-info.java
@@ -13,7 +13,7 @@
 
 module org.eclipse.jetty.ee10.proxy
 {
-    requires  jakarta.servlet;
+    requires transitive jakarta.servlet;
     requires transitive org.eclipse.jetty.client;
     requires transitive org.eclipse.jetty.server;
     requires transitive org.slf4j;

--- a/jetty-ee10/jetty-ee10-servlets/src/main/java/module-info.java
+++ b/jetty-ee10/jetty-ee10-servlets/src/main/java/module-info.java
@@ -26,7 +26,7 @@ module org.eclipse.jetty.ee10.servlets
     requires static org.eclipse.jetty.http;
     requires static org.eclipse.jetty.server;
     // Only required if using CrossOriginFilter, DoSFilter, etc.
-    requires static org.eclipse.jetty.util;
+    requires static transitive org.eclipse.jetty.util;
 
     exports org.eclipse.jetty.ee10.servlets;
 }

--- a/jetty-ee8/jetty-ee8-annotations/pom.xml
+++ b/jetty-ee8/jetty-ee8-annotations/pom.xml
@@ -50,11 +50,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>jakarta.transaction</groupId>
-      <artifactId>jakarta.transaction-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-slf4j-impl</artifactId>
       <scope>test</scope>

--- a/jetty-ee9/jetty-ee9-annotations/pom.xml
+++ b/jetty-ee9/jetty-ee9-annotations/pom.xml
@@ -49,11 +49,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>jakarta.transaction</groupId>
-      <artifactId>jakarta.transaction-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-slf4j-impl</artifactId>
       <scope>test</scope>

--- a/jetty-ee9/jetty-ee9-apache-jsp/src/main/java/module-info.java
+++ b/jetty-ee9/jetty-ee9-apache-jsp/src/main/java/module-info.java
@@ -14,9 +14,9 @@
 module org.eclipse.jetty.ee9.apache.jsp
 {
     requires java.xml;
-    requires jetty.servlet.api;
+    requires transitive jetty.servlet.api;
     requires org.eclipse.jetty.util;
-    requires org.mortbay.apache.jasper;
+    requires transitive org.mortbay.apache.jasper;
     requires org.slf4j;
 
     exports org.eclipse.jetty.ee9.apache.jsp;

--- a/jetty-ee9/jetty-ee9-jndi/src/main/java/module-info.java
+++ b/jetty-ee9/jetty-ee9-jndi/src/main/java/module-info.java
@@ -19,7 +19,7 @@ module org.eclipse.jetty.ee9.jndi
     requires transitive java.naming;
 
     // Only required if using MailSessionReference.
-    requires static jakarta.mail;
+    requires static transitive jakarta.mail;
 
     exports org.eclipse.jetty.ee9.jndi.factories;
 }

--- a/jetty-ee9/jetty-ee9-plus/src/main/java/module-info.java
+++ b/jetty-ee9/jetty-ee9-plus/src/main/java/module-info.java
@@ -23,7 +23,7 @@ module org.eclipse.jetty.ee9.plus
     requires transitive org.eclipse.jetty.plus;
 
     // Only required if using Transaction.
-    requires static jakarta.transaction;
+    requires static transitive jakarta.transaction;
 
     exports org.eclipse.jetty.ee9.plus.jndi;
     exports org.eclipse.jetty.ee9.plus.webapp;

--- a/jetty-ee9/jetty-ee9-servlets/src/main/java/module-info.java
+++ b/jetty-ee9/jetty-ee9-servlets/src/main/java/module-info.java
@@ -26,7 +26,7 @@ module org.eclipse.jetty.ee9.servlets
     requires static org.eclipse.jetty.http;
     requires static org.eclipse.jetty.server;
     // Only required if using CrossOriginFilter, DoSFilter, etc.
-    requires static org.eclipse.jetty.util;
+    requires static transitive org.eclipse.jetty.util;
     // Only required if using DataRateLimitedServlet
     requires static org.eclipse.jetty.ee9.nested;
 


### PR DESCRIPTION
Some require transitive was missing, and has been added. 

In other cases, making a field private (e.g. for log instances) made the warning go away. 

In another case, removed explicit dependency on websocket core exception, as it was not necessary.

Clean up the POMs for jetty-eeN-annotations, that had unnecessary dependencies.