### PR TITLE
Fixes #11778 - jetty-http-spi does not properly provide SPI for modules.

### DIFF
--- a/jetty-core/jetty-http-spi/src/main/java/module-info.java
+++ b/jetty-core/jetty-http-spi/src/main/java/module-info.java
@@ -11,6 +11,9 @@
 // ========================================================================
 //
 
+import com.sun.net.httpserver.spi.HttpServerProvider;
+import org.eclipse.jetty.http.spi.JettyHttpServerProvider;
+
 module org.eclipse.jetty.http.spi
 {
     requires transitive jdk.httpserver;
@@ -19,4 +22,6 @@ module org.eclipse.jetty.http.spi
     requires transitive org.eclipse.jetty.util;
 
     exports org.eclipse.jetty.http.spi;
+
+    provides HttpServerProvider with JettyHttpServerProvider;
 }

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/module-info.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/module-info.java
@@ -27,9 +27,10 @@ module org.eclipse.jetty.websocket.core.common
         org.eclipse.jetty.util; // Export to DecoratedObjectFactory.
 
     uses org.eclipse.jetty.websocket.core.Extension;
-    
+
     provides org.eclipse.jetty.websocket.core.Extension with
         org.eclipse.jetty.websocket.core.internal.FragmentExtension,
+        org.eclipse.jetty.websocket.core.internal.FrameCaptureExtension,
         org.eclipse.jetty.websocket.core.internal.IdentityExtension,
         org.eclipse.jetty.websocket.core.internal.PerMessageDeflateExtension,
         org.eclipse.jetty.websocket.core.internal.ValidationExtension;

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/resources/META-INF/services/org.eclipse.jetty.websocket.core.Extension
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/resources/META-INF/services/org.eclipse.jetty.websocket.core.Extension
@@ -1,5 +1,5 @@
-org.eclipse.jetty.websocket.core.internal.IdentityExtension
 org.eclipse.jetty.websocket.core.internal.FragmentExtension
+org.eclipse.jetty.websocket.core.internal.FrameCaptureExtension
+org.eclipse.jetty.websocket.core.internal.IdentityExtension
 org.eclipse.jetty.websocket.core.internal.PerMessageDeflateExtension
 org.eclipse.jetty.websocket.core.internal.ValidationExtension
-org.eclipse.jetty.websocket.core.internal.FrameCaptureExtension

--- a/jetty-ee10/jetty-ee10-cdi/src/main/java/module-info.java
+++ b/jetty-ee10/jetty-ee10-cdi/src/main/java/module-info.java
@@ -11,6 +11,11 @@
 // ========================================================================
 //
 
+import jakarta.servlet.ServletContainerInitializer;
+import org.eclipse.jetty.ee10.cdi.CdiConfiguration;
+import org.eclipse.jetty.ee10.cdi.CdiServletContainerInitializer;
+import org.eclipse.jetty.ee10.webapp.Configuration;
+
 module org.eclipse.jetty.ee10.cdi
 {
     requires org.eclipse.jetty.ee10.annotations;
@@ -19,4 +24,7 @@ module org.eclipse.jetty.ee10.cdi
     requires transitive org.eclipse.jetty.ee10.webapp;
 
     exports org.eclipse.jetty.ee10.cdi;
-} 
+
+    provides ServletContainerInitializer with CdiServletContainerInitializer;
+    provides Configuration with CdiConfiguration;
+}

--- a/jetty-ee10/jetty-ee10-plus/src/main/resources/META-INF/services/org.eclipse.jetty.ee10.webapp.Configuration
+++ b/jetty-ee10/jetty-ee10-plus/src/main/resources/META-INF/services/org.eclipse.jetty.ee10.webapp.Configuration
@@ -1,2 +1,2 @@
-org.eclipse.jetty.ee10.plus.webapp.PlusConfiguration
 org.eclipse.jetty.ee10.plus.webapp.EnvConfiguration
+org.eclipse.jetty.ee10.plus.webapp.PlusConfiguration

--- a/jetty-ee10/jetty-ee10-quickstart/src/main/java/module-info.java
+++ b/jetty-ee10/jetty-ee10-quickstart/src/main/java/module-info.java
@@ -11,6 +11,10 @@
 // ========================================================================
 //
 
+import org.eclipse.jetty.ee10.quickstart.QuickStartConfiguration;
+import org.eclipse.jetty.ee10.quickstart.QuickStartGeneratorConfiguration;
+import org.eclipse.jetty.ee10.webapp.Configuration;
+
 module org.eclipse.jetty.ee10.quickstart
 {
     requires  jakarta.servlet;
@@ -19,4 +23,6 @@ module org.eclipse.jetty.ee10.quickstart
     requires transitive org.eclipse.jetty.ee10.annotations;
 
     exports org.eclipse.jetty.ee10.quickstart;
+
+    provides Configuration with QuickStartConfiguration, QuickStartGeneratorConfiguration;
 }

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jmx/jetty-ee10-jmx-webapp/src/main/resources/META-INF/services/jakarta.servlet.ServletContainerInitializer
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jmx/jetty-ee10-jmx-webapp/src/main/resources/META-INF/services/jakarta.servlet.ServletContainerInitializer
@@ -1,1 +1,1 @@
-org.eclipse.jetty.test.jmx.MyContainerInitializer
+org.eclipse.jetty.ee10.test.jmx.MyContainerInitializer

--- a/jetty-ee10/jetty-ee10-webapp/src/main/resources/META-INF/services/org.eclipse.jetty.ee10.webapp.Configuration
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/resources/META-INF/services/org.eclipse.jetty.ee10.webapp.Configuration
@@ -1,7 +1,7 @@
 org.eclipse.jetty.ee10.webapp.FragmentConfiguration
-org.eclipse.jetty.ee10.webapp.JettyWebXmlConfiguration
 org.eclipse.jetty.ee10.webapp.JaasConfiguration
 org.eclipse.jetty.ee10.webapp.JaspiConfiguration
+org.eclipse.jetty.ee10.webapp.JettyWebXmlConfiguration
 org.eclipse.jetty.ee10.webapp.JmxConfiguration
 org.eclipse.jetty.ee10.webapp.JndiConfiguration
 org.eclipse.jetty.ee10.webapp.JspConfiguration

--- a/jetty-ee9/jetty-ee9-cdi/src/main/java/module-info.java
+++ b/jetty-ee9/jetty-ee9-cdi/src/main/java/module-info.java
@@ -11,6 +11,11 @@
 // ========================================================================
 //
 
+import jakarta.servlet.ServletContainerInitializer;
+import org.eclipse.jetty.ee9.cdi.CdiConfiguration;
+import org.eclipse.jetty.ee9.cdi.CdiServletContainerInitializer;
+import org.eclipse.jetty.ee9.webapp.Configuration;
+
 module org.eclipse.jetty.ee9.cdi
 {
     requires org.eclipse.jetty.ee9.annotations;
@@ -18,4 +23,7 @@ module org.eclipse.jetty.ee9.cdi
     requires transitive org.eclipse.jetty.ee9.webapp;
 
     exports org.eclipse.jetty.ee9.cdi;
-} 
+
+    provides ServletContainerInitializer with CdiServletContainerInitializer;
+    provides Configuration with CdiConfiguration;
+}

--- a/jetty-ee9/jetty-ee9-plus/src/main/resources/META-INF/services/org.eclipse.jetty.ee9.webapp.Configuration
+++ b/jetty-ee9/jetty-ee9-plus/src/main/resources/META-INF/services/org.eclipse.jetty.ee9.webapp.Configuration
@@ -1,2 +1,2 @@
-org.eclipse.jetty.ee9.plus.webapp.PlusConfiguration
 org.eclipse.jetty.ee9.plus.webapp.EnvConfiguration
+org.eclipse.jetty.ee9.plus.webapp.PlusConfiguration

--- a/jetty-ee9/jetty-ee9-quickstart/src/main/java/module-info.java
+++ b/jetty-ee9/jetty-ee9-quickstart/src/main/java/module-info.java
@@ -11,6 +11,10 @@
 // ========================================================================
 //
 
+import org.eclipse.jetty.ee9.quickstart.QuickStartConfiguration;
+import org.eclipse.jetty.ee9.quickstart.QuickStartGeneratorConfiguration;
+import org.eclipse.jetty.ee9.webapp.Configuration;
+
 module org.eclipse.jetty.ee9.quickstart
 {
     requires jetty.servlet.api;
@@ -19,4 +23,6 @@ module org.eclipse.jetty.ee9.quickstart
     requires transitive org.eclipse.jetty.ee9.annotations;
 
     exports org.eclipse.jetty.ee9.quickstart;
+
+    provides Configuration with QuickStartConfiguration, QuickStartGeneratorConfiguration;
 }

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jmx/jetty-ee9-jmx-webapp/src/main/resources/META-INF/services/jakarta.servlet.ServletContainerInitializer
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jmx/jetty-ee9-jmx-webapp/src/main/resources/META-INF/services/jakarta.servlet.ServletContainerInitializer
@@ -1,1 +1,1 @@
-org.eclipse.jetty.test.jmx.MyContainerInitializer
+org.eclipse.jetty.ee9.test.jmx.MyContainerInitializer

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-owb-cdi-webapp/src/main/resources/META-INF/services/jakarta.servlet.ServletContainerInitializer
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-owb-cdi-webapp/src/main/resources/META-INF/services/jakarta.servlet.ServletContainerInitializer
@@ -1,1 +1,0 @@
-org.eclipse.jetty.ee9.cdi.owb.OwbServletContainerInitializer

--- a/jetty-ee9/jetty-ee9-webapp/src/main/resources/META-INF/services/org.eclipse.jetty.ee9.webapp.Configuration
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/resources/META-INF/services/org.eclipse.jetty.ee9.webapp.Configuration
@@ -1,7 +1,7 @@
 org.eclipse.jetty.ee9.webapp.FragmentConfiguration
-org.eclipse.jetty.ee9.webapp.JettyWebXmlConfiguration
 org.eclipse.jetty.ee9.webapp.JaasConfiguration
 org.eclipse.jetty.ee9.webapp.JaspiConfiguration
+org.eclipse.jetty.ee9.webapp.JettyWebXmlConfiguration
 org.eclipse.jetty.ee9.webapp.JmxConfiguration
 org.eclipse.jetty.ee9.webapp.JndiConfiguration
 org.eclipse.jetty.ee9.webapp.JspConfiguration


### PR DESCRIPTION
Fixed all module-info.java files that did not have a "provides" declaration but had META-INF/services files.