### PR TITLE
Fix #9177 dump JVM info

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java
@@ -54,6 +54,7 @@ import org.eclipse.jetty.util.component.AttributeContainerMap;
 import org.eclipse.jetty.util.component.ClassLoaderDump;
 import org.eclipse.jetty.util.component.DumpableAttributes;
 import org.eclipse.jetty.util.component.DumpableCollection;
+import org.eclipse.jetty.util.component.DumpableMap;
 import org.eclipse.jetty.util.component.Environment;
 import org.eclipse.jetty.util.component.Graceful;
 import org.eclipse.jetty.util.component.LifeCycle;
@@ -137,6 +138,7 @@ public class Server extends Handler.Wrapper implements Attributes
     public Server(@Name("threadPool") ThreadPool pool)
     {
         this(pool, null, null);
+        installBean(new DumpableMap("System Properties", System.getProperties()));
     }
 
     public Server(@Name("threadPool") ThreadPool threadPool, @Name("scheduler") Scheduler scheduler, @Name("bufferPool") ByteBufferPool bufferPool)

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ServerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ServerTest.java
@@ -151,6 +151,7 @@ public class ServerTest
         testSimpleGET();
         ((QueuedThreadPool)(_server.getThreadPool())).tryExecute(() -> {});
         String dump = _server.dump();
+        System.err.println(dump);
         assertThat(dump, containsString("oejs.Server@"));
         assertThat(dump, containsString("QueuedThreadPool"));
         assertThat(dump, containsString("+= ReservedThreadExecutor@"));

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ServerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ServerTest.java
@@ -155,7 +155,6 @@ public class ServerTest
         assertThat(dump, containsString("oejs.Server@"));
         assertThat(dump, containsString("QueuedThreadPool"));
         assertThat(dump, containsString("+= ReservedThreadExecutor@"));
-        assertThat(dump, containsString("1: ReservedThread@"));
         assertThat(dump, containsString(".ArrayByteBufferPool@"));
         assertThat(dump, containsString("+- System Properties size="));
         assertThat(dump, containsString("+> java.home: "));

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ServerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ServerTest.java
@@ -151,7 +151,6 @@ public class ServerTest
         testSimpleGET();
         ((QueuedThreadPool)(_server.getThreadPool())).tryExecute(() -> {});
         String dump = _server.dump();
-        System.err.println(dump);
         assertThat(dump, containsString("oejs.Server@"));
         assertThat(dump, containsString("QueuedThreadPool"));
         assertThat(dump, containsString("+= ReservedThreadExecutor@"));

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ServerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ServerTest.java
@@ -151,6 +151,7 @@ public class ServerTest
         testSimpleGET();
         ((QueuedThreadPool)(_server.getThreadPool())).tryExecute(() -> {});
         String dump = _server.dump();
+        // System.err.println(dump);
         assertThat(dump, containsString("oejs.Server@"));
         assertThat(dump, containsString("QueuedThreadPool"));
         assertThat(dump, containsString("+= ReservedThreadExecutor@"));

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ServerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ServerTest.java
@@ -151,7 +151,6 @@ public class ServerTest
         testSimpleGET();
         ((QueuedThreadPool)(_server.getThreadPool())).tryExecute(() -> {});
         String dump = _server.dump();
-        // System.err.println(dump);
         assertThat(dump, containsString("oejs.Server@"));
         assertThat(dump, containsString("QueuedThreadPool"));
         assertThat(dump, containsString("+= ReservedThreadExecutor@"));

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ServerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ServerTest.java
@@ -32,8 +32,10 @@ import org.eclipse.jetty.server.internal.HttpChannelState;
 import org.eclipse.jetty.server.internal.HttpConnection;
 import org.eclipse.jetty.util.Blocker;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.Jetty;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.thread.Invocable;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -141,6 +143,27 @@ public class ServerTest
         HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse(request));
         assertThat(response.getStatus(), is(HttpStatus.OK_200));
         assertThat(response.getContent(), is("Hello"));
+    }
+
+    @Test
+    public void testDump() throws Exception
+    {
+        testSimpleGET();
+        ((QueuedThreadPool)(_server.getThreadPool())).tryExecute(() -> {});
+        String dump = _server.dump();
+        assertThat(dump, containsString("oejs.Server@"));
+        assertThat(dump, containsString("QueuedThreadPool"));
+        assertThat(dump, containsString("+= ReservedThreadExecutor@"));
+        assertThat(dump, containsString("1: ReservedThread@"));
+        assertThat(dump, containsString(".ArrayByteBufferPool@"));
+        assertThat(dump, containsString("+- System Properties size="));
+        assertThat(dump, containsString("+> java.home: "));
+        assertThat(dump, containsString("+> java.runtime.version: "));
+        assertThat(dump, containsString("+= oejsh.ContextHandler@"));
+        assertThat(dump, containsString("+= LocalConnector@"));
+        assertThat(dump, containsString("key: +-"));
+        assertThat(dump, containsString("JVM: "));
+        assertThat(dump, containsString(Jetty.VERSION));
     }
 
     public static Stream<Arguments> completionScenarios()

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/ContainerLifeCycle.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/ContainerLifeCycle.java
@@ -745,10 +745,10 @@ public class ContainerLifeCycle extends AbstractLifeCycle implements Container, 
     {
         try
         {
-            dump(System.err, "");
-            System.err.println(Dumpable.KEY);
+            Dumpable.dump(this, System.err);
+            System.err.println();
         }
-        catch (IOException e)
+        catch (Throwable e)
         {
             LOG.warn("Unable to dump", e);
         }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/Dumpable.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/Dumpable.java
@@ -56,7 +56,7 @@ public interface Dumpable
     void dump(Appendable out, String indent) throws IOException;
 
     /**
-     * Utility method to call dump to a {@link String}
+     * Utility method to dump to a {@link String}
      *
      * @param dumpable The dumpable to dump
      * @return The dumped string

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/Dumpable.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/Dumpable.java
@@ -69,9 +69,6 @@ public interface Dumpable
         return b.toString();
     }
 
-    DateTimeFormatter UTC_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC);
-    DateTimeFormatter LOCAL_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS Z").withZone(ZoneId.of(System.getProperty("user.timezone")));
-
     /**
      * Utility method to dump to an {@link Appendable}
      *
@@ -87,9 +84,11 @@ public interface Dumpable
             out.append(KEY);
             Runtime runtime = Runtime.getRuntime();
             Instant now = Instant.now();
-            out.append("JVM: %s %s; OS: %s %s %s; Jetty: %s; CPUs: %d; mem(free/total/max): %,d/%,d/%,d MB\nUTC: %s; %s: %s".formatted(
-                System.getProperty("java.runtime.name"),
-                System.getProperty("java.runtime.version"),
+            String zone = System.getProperty("user.timezone");
+            out.append("JVM: %s %s %s; OS: %s %s %s; Jetty: %s; CPUs: %d; mem(free/total/max): %,d/%,d/%,d MiB\nUTC: %s; %s: %s".formatted(
+                System.getProperty("java.vm.vendor"),
+                System.getProperty("java.vm.name"),
+                System.getProperty("java.vm.version"),
                 System.getProperty("os.name"),
                 System.getProperty("os.arch"),
                 System.getProperty("os.version"),
@@ -98,9 +97,9 @@ public interface Dumpable
                 runtime.freeMemory() / (1024 * 1024),
                 runtime.totalMemory() / (1024 * 1024),
                 runtime.maxMemory() / (1024 * 1024),
-                UTC_FORMATTER.format(now),
-                System.getProperty("user.timezone"),
-                LOCAL_FORMATTER.format(now)));
+                DateTimeFormatter.ISO_DATE_TIME.format(now.atOffset(ZoneOffset.UTC)),
+                zone,
+                DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(now.atZone(ZoneId.of(zone)))));
         }
         catch (IOException e)
         {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/DumpableMap.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/DumpableMap.java
@@ -1,0 +1,39 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.util.component;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.Map;
+
+public class DumpableMap implements Dumpable
+{
+    private final String _name;
+    private final Map<?, ?> _map;
+
+    public DumpableMap(String name, Map<?, ?> map)
+    {
+        _name = name;
+        _map = map;
+    }
+
+    @Override
+    public void dump(Appendable out, String indent) throws IOException
+    {
+        Object[] array = _map.entrySet().stream()
+            .sorted(Map.Entry.comparingByKey(Comparator.comparing(String::valueOf)))
+            .map(e -> Dumpable.named(String.valueOf(e.getKey()), e.getValue())).toArray(Object[]::new);
+        Dumpable.dumpObjects(out, indent, _name + " size=" + array.length, array);
+    }
+}

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ThreadIdPool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ThreadIdPool.java
@@ -25,7 +25,6 @@ import org.eclipse.jetty.util.MemoryUtils;
 import org.eclipse.jetty.util.ProcessorUtils;
 import org.eclipse.jetty.util.TypeUtil;
 import org.eclipse.jetty.util.component.Dumpable;
-import org.eclipse.jetty.util.component.DumpableCollection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -236,8 +235,12 @@ public class ThreadIdPool<E> implements Dumpable
         int capacity = capacity();
         List<Object> slots = new ArrayList<>(capacity);
         for (int i = 0; i < capacity; i++)
-            slots.add(_items.get(toSlot(i)));
-        Dumpable.dumpObjects(out, indent, this, new DumpableCollection("items", slots));
+        {
+            E slot = _items.get(toSlot(i));
+            if (slot != null)
+                slots.add(Dumpable.named(Integer.toString(i), slot));
+        }
+        Dumpable.dumpObjects(out, indent, this, slots.toArray());
     }
 
     @Override

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/thread/QueuedThreadPoolTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/thread/QueuedThreadPoolTest.java
@@ -833,8 +833,7 @@ public class QueuedThreadPoolTest extends AbstractThreadPoolTest
         assertThat(count(dump, " - STARTED"), is(3));
         assertThat(dump, containsString(",3<=3<=4,i=1,r=2,"));
         assertThat(dump, containsString("[ReservedThreadExecutor@"));
-        assertThat(count(dump, "> ReservedThread@"), is(1));
-        assertThat(count(dump, "> null"), is(1));
+        assertThat(count(dump, "+> 0: ReservedThread@"), is(1));
         assertThat(count(dump, "QueuedThreadPoolTest.lambda$testDump$"), is(0));
 
         pool.setDetailedDump(true);

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/DebugListener.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/DebugListener.java
@@ -125,14 +125,12 @@ public class DebugListener extends AbstractLifeCycle implements ServletContextLi
             if (_out == null)
             {
                 handler.dumpStdErr();
-                System.err.println(Dumpable.KEY);
             }
             else
             {
                 try
                 {
-                    handler.dump(_out);
-                    _out.println(Dumpable.KEY);
+                    Dumpable.dump(handler, _out);
                 }
                 catch (Exception e)
                 {

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/DebugListener.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/DebugListener.java
@@ -121,14 +121,12 @@ public class DebugListener extends AbstractLifeCycle implements ServletContextLi
             if (_out == null)
             {
                 handler.dumpStdErr();
-                System.err.println(Dumpable.KEY);
             }
             else
             {
                 try
                 {
-                    handler.dump(_out);
-                    _out.println(Dumpable.KEY);
+                    Dumpable.dump(handler, _out);
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
Fix #9177 dump info from Runtime, Jetty.VERSION and `System.getProperties`:
 + The summary info is included afdter the dump key.
 + A dump of the Server now includes a full dump of the System.properties
 + Cleanup of the ThreadIdPool dump

Sample output is:
```
oejs.Server@273e7444{STARTED}[12.0.10-SNAPSHOT,sto=0] - STARTED
+= QueuedThreadPool[qtp1194893830]@4738a206{STARTED,8<=8<=200,i=6,r=-1,t=59731ms,q=0}[ReservedThreadExecutor@790da477{capacity=32,threads=ThreadIdPool@5c7933ad{capacity=32}}] - STARTED
|  +- org.eclipse.jetty.util.thread.ThreadPoolBudget@57bc27f5
|  += ReservedThreadExecutor@790da477{capacity=32,threads=ThreadIdPool@5c7933ad{capacity=32}} - STARTED
|  |  +~ QueuedThreadPool[qtp1194893830]@4738a206{STARTED,8<=8<=200,i=6,r=-1,t=59731ms,q=0}[ReservedThreadExecutor@790da477{capacity=32,threads=ThreadIdPool@5c7933ad{capacity=32}}] - STARTED
|  |  +- ThreadIdPool@5c7933ad{capacity=32}
|  |     +> 1: ReservedThread@4b8d604b{thread=Thread[#33,qtp1194893830-33,5,main]}
|  +> threads size=8
|     +> qtp1194893830-31-acceptor-0@5116a1f-LocalConnector@742ff096{HTTP/1.1, (http/1.1)} WAITING tid=31 prio=3 @ java.base/jdk.internal.misc.Unsafe.park(Native Method)
|     +> qtp1194893830-32 TIMED_WAITING tid=32 prio=5 IDLE
|     +> qtp1194893830-37 TIMED_WAITING tid=37 prio=5 IDLE
|     +> qtp1194893830-35 TIMED_WAITING tid=35 prio=5 IDLE
|     +> qtp1194893830-33 TIMED_WAITING tid=33 prio=5 @ java.base/jdk.internal.misc.Unsafe.park(Native Method)
|     +> qtp1194893830-38 TIMED_WAITING tid=38 prio=5 IDLE
|     +> qtp1194893830-36 TIMED_WAITING tid=36 prio=5 IDLE
|     +> qtp1194893830-34 TIMED_WAITING tid=34 prio=5 IDLE
+= oejut.ScheduledExecutorScheduler@58d75e99{STARTED} - STARTED
|  +> java.base/jdk.internal.misc.Unsafe.park(Native Method)
|  +> java.base/java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:269)
|  +> java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(AbstractQueuedSynchronizer.java:1758)
|  +> java.base/java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ScheduledThreadPoolExecutor.java:1182)
|  +> java.base/java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ScheduledThreadPoolExecutor.java:899)
|  +> java.base/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1070)
|  +> java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
|  +> java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
|  +> java.base/java.lang.Thread.run(Thread.java:1570)
+- org.eclipse.jetty.io.ArrayByteBufferPool@5e7cd6cc{min=0,max=65536,buckets=16,heap=0/805306368,direct=8192/805306368}
|  +> direct size=16
|  |  +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@15888343{capacity=4096,in-use=0/0,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
|  |  +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@33ecda92{capacity=8192,in-use=0/1,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
|  |  +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@14fc5f04{capacity=12288,in-use=0/0,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
|  |  +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@6e2829c7{capacity=16384,in-use=0/0,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
|  |  +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@3feb2dda{capacity=20480,in-use=0/0,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
|  |  +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@6a8658ff{capacity=24576,in-use=0/0,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
|  |  +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@1c742ed4{capacity=28672,in-use=0/0,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
|  |  +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@333d4a8c{capacity=32768,in-use=0/0,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
|  |  +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@55de24cc{capacity=36864,in-use=0/0,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
|  |  +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@dc7df28{capacity=40960,in-use=0/0,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
|  |  +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@30f842ca{capacity=45056,in-use=0/0,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
|  |  +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@69c81773{capacity=49152,in-use=0/0,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
|  |  +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@4d14b6c2{capacity=53248,in-use=0/0,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
|  |  +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@7e990ed7{capacity=57344,in-use=0/0,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
|  |  +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@c05fddc{capacity=61440,in-use=0/0,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
|  |  +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@25df00a0{capacity=65536,in-use=0/0,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
|  +> indirect size=16
|     +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@4d15107f{capacity=4096,in-use=0/0,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
|     +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@7b4c50bc{capacity=8192,in-use=0/0,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
|     +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@5884a914{capacity=12288,in-use=0/0,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
|     +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@50378a4{capacity=16384,in-use=0/0,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
|     +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@60f00693{capacity=20480,in-use=0/0,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
|     +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@79207381{capacity=24576,in-use=0/0,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
|     +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@491b9b8{capacity=28672,in-use=0/0,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
|     +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@1a4927d6{capacity=32768,in-use=0/0,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
|     +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@7a6d7e92{capacity=36864,in-use=0/0,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
|     +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@aba625{capacity=40960,in-use=0/0,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
|     +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@97e93f1{capacity=45056,in-use=0/0,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
|     +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@5a5a729f{capacity=49152,in-use=0/0,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
|     +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@4b520ea8{capacity=53248,in-use=0/0,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
|     +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@16150369{capacity=57344,in-use=0/0,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
|     +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@6b09fb41{capacity=61440,in-use=0/0,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
|     +> org.eclipse.jetty.io.ArrayByteBufferPool$RetainedBucket@624ea235{capacity=65536,in-use=0/0,pooled/acquires=0/0(NaN%),non-pooled/evicts/removes/releases=0/0/0/0}
+~ org.eclipse.jetty.util.resource.FileSystemPool@3932c79a
+- System Properties size=56
|  +> file.encoding: UTF-8
|  +> file.separator: /
|  +> idea.test.cyclic.buffer.size: 4194304
|  +> java.class.path: /home/gregw/.m2/repository/org/junit/platform/junit-platform-launcher/1.10.2/junit-platform-launcher-1.10.2.jar:/home/gregw/.local/share/JetBrains/Toolbox/apps/intellij-idea-ultimate/lib/idea_rt.jar:/home/gregw/.local/share/JetBrains/Toolbox/apps/intellij-idea-ultimate/plugins/junit/lib/junit5-rt.jar:/home/gregw/.local/share/JetBrains/Toolbox/apps/intellij-idea-ultimate/plugins/junit/lib/junit-rt.jar:/home/gregw/src/jetty-12.0.x/jetty-core/jetty-server/target/test-classes:/home/gregw/.m2/repository/org/awaitility/awaitility/4.2.1/awaitility-4.2.1.jar:/home/gregw/.m2/repository/org/hamcrest/hamcrest/2.2/hamcrest-2.2.jar:/home/gregw/src/jetty-12.0.x/jetty-core/jetty-http-tools/target/classes:/home/gregw/src/jetty-12.0.x/jetty-core/jetty-slf4j-impl/target/classes:/home/gregw/src/jetty-12.0.x/jetty-core/jetty-util-ajax/target/classes:/home/gregw/src/jetty-12.0.x/jetty-core/jetty-xml/target/classes:/home/gregw/.m2/repository/org/eclipse/jetty/toolchain/jetty-test-helper/6.2/jetty-test-helper-6.2.jar:/home/gregw/.m2/repository/org/eclipse/jetty/toolchain/jetty-xhtml-schemas/1.4/jetty-xhtml-schemas-1.4.jar:/home/gregw/.m2/repository/org/openjdk/jmh/jmh-core/1.37/jmh-core-1.37.jar:/home/gregw/.m2/repository/net/sf/jopt-simple/jopt-simple/5.0.4/jopt-simple-5.0.4.jar:/home/gregw/.m2/repository/org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar:/home/gregw/.m2/repository/org/openjdk/jmh/jmh-generator-annprocess/1.37/jmh-generator-annprocess-1.37.jar:/home/gregw/.m2/repository/org/junit/jupiter/junit-jupiter/5.10.2/junit-jupiter-5.10.2.jar:/home/gregw/.m2/repository/org/junit/jupiter/junit-jupiter-api/5.10.2/junit-jupiter-api-5.10.2.jar:/home/gregw/.m2/repository/org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar:/home/gregw/.m2/repository/org/junit/platform/junit-platform-commons/1.10.2/junit-platform-commons-1.10.2.jar:/home/gregw/.m2/repository/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar:/home/gregw/.m2/repository/org/junit/jupiter/junit-jupiter-params/5.10.2/junit-jupiter-params-5.10.2.jar:/home/gregw/.m2/repository/org/junit/jupiter/junit-jupiter-engine/5.10.2/junit-jupiter-engine-5.10.2.jar:/home/gregw/.m2/repository/org/junit/platform/junit-platform-engine/1.10.2/junit-platform-engine-1.10.2.jar
|  +> java.class.version: 66.0
|  +> java.home: /home/gregw/.sdkman/candidates/java/22-open
|  +> java.io.tmpdir: /home/gregw/src/jetty-12.0.x/jetty-core/jetty-server/target
|  +> java.library.path: /usr/java/packages/lib:/usr/lib64:/lib64:/lib:/usr/lib
|  +> java.runtime.name: OpenJDK Runtime Environment
|  +> java.runtime.version: 22+36-2370
|  +> java.specification.name: Java Platform API Specification
|  +> java.specification.vendor: Oracle Corporation
|  +> java.specification.version: 22
|  +> java.vendor: Oracle Corporation
|  +> java.vendor.url: https://java.oracle.com/
|  +> java.vendor.url.bug: https://bugreport.java.com/bugreport/
|  +> java.version: 22
|  +> java.version.date: 2024-03-19
|  +> java.vm.compressedOopsMode: Zero based
|  +> java.vm.info: mixed mode
|  +> java.vm.name: OpenJDK 64-Bit Server VM
|  +> java.vm.specification.name: Java Virtual Machine Specification
|  +> java.vm.specification.vendor: Oracle Corporation
|  +> java.vm.specification.version: 22
|  +> java.vm.vendor: Oracle Corporation
|  +> java.vm.version: 22+36-2370
|  +> jdk.debug: release
|  +> jdk.module.path: /home/gregw/src/jetty-12.0.x/jetty-core/jetty-jmx/target/classes:/home/gregw/src/jetty-12.0.x/jetty-core/jetty-io/target/classes:/home/gregw/src/jetty-12.0.x/jetty-core/jetty-http/target/classes:/home/gregw/src/jetty-12.0.x/jetty-core/jetty-http/target/jetty-http-12.0.10-SNAPSHOT.jar:/home/gregw/src/jetty-12.0.x/jetty-core/jetty-server/target/classes:/home/gregw/.m2/repository/org/slf4j/slf4j-api/2.0.12/slf4j-api-2.0.12.jar:/home/gregw/src/jetty-12.0.x/jetty-core/jetty-util/target/classes
|  +> jetty.git.hash: 
|  +> jetty.testtracker.log: true
|  +> jetty.unixdomain.dir: /tmp
|  +> line.separator: |
|  +> native.encoding: UTF-8
|  +> os.arch: amd64
|  +> os.name: Linux
|  +> os.version: 6.5.0-35-generic
|  +> path.separator: :
|  +> stderr.encoding: UTF-8
|  +> stdout.encoding: UTF-8
|  +> sun.arch.data.model: 64
|  +> sun.boot.library.path: /home/gregw/.sdkman/candidates/java/22-open/lib
|  +> sun.cpu.endian: little
|  +> sun.io.unicode.encoding: UnicodeLittle
|  +> sun.java.command: com.intellij.rt.junit.JUnitStarter -ideVersion5 -junit5 org.eclipse.jetty.server.ServerTest,testDump
|  +> sun.java.launcher: SUN_STANDARD
|  +> sun.jnu.encoding: UTF-8
|  +> sun.management.compiler: HotSpot 64-Bit Tiered Compilers
|  +> sun.stderr.encoding: UTF-8
|  +> sun.stdout.encoding: UTF-8
|  +> user.country: US
|  +> user.dir: /home/gregw/src/jetty-12.0.x/jetty-core/jetty-server
|  +> user.home: /home/gregw
|  +> user.language: en
|  +> user.name: gregw
|  +> user.region: US
|  +> user.timezone: Europe/Rome
+= oejsh.ContextHandler@6bbe85a8{ROOT,/,b=null,a=AVAILABLE,h=oejs.ServerTest$@4be29ed9{STARTED}} - STARTED
|  += SymlinkAllowedResourceAliasChecker@5db6b9cd{base=null,protected=[]} - STARTED
|  += oejs.ServerTest$@4be29ed9{STARTED} - STARTED
|  +- org.eclipse.jetty.server.AllowedResourceAliasChecker$AllowedResourceAliasCheckListener@210ab13f
|  +> No ClassLoader
|  +> handler attributes size=0
|  +> attributes size=0
+= LocalConnector@742ff096{HTTP/1.1, (http/1.1)} - STARTED
|  +~ QueuedThreadPool[qtp1194893830]@4738a206{STARTED,8<=8<=200,i=6,r=-1,t=59699ms,q=0}[ReservedThreadExecutor@790da477{capacity=32,threads=ThreadIdPool@5c7933ad{capacity=32}}] - STARTED
|  +~ oejut.ScheduledExecutorScheduler@58d75e99{STARTED} - STARTED
|  +~ org.eclipse.jetty.io.ArrayByteBufferPool@5e7cd6cc{min=0,max=65536,buckets=16,heap=0/805306368,direct=8192/805306368}
|  += @1b11171f[HTTP/1.1] - STARTED
|  |  +- HttpConfiguration@69504ae9{32768/8192,8192/8192,https://:0,[]}
|  |     +> customizers size=0
|  |     +> formEncodedMethods size=2
|  |     |  +> POST
|  |     |  +> PUT
|  |     +> outputBufferSize=32768
|  |     +> outputAggregationSize=8192
|  |     +> requestHeaderSize=8192
|  |     +> responseHeaderSize=8192
|  |     +> headerCacheSize=1024
|  |     +> secureScheme=https
|  |     +> securePort=0
|  |     +> idleTimeout=-1
|  |     +> sendDateHeader=true
|  |     +> sendServerVersion=true
|  |     +> sendXPoweredBy=false
|  |     +> delayDispatchUntilContent=true
|  |     +> persistentConnectionsEnabled=true
|  |     +> maxErrorDispatches=10
|  |     +> minRequestDataRate=0
|  |     +> minResponseDataRate=0
|  |     +> requestCookieCompliance=RFC6265@7139992f[INVALID_COOKIES, OPTIONAL_WHITE_SPACE, SPACE_IN_VALUES]
|  |     +> responseCookieCompliance=RFC6265@7139992f[INVALID_COOKIES, OPTIONAL_WHITE_SPACE, SPACE_IN_VALUES]
|  |     +> notifyRemoteAsyncErrors=true
|  |     +> relativeRedirectAllowed=true
|  +- qtp1194893830-31-acceptor-0@5116a1f-LocalConnector@742ff096{HTTP/1.1, (http/1.1)}
+- org.eclipse.jetty.server.Server$DynamicErrorHandler@387a8303
+> jdk.internal.loader.ClassLoaders$AppClassLoader@6df97b55
|  +> packages size=59
|  |  +> package com.intellij.rt.execution.application
|  |  +> package org.slf4j
|  |  +> package org.opentest4j, opentest4j, version 1.3.0
|  |  +> package org.junit.jupiter.params.support, junit-jupiter-params, version 5.10.2
|  |  +> package org.junit.platform.commons.support, junit-platform-commons, version 1.10.2
|  |  +> package org.junit.jupiter.engine.support, junit-jupiter-engine, version 5.10.2
|  |  +> package com.intellij.rt.execution.junit
|  |  +> package org.junit.jupiter.engine.descriptor, junit-jupiter-engine, version 5.10.2
|  |  +> package org.junit.jupiter.engine.execution, junit-jupiter-engine, version 5.10.2
|  |  +> package org.slf4j.spi
|  |  +> package com.intellij.rt.junit
|  |  +> package org.eclipse.jetty.io
|  |  +> package org.junit.platform.commons.function, junit-platform-commons, version 1.10.2
|  |  +> package org.eclipse.jetty.util.resource
|  |  +> package org.junit.platform.engine.reporting, junit-platform-engine, version 1.10.2
|  |  +> package org.junit.platform.launcher, junit-platform-launcher, version 1.10.2
|  |  +> package org.eclipse.jetty.logging
|  |  +> package org.junit.platform.launcher.core, junit-platform-launcher, version 1.10.2
|  |  +> package org.junit.platform.commons.logging, junit-platform-commons, version 1.10.2
|  |  +> package org.junit.platform.engine, junit-platform-engine, version 1.10.2
|  |  +> package org.eclipse.jetty.server
|  |  +> package org.junit.jupiter.api.extension, junit-jupiter-api, version 5.10.2
|  |  +> package org.junit.jupiter.engine.discovery, junit-jupiter-engine, version 5.10.2
|  |  +> package org.eclipse.jetty.util.component
|  |  +> package org.junit.platform.commons.util, junit-platform-commons, version 1.10.2
|  |  +> package org.junit.jupiter.engine.discovery.predicates, junit-jupiter-engine, version 5.10.2
|  |  +> package org.eclipse.jetty.io.content
|  |  +> package org.eclipse.jetty.util
|  |  +> package org.junit.platform.launcher.listeners.discovery, junit-platform-launcher, version 1.10.2
|  |  +> package org.junit.jupiter.engine.config, junit-jupiter-engine, version 5.10.2
|  |  +> package org.junit.platform.engine.support.store, junit-platform-engine, version 1.10.2
|  |  +> package org.junit.platform.launcher.listeners.session, junit-platform-launcher, version 1.10.2
|  |  +> package org.eclipse.jetty.io.ssl
|  |  +> package org.eclipse.jetty.http
|  |  +> package org.eclipse.jetty.util.thread
|  |  +> package org.slf4j.event
|  |  +> package org.slf4j.helpers
|  |  +> package org.junit.platform.engine.support.hierarchical, junit-platform-engine, version 1.10.2
|  |  +> package org.eclipse.jetty.server.internal
|  |  +> package org.junit.jupiter.params, junit-jupiter-params, version 5.10.2
|  |  +> package org.eclipse.jetty.util.security
|  |  +> package org.apiguardian.api, apiguardian-api, version 1.1.2
|  |  +> package org.junit.platform.commons.annotation, junit-platform-commons, version 1.10.2
|  |  +> package com.intellij.junit5
|  |  +> package org.eclipse.jetty.server.handler
|  |  +> package org.junit.jupiter.api.io, junit-jupiter-api, version 5.10.2
|  |  +> package org.junit.jupiter.engine, junit-jupiter-engine, version 5.10.2
|  |  +> package org.junit.jupiter.api.parallel, junit-jupiter-api, version 5.10.2
|  |  +> package org.junit.platform.launcher.listeners, junit-platform-launcher, version 1.10.2
|  |  +> package org.junit.jupiter.api, junit-jupiter-api, version 5.10.2
|  |  +> package org.hamcrest.core
|  |  +> package org.junit.platform.engine.discovery, junit-platform-engine, version 1.10.2
|  |  +> package org.junit.platform.engine.support.descriptor, junit-platform-engine, version 1.10.2
|  |  +> package org.junit.platform.engine.support.discovery, junit-platform-engine, version 1.10.2
|  |  +> package org.junit.jupiter.engine.extension, junit-jupiter-engine, version 5.10.2
|  |  +> package org.junit.jupiter.params.provider, junit-jupiter-params, version 5.10.2
|  |  +> package org.hamcrest
|  |  +> package org.junit.platform.commons, junit-platform-commons, version 1.10.2
|  |  +> package org.eclipse.jetty.io.internal
|  +> parent: jdk.internal.loader.ClassLoaders$PlatformClassLoader@475c9c31
|     +> packages size=2
|        +> package sun.util.resources.provider
|        +> package sun.util.resources.cldr.provider
+> environments size=1
|  +> oejuc.Environment$Named@0{core}
|     +> jdk.internal.loader.ClassLoaders$AppClassLoader@6df97b55
|     |  +> packages size=59
|     |  |  +> package com.intellij.rt.execution.application
|     |  |  +> package org.slf4j
|     |  |  +> package org.opentest4j, opentest4j, version 1.3.0
|     |  |  +> package org.junit.jupiter.params.support, junit-jupiter-params, version 5.10.2
|     |  |  +> package org.junit.platform.commons.support, junit-platform-commons, version 1.10.2
|     |  |  +> package org.junit.jupiter.engine.support, junit-jupiter-engine, version 5.10.2
|     |  |  +> package com.intellij.rt.execution.junit
|     |  |  +> package org.junit.jupiter.engine.descriptor, junit-jupiter-engine, version 5.10.2
|     |  |  +> package org.junit.jupiter.engine.execution, junit-jupiter-engine, version 5.10.2
|     |  |  +> package org.slf4j.spi
|     |  |  +> package com.intellij.rt.junit
|     |  |  +> package org.eclipse.jetty.io
|     |  |  +> package org.junit.platform.commons.function, junit-platform-commons, version 1.10.2
|     |  |  +> package org.eclipse.jetty.util.resource
|     |  |  +> package org.junit.platform.engine.reporting, junit-platform-engine, version 1.10.2
|     |  |  +> package org.junit.platform.launcher, junit-platform-launcher, version 1.10.2
|     |  |  +> package org.eclipse.jetty.logging
|     |  |  +> package org.junit.platform.launcher.core, junit-platform-launcher, version 1.10.2
|     |  |  +> package org.junit.platform.commons.logging, junit-platform-commons, version 1.10.2
|     |  |  +> package org.junit.platform.engine, junit-platform-engine, version 1.10.2
|     |  |  +> package org.eclipse.jetty.server
|     |  |  +> package org.junit.jupiter.api.extension, junit-jupiter-api, version 5.10.2
|     |  |  +> package org.junit.jupiter.engine.discovery, junit-jupiter-engine, version 5.10.2
|     |  |  +> package org.eclipse.jetty.util.component
|     |  |  +> package org.junit.platform.commons.util, junit-platform-commons, version 1.10.2
|     |  |  +> package org.junit.jupiter.engine.discovery.predicates, junit-jupiter-engine, version 5.10.2
|     |  |  +> package org.eclipse.jetty.io.content
|     |  |  +> package org.eclipse.jetty.util
|     |  |  +> package org.junit.platform.launcher.listeners.discovery, junit-platform-launcher, version 1.10.2
|     |  |  +> package org.junit.jupiter.engine.config, junit-jupiter-engine, version 5.10.2
|     |  |  +> package org.junit.platform.engine.support.store, junit-platform-engine, version 1.10.2
|     |  |  +> package org.junit.platform.launcher.listeners.session, junit-platform-launcher, version 1.10.2
|     |  |  +> package org.eclipse.jetty.io.ssl
|     |  |  +> package org.eclipse.jetty.http
|     |  |  +> package org.eclipse.jetty.util.thread
|     |  |  +> package org.slf4j.event
|     |  |  +> package org.slf4j.helpers
|     |  |  +> package org.junit.platform.engine.support.hierarchical, junit-platform-engine, version 1.10.2
|     |  |  +> package org.eclipse.jetty.server.internal
|     |  |  +> package org.junit.jupiter.params, junit-jupiter-params, version 5.10.2
|     |  |  +> package org.eclipse.jetty.util.security
|     |  |  +> package org.apiguardian.api, apiguardian-api, version 1.1.2
|     |  |  +> package org.junit.platform.commons.annotation, junit-platform-commons, version 1.10.2
|     |  |  +> package com.intellij.junit5
|     |  |  +> package org.eclipse.jetty.server.handler
|     |  |  +> package org.junit.jupiter.api.io, junit-jupiter-api, version 5.10.2
|     |  |  +> package org.junit.jupiter.engine, junit-jupiter-engine, version 5.10.2
|     |  |  +> package org.junit.jupiter.api.parallel, junit-jupiter-api, version 5.10.2
|     |  |  +> package org.junit.platform.launcher.listeners, junit-platform-launcher, version 1.10.2
|     |  |  +> package org.junit.jupiter.api, junit-jupiter-api, version 5.10.2
|     |  |  +> package org.hamcrest.core
|     |  |  +> package org.junit.platform.engine.discovery, junit-platform-engine, version 1.10.2
|     |  |  +> package org.junit.platform.engine.support.descriptor, junit-platform-engine, version 1.10.2
|     |  |  +> package org.junit.platform.engine.support.discovery, junit-platform-engine, version 1.10.2
|     |  |  +> package org.junit.jupiter.engine.extension, junit-jupiter-engine, version 5.10.2
|     |  |  +> package org.junit.jupiter.params.provider, junit-jupiter-params, version 5.10.2
|     |  |  +> package org.hamcrest
|     |  |  +> package org.junit.platform.commons, junit-platform-commons, version 1.10.2
|     |  |  +> package org.eclipse.jetty.io.internal
|     |  +> parent: jdk.internal.loader.ClassLoaders$PlatformClassLoader@475c9c31
|     |     +> packages size=2
|     |        +> package sun.util.resources.provider
|     |        +> package sun.util.resources.cldr.provider
|     +> Attributes core size=0
+> attributes size=0
+> org.eclipse.jetty.util.resource.FileSystemPool@3932c79a
   +> buckets size=0
key: +- bean, += managed, +~ unmanaged, +? auto, +: iterable, +] array, +@ map, +> undefined
JVM: OpenJDK Runtime Environment 22+36-2370; Jetty: 12.0.10-SNAPSHOT; CPUs: 20; mem(free/total/max)B:4,217,372,672/4,294,967,296/6,442,450,944
```