### PR TITLE
Fixes #11668 - WebSocketOverHTTP2Test.testWebSocketConnectPortDoesNotExist() is flaky

### DIFF
--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee10/websocket/tests/WebSocketOverHTTP2Test.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee10/websocket/tests/WebSocketOverHTTP2Test.java
@@ -264,8 +264,11 @@ public class WebSocketOverHTTP2Test
         startServer();
         startClient(clientConnector -> new ClientConnectionFactoryOverHTTP2.HTTP2(new HTTP2Client(clientConnector)));
 
+        // Port 293 is not assigned by IANA, so
+        // it should be impossible to connect.
+        int nonExistingPort = 293;
         EventSocket wsEndPoint = new EventSocket();
-        URI uri = URI.create("ws://localhost:" + (connector.getLocalPort() + 1) + "/ws/echo");
+        URI uri = URI.create("ws://localhost:" + nonExistingPort + "/ws/echo");
 
         ExecutionException failure = Assertions.assertThrows(ExecutionException.class, () ->
             wsClient.connect(wsEndPoint, uri).get(5, TimeUnit.SECONDS));

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/WebSocketOverHTTP2Test.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/WebSocketOverHTTP2Test.java
@@ -248,8 +248,11 @@ public class WebSocketOverHTTP2Test
         startServer();
         startClient(clientConnector -> new ClientConnectionFactoryOverHTTP2.HTTP2(new HTTP2Client(clientConnector)));
 
+        // Port 293 is not assigned by IANA, so
+        // it should be impossible to connect.
+        int nonExistingPort = 293;
         EventSocket wsEndPoint = new EventSocket();
-        URI uri = URI.create("ws://localhost:" + (connector.getLocalPort() + 1) + "/ws/echo");
+        URI uri = URI.create("ws://localhost:" + nonExistingPort + "/ws/echo");
 
         ExecutionException failure = Assertions.assertThrows(ExecutionException.class, () ->
             wsClient.connect(wsEndPoint, uri).get(5, TimeUnit.SECONDS));


### PR DESCRIPTION
Sometimes it happens that some process is listening to `connector.getLocalPort() + 1`, making this test fail.

Now using a non-allocated privileged port from IANA, that nobody should listen to, so the test should not fail. It is not a 100% guarantee, but perhaps better than before, especially because now a port < 1024 is used.