### PR TITLE
Merge back 10.0.21 release commits

### DIFF
--- a/VERSION.txt
+++ b/VERSION.txt
@@ -1,3 +1,5 @@
+jetty-10.0.22-SNAPSHOT
+
 jetty-10.0.21 - 14 May 2024
  + 10805 Jetty response with an invalid HTTP2 packet if the client set the
    hpack table size as 0

--- a/VERSION.txt
+++ b/VERSION.txt
@@ -1,4 +1,10 @@
-jetty-10.0.21-SNAPSHOT
+jetty-10.0.21 - 14 May 2024
+ + 10805 Jetty response with an invalid HTTP2 packet if the client set the
+   hpack table size as 0
+ + 11527 Reduce ByteBuffer churning in HttpOutput
+ + 11634 Socks5Proxy does not support IP addresses with IP segments above 127
+ + 11656 Upgrade jetty-quiche-native to version 0.21.0
+ + 11782 HttpExchange retained by HttpSenderOverHTTP which caused memory leak
 
 jetty-10.0.20 - 29 January 2024
  + 11081 Dropped WebSocket messages due to race condition in WebSocket frame
@@ -15,7 +21,7 @@ jetty-9.4.54.v20240208 - 08 February 2024
  + 11259 HTTP/2 connection not closed after idle timeout when TCP congested
    (CVE-2024-22201)
  + 11389 Strip default ports on ws/wss scheme uris too
- 
+
 jetty-10.0.19 - 15 December 2023
  + 9900 Improve `Request.getBeginNanoTime()` accuracy
  + 10812 jetty-deploy has unnecessary dependency on awaitility/hamcrest pulled

--- a/VERSION.txt
+++ b/VERSION.txt
@@ -1,11 +1,5 @@
 jetty-10.0.21-SNAPSHOT
 
-jetty-9.4.54.v20240208 - 08 February 2024
- + 1256 DoSFilter leaks USER_AUTH entries
- + 11259 HTTP/2 connection not closed after idle timeout when TCP congested
-   (CVE-2024-22201)
- + 11389 Strip default ports on ws/wss scheme uris too
- 
 jetty-10.0.20 - 29 January 2024
  + 11081 Dropped WebSocket messages due to race condition in WebSocket frame
    handling
@@ -16,6 +10,12 @@ jetty-10.0.20 - 29 January 2024
  + 11273 Support BSD expr in startup script
  + 11349 Update quiche to 0.20.0
 
+jetty-9.4.54.v20240208 - 08 February 2024
+ + 1256 DoSFilter leaks USER_AUTH entries
+ + 11259 HTTP/2 connection not closed after idle timeout when TCP congested
+   (CVE-2024-22201)
+ + 11389 Strip default ports on ws/wss scheme uris too
+ 
 jetty-10.0.19 - 15 December 2023
  + 9900 Improve `Request.getBeginNanoTime()` accuracy
  + 10812 jetty-deploy has unnecessary dependency on awaitility/hamcrest pulled

--- a/apache-jsp/pom.xml
+++ b/apache-jsp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>apache-jsp</artifactId>
   <name>Jetty :: Apache JSP Implementation</name>

--- a/apache-jsp/pom.xml
+++ b/apache-jsp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>apache-jsp</artifactId>
   <name>Jetty :: Apache JSP Implementation</name>

--- a/apache-jstl/pom.xml
+++ b/apache-jstl/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>apache-jstl</artifactId>
   <packaging>jar</packaging>

--- a/apache-jstl/pom.xml
+++ b/apache-jstl/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>apache-jstl</artifactId>
   <packaging>jar</packaging>

--- a/build-resources/pom.xml
+++ b/build-resources/pom.xml
@@ -8,7 +8,7 @@
     -->
   <groupId>org.eclipse.jetty</groupId>
   <artifactId>build-resources</artifactId>
-  <version>10.0.21-SNAPSHOT</version>
+  <version>10.0.21</version>
   <packaging>jar</packaging>
   <name>Jetty :: Build Resources</name>
 

--- a/build-resources/pom.xml
+++ b/build-resources/pom.xml
@@ -8,7 +8,7 @@
     -->
   <groupId>org.eclipse.jetty</groupId>
   <artifactId>build-resources</artifactId>
-  <version>10.0.21</version>
+  <version>10.0.22-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Jetty :: Build Resources</name>
 

--- a/demos/demo-async-rest/demo-async-rest-jar/pom.xml
+++ b/demos/demo-async-rest/demo-async-rest-jar/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demo-async-rest-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>demo-async-rest-jar</artifactId>
   <packaging>jar</packaging>

--- a/demos/demo-async-rest/demo-async-rest-jar/pom.xml
+++ b/demos/demo-async-rest/demo-async-rest-jar/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demo-async-rest-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>demo-async-rest-jar</artifactId>
   <packaging>jar</packaging>

--- a/demos/demo-async-rest/demo-async-rest-server/pom.xml
+++ b/demos/demo-async-rest/demo-async-rest-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demo-async-rest-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>demo-async-rest-server</artifactId>
   <packaging>jar</packaging>

--- a/demos/demo-async-rest/demo-async-rest-server/pom.xml
+++ b/demos/demo-async-rest/demo-async-rest-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demo-async-rest-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>demo-async-rest-server</artifactId>
   <packaging>jar</packaging>

--- a/demos/demo-async-rest/demo-async-rest-webapp/pom.xml
+++ b/demos/demo-async-rest/demo-async-rest-webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demo-async-rest-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>demo-async-rest-webapp</artifactId>
   <packaging>war</packaging>

--- a/demos/demo-async-rest/demo-async-rest-webapp/pom.xml
+++ b/demos/demo-async-rest/demo-async-rest-webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demo-async-rest-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>demo-async-rest-webapp</artifactId>
   <packaging>war</packaging>

--- a/demos/demo-async-rest/pom.xml
+++ b/demos/demo-async-rest/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demos-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>demo-async-rest-parent</artifactId>
   <packaging>pom</packaging>

--- a/demos/demo-async-rest/pom.xml
+++ b/demos/demo-async-rest/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demos-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>demo-async-rest-parent</artifactId>
   <packaging>pom</packaging>

--- a/demos/demo-jaas-webapp/pom.xml
+++ b/demos/demo-jaas-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demos-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>demo-jaas-webapp</artifactId>
   <packaging>war</packaging>

--- a/demos/demo-jaas-webapp/pom.xml
+++ b/demos/demo-jaas-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demos-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>demo-jaas-webapp</artifactId>
   <packaging>war</packaging>

--- a/demos/demo-jetty-webapp/pom.xml
+++ b/demos/demo-jetty-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demos-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>demo-jetty-webapp</artifactId>

--- a/demos/demo-jetty-webapp/pom.xml
+++ b/demos/demo-jetty-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demos-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>demo-jetty-webapp</artifactId>

--- a/demos/demo-jndi-webapp/pom.xml
+++ b/demos/demo-jndi-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demos-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>demo-jndi-webapp</artifactId>
   <packaging>war</packaging>

--- a/demos/demo-jndi-webapp/pom.xml
+++ b/demos/demo-jndi-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demos-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>demo-jndi-webapp</artifactId>
   <packaging>war</packaging>

--- a/demos/demo-jsp-webapp/pom.xml
+++ b/demos/demo-jsp-webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demos-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>demo-jsp-webapp</artifactId>
   <packaging>war</packaging>

--- a/demos/demo-jsp-webapp/pom.xml
+++ b/demos/demo-jsp-webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demos-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>demo-jsp-webapp</artifactId>
   <packaging>war</packaging>

--- a/demos/demo-mock-resources/pom.xml
+++ b/demos/demo-mock-resources/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demos-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>demo-mock-resources</artifactId>
   <packaging>jar</packaging>

--- a/demos/demo-mock-resources/pom.xml
+++ b/demos/demo-mock-resources/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demos-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>demo-mock-resources</artifactId>
   <packaging>jar</packaging>

--- a/demos/demo-proxy-webapp/pom.xml
+++ b/demos/demo-proxy-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demos-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>demo-proxy-webapp</artifactId>
   <packaging>war</packaging>

--- a/demos/demo-proxy-webapp/pom.xml
+++ b/demos/demo-proxy-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demos-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>demo-proxy-webapp</artifactId>
   <packaging>war</packaging>

--- a/demos/demo-simple-webapp/pom.xml
+++ b/demos/demo-simple-webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demos-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>demo-simple-webapp</artifactId>
   <packaging>war</packaging>

--- a/demos/demo-simple-webapp/pom.xml
+++ b/demos/demo-simple-webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demos-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>demo-simple-webapp</artifactId>
   <packaging>war</packaging>

--- a/demos/demo-spec/demo-container-initializer/pom.xml
+++ b/demos/demo-spec/demo-container-initializer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demos-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>demo-container-initializer</artifactId>

--- a/demos/demo-spec/demo-container-initializer/pom.xml
+++ b/demos/demo-spec/demo-container-initializer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demos-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>demo-container-initializer</artifactId>

--- a/demos/demo-spec/demo-spec-webapp/pom.xml
+++ b/demos/demo-spec/demo-spec-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demos-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>demo-spec-webapp</artifactId>

--- a/demos/demo-spec/demo-spec-webapp/pom.xml
+++ b/demos/demo-spec/demo-spec-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demos-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>demo-spec-webapp</artifactId>

--- a/demos/demo-spec/demo-web-fragment/pom.xml
+++ b/demos/demo-spec/demo-web-fragment/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demos-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>demo-web-fragment</artifactId>

--- a/demos/demo-spec/demo-web-fragment/pom.xml
+++ b/demos/demo-spec/demo-web-fragment/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demos-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>demo-web-fragment</artifactId>

--- a/demos/demo-spec/pom.xml
+++ b/demos/demo-spec/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demos-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>demo-spec</artifactId>
   <packaging>pom</packaging>

--- a/demos/demo-spec/pom.xml
+++ b/demos/demo-spec/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demos-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>demo-spec</artifactId>
   <packaging>pom</packaging>

--- a/demos/embedded/pom.xml
+++ b/demos/embedded/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demos-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>demos-jetty-embedded</artifactId>
   <name>Demo :: Embedded Jetty</name>

--- a/demos/embedded/pom.xml
+++ b/demos/embedded/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.demos</groupId>
     <artifactId>demos-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>demos-jetty-embedded</artifactId>
   <name>Demo :: Embedded Jetty</name>

--- a/demos/pom.xml
+++ b/demos/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <groupId>org.eclipse.jetty.demos</groupId>
   <artifactId>demos-parent</artifactId>

--- a/demos/pom.xml
+++ b/demos/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.jetty.demos</groupId>
   <artifactId>demos-parent</artifactId>

--- a/documentation/jetty-asciidoctor-extensions/pom.xml
+++ b/documentation/jetty-asciidoctor-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.documentation</groupId>
     <artifactId>documentation-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-asciidoctor-extensions</artifactId>
   <packaging>jar</packaging>

--- a/documentation/jetty-asciidoctor-extensions/pom.xml
+++ b/documentation/jetty-asciidoctor-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.documentation</groupId>
     <artifactId>documentation-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-asciidoctor-extensions</artifactId>
   <packaging>jar</packaging>

--- a/documentation/jetty-documentation/pom.xml
+++ b/documentation/jetty-documentation/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.documentation</groupId>
     <artifactId>documentation-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-documentation</artifactId>
   <packaging>jar</packaging>

--- a/documentation/jetty-documentation/pom.xml
+++ b/documentation/jetty-documentation/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.documentation</groupId>
     <artifactId>documentation-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-documentation</artifactId>
   <packaging>jar</packaging>

--- a/documentation/jetty/modules/code/examples/pom.xml
+++ b/documentation/jetty/modules/code/examples/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.documentation</groupId>
     <artifactId>documentation-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.22-SNAPSHOT</version>
     <relativePath>../../../../pom.xml</relativePath>
   </parent>
   <artifactId>code-examples</artifactId>

--- a/documentation/jetty/pom.xml
+++ b/documentation/jetty/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.documentation</groupId>
     <artifactId>documentation-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty</artifactId>
   <packaging>pom</packaging>

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.jetty.documentation</groupId>
   <artifactId>documentation-parent</artifactId>

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <groupId>org.eclipse.jetty.documentation</groupId>
   <artifactId>documentation-parent</artifactId>

--- a/javadoc/pom.xml
+++ b/javadoc/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>javadoc</artifactId>
   <packaging>jar</packaging>

--- a/javadoc/pom.xml
+++ b/javadoc/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>javadoc</artifactId>
   <packaging>jar</packaging>

--- a/jetty-alpn/jetty-alpn-client/pom.xml
+++ b/jetty-alpn/jetty-alpn-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-alpn-client</artifactId>
   <name>Jetty :: ALPN :: Client</name>

--- a/jetty-alpn/jetty-alpn-client/pom.xml
+++ b/jetty-alpn/jetty-alpn-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-alpn-client</artifactId>
   <name>Jetty :: ALPN :: Client</name>

--- a/jetty-alpn/jetty-alpn-conscrypt-client/pom.xml
+++ b/jetty-alpn/jetty-alpn-conscrypt-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-alpn-conscrypt-client</artifactId>
   <name>Jetty :: ALPN :: Conscrypt Client Implementation</name>

--- a/jetty-alpn/jetty-alpn-conscrypt-client/pom.xml
+++ b/jetty-alpn/jetty-alpn-conscrypt-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-alpn-conscrypt-client</artifactId>
   <name>Jetty :: ALPN :: Conscrypt Client Implementation</name>

--- a/jetty-alpn/jetty-alpn-conscrypt-server/pom.xml
+++ b/jetty-alpn/jetty-alpn-conscrypt-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-alpn-conscrypt-server</artifactId>
   <name>Jetty :: ALPN :: Conscrypt Server Implementation</name>

--- a/jetty-alpn/jetty-alpn-conscrypt-server/pom.xml
+++ b/jetty-alpn/jetty-alpn-conscrypt-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-alpn-conscrypt-server</artifactId>
   <name>Jetty :: ALPN :: Conscrypt Server Implementation</name>

--- a/jetty-alpn/jetty-alpn-java-client/pom.xml
+++ b/jetty-alpn/jetty-alpn-java-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-alpn-java-client</artifactId>
   <name>Jetty :: ALPN :: JDK9 Client Implementation</name>

--- a/jetty-alpn/jetty-alpn-java-client/pom.xml
+++ b/jetty-alpn/jetty-alpn-java-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-alpn-java-client</artifactId>
   <name>Jetty :: ALPN :: JDK9 Client Implementation</name>

--- a/jetty-alpn/jetty-alpn-java-server/pom.xml
+++ b/jetty-alpn/jetty-alpn-java-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-alpn-java-server</artifactId>
   <name>Jetty :: ALPN :: JDK9 Server Implementation</name>

--- a/jetty-alpn/jetty-alpn-java-server/pom.xml
+++ b/jetty-alpn/jetty-alpn-java-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-alpn-java-server</artifactId>
   <name>Jetty :: ALPN :: JDK9 Server Implementation</name>

--- a/jetty-alpn/jetty-alpn-server/pom.xml
+++ b/jetty-alpn/jetty-alpn-server/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-alpn-server</artifactId>
   <name>Jetty :: ALPN :: Server</name>

--- a/jetty-alpn/jetty-alpn-server/pom.xml
+++ b/jetty-alpn/jetty-alpn-server/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-alpn-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-alpn-server</artifactId>
   <name>Jetty :: ALPN :: Server</name>

--- a/jetty-alpn/pom.xml
+++ b/jetty-alpn/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-alpn-parent</artifactId>
   <packaging>pom</packaging>

--- a/jetty-alpn/pom.xml
+++ b/jetty-alpn/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-alpn-parent</artifactId>
   <packaging>pom</packaging>

--- a/jetty-annotations/pom.xml
+++ b/jetty-annotations/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-annotations</artifactId>
   <name>Jetty :: Servlet Annotations</name>

--- a/jetty-annotations/pom.xml
+++ b/jetty-annotations/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-annotations</artifactId>
   <name>Jetty :: Servlet Annotations</name>

--- a/jetty-ant/pom.xml
+++ b/jetty-ant/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-ant</artifactId>
   <packaging>jar</packaging>

--- a/jetty-ant/pom.xml
+++ b/jetty-ant/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ant</artifactId>
   <packaging>jar</packaging>

--- a/jetty-bom/pom.xml
+++ b/jetty-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
 
   <artifactId>jetty-bom</artifactId>
@@ -18,409 +18,409 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>apache-jsp</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>apache-jstl</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>infinispan-common</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>infinispan-embedded-query</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>infinispan-remote-query</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-client</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-conscrypt-client</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-conscrypt-server</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-java-client</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-java-server</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-server</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-annotations</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-ant</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-cdi</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-client</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-deploy</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-hazelcast</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-home</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
         <type>zip</type>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-home</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
         <type>tar.gz</type>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-http</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-http-spi</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-io</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jaas</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jaspi</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jmx</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jndi</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-keystore</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-nosql</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-openid</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-plus</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-proxy</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-quickstart</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-rewrite</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-security</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-servlet</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-servlets</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-slf4j-impl</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-unixdomain-server</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-unixsocket-client</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-unixsocket-common</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-unixsocket-server</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util-ajax</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-webapp</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-xml</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.fcgi</groupId>
         <artifactId>fcgi-client</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.fcgi</groupId>
         <artifactId>fcgi-server</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.gcloud</groupId>
         <artifactId>jetty-gcloud-session-manager</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-client</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-common</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-hpack</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-http-client-transport</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-server</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http3</groupId>
         <artifactId>http3-client</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http3</groupId>
         <artifactId>http3-common</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http3</groupId>
         <artifactId>http3-http-client-transport</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http3</groupId>
         <artifactId>http3-qpack</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http3</groupId>
         <artifactId>http3-server</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.memcached</groupId>
         <artifactId>jetty-memcached-sessions</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.osgi</groupId>
         <artifactId>jetty-httpservice</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.osgi</groupId>
         <artifactId>jetty-osgi-alpn</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.osgi</groupId>
         <artifactId>jetty-osgi-boot</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.osgi</groupId>
         <artifactId>jetty-osgi-boot-jsp</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.osgi</groupId>
         <artifactId>jetty-osgi-boot-warurl</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.quic</groupId>
         <artifactId>quic-client</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.quic</groupId>
         <artifactId>quic-common</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.quic</groupId>
         <artifactId>quic-quiche-common</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.quic</groupId>
         <artifactId>quic-quiche-jna</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.quic</groupId>
         <artifactId>quic-server</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-core-client</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-core-common</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-core-server</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-javax-client</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-javax-common</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-javax-server</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-jetty-api</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-jetty-client</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-jetty-common</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-jetty-server</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-servlet</artifactId>
-        <version>10.0.21-SNAPSHOT</version>
+        <version>10.0.21</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -472,7 +472,7 @@
           <dependency>
             <groupId>org.eclipse.jetty.quic</groupId>
             <artifactId>quic-quiche-foreign-incubator</artifactId>
-            <version>10.0.21-SNAPSHOT</version>
+            <version>10.0.21</version>
           </dependency>
         </dependencies>
       </dependencyManagement>

--- a/jetty-bom/pom.xml
+++ b/jetty-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
 
   <artifactId>jetty-bom</artifactId>
@@ -18,409 +18,409 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>apache-jsp</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>apache-jstl</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>infinispan-common</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>infinispan-embedded-query</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>infinispan-remote-query</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-client</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-conscrypt-client</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-conscrypt-server</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-java-client</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-java-server</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-server</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-annotations</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-ant</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-cdi</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-client</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-deploy</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-hazelcast</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-home</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
         <type>zip</type>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-home</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
         <type>tar.gz</type>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-http</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-http-spi</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-io</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jaas</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jaspi</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jmx</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jndi</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-keystore</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-nosql</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-openid</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-plus</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-proxy</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-quickstart</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-rewrite</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-security</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-servlet</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-servlets</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-slf4j-impl</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-unixdomain-server</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-unixsocket-client</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-unixsocket-common</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-unixsocket-server</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util-ajax</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-webapp</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-xml</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.fcgi</groupId>
         <artifactId>fcgi-client</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.fcgi</groupId>
         <artifactId>fcgi-server</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.gcloud</groupId>
         <artifactId>jetty-gcloud-session-manager</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-client</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-common</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-hpack</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-http-client-transport</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-server</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http3</groupId>
         <artifactId>http3-client</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http3</groupId>
         <artifactId>http3-common</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http3</groupId>
         <artifactId>http3-http-client-transport</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http3</groupId>
         <artifactId>http3-qpack</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http3</groupId>
         <artifactId>http3-server</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.memcached</groupId>
         <artifactId>jetty-memcached-sessions</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.osgi</groupId>
         <artifactId>jetty-httpservice</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.osgi</groupId>
         <artifactId>jetty-osgi-alpn</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.osgi</groupId>
         <artifactId>jetty-osgi-boot</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.osgi</groupId>
         <artifactId>jetty-osgi-boot-jsp</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.osgi</groupId>
         <artifactId>jetty-osgi-boot-warurl</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.quic</groupId>
         <artifactId>quic-client</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.quic</groupId>
         <artifactId>quic-common</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.quic</groupId>
         <artifactId>quic-quiche-common</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.quic</groupId>
         <artifactId>quic-quiche-jna</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.quic</groupId>
         <artifactId>quic-server</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-core-client</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-core-common</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-core-server</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-javax-client</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-javax-common</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-javax-server</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-jetty-api</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-jetty-client</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-jetty-common</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-jetty-server</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-servlet</artifactId>
-        <version>10.0.21</version>
+        <version>10.0.22-SNAPSHOT</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -472,7 +472,7 @@
           <dependency>
             <groupId>org.eclipse.jetty.quic</groupId>
             <artifactId>quic-quiche-foreign-incubator</artifactId>
-            <version>10.0.21</version>
+            <version>10.0.22-SNAPSHOT</version>
           </dependency>
         </dependencies>
       </dependencyManagement>

--- a/jetty-cdi/pom.xml
+++ b/jetty-cdi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <groupId>org.eclipse.jetty</groupId>
   <artifactId>jetty-cdi</artifactId>

--- a/jetty-cdi/pom.xml
+++ b/jetty-cdi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.jetty</groupId>
   <artifactId>jetty-cdi</artifactId>

--- a/jetty-client/pom.xml
+++ b/jetty-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-client</artifactId>
   <name>Jetty :: Asynchronous HTTP Client</name>

--- a/jetty-client/pom.xml
+++ b/jetty-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-client</artifactId>
   <name>Jetty :: Asynchronous HTTP Client</name>

--- a/jetty-deploy/pom.xml
+++ b/jetty-deploy/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-deploy</artifactId>
   <name>Jetty :: Deployers</name>

--- a/jetty-deploy/pom.xml
+++ b/jetty-deploy/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-deploy</artifactId>
   <name>Jetty :: Deployers</name>

--- a/jetty-fcgi/fcgi-client/pom.xml
+++ b/jetty-fcgi/fcgi-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.fcgi</groupId>
     <artifactId>fcgi-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>fcgi-client</artifactId>
   <name>Jetty :: FastCGI :: Client</name>

--- a/jetty-fcgi/fcgi-client/pom.xml
+++ b/jetty-fcgi/fcgi-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.fcgi</groupId>
     <artifactId>fcgi-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>fcgi-client</artifactId>
   <name>Jetty :: FastCGI :: Client</name>

--- a/jetty-fcgi/fcgi-server/pom.xml
+++ b/jetty-fcgi/fcgi-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.fcgi</groupId>
     <artifactId>fcgi-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>fcgi-server</artifactId>
   <name>Jetty :: FastCGI :: Server</name>

--- a/jetty-fcgi/fcgi-server/pom.xml
+++ b/jetty-fcgi/fcgi-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.fcgi</groupId>
     <artifactId>fcgi-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>fcgi-server</artifactId>
   <name>Jetty :: FastCGI :: Server</name>

--- a/jetty-fcgi/pom.xml
+++ b/jetty-fcgi/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.jetty.fcgi</groupId>
   <artifactId>fcgi-parent</artifactId>

--- a/jetty-fcgi/pom.xml
+++ b/jetty-fcgi/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <groupId>org.eclipse.jetty.fcgi</groupId>
   <artifactId>fcgi-parent</artifactId>

--- a/jetty-gcloud/jetty-gcloud-session-manager/pom.xml
+++ b/jetty-gcloud/jetty-gcloud-session-manager/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.gcloud</groupId>
     <artifactId>gcloud-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-gcloud-session-manager</artifactId>
   <name>Jetty :: GCloud :: Session Manager</name>

--- a/jetty-gcloud/jetty-gcloud-session-manager/pom.xml
+++ b/jetty-gcloud/jetty-gcloud-session-manager/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.gcloud</groupId>
     <artifactId>gcloud-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-gcloud-session-manager</artifactId>
   <name>Jetty :: GCloud :: Session Manager</name>

--- a/jetty-gcloud/pom.xml
+++ b/jetty-gcloud/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <groupId>org.eclipse.jetty.gcloud</groupId>
   <artifactId>gcloud-parent</artifactId>

--- a/jetty-gcloud/pom.xml
+++ b/jetty-gcloud/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.jetty.gcloud</groupId>
   <artifactId>gcloud-parent</artifactId>

--- a/jetty-hazelcast/pom.xml
+++ b/jetty-hazelcast/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-hazelcast</artifactId>
   <name>Jetty :: Hazelcast Session Manager</name>

--- a/jetty-hazelcast/pom.xml
+++ b/jetty-hazelcast/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-hazelcast</artifactId>
   <name>Jetty :: Hazelcast Session Manager</name>

--- a/jetty-home/pom.xml
+++ b/jetty-home/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-home</artifactId>
   <packaging>pom</packaging>

--- a/jetty-home/pom.xml
+++ b/jetty-home/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-home</artifactId>
   <packaging>pom</packaging>

--- a/jetty-http-spi/pom.xml
+++ b/jetty-http-spi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-http-spi</artifactId>
   <name>Jetty :: Http Service Provider Interface</name>

--- a/jetty-http-spi/pom.xml
+++ b/jetty-http-spi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-http-spi</artifactId>
   <name>Jetty :: Http Service Provider Interface</name>

--- a/jetty-http/pom.xml
+++ b/jetty-http/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-http</artifactId>
   <name>Jetty :: Http Utility</name>

--- a/jetty-http/pom.xml
+++ b/jetty-http/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-http</artifactId>
   <name>Jetty :: Http Utility</name>

--- a/jetty-http2/http2-client/pom.xml
+++ b/jetty-http2/http2-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http2</groupId>
     <artifactId>http2-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>http2-client</artifactId>
   <name>Jetty :: HTTP2 :: Client</name>

--- a/jetty-http2/http2-client/pom.xml
+++ b/jetty-http2/http2-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http2</groupId>
     <artifactId>http2-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>http2-client</artifactId>
   <name>Jetty :: HTTP2 :: Client</name>

--- a/jetty-http2/http2-common/pom.xml
+++ b/jetty-http2/http2-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http2</groupId>
     <artifactId>http2-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>http2-common</artifactId>
   <name>Jetty :: HTTP2 :: Common</name>

--- a/jetty-http2/http2-common/pom.xml
+++ b/jetty-http2/http2-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http2</groupId>
     <artifactId>http2-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>http2-common</artifactId>
   <name>Jetty :: HTTP2 :: Common</name>

--- a/jetty-http2/http2-hpack/pom.xml
+++ b/jetty-http2/http2-hpack/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http2</groupId>
     <artifactId>http2-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>http2-hpack</artifactId>
   <name>Jetty :: HTTP2 :: HPACK</name>

--- a/jetty-http2/http2-hpack/pom.xml
+++ b/jetty-http2/http2-hpack/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http2</groupId>
     <artifactId>http2-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>http2-hpack</artifactId>
   <name>Jetty :: HTTP2 :: HPACK</name>

--- a/jetty-http2/http2-http-client-transport/pom.xml
+++ b/jetty-http2/http2-http-client-transport/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http2</groupId>
     <artifactId>http2-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>http2-http-client-transport</artifactId>
   <name>Jetty :: HTTP2 :: HTTP Client Transport</name>

--- a/jetty-http2/http2-http-client-transport/pom.xml
+++ b/jetty-http2/http2-http-client-transport/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http2</groupId>
     <artifactId>http2-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>http2-http-client-transport</artifactId>
   <name>Jetty :: HTTP2 :: HTTP Client Transport</name>

--- a/jetty-http2/http2-server/pom.xml
+++ b/jetty-http2/http2-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http2</groupId>
     <artifactId>http2-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>http2-server</artifactId>
   <name>Jetty :: HTTP2 :: Server</name>

--- a/jetty-http2/http2-server/pom.xml
+++ b/jetty-http2/http2-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http2</groupId>
     <artifactId>http2-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>http2-server</artifactId>
   <name>Jetty :: HTTP2 :: Server</name>

--- a/jetty-http2/pom.xml
+++ b/jetty-http2/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <groupId>org.eclipse.jetty.http2</groupId>
   <artifactId>http2-parent</artifactId>

--- a/jetty-http2/pom.xml
+++ b/jetty-http2/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.jetty.http2</groupId>
   <artifactId>http2-parent</artifactId>

--- a/jetty-http3/http3-client/pom.xml
+++ b/jetty-http3/http3-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http3</groupId>
     <artifactId>http3-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>http3-client</artifactId>
   <name>Jetty :: HTTP3 :: Client</name>

--- a/jetty-http3/http3-client/pom.xml
+++ b/jetty-http3/http3-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http3</groupId>
     <artifactId>http3-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>http3-client</artifactId>
   <name>Jetty :: HTTP3 :: Client</name>

--- a/jetty-http3/http3-common/pom.xml
+++ b/jetty-http3/http3-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http3</groupId>
     <artifactId>http3-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>http3-common</artifactId>
   <name>Jetty :: HTTP3 :: Common</name>

--- a/jetty-http3/http3-common/pom.xml
+++ b/jetty-http3/http3-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http3</groupId>
     <artifactId>http3-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>http3-common</artifactId>
   <name>Jetty :: HTTP3 :: Common</name>

--- a/jetty-http3/http3-http-client-transport/pom.xml
+++ b/jetty-http3/http3-http-client-transport/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http3</groupId>
     <artifactId>http3-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>http3-http-client-transport</artifactId>
   <name>Jetty :: HTTP3 :: HTTP Client Transport</name>

--- a/jetty-http3/http3-http-client-transport/pom.xml
+++ b/jetty-http3/http3-http-client-transport/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http3</groupId>
     <artifactId>http3-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>http3-http-client-transport</artifactId>
   <name>Jetty :: HTTP3 :: HTTP Client Transport</name>

--- a/jetty-http3/http3-qpack/pom.xml
+++ b/jetty-http3/http3-qpack/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http3</groupId>
     <artifactId>http3-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>http3-qpack</artifactId>
   <name>Jetty :: HTTP3 :: QPACK</name>

--- a/jetty-http3/http3-qpack/pom.xml
+++ b/jetty-http3/http3-qpack/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http3</groupId>
     <artifactId>http3-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>http3-qpack</artifactId>
   <name>Jetty :: HTTP3 :: QPACK</name>

--- a/jetty-http3/http3-server/pom.xml
+++ b/jetty-http3/http3-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http3</groupId>
     <artifactId>http3-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>http3-server</artifactId>
   <name>Jetty :: HTTP3 :: Server</name>

--- a/jetty-http3/http3-server/pom.xml
+++ b/jetty-http3/http3-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http3</groupId>
     <artifactId>http3-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>http3-server</artifactId>
   <name>Jetty :: HTTP3 :: Server</name>

--- a/jetty-http3/http3-tests/pom.xml
+++ b/jetty-http3/http3-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http3</groupId>
     <artifactId>http3-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>http3-tests</artifactId>
   <name>Jetty :: HTTP3 :: Tests</name>

--- a/jetty-http3/http3-tests/pom.xml
+++ b/jetty-http3/http3-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.http3</groupId>
     <artifactId>http3-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>http3-tests</artifactId>
   <name>Jetty :: HTTP3 :: Tests</name>

--- a/jetty-http3/pom.xml
+++ b/jetty-http3/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <groupId>org.eclipse.jetty.http3</groupId>
   <artifactId>http3-parent</artifactId>

--- a/jetty-http3/pom.xml
+++ b/jetty-http3/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.jetty.http3</groupId>
   <artifactId>http3-parent</artifactId>

--- a/jetty-infinispan/infinispan-common/pom.xml
+++ b/jetty-infinispan/infinispan-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>infinispan-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>infinispan-common</artifactId>
   <name>Jetty :: Infinispan Session Manager Common</name>

--- a/jetty-infinispan/infinispan-common/pom.xml
+++ b/jetty-infinispan/infinispan-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>infinispan-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>infinispan-common</artifactId>
   <name>Jetty :: Infinispan Session Manager Common</name>

--- a/jetty-infinispan/infinispan-embedded-query/pom.xml
+++ b/jetty-infinispan/infinispan-embedded-query/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>infinispan-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>infinispan-embedded-query</artifactId>
   <name>Jetty :: Infinispan Session Manager Embedded with Querying</name>

--- a/jetty-infinispan/infinispan-embedded-query/pom.xml
+++ b/jetty-infinispan/infinispan-embedded-query/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>infinispan-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>infinispan-embedded-query</artifactId>
   <name>Jetty :: Infinispan Session Manager Embedded with Querying</name>

--- a/jetty-infinispan/infinispan-embedded/pom.xml
+++ b/jetty-infinispan/infinispan-embedded/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>infinispan-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>infinispan-embedded</artifactId>
   <packaging>pom</packaging>

--- a/jetty-infinispan/infinispan-embedded/pom.xml
+++ b/jetty-infinispan/infinispan-embedded/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>infinispan-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>infinispan-embedded</artifactId>
   <packaging>pom</packaging>

--- a/jetty-infinispan/infinispan-remote-query/pom.xml
+++ b/jetty-infinispan/infinispan-remote-query/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>infinispan-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>infinispan-remote-query</artifactId>
   <name>Jetty :: Infinispan Session Manager Remote with Querying</name>

--- a/jetty-infinispan/infinispan-remote-query/pom.xml
+++ b/jetty-infinispan/infinispan-remote-query/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>infinispan-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>infinispan-remote-query</artifactId>
   <name>Jetty :: Infinispan Session Manager Remote with Querying</name>

--- a/jetty-infinispan/infinispan-remote/pom.xml
+++ b/jetty-infinispan/infinispan-remote/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>infinispan-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>infinispan-remote</artifactId>
   <packaging>pom</packaging>

--- a/jetty-infinispan/infinispan-remote/pom.xml
+++ b/jetty-infinispan/infinispan-remote/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>infinispan-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>infinispan-remote</artifactId>
   <packaging>pom</packaging>

--- a/jetty-infinispan/pom.xml
+++ b/jetty-infinispan/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.jetty</groupId>
   <artifactId>infinispan-parent</artifactId>

--- a/jetty-infinispan/pom.xml
+++ b/jetty-infinispan/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <groupId>org.eclipse.jetty</groupId>
   <artifactId>infinispan-parent</artifactId>

--- a/jetty-io/pom.xml
+++ b/jetty-io/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-io</artifactId>
   <name>Jetty :: IO Utility</name>

--- a/jetty-io/pom.xml
+++ b/jetty-io/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-io</artifactId>
   <name>Jetty :: IO Utility</name>

--- a/jetty-jaas/pom.xml
+++ b/jetty-jaas/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-jaas</artifactId>
   <name>Jetty :: JAAS</name>

--- a/jetty-jaas/pom.xml
+++ b/jetty-jaas/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-jaas</artifactId>
   <name>Jetty :: JAAS</name>

--- a/jetty-jaspi/pom.xml
+++ b/jetty-jaspi/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-jaspi</artifactId>
   <name>Jetty :: JASPI Security</name>

--- a/jetty-jaspi/pom.xml
+++ b/jetty-jaspi/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-jaspi</artifactId>
   <name>Jetty :: JASPI Security</name>

--- a/jetty-jmx/pom.xml
+++ b/jetty-jmx/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-jmx</artifactId>
   <name>Jetty :: JMX Management</name>

--- a/jetty-jmx/pom.xml
+++ b/jetty-jmx/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-jmx</artifactId>
   <name>Jetty :: JMX Management</name>

--- a/jetty-jndi/pom.xml
+++ b/jetty-jndi/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-jndi</artifactId>
   <name>Jetty :: JNDI Naming</name>

--- a/jetty-jndi/pom.xml
+++ b/jetty-jndi/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-jndi</artifactId>
   <name>Jetty :: JNDI Naming</name>

--- a/jetty-jspc-maven-plugin/pom.xml
+++ b/jetty-jspc-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-jspc-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>

--- a/jetty-jspc-maven-plugin/pom.xml
+++ b/jetty-jspc-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-jspc-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>

--- a/jetty-keystore/pom.xml
+++ b/jetty-keystore/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-keystore</artifactId>
   <packaging>jar</packaging>

--- a/jetty-keystore/pom.xml
+++ b/jetty-keystore/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-keystore</artifactId>
   <packaging>jar</packaging>

--- a/jetty-maven-plugin/pom.xml
+++ b/jetty-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>

--- a/jetty-maven-plugin/pom.xml
+++ b/jetty-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>

--- a/jetty-memcached/jetty-memcached-sessions/pom.xml
+++ b/jetty-memcached/jetty-memcached-sessions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.memcached</groupId>
     <artifactId>memcached-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-memcached-sessions</artifactId>
   <name>Jetty :: Memcached :: Sessions</name>

--- a/jetty-memcached/jetty-memcached-sessions/pom.xml
+++ b/jetty-memcached/jetty-memcached-sessions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.memcached</groupId>
     <artifactId>memcached-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-memcached-sessions</artifactId>
   <name>Jetty :: Memcached :: Sessions</name>

--- a/jetty-memcached/pom.xml
+++ b/jetty-memcached/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.jetty.memcached</groupId>
   <artifactId>memcached-parent</artifactId>

--- a/jetty-memcached/pom.xml
+++ b/jetty-memcached/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <groupId>org.eclipse.jetty.memcached</groupId>
   <artifactId>memcached-parent</artifactId>

--- a/jetty-nosql/pom.xml
+++ b/jetty-nosql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-nosql</artifactId>
   <name>Jetty :: NoSQL Session Managers</name>

--- a/jetty-nosql/pom.xml
+++ b/jetty-nosql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-nosql</artifactId>
   <name>Jetty :: NoSQL Session Managers</name>

--- a/jetty-openid/pom.xml
+++ b/jetty-openid/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-openid</artifactId>
   <name>Jetty :: OpenID</name>

--- a/jetty-openid/pom.xml
+++ b/jetty-openid/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-openid</artifactId>
   <name>Jetty :: OpenID</name>

--- a/jetty-osgi/jetty-osgi-alpn/pom.xml
+++ b/jetty-osgi/jetty-osgi-alpn/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-osgi-alpn</artifactId>
   <packaging>jar</packaging>

--- a/jetty-osgi/jetty-osgi-alpn/pom.xml
+++ b/jetty-osgi/jetty-osgi-alpn/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-osgi-alpn</artifactId>
   <packaging>jar</packaging>

--- a/jetty-osgi/jetty-osgi-boot-jsp/pom.xml
+++ b/jetty-osgi/jetty-osgi-boot-jsp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-osgi-boot-jsp</artifactId>
   <name>Jetty :: OSGi :: Boot JSP</name>

--- a/jetty-osgi/jetty-osgi-boot-jsp/pom.xml
+++ b/jetty-osgi/jetty-osgi-boot-jsp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-osgi-boot-jsp</artifactId>
   <name>Jetty :: OSGi :: Boot JSP</name>

--- a/jetty-osgi/jetty-osgi-boot-warurl/pom.xml
+++ b/jetty-osgi/jetty-osgi-boot-warurl/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>jetty-osgi-boot-warurl</artifactId>

--- a/jetty-osgi/jetty-osgi-boot-warurl/pom.xml
+++ b/jetty-osgi/jetty-osgi-boot-warurl/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>jetty-osgi-boot-warurl</artifactId>

--- a/jetty-osgi/jetty-osgi-boot/pom.xml
+++ b/jetty-osgi/jetty-osgi-boot/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-osgi-boot</artifactId>
   <name>Jetty :: OSGi :: Boot</name>

--- a/jetty-osgi/jetty-osgi-boot/pom.xml
+++ b/jetty-osgi/jetty-osgi-boot/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-osgi-boot</artifactId>
   <name>Jetty :: OSGi :: Boot</name>

--- a/jetty-osgi/jetty-osgi-httpservice/pom.xml
+++ b/jetty-osgi/jetty-osgi-httpservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-httpservice</artifactId>
   <name>Jetty :: OSGi :: HttpService</name>

--- a/jetty-osgi/jetty-osgi-httpservice/pom.xml
+++ b/jetty-osgi/jetty-osgi-httpservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-httpservice</artifactId>
   <name>Jetty :: OSGi :: HttpService</name>

--- a/jetty-osgi/pom.xml
+++ b/jetty-osgi/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <groupId>org.eclipse.jetty.osgi</groupId>
   <artifactId>jetty-osgi-project</artifactId>

--- a/jetty-osgi/pom.xml
+++ b/jetty-osgi/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.jetty.osgi</groupId>
   <artifactId>jetty-osgi-project</artifactId>

--- a/jetty-osgi/test-jetty-osgi-context/pom.xml
+++ b/jetty-osgi/test-jetty-osgi-context/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-jetty-osgi-context</artifactId>
   <name>Jetty :: OSGi :: Test Context</name>

--- a/jetty-osgi/test-jetty-osgi-context/pom.xml
+++ b/jetty-osgi/test-jetty-osgi-context/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-jetty-osgi-context</artifactId>
   <name>Jetty :: OSGi :: Test Context</name>

--- a/jetty-osgi/test-jetty-osgi-fragment/pom.xml
+++ b/jetty-osgi/test-jetty-osgi-fragment/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>test-jetty-osgi-fragment</artifactId>

--- a/jetty-osgi/test-jetty-osgi-fragment/pom.xml
+++ b/jetty-osgi/test-jetty-osgi-fragment/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>test-jetty-osgi-fragment</artifactId>

--- a/jetty-osgi/test-jetty-osgi-server/pom.xml
+++ b/jetty-osgi/test-jetty-osgi-server/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-jetty-osgi-server</artifactId>
   <name>Jetty :: OSGi :: Server</name>

--- a/jetty-osgi/test-jetty-osgi-server/pom.xml
+++ b/jetty-osgi/test-jetty-osgi-server/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-jetty-osgi-server</artifactId>
   <name>Jetty :: OSGi :: Server</name>

--- a/jetty-osgi/test-jetty-osgi-webapp-resources/pom.xml
+++ b/jetty-osgi/test-jetty-osgi-webapp-resources/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-jetty-osgi-webapp-resources</artifactId>
   <packaging>war</packaging>

--- a/jetty-osgi/test-jetty-osgi-webapp-resources/pom.xml
+++ b/jetty-osgi/test-jetty-osgi-webapp-resources/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-jetty-osgi-webapp-resources</artifactId>
   <packaging>war</packaging>

--- a/jetty-osgi/test-jetty-osgi-webapp/pom.xml
+++ b/jetty-osgi/test-jetty-osgi-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>test-jetty-osgi-webapp</artifactId>

--- a/jetty-osgi/test-jetty-osgi-webapp/pom.xml
+++ b/jetty-osgi/test-jetty-osgi-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>test-jetty-osgi-webapp</artifactId>

--- a/jetty-osgi/test-jetty-osgi/pom.xml
+++ b/jetty-osgi/test-jetty-osgi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>test-jetty-osgi</artifactId>

--- a/jetty-osgi/test-jetty-osgi/pom.xml
+++ b/jetty-osgi/test-jetty-osgi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.osgi</groupId>
     <artifactId>jetty-osgi-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>test-jetty-osgi</artifactId>

--- a/jetty-p2/pom.xml
+++ b/jetty-p2/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-p2</artifactId>
   <packaging>pom</packaging>

--- a/jetty-p2/pom.xml
+++ b/jetty-p2/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-p2</artifactId>
   <packaging>pom</packaging>

--- a/jetty-plus/pom.xml
+++ b/jetty-plus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-plus</artifactId>
   <name>Jetty :: Plus</name>

--- a/jetty-plus/pom.xml
+++ b/jetty-plus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-plus</artifactId>
   <name>Jetty :: Plus</name>

--- a/jetty-proxy/pom.xml
+++ b/jetty-proxy/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-proxy</artifactId>
   <name>Jetty :: Proxy</name>

--- a/jetty-proxy/pom.xml
+++ b/jetty-proxy/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-proxy</artifactId>
   <name>Jetty :: Proxy</name>

--- a/jetty-quic/pom.xml
+++ b/jetty-quic/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.jetty.quic</groupId>
   <artifactId>quic-parent</artifactId>

--- a/jetty-quic/pom.xml
+++ b/jetty-quic/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <groupId>org.eclipse.jetty.quic</groupId>
   <artifactId>quic-parent</artifactId>

--- a/jetty-quic/quic-client/pom.xml
+++ b/jetty-quic/quic-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.quic</groupId>
     <artifactId>quic-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>quic-client</artifactId>
   <name>Jetty :: QUIC :: Client</name>

--- a/jetty-quic/quic-client/pom.xml
+++ b/jetty-quic/quic-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.quic</groupId>
     <artifactId>quic-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>quic-client</artifactId>
   <name>Jetty :: QUIC :: Client</name>

--- a/jetty-quic/quic-common/pom.xml
+++ b/jetty-quic/quic-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.quic</groupId>
     <artifactId>quic-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>quic-common</artifactId>
   <name>Jetty :: QUIC :: Common</name>

--- a/jetty-quic/quic-common/pom.xml
+++ b/jetty-quic/quic-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.quic</groupId>
     <artifactId>quic-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>quic-common</artifactId>
   <name>Jetty :: QUIC :: Common</name>

--- a/jetty-quic/quic-quiche/pom.xml
+++ b/jetty-quic/quic-quiche/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.quic</groupId>
     <artifactId>quic-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>quic-quiche</artifactId>
   <packaging>pom</packaging>

--- a/jetty-quic/quic-quiche/pom.xml
+++ b/jetty-quic/quic-quiche/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.quic</groupId>
     <artifactId>quic-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>quic-quiche</artifactId>
   <packaging>pom</packaging>

--- a/jetty-quic/quic-quiche/quic-quiche-common/pom.xml
+++ b/jetty-quic/quic-quiche/quic-quiche-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.quic</groupId>
     <artifactId>quic-quiche</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>quic-quiche-common</artifactId>
   <name>Jetty :: QUIC :: Quiche :: Common</name>

--- a/jetty-quic/quic-quiche/quic-quiche-common/pom.xml
+++ b/jetty-quic/quic-quiche/quic-quiche-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.quic</groupId>
     <artifactId>quic-quiche</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>quic-quiche-common</artifactId>
   <name>Jetty :: QUIC :: Quiche :: Common</name>

--- a/jetty-quic/quic-quiche/quic-quiche-foreign-incubator/pom.xml
+++ b/jetty-quic/quic-quiche/quic-quiche-foreign-incubator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.quic</groupId>
     <artifactId>quic-quiche</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>quic-quiche-foreign-incubator</artifactId>
   <name>Jetty :: QUIC :: Quiche :: Foreign Binding (incubator)</name>

--- a/jetty-quic/quic-quiche/quic-quiche-foreign-incubator/pom.xml
+++ b/jetty-quic/quic-quiche/quic-quiche-foreign-incubator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.quic</groupId>
     <artifactId>quic-quiche</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>quic-quiche-foreign-incubator</artifactId>
   <name>Jetty :: QUIC :: Quiche :: Foreign Binding (incubator)</name>

--- a/jetty-quic/quic-quiche/quic-quiche-jna/pom.xml
+++ b/jetty-quic/quic-quiche/quic-quiche-jna/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.quic</groupId>
     <artifactId>quic-quiche</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>quic-quiche-jna</artifactId>
   <name>Jetty :: QUIC :: Quiche :: JNA Binding</name>

--- a/jetty-quic/quic-quiche/quic-quiche-jna/pom.xml
+++ b/jetty-quic/quic-quiche/quic-quiche-jna/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.quic</groupId>
     <artifactId>quic-quiche</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>quic-quiche-jna</artifactId>
   <name>Jetty :: QUIC :: Quiche :: JNA Binding</name>

--- a/jetty-quic/quic-server/pom.xml
+++ b/jetty-quic/quic-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.quic</groupId>
     <artifactId>quic-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>quic-server</artifactId>
   <name>Jetty :: QUIC :: Server</name>

--- a/jetty-quic/quic-server/pom.xml
+++ b/jetty-quic/quic-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.quic</groupId>
     <artifactId>quic-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>quic-server</artifactId>
   <name>Jetty :: QUIC :: Server</name>

--- a/jetty-quickstart/pom.xml
+++ b/jetty-quickstart/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-quickstart</artifactId>
   <name>Jetty :: Quick Start</name>

--- a/jetty-quickstart/pom.xml
+++ b/jetty-quickstart/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-quickstart</artifactId>
   <name>Jetty :: Quick Start</name>

--- a/jetty-rewrite/pom.xml
+++ b/jetty-rewrite/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-rewrite</artifactId>
   <name>Jetty :: Rewrite Handler</name>

--- a/jetty-rewrite/pom.xml
+++ b/jetty-rewrite/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-rewrite</artifactId>
   <name>Jetty :: Rewrite Handler</name>

--- a/jetty-runner/pom.xml
+++ b/jetty-runner/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-runner</artifactId>
   <name>Jetty :: Runner</name>

--- a/jetty-runner/pom.xml
+++ b/jetty-runner/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-runner</artifactId>
   <name>Jetty :: Runner</name>

--- a/jetty-security/pom.xml
+++ b/jetty-security/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-security</artifactId>
   <name>Jetty :: Security</name>

--- a/jetty-security/pom.xml
+++ b/jetty-security/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-security</artifactId>
   <name>Jetty :: Security</name>

--- a/jetty-server/pom.xml
+++ b/jetty-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-server</artifactId>
   <name>Jetty :: Server Core</name>

--- a/jetty-server/pom.xml
+++ b/jetty-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-server</artifactId>
   <name>Jetty :: Server Core</name>

--- a/jetty-servlet/pom.xml
+++ b/jetty-servlet/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-servlet</artifactId>
   <name>Jetty :: Servlet Handling</name>

--- a/jetty-servlet/pom.xml
+++ b/jetty-servlet/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-servlet</artifactId>
   <name>Jetty :: Servlet Handling</name>

--- a/jetty-servlets/pom.xml
+++ b/jetty-servlets/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-servlets</artifactId>
   <name>Jetty :: Utility Servlets and Filters</name>

--- a/jetty-servlets/pom.xml
+++ b/jetty-servlets/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-servlets</artifactId>
   <name>Jetty :: Utility Servlets and Filters</name>

--- a/jetty-slf4j-impl/pom.xml
+++ b/jetty-slf4j-impl/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-slf4j-impl</artifactId>
   <name>Jetty :: Slf4j Implementation</name>

--- a/jetty-slf4j-impl/pom.xml
+++ b/jetty-slf4j-impl/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-slf4j-impl</artifactId>
   <name>Jetty :: Slf4j Implementation</name>

--- a/jetty-start/pom.xml
+++ b/jetty-start/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-start</artifactId>
   <name>Jetty :: Start</name>

--- a/jetty-start/pom.xml
+++ b/jetty-start/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-start</artifactId>
   <name>Jetty :: Start</name>

--- a/jetty-unixdomain-server/pom.xml
+++ b/jetty-unixdomain-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-unixdomain-server</artifactId>
   <name>Jetty :: Unix-Domain Sockets :: Server</name>

--- a/jetty-unixdomain-server/pom.xml
+++ b/jetty-unixdomain-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-unixdomain-server</artifactId>
   <name>Jetty :: Unix-Domain Sockets :: Server</name>

--- a/jetty-unixsocket/jetty-unixsocket-client/pom.xml
+++ b/jetty-unixsocket/jetty-unixsocket-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-unixsocket</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-unixsocket-client</artifactId>
   <name>Jetty :: UnixSocket :: Client</name>

--- a/jetty-unixsocket/jetty-unixsocket-client/pom.xml
+++ b/jetty-unixsocket/jetty-unixsocket-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-unixsocket</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-unixsocket-client</artifactId>
   <name>Jetty :: UnixSocket :: Client</name>

--- a/jetty-unixsocket/jetty-unixsocket-common/pom.xml
+++ b/jetty-unixsocket/jetty-unixsocket-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-unixsocket</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-unixsocket-common</artifactId>
   <name>Jetty :: UnixSocket :: Common</name>

--- a/jetty-unixsocket/jetty-unixsocket-common/pom.xml
+++ b/jetty-unixsocket/jetty-unixsocket-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-unixsocket</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-unixsocket-common</artifactId>
   <name>Jetty :: UnixSocket :: Common</name>

--- a/jetty-unixsocket/jetty-unixsocket-server/pom.xml
+++ b/jetty-unixsocket/jetty-unixsocket-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-unixsocket</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-unixsocket-server</artifactId>
   <name>Jetty :: UnixSocket :: Server</name>

--- a/jetty-unixsocket/jetty-unixsocket-server/pom.xml
+++ b/jetty-unixsocket/jetty-unixsocket-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-unixsocket</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-unixsocket-server</artifactId>
   <name>Jetty :: UnixSocket :: Server</name>

--- a/jetty-unixsocket/pom.xml
+++ b/jetty-unixsocket/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-unixsocket</artifactId>
   <packaging>pom</packaging>

--- a/jetty-unixsocket/pom.xml
+++ b/jetty-unixsocket/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-unixsocket</artifactId>
   <packaging>pom</packaging>

--- a/jetty-util-ajax/pom.xml
+++ b/jetty-util-ajax/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-util-ajax</artifactId>
   <name>Jetty :: Utilities :: Ajax(JSON)</name>

--- a/jetty-util-ajax/pom.xml
+++ b/jetty-util-ajax/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-util-ajax</artifactId>
   <name>Jetty :: Utilities :: Ajax(JSON)</name>

--- a/jetty-util/pom.xml
+++ b/jetty-util/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-util</artifactId>
   <name>Jetty :: Utilities</name>

--- a/jetty-util/pom.xml
+++ b/jetty-util/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-util</artifactId>
   <name>Jetty :: Utilities</name>

--- a/jetty-webapp/pom.xml
+++ b/jetty-webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-webapp</artifactId>
   <name>Jetty :: Webapp Application Support</name>

--- a/jetty-webapp/pom.xml
+++ b/jetty-webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-webapp</artifactId>
   <name>Jetty :: Webapp Application Support</name>

--- a/jetty-websocket/pom.xml
+++ b/jetty-websocket/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.jetty.websocket</groupId>
   <artifactId>websocket-parent</artifactId>

--- a/jetty-websocket/pom.xml
+++ b/jetty-websocket/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <groupId>org.eclipse.jetty.websocket</groupId>
   <artifactId>websocket-parent</artifactId>

--- a/jetty-websocket/websocket-core-client/pom.xml
+++ b/jetty-websocket/websocket-core-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>websocket-core-client</artifactId>
   <name>Jetty :: Websocket :: Core :: Client</name>

--- a/jetty-websocket/websocket-core-client/pom.xml
+++ b/jetty-websocket/websocket-core-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>websocket-core-client</artifactId>
   <name>Jetty :: Websocket :: Core :: Client</name>

--- a/jetty-websocket/websocket-core-common/pom.xml
+++ b/jetty-websocket/websocket-core-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>websocket-core-common</artifactId>
   <name>Jetty :: Websocket :: Core :: Common</name>

--- a/jetty-websocket/websocket-core-common/pom.xml
+++ b/jetty-websocket/websocket-core-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>websocket-core-common</artifactId>
   <name>Jetty :: Websocket :: Core :: Common</name>

--- a/jetty-websocket/websocket-core-server/pom.xml
+++ b/jetty-websocket/websocket-core-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>websocket-core-server</artifactId>
   <name>Jetty :: Websocket :: Core :: Server</name>

--- a/jetty-websocket/websocket-core-server/pom.xml
+++ b/jetty-websocket/websocket-core-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>websocket-core-server</artifactId>
   <name>Jetty :: Websocket :: Core :: Server</name>

--- a/jetty-websocket/websocket-core-tests/pom.xml
+++ b/jetty-websocket/websocket-core-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>websocket-core-tests</artifactId>
   <name>Jetty :: Websocket :: Core :: Tests</name>

--- a/jetty-websocket/websocket-core-tests/pom.xml
+++ b/jetty-websocket/websocket-core-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>websocket-core-tests</artifactId>
   <name>Jetty :: Websocket :: Core :: Tests</name>

--- a/jetty-websocket/websocket-javax-client/pom.xml
+++ b/jetty-websocket/websocket-javax-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>websocket-javax-client</artifactId>
   <name>Jetty :: Websocket :: javax.websocket :: Client</name>

--- a/jetty-websocket/websocket-javax-client/pom.xml
+++ b/jetty-websocket/websocket-javax-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>websocket-javax-client</artifactId>
   <name>Jetty :: Websocket :: javax.websocket :: Client</name>

--- a/jetty-websocket/websocket-javax-common/pom.xml
+++ b/jetty-websocket/websocket-javax-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>websocket-javax-common</artifactId>
   <name>Jetty :: Websocket :: javax.websocket :: Common</name>

--- a/jetty-websocket/websocket-javax-common/pom.xml
+++ b/jetty-websocket/websocket-javax-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>websocket-javax-common</artifactId>
   <name>Jetty :: Websocket :: javax.websocket :: Common</name>

--- a/jetty-websocket/websocket-javax-server/pom.xml
+++ b/jetty-websocket/websocket-javax-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>websocket-javax-server</artifactId>
   <name>Jetty :: Websocket :: javax.websocket :: Server</name>

--- a/jetty-websocket/websocket-javax-server/pom.xml
+++ b/jetty-websocket/websocket-javax-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>websocket-javax-server</artifactId>
   <name>Jetty :: Websocket :: javax.websocket :: Server</name>

--- a/jetty-websocket/websocket-javax-tests/pom.xml
+++ b/jetty-websocket/websocket-javax-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>websocket-javax-tests</artifactId>
   <name>Jetty :: Websocket :: javax.websocket :: Tests</name>

--- a/jetty-websocket/websocket-javax-tests/pom.xml
+++ b/jetty-websocket/websocket-javax-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>websocket-javax-tests</artifactId>
   <name>Jetty :: Websocket :: javax.websocket :: Tests</name>

--- a/jetty-websocket/websocket-jetty-api/pom.xml
+++ b/jetty-websocket/websocket-jetty-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>websocket-jetty-api</artifactId>
   <name>Jetty :: Websocket :: org.eclipse.jetty.websocket :: API</name>

--- a/jetty-websocket/websocket-jetty-api/pom.xml
+++ b/jetty-websocket/websocket-jetty-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>websocket-jetty-api</artifactId>
   <name>Jetty :: Websocket :: org.eclipse.jetty.websocket :: API</name>

--- a/jetty-websocket/websocket-jetty-client/pom.xml
+++ b/jetty-websocket/websocket-jetty-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>websocket-jetty-client</artifactId>
   <name>Jetty :: Websocket :: org.eclipse.jetty.websocket :: Client</name>

--- a/jetty-websocket/websocket-jetty-client/pom.xml
+++ b/jetty-websocket/websocket-jetty-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>websocket-jetty-client</artifactId>
   <name>Jetty :: Websocket :: org.eclipse.jetty.websocket :: Client</name>

--- a/jetty-websocket/websocket-jetty-common/pom.xml
+++ b/jetty-websocket/websocket-jetty-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>websocket-jetty-common</artifactId>
   <name>Jetty :: Websocket :: org.eclipse.jetty.websocket :: Common</name>

--- a/jetty-websocket/websocket-jetty-common/pom.xml
+++ b/jetty-websocket/websocket-jetty-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>websocket-jetty-common</artifactId>
   <name>Jetty :: Websocket :: org.eclipse.jetty.websocket :: Common</name>

--- a/jetty-websocket/websocket-jetty-server/pom.xml
+++ b/jetty-websocket/websocket-jetty-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>websocket-jetty-server</artifactId>
   <name>Jetty :: Websocket :: org.eclipse.jetty.websocket :: Server</name>

--- a/jetty-websocket/websocket-jetty-server/pom.xml
+++ b/jetty-websocket/websocket-jetty-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>websocket-jetty-server</artifactId>
   <name>Jetty :: Websocket :: org.eclipse.jetty.websocket :: Server</name>

--- a/jetty-websocket/websocket-jetty-tests/pom.xml
+++ b/jetty-websocket/websocket-jetty-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>websocket-jetty-tests</artifactId>
   <name>Jetty :: Websocket :: org.eclipse.jetty.websocket :: Tests</name>

--- a/jetty-websocket/websocket-jetty-tests/pom.xml
+++ b/jetty-websocket/websocket-jetty-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>websocket-jetty-tests</artifactId>
   <name>Jetty :: Websocket :: org.eclipse.jetty.websocket :: Tests</name>

--- a/jetty-websocket/websocket-servlet/pom.xml
+++ b/jetty-websocket/websocket-servlet/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>websocket-servlet</artifactId>
   <name>Jetty :: Websocket :: Servlet</name>

--- a/jetty-websocket/websocket-servlet/pom.xml
+++ b/jetty-websocket/websocket-servlet/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>websocket-servlet</artifactId>
   <name>Jetty :: Websocket :: Servlet</name>

--- a/jetty-xml/pom.xml
+++ b/jetty-xml/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-xml</artifactId>
   <name>Jetty :: XML utilities</name>

--- a/jetty-xml/pom.xml
+++ b/jetty-xml/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-xml</artifactId>
   <name>Jetty :: XML utilities</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.jetty</groupId>
   <artifactId>jetty-project</artifactId>
-  <version>10.0.21</version>
+  <version>10.0.22-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Jetty :: Project</name>
   <description>The Eclipse Jetty Project</description>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.jetty</groupId>
   <artifactId>jetty-project</artifactId>
-  <version>10.0.21-SNAPSHOT</version>
+  <version>10.0.21</version>
   <packaging>pom</packaging>
   <name>Jetty :: Project</name>
   <description>The Eclipse Jetty Project</description>

--- a/scripts/release-jetty.sh
+++ b/scripts/release-jetty.sh
@@ -92,7 +92,7 @@ DEPLOY_OPTS="-DskipTests"
 # DEPLOY_OPTS="$DEPLOY_OPTS -DaltDeploymentRepository=intarget::default::file://$ALT_DEPLOY_DIR/"
 
 # Uncomment for Java 1.7
-export MAVEN_OPTS="-Xmx2g"
+export MAVEN_OPTS="-Xmx4g"
 
 echo ""
 echo "-----------------------------------------------"
@@ -134,7 +134,7 @@ if proceedyn "Are you sure you want to release using above? (y/N)" n; then
     mvn clean install -pl build-resources
     echo ""
     if proceedyn "Update VERSION.txt for $VER_RELEASE? (Y/n)" y; then
-        mvn -N -Pupdate-version generate-resources
+        mvn -N -Pupdate-version generate-resources -e
         cp VERSION.txt VERSION.txt.backup
         cat VERSION.txt.backup | sed -e "s/$VER_CURRENT/$VER_RELEASE/" > VERSION.txt
         rm VERSION.txt.backup
@@ -149,7 +149,7 @@ if proceedyn "Are you sure you want to release using above? (y/N)" n; then
             -Peclipse-release \
             -DoldVersion="$VER_CURRENT" \
             -DnewVersion="$VER_RELEASE" \
-            -DprocessAllModules=true 
+            -DprocessAllModules=true -e
     fi
     if proceedyn "Commit $VER_RELEASE updates? (Y/n)" y; then
         git commit -a -m "Updating to version $VER_RELEASE"
@@ -175,7 +175,7 @@ if proceedyn "Are you sure you want to release using above? (y/N)" n; then
             -Peclipse-release \
             -DoldVersion="$VER_RELEASE" \
             -DnewVersion="$VER_NEXT" \
-            -DprocessAllModules=true 
+            -DprocessAllModules=true -e
         echo "Commit $VER_NEXT"
         if proceedyn "Commit updates in working directory for $VER_NEXT? (Y/n)" y; then
             git commit -a -m "Updating to version $VER_NEXT"

--- a/tests/jetty-home-tester/pom.xml
+++ b/tests/jetty-home-tester/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-home-tester</artifactId>
   <packaging>jar</packaging>

--- a/tests/jetty-home-tester/pom.xml
+++ b/tests/jetty-home-tester/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-home-tester</artifactId>
   <packaging>jar</packaging>

--- a/tests/jetty-http-tools/pom.xml
+++ b/tests/jetty-http-tools/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-http-tools</artifactId>
   <name>Jetty Tests :: HTTP Utilities</name>

--- a/tests/jetty-http-tools/pom.xml
+++ b/tests/jetty-http-tools/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-http-tools</artifactId>
   <name>Jetty Tests :: HTTP Utilities</name>

--- a/tests/jetty-jmh/pom.xml
+++ b/tests/jetty-jmh/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jetty-jmh</artifactId>
   <name>Jetty :: Jmh</name>

--- a/tests/jetty-jmh/pom.xml
+++ b/tests/jetty-jmh/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-jmh</artifactId>
   <name>Jetty :: Jmh</name>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>org.eclipse.jetty.tests</groupId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-project</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>org.eclipse.jetty.tests</groupId>

--- a/tests/test-cdi/pom.xml
+++ b/tests/test-cdi/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-cdi</artifactId>
   <packaging>jar</packaging>

--- a/tests/test-cdi/pom.xml
+++ b/tests/test-cdi/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-cdi</artifactId>
   <packaging>jar</packaging>

--- a/tests/test-distribution/pom.xml
+++ b/tests/test-distribution/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-distribution</artifactId>
   <packaging>jar</packaging>

--- a/tests/test-distribution/pom.xml
+++ b/tests/test-distribution/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-distribution</artifactId>
   <packaging>jar</packaging>

--- a/tests/test-http-client-transport/pom.xml
+++ b/tests/test-http-client-transport/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-http-client-transport</artifactId>
   <packaging>jar</packaging>

--- a/tests/test-http-client-transport/pom.xml
+++ b/tests/test-http-client-transport/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-http-client-transport</artifactId>
   <packaging>jar</packaging>

--- a/tests/test-integration/pom.xml
+++ b/tests/test-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-integration</artifactId>
   <packaging>jar</packaging>

--- a/tests/test-integration/pom.xml
+++ b/tests/test-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-integration</artifactId>
   <packaging>jar</packaging>

--- a/tests/test-jmx/jmx-webapp-it/pom.xml
+++ b/tests/test-jmx/jmx-webapp-it/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-jmx-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jmx-webapp-it</artifactId>
   <packaging>jar</packaging>

--- a/tests/test-jmx/jmx-webapp-it/pom.xml
+++ b/tests/test-jmx/jmx-webapp-it/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-jmx-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jmx-webapp-it</artifactId>
   <packaging>jar</packaging>

--- a/tests/test-jmx/jmx-webapp/pom.xml
+++ b/tests/test-jmx/jmx-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-jmx-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>jmx-webapp</artifactId>
   <packaging>war</packaging>

--- a/tests/test-jmx/jmx-webapp/pom.xml
+++ b/tests/test-jmx/jmx-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-jmx-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jmx-webapp</artifactId>
   <packaging>war</packaging>

--- a/tests/test-jmx/pom.xml
+++ b/tests/test-jmx/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-jmx-parent</artifactId>
   <packaging>pom</packaging>

--- a/tests/test-jmx/pom.xml
+++ b/tests/test-jmx/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-jmx-parent</artifactId>
   <packaging>pom</packaging>

--- a/tests/test-jpms/pom.xml
+++ b/tests/test-jpms/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-jpms</artifactId>
   <packaging>pom</packaging>

--- a/tests/test-jpms/pom.xml
+++ b/tests/test-jpms/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-jpms</artifactId>
   <packaging>pom</packaging>

--- a/tests/test-jpms/test-jpms-websocket-core/pom.xml
+++ b/tests/test-jpms/test-jpms-websocket-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-jpms</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-jpms-websocket-core</artifactId>
   <packaging>jar</packaging>

--- a/tests/test-jpms/test-jpms-websocket-core/pom.xml
+++ b/tests/test-jpms/test-jpms-websocket-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-jpms</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-jpms-websocket-core</artifactId>
   <packaging>jar</packaging>

--- a/tests/test-loginservice/pom.xml
+++ b/tests/test-loginservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-loginservice</artifactId>
   <name>Jetty Tests :: Login Service</name>

--- a/tests/test-loginservice/pom.xml
+++ b/tests/test-loginservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-loginservice</artifactId>
   <name>Jetty Tests :: Login Service</name>

--- a/tests/test-quickstart/pom.xml
+++ b/tests/test-quickstart/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>org.eclipse.jetty</groupId>

--- a/tests/test-quickstart/pom.xml
+++ b/tests/test-quickstart/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>org.eclipse.jetty</groupId>

--- a/tests/test-sessions/pom.xml
+++ b/tests/test-sessions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-sessions-parent</artifactId>
   <packaging>pom</packaging>

--- a/tests/test-sessions/pom.xml
+++ b/tests/test-sessions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-sessions-parent</artifactId>
   <packaging>pom</packaging>

--- a/tests/test-sessions/test-file-sessions/pom.xml
+++ b/tests/test-sessions/test-file-sessions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-sessions-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-file-sessions</artifactId>
   <name>Jetty Tests :: Sessions :: File</name>

--- a/tests/test-sessions/test-file-sessions/pom.xml
+++ b/tests/test-sessions/test-file-sessions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-sessions-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-file-sessions</artifactId>
   <name>Jetty Tests :: Sessions :: File</name>

--- a/tests/test-sessions/test-gcloud-sessions/pom.xml
+++ b/tests/test-sessions/test-gcloud-sessions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-sessions-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-gcloud-sessions</artifactId>
   <name>Jetty Tests :: Sessions :: GCloud</name>

--- a/tests/test-sessions/test-gcloud-sessions/pom.xml
+++ b/tests/test-sessions/test-gcloud-sessions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-sessions-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-gcloud-sessions</artifactId>
   <name>Jetty Tests :: Sessions :: GCloud</name>

--- a/tests/test-sessions/test-hazelcast-sessions/pom.xml
+++ b/tests/test-sessions/test-hazelcast-sessions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-sessions-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-hazelcast-sessions</artifactId>
   <name>Jetty Tests :: Sessions :: Hazelcast</name>

--- a/tests/test-sessions/test-hazelcast-sessions/pom.xml
+++ b/tests/test-sessions/test-hazelcast-sessions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-sessions-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-hazelcast-sessions</artifactId>
   <name>Jetty Tests :: Sessions :: Hazelcast</name>

--- a/tests/test-sessions/test-infinispan-sessions/pom.xml
+++ b/tests/test-sessions/test-infinispan-sessions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-sessions-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-infinispan-sessions</artifactId>
   <name>Jetty Tests :: Sessions :: Infinispan</name>

--- a/tests/test-sessions/test-infinispan-sessions/pom.xml
+++ b/tests/test-sessions/test-infinispan-sessions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-sessions-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-infinispan-sessions</artifactId>
   <name>Jetty Tests :: Sessions :: Infinispan</name>

--- a/tests/test-sessions/test-jdbc-sessions/pom.xml
+++ b/tests/test-sessions/test-jdbc-sessions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-sessions-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-jdbc-sessions</artifactId>
   <name>Jetty Tests :: Sessions :: JDBC</name>

--- a/tests/test-sessions/test-jdbc-sessions/pom.xml
+++ b/tests/test-sessions/test-jdbc-sessions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-sessions-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-jdbc-sessions</artifactId>
   <name>Jetty Tests :: Sessions :: JDBC</name>

--- a/tests/test-sessions/test-memcached-sessions/pom.xml
+++ b/tests/test-sessions/test-memcached-sessions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-sessions-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-memcached-sessions</artifactId>
   <name>Jetty Tests :: Sessions :: Memcached</name>

--- a/tests/test-sessions/test-memcached-sessions/pom.xml
+++ b/tests/test-sessions/test-memcached-sessions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-sessions-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-memcached-sessions</artifactId>
   <name>Jetty Tests :: Sessions :: Memcached</name>

--- a/tests/test-sessions/test-mongodb-sessions/pom.xml
+++ b/tests/test-sessions/test-mongodb-sessions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-sessions-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-mongodb-sessions</artifactId>
   <name>Jetty Tests :: Sessions :: Mongo</name>

--- a/tests/test-sessions/test-mongodb-sessions/pom.xml
+++ b/tests/test-sessions/test-mongodb-sessions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-sessions-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-mongodb-sessions</artifactId>
   <name>Jetty Tests :: Sessions :: Mongo</name>

--- a/tests/test-sessions/test-sessions-common/pom.xml
+++ b/tests/test-sessions/test-sessions-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-sessions-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-sessions-common</artifactId>
   <name>Jetty Tests :: Sessions :: Common</name>

--- a/tests/test-sessions/test-sessions-common/pom.xml
+++ b/tests/test-sessions/test-sessions-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-sessions-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-sessions-common</artifactId>
   <name>Jetty Tests :: Sessions :: Common</name>

--- a/tests/test-webapps/pom.xml
+++ b/tests/test-webapps/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>test-webapps-parent</artifactId>

--- a/tests/test-webapps/pom.xml
+++ b/tests/test-webapps/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>test-webapps-parent</artifactId>

--- a/tests/test-webapps/test-bad-websocket-webapp/pom.xml
+++ b/tests/test-webapps/test-bad-websocket-webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-bad-websocket-webapp</artifactId>
   <packaging>war</packaging>

--- a/tests/test-webapps/test-bad-websocket-webapp/pom.xml
+++ b/tests/test-webapps/test-bad-websocket-webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-bad-websocket-webapp</artifactId>
   <packaging>war</packaging>

--- a/tests/test-webapps/test-cdi-common-webapp/pom.xml
+++ b/tests/test-webapps/test-cdi-common-webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-cdi-common-webapp</artifactId>
   <packaging>war</packaging>

--- a/tests/test-webapps/test-cdi-common-webapp/pom.xml
+++ b/tests/test-webapps/test-cdi-common-webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-cdi-common-webapp</artifactId>
   <packaging>war</packaging>

--- a/tests/test-webapps/test-felix-webapp/pom.xml
+++ b/tests/test-webapps/test-felix-webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-felix-webapp</artifactId>
   <packaging>war</packaging>

--- a/tests/test-webapps/test-felix-webapp/pom.xml
+++ b/tests/test-webapps/test-felix-webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-felix-webapp</artifactId>
   <packaging>war</packaging>

--- a/tests/test-webapps/test-http2-webapp/pom.xml
+++ b/tests/test-webapps/test-http2-webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-http2-webapp</artifactId>
   <packaging>war</packaging>

--- a/tests/test-webapps/test-http2-webapp/pom.xml
+++ b/tests/test-webapps/test-http2-webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-http2-webapp</artifactId>
   <packaging>war</packaging>

--- a/tests/test-webapps/test-openid-webapp/pom.xml
+++ b/tests/test-webapps/test-openid-webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-openid-webapp</artifactId>
   <packaging>war</packaging>

--- a/tests/test-webapps/test-openid-webapp/pom.xml
+++ b/tests/test-webapps/test-openid-webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-openid-webapp</artifactId>
   <packaging>war</packaging>

--- a/tests/test-webapps/test-owb-cdi-webapp/pom.xml
+++ b/tests/test-webapps/test-owb-cdi-webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-owb-cdi-webapp</artifactId>
   <packaging>war</packaging>

--- a/tests/test-webapps/test-owb-cdi-webapp/pom.xml
+++ b/tests/test-webapps/test-owb-cdi-webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-owb-cdi-webapp</artifactId>
   <packaging>war</packaging>

--- a/tests/test-webapps/test-simple-session-webapp/pom.xml
+++ b/tests/test-webapps/test-simple-session-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
 
   <artifactId>test-simple-session-webapp</artifactId>

--- a/tests/test-webapps/test-simple-session-webapp/pom.xml
+++ b/tests/test-webapps/test-simple-session-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
 
   <artifactId>test-simple-session-webapp</artifactId>

--- a/tests/test-webapps/test-webapp-rfc2616/pom.xml
+++ b/tests/test-webapps/test-webapp-rfc2616/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-webapp-rfc2616</artifactId>
   <packaging>war</packaging>

--- a/tests/test-webapps/test-webapp-rfc2616/pom.xml
+++ b/tests/test-webapps/test-webapp-rfc2616/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-webapp-rfc2616</artifactId>
   <packaging>war</packaging>

--- a/tests/test-webapps/test-websocket-client-provided-webapp/pom.xml
+++ b/tests/test-webapps/test-websocket-client-provided-webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-websocket-client-provided-webapp</artifactId>
   <packaging>war</packaging>

--- a/tests/test-webapps/test-websocket-client-provided-webapp/pom.xml
+++ b/tests/test-webapps/test-websocket-client-provided-webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-websocket-client-provided-webapp</artifactId>
   <packaging>war</packaging>

--- a/tests/test-webapps/test-websocket-client-webapp/pom.xml
+++ b/tests/test-webapps/test-websocket-client-webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-websocket-client-webapp</artifactId>
   <packaging>war</packaging>

--- a/tests/test-webapps/test-websocket-client-webapp/pom.xml
+++ b/tests/test-webapps/test-websocket-client-webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-websocket-client-webapp</artifactId>
   <packaging>war</packaging>

--- a/tests/test-webapps/test-websocket-webapp/pom.xml
+++ b/tests/test-webapps/test-websocket-webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-websocket-webapp</artifactId>
   <packaging>war</packaging>

--- a/tests/test-webapps/test-websocket-webapp/pom.xml
+++ b/tests/test-webapps/test-websocket-webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-websocket-webapp</artifactId>
   <packaging>war</packaging>

--- a/tests/test-webapps/test-weld-cdi-webapp/pom.xml
+++ b/tests/test-webapps/test-weld-cdi-webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-weld-cdi-webapp</artifactId>
   <packaging>war</packaging>

--- a/tests/test-webapps/test-weld-cdi-webapp/pom.xml
+++ b/tests/test-webapps/test-weld-cdi-webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>test-webapps-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-weld-cdi-webapp</artifactId>
   <packaging>war</packaging>

--- a/tests/test-websocket-autobahn/pom.xml
+++ b/tests/test-websocket-autobahn/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>10.0.21</version>
+    <version>10.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>test-websocket-autobahn</artifactId>
   <name>Jetty Tests :: WebSocket Autobahn Tests</name>

--- a/tests/test-websocket-autobahn/pom.xml
+++ b/tests/test-websocket-autobahn/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>10.0.21-SNAPSHOT</version>
+    <version>10.0.21</version>
   </parent>
   <artifactId>test-websocket-autobahn</artifactId>
   <name>Jetty Tests :: WebSocket Autobahn Tests</name>


### PR DESCRIPTION
- **enable maven stack trace if failure**
- **last Jetty 10 release last as we do not want a huge VERSION.TXT**
- **Updating to version 10.0.21**
- **Updating to version 10.0.22-SNAPSHOT**
