### PR TITLE
Fixes #9778 - Jetty 12 - Remove WriteFlusher.Listener.

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Connection.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Connection.java
@@ -38,7 +38,6 @@ import org.eclipse.jetty.io.Connection;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.io.Retainable;
 import org.eclipse.jetty.io.RetainableByteBuffer;
-import org.eclipse.jetty.io.WriteFlusher;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.component.LifeCycle;
@@ -48,7 +47,7 @@ import org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class HTTP2Connection extends AbstractConnection implements Parser.Listener, WriteFlusher.Listener, Connection.UpgradeTo
+public class HTTP2Connection extends AbstractConnection implements Parser.Listener, Connection.UpgradeTo
 {
     private static final Logger LOG = LoggerFactory.getLogger(HTTP2Connection.class);
 
@@ -300,12 +299,6 @@ public class HTTP2Connection extends AbstractConnection implements Parser.Listen
     {
         producer.failed = true;
         session.onConnectionFailure(error, reason);
-    }
-
-    @Override
-    public void onFlushed(long bytes) throws IOException
-    {
-        session.onFlushed(bytes);
     }
 
     protected class HTTP2Producer implements ExecutionStrategy.Producer

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -60,7 +60,6 @@ import org.eclipse.jetty.http2.parser.Parser;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.CyclicTimeouts;
 import org.eclipse.jetty.io.EndPoint;
-import org.eclipse.jetty.io.WriteFlusher;
 import org.eclipse.jetty.util.AtomicBiInteger;
 import org.eclipse.jetty.util.Atomics;
 import org.eclipse.jetty.util.Callback;
@@ -1084,11 +1083,6 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
         streamsState.onStreamDestroyed();
     }
 
-    public void onFlushed(long bytes) throws IOException
-    {
-        flusher.onFlushed(bytes);
-    }
-
     private void terminate(Throwable cause)
     {
         flusher.terminate(cause);
@@ -1263,8 +1257,6 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
 
         public abstract boolean generate(ByteBufferPool.Accumulator accumulator) throws HpackException;
 
-        public abstract long onFlushed(long bytes) throws IOException;
-
         boolean hasHighPriority()
         {
             return false;
@@ -1355,16 +1347,6 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
             return true;
         }
 
-        @Override
-        public long onFlushed(long bytes)
-        {
-            long flushed = Math.min(frameBytes, bytes);
-            if (LOG.isDebugEnabled())
-                LOG.debug("Flushed {}/{} frame bytes for {}", flushed, bytes, this);
-            frameBytes -= flushed;
-            return bytes - flushed;
-        }
-
         /**
          * <p>Performs actions just before writing the frame to the network.</p>
          * <p>Some frame, when sent over the network, causes the receiver
@@ -1433,7 +1415,6 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
     private class DataEntry extends Entry
     {
         private int frameBytes;
-        private int frameRemaining;
         private int dataBytes;
         private int dataRemaining;
 
@@ -1477,7 +1458,6 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
             DataFrame dataFrame = (DataFrame)frame;
             int frameBytes = generator.data(accumulator, dataFrame, length);
             this.frameBytes += frameBytes;
-            this.frameRemaining += frameBytes;
 
             int dataBytes = frameBytes - Frame.HEADER_LENGTH;
             this.dataBytes += dataBytes;
@@ -1493,26 +1473,10 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
         }
 
         @Override
-        public long onFlushed(long bytes) throws IOException
-        {
-            long flushed = Math.min(frameRemaining, bytes);
-            if (LOG.isDebugEnabled())
-                LOG.debug("Flushed {}/{} frame bytes for {}", flushed, bytes, this);
-            frameRemaining -= flushed;
-            // We should only forward data (not frame) bytes,
-            // but we trade precision for simplicity.
-            Object channel = stream.getAttachment();
-            if (channel instanceof WriteFlusher.Listener)
-                ((WriteFlusher.Listener)channel).onFlushed(flushed);
-            return bytes - flushed;
-        }
-
-        @Override
         public void succeeded()
         {
             bytesWritten.addAndGet(frameBytes);
             frameBytes = 0;
-            frameRemaining = 0;
 
             flowControl.onDataSent(stream, dataBytes);
             dataBytes = 0;

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/internal/HTTP2Flusher.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/internal/HTTP2Flusher.java
@@ -293,15 +293,6 @@ public class HTTP2Flusher extends IteratingCallback implements Dumpable
         return Action.SCHEDULED;
     }
 
-    public void onFlushed(long bytes) throws IOException
-    {
-        // A single EndPoint write may be flushed multiple times (for example with SSL).
-        for (HTTP2Session.Entry entry : processedEntries)
-        {
-            bytes = entry.onFlushed(bytes);
-        }
-    }
-
     @Override
     public void succeeded()
     {

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/WriteFlusher.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/WriteFlusher.java
@@ -429,8 +429,8 @@ public abstract class WriteFlusher
             if (written > 0)
             {
                 Connection connection = _endPoint.getConnection();
-                if (connection instanceof Listener)
-                    ((Listener)connection).onFlushed(written);
+                if (connection instanceof Listener listener)
+                    listener.onFlushed(written);
             }
 
             if (flushed)
@@ -581,7 +581,10 @@ public abstract class WriteFlusher
     /**
      * <p>A listener of {@link WriteFlusher} events.
      * If implemented by a Connection class, the {@link #onFlushed(long)} event will be delivered to it.</p>
+     *
+     * @deprecated functionality removed, no replacement
      */
+    @Deprecated(since = "12.0.9", forRemoval = true)
     public interface Listener
     {
         /**

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/WriteFlusher.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/WriteFlusher.java
@@ -584,7 +584,7 @@ public abstract class WriteFlusher
      *
      * @deprecated functionality removed, no replacement
      */
-    @Deprecated(since = "12.0.9", forRemoval = true)
+    @Deprecated(since = "12.0.10", forRemoval = true)
     public interface Listener
     {
         /**

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -52,7 +52,6 @@ import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.io.EofException;
 import org.eclipse.jetty.io.RetainableByteBuffer;
 import org.eclipse.jetty.io.RuntimeIOException;
-import org.eclipse.jetty.io.WriteFlusher;
 import org.eclipse.jetty.io.ssl.SslConnection;
 import org.eclipse.jetty.server.AbstractMetaDataConnection;
 import org.eclipse.jetty.server.ConnectionFactory;
@@ -81,7 +80,7 @@ import static org.eclipse.jetty.http.HttpStatus.INTERNAL_SERVER_ERROR_500;
 /**
  * <p>A {@link Connection} that handles the HTTP protocol.</p>
  */
-public class HttpConnection extends AbstractMetaDataConnection implements Runnable, WriteFlusher.Listener, Connection.UpgradeFrom, Connection.UpgradeTo, ConnectionMetaData
+public class HttpConnection extends AbstractMetaDataConnection implements Runnable, Connection.UpgradeFrom, Connection.UpgradeTo, ConnectionMetaData
 {
     private static final Logger LOG = LoggerFactory.getLogger(HttpConnection.class);
     private static final HttpField PREAMBLE_UPGRADE_H2C = new HttpField(HttpHeader.UPGRADE, "h2c");
@@ -334,13 +333,6 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
     public void onUpgradeTo(ByteBuffer buffer)
     {
         BufferUtil.append(getRequestBuffer(), buffer);
-    }
-
-    @Override
-    public void onFlushed(long bytes) throws IOException
-    {
-        // TODO is this callback still needed?   Couldn't we wrap send callback instead?
-        //      Either way, the dat rate calculations from HttpOutput.onFlushed should be moved to Channel.
     }
 
     void releaseRequestBuffer()


### PR DESCRIPTION
This listener is not necessary anymore, as the min data rate checks have been moved to a StatisticsHandler.MinimumDataRateHandler.