### PR TITLE
Fix contains in HttpFields name set and prove random access to HttpFields via EnumMap not worth it.

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -44,10 +44,10 @@ import java.util.stream.StreamSupport;
  * typically used in server-side HTTP responses and client-side HTTP requests.</p>
  *
  * <p>Access is always more efficient using {@link HttpHeader} keys rather than {@link String} field names.</p>
- * 
+ *
  * <p>The primary implementations of {@code HttpFields} have been optimized assuming few
  * lookup operations, thus typically if many {@link HttpField}s need to looked up, it may be
- * better to use an {@link Iterator} or the {@link #asMappedAccess()} method.</p>
+ * better to use an {@link Iterator} to find multiple fields in a single iteration.</p>
  */
 public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
 {
@@ -201,18 +201,6 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
     default HttpFields asImmutable()
     {
         return HttpFields.build(this).asImmutable();
-    }
-
-    /**
-     * <p>Returns an immutable version of this {@code HttpFields} instance, possibly optimized for random field
-     * access via {@link Map} implementations. If this {@code HttpFields} is mutable, then subsequent modifications
-     * are not reflected in the instance returned by this method.</p>
-     *
-     * @return an {@link HttpFields} instance, which may be optimized for random access.
-     */
-    default HttpFields asMappedAccess()
-    {
-        return asImmutable();
     }
 
     /**

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -617,7 +617,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
     default Set<String> getFieldNamesCollection()
     {
         Set<HttpHeader> seenByHeader = EnumSet.noneOf(HttpHeader.class);
-        Set<String> seenByName = null;
+        Set<String> buildByName = null;
         List<String> list = new ArrayList<>(size());
 
         for (HttpField f : this)
@@ -625,9 +625,9 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
             HttpHeader header = f.getHeader();
             if (header == null)
             {
-                if (seenByName == null)
-                    seenByName = new TreeSet<>(String::compareToIgnoreCase);
-                if (seenByName.add(f.getName()))
+                if (buildByName == null)
+                    buildByName = new TreeSet<>(String::compareToIgnoreCase);
+                if (buildByName.add(f.getName()))
                     list.add(f.getName());
             }
             else if (seenByHeader.add(header))
@@ -635,6 +635,8 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
                 list.add(f.getName());
             }
         }
+
+        Set<String> seenByName = buildByName;
 
         // use the list to retain a rough ordering
         return new AbstractSet<>()
@@ -649,6 +651,14 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
             public int size()
             {
                 return list.size();
+            }
+
+            @Override
+            public boolean contains(Object o)
+            {
+                if (o instanceof String s)
+                    return seenByName != null && seenByName.contains(s) || seenByHeader.contains(HttpHeader.CACHE.get(s));
+                return false;
             }
         };
     }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -204,8 +204,9 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
     }
 
     /**
-     * <p>Returns an immutable version of this {@link HttpFields} instance, possibly optimized for random field
-     * access via {@link Map} implementations.</p>
+     * <p>Returns an immutable version of this {@code HttpFields} instance, possibly optimized for random field
+     * access via {@link Map} implementations. If this {@code HttpFields} is mutable, then subsequent modifications
+     * are not reflected in the instance returned by this method.</p>
      *
      * @return an {@link HttpFields} instance, which may be optimized for random access.
      */

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -38,9 +38,14 @@ import java.util.stream.StreamSupport;
 /**
  * <p>An ordered collection of {@link HttpField}s that represent the HTTP headers
  * or HTTP trailers of an HTTP request or an HTTP response.</p>
+ *
  * <p>{@link HttpFields} is immutable and typically used in server-side HTTP requests
  * and client-side HTTP responses, while {@link HttpFields.Mutable} is mutable and
  * typically used in server-side HTTP responses and client-side HTTP requests.</p>
+ *
+ * <p>The primary implementations of {@code HttpFields} have been optimized assuming few
+ * lookup operations, thus typically if many {@link HttpField}s need to looked up, it may be
+ * better to use an {@link Iterator} or the {@link #asRandomAccess()} method.</p>
  */
 public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
 {
@@ -194,6 +199,18 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
     default HttpFields asImmutable()
     {
         return HttpFields.build(this).asImmutable();
+    }
+
+    /**
+     * <p>Returns an immutable version of this {@link HttpFields} instance, possibly optimized for random access.</p>
+     * <p>Mutable {@code HttpFields} cannot be optimized for random access, so {@link #asImmutable()} should be called
+     * first if a random access version of mutable Fields are required.</p>
+     *
+     * @return an {@link HttpFields} instance, which may be optimized for RandomAccess
+     */
+    default HttpFields asRandomAccess()
+    {
+        return this;
     }
 
     /**
@@ -594,7 +611,8 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
      * <p>Returns a {@link Set} of the field names.</p>
      * <p>Case-sensitivity of the field names is preserved.</p>
      *
-     * @return a {@link Set} of the field names
+     * @return an immutable {@link Set} of the field names. Changes made to the
+     * {@code HttpFields} after this call are not reflected in the set.
      */
     default Set<String> getFieldNamesCollection()
     {

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -43,9 +43,11 @@ import java.util.stream.StreamSupport;
  * and client-side HTTP responses, while {@link HttpFields.Mutable} is mutable and
  * typically used in server-side HTTP responses and client-side HTTP requests.</p>
  *
+ * <p>Access is always more efficient using {@link HttpHeader} keys rather than {@link String} field names.</p>
+ * 
  * <p>The primary implementations of {@code HttpFields} have been optimized assuming few
  * lookup operations, thus typically if many {@link HttpField}s need to looked up, it may be
- * better to use an {@link Iterator} or the {@link #asRandomAccess()} method.</p>
+ * better to use an {@link Iterator} or the {@link #asMappedAccess()} method.</p>
  */
 public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
 {
@@ -202,15 +204,14 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
     }
 
     /**
-     * <p>Returns an immutable version of this {@link HttpFields} instance, possibly optimized for random access.</p>
-     * <p>Mutable {@code HttpFields} cannot be optimized for random access, so {@link #asImmutable()} should be called
-     * first if a random access version of mutable Fields are required.</p>
+     * <p>Returns an immutable version of this {@link HttpFields} instance, possibly optimized for random field
+     * access via {@link Map} implementations.</p>
      *
-     * @return an {@link HttpFields} instance, which may be optimized for RandomAccess
+     * @return an {@link HttpFields} instance, which may be optimized for random access.
      */
-    default HttpFields asRandomAccess()
+    default HttpFields asMappedAccess()
     {
-        return this;
+        return asImmutable();
     }
 
     /**
@@ -367,10 +368,12 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
     /**
      * <p>Returns whether this instance contains the given field name.</p>
      * <p>The comparison of field name is case-insensitive via
-     * {@link HttpField#is(String)}.
+     * {@link HttpField#is(String)}. If possible, it is more efficient to use
+     * {@link #contains(HttpHeader)}.
      *
      * @param name the case-insensitive field name to search for
      * @return whether this instance contains the given field name
+     * @see #contains(HttpHeader) 
      */
     default boolean contains(String name)
     {
@@ -429,7 +432,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
      * <p>Returns the encoded value of the first field with the given field name,
      * or {@code null} if no such field is present.</p>
      * <p>The comparison of field name is case-insensitive via
-     * {@link HttpField#is(String)}.</p>
+     * {@link HttpField#is(String)}. If possible, it is more efficient to use {@link #get(HttpHeader)}.</p>
      * <p>In case of multi-valued fields, the returned value is the encoded
      * value, including commas and quotes, as returned by {@link HttpField#getValue()}.</p>
      *
@@ -437,6 +440,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
      * @return the raw value of the first field with the given field name,
      * or {@code null} if no such field is present
      * @see HttpField#getValue()
+     * @see #get(HttpHeader) 
      */
     default String get(String name)
     {

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/ImmutableHttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/ImmutableHttpFields.java
@@ -35,7 +35,6 @@ class ImmutableHttpFields implements HttpFields
 {
     final HttpField[] _fields;
     final int _size;
-    RandomAccess _randomAccess;
 
     /**
      * Initialize HttpFields from copy.
@@ -60,11 +59,9 @@ class ImmutableHttpFields implements HttpFields
     }
 
     @Override
-    public HttpFields asRandomAccess()
+    public HttpFields asMappedAccess()
     {
-        if (_randomAccess == null)
-            _randomAccess = new RandomAccess(this);
-        return _randomAccess;
+        return new RandomAccess(this);
     }
 
     @Override
@@ -242,9 +239,10 @@ class ImmutableHttpFields implements HttpFields
     }
 
     /**
-     * An immutable {@link HttpFields} instance, optimized for random field access.
+     * An immutable {@link HttpFields} instance, optimized for random access to
+     * single valued fields
      */
-    public static class RandomAccess implements HttpFields
+    private static class RandomAccess implements HttpFields
     {
         private final HttpFields _httpFields;
         private final EnumMap<HttpHeader, HttpField> _enumMap = new EnumMap<>(HttpHeader.class);
@@ -252,7 +250,7 @@ class ImmutableHttpFields implements HttpFields
 
         RandomAccess(HttpFields httpFields)
         {
-            _httpFields = Objects.requireNonNull(httpFields.asImmutable());
+            _httpFields = Objects.requireNonNull(httpFields);
             Map<String, HttpField> stringMap = null;
             for (HttpField field : httpFields)
             {

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/ImmutableHttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/ImmutableHttpFields.java
@@ -14,18 +14,9 @@
 package org.eclipse.jetty.http;
 
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.EnumMap;
-import java.util.EnumSet;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.ListIterator;
-import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.TreeSet;
 import java.util.stream.Stream;
 
 /**
@@ -56,12 +47,6 @@ class ImmutableHttpFields implements HttpFields
     public HttpFields asImmutable()
     {
         return this;
-    }
-
-    @Override
-    public HttpFields asMappedAccess()
-    {
-        return new RandomAccess(this);
     }
 
     @Override
@@ -235,148 +220,6 @@ class ImmutableHttpFields implements HttpFields
         public void set(HttpField field)
         {
             throw new UnsupportedOperationException();
-        }
-    }
-
-    /**
-     * An immutable {@link HttpFields} instance, optimized for random access to
-     * single valued fields
-     */
-    private static class RandomAccess implements HttpFields
-    {
-        private final HttpFields _httpFields;
-        private final EnumMap<HttpHeader, HttpField> _enumMap = new EnumMap<>(HttpHeader.class);
-        private final Map<String, HttpField> _stringMap;
-
-        RandomAccess(HttpFields httpFields)
-        {
-            _httpFields = Objects.requireNonNull(httpFields);
-            Map<String, HttpField> stringMap = null;
-            for (HttpField field : httpFields)
-            {
-                HttpHeader header = field.getHeader();
-                if (header != null)
-                {
-                    _enumMap.putIfAbsent(header, field);
-                }
-                else
-                {
-                    if (stringMap == null)
-                        stringMap = new TreeMap<>(String::compareToIgnoreCase);
-                    stringMap.putIfAbsent(field.getName(), field);
-                }
-            }
-            _stringMap = stringMap == null ? Collections.emptyMap() : stringMap;
-        }
-
-        @Override
-        public HttpFields asImmutable()
-        {
-            return this;
-        }
-
-        @Override
-        public String get(HttpHeader header)
-        {
-            HttpField field = _enumMap.get(header);
-            return field == null ? null : field.getValue();
-        }
-
-        @Override
-        public String get(String name)
-        {
-            HttpField field = _stringMap.get(name);
-            if (field == null)
-                field = _enumMap.get(HttpHeader.CACHE.get(name));
-            return field == null ? null : field.getValue();
-        }
-
-        @Override
-        public boolean contains(HttpHeader header)
-        {
-            return _enumMap.containsKey(header);
-        }
-
-        @Override
-        public boolean contains(EnumSet<HttpHeader> headers)
-        {
-            for (HttpHeader header : headers)
-                if (_enumMap.containsKey(header))
-                    return true;
-            return false;
-        }
-
-        @Override
-        public boolean contains(String name)
-        {
-            return _stringMap.containsKey(name) || _enumMap.containsKey(HttpHeader.CACHE.get(name));
-        }
-
-        @Override
-        public HttpField getField(HttpHeader header)
-        {
-            return _enumMap.get(header);
-        }
-
-        @Override
-        public HttpField getField(String name)
-        {
-            HttpField field = _stringMap.get(name);
-            return field == null ? _enumMap.get(HttpHeader.CACHE.get(name)) : field;
-        }
-
-        @Override
-        public Iterator<HttpField> iterator()
-        {
-            return _httpFields.iterator();
-        }
-
-        @Override
-        public ListIterator<HttpField> listIterator()
-        {
-            return _httpFields.listIterator();
-        }
-
-        @Override
-        public int size()
-        {
-            return _httpFields.size();
-        }
-
-        @Override
-        public ListIterator<HttpField> listIterator(int index)
-        {
-            return _httpFields.listIterator(index);
-        }
-
-        @Override
-        public Set<String> getFieldNamesCollection()
-        {
-            LinkedHashSet<String> set = new LinkedHashSet<>()
-            {
-                @Override
-                public boolean contains(Object o)
-                {
-                    if (o instanceof String s)
-                        return _stringMap.containsKey(s) || _enumMap.containsKey(HttpHeader.CACHE.get(s));
-                    return false;
-                }
-            };
-            TreeSet<String> seenByName = null;
-            for (HttpField field : _httpFields)
-            {
-                HttpHeader header = field.getHeader();
-                if (_enumMap.containsKey(header))
-                    set.add(header.asString());
-                else if (_stringMap.containsKey(field.getName()))
-                {
-                    if (seenByName == null)
-                        seenByName = new TreeSet<>(String::compareToIgnoreCase);
-                    if (seenByName.add(field.getName()))
-                        set.add(field.getName());
-                }
-            }
-            return set;
         }
     }
 }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/ImmutableHttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/ImmutableHttpFields.java
@@ -244,15 +244,15 @@ class ImmutableHttpFields implements HttpFields
     /**
      * An immutable {@link HttpFields} instance, optimized for random field access.
      */
-    private static class RandomAccess implements HttpFields
+    public static class RandomAccess implements HttpFields
     {
         private final HttpFields _httpFields;
         private final EnumMap<HttpHeader, HttpField> _enumMap = new EnumMap<>(HttpHeader.class);
         private final Map<String, HttpField> _stringMap;
 
-        RandomAccess(org.eclipse.jetty.http.ImmutableHttpFields httpFields)
+        RandomAccess(HttpFields httpFields)
         {
-            _httpFields = Objects.requireNonNull(httpFields);
+            _httpFields = Objects.requireNonNull(httpFields.asImmutable());
             Map<String, HttpField> stringMap = null;
             for (HttpField field : httpFields)
             {
@@ -354,7 +354,16 @@ class ImmutableHttpFields implements HttpFields
         @Override
         public Set<String> getFieldNamesCollection()
         {
-            LinkedHashSet<String> set = new LinkedHashSet<>();
+            LinkedHashSet<String> set = new LinkedHashSet<>()
+            {
+                @Override
+                public boolean contains(Object o)
+                {
+                    if (o instanceof String s)
+                        return _stringMap.containsKey(s) || _enumMap.containsKey(HttpHeader.CACHE.get(s));
+                    return false;
+                }
+            };
             TreeSet<String> seenByName = null;
             for (HttpField field : _httpFields)
             {

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MutableHttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MutableHttpFields.java
@@ -67,7 +67,7 @@ class MutableHttpFields implements HttpFields.Mutable
      */
     protected MutableHttpFields(HttpFields fields)
     {
-        if (fields instanceof ImmutableHttpFields immutable)
+        if (fields instanceof org.eclipse.jetty.http.ImmutableHttpFields immutable)
         {
             _immutable = true;
             _fields = immutable._fields;
@@ -180,7 +180,7 @@ class MutableHttpFields implements HttpFields.Mutable
     public HttpFields asImmutable()
     {
         _immutable = true;
-        return new ImmutableHttpFields(_fields, _size);
+        return new org.eclipse.jetty.http.ImmutableHttpFields(_fields, _size);
     }
 
     private void copyImmutable()

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
@@ -1496,7 +1496,7 @@ public class HttpFieldsTest
     public void testRandomAccess()
     {
         HttpFields.Mutable mutable = HttpFields.build();
-        assertThat(mutable.asRandomAccess(), sameInstance(mutable));
+        assertThat(mutable.asMappedAccess(), sameInstance(mutable));
 
         mutable.add("expect", "100")
             .add("RaNdOm", "value")
@@ -1506,7 +1506,7 @@ public class HttpFieldsTest
             .add("Foo-Bar", "two")
             .asImmutable();
 
-        HttpFields header = mutable.asImmutable().asRandomAccess();
+        HttpFields header = mutable.asImmutable().asMappedAccess();
         assertThat(header, not(sameInstance(mutable)));
 
         assertThat(header.get("expect"), is("100"));

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
@@ -43,9 +43,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -1490,71 +1488,5 @@ public class HttpFieldsTest
         assertThat(wrapper.size(), is(0));
         assertThat(wrapper.actions, is(List.of("onAddField", "onReplaceField", "onRemoveField")));
         wrapper.actions.clear();
-    }
-
-    @Test
-    public void testRandomAccess()
-    {
-        HttpFields.Mutable mutable = HttpFields.build();
-
-        mutable.add("expect", "100")
-            .add("RaNdOm", "value")
-            .add("Accept-Charset", "UTF-8")
-            .add("accept-charset", "UTF-16")
-            .add("foo-bar", "one")
-            .add("Foo-Bar", "two")
-            .asImmutable();
-
-        HttpFields header = mutable.asImmutable().asMappedAccess();
-        assertThat(header, not(sameInstance(mutable)));
-
-        assertThat(header.get("expect"), is("100"));
-        assertThat(header.get("Expect"), is("100"));
-        assertThat(header.get("EXPECT"), is("100"));
-        assertThat(header.get("eXpEcT"), is("100"));
-        assertThat(header.get(HttpHeader.EXPECT), is("100"));
-        assertTrue(header.contains("expect"));
-        assertTrue(header.contains("Expect"));
-        assertTrue(header.contains("EXPECT"));
-        assertTrue(header.contains("eXpEcT"));
-
-        assertThat(header.get("random"), is("value"));
-        assertThat(header.get("Random"), is("value"));
-        assertThat(header.get("RANDOM"), is("value"));
-        assertThat(header.get("rAnDoM"), is("value"));
-        assertThat(header.get("RaNdOm"), is("value"));
-        assertTrue(header.contains("random"));
-        assertTrue(header.contains("Random"));
-        assertTrue(header.contains("RANDOM"));
-        assertTrue(header.contains("rAnDoM"));
-        assertTrue(header.contains("RaNdOm"));
-
-        assertThat(header.get("Accept-Charset"), is("UTF-8"));
-        assertThat(header.get("accept-charset"), is("UTF-8"));
-        assertThat(header.get(HttpHeader.ACCEPT_CHARSET), is("UTF-8"));
-        assertTrue(header.contains("Accept-Charset"));
-        assertTrue(header.contains("accept-charset"));
-
-        assertThat(header.getValuesList("Accept-Charset"), contains("UTF-8", "UTF-16"));
-        assertThat(header.getValuesList("accept-charset"), contains("UTF-8", "UTF-16"));
-        assertThat(header.getValuesList(HttpHeader.ACCEPT_CHARSET), contains("UTF-8", "UTF-16"));
-
-        assertThat(header.get("foo-bar"), is("one"));
-        assertThat(header.get("Foo-Bar"), is("one"));
-        assertThat(header.getValuesList("foo-bar"), contains("one", "two"));
-        assertThat(header.getValuesList("Foo-Bar"), contains("one", "two"));
-        assertTrue(header.contains("foo-bar"));
-        assertTrue(header.contains("Foo-Bar"));
-
-        // We know the order of the set is deterministic
-        Set<String> names = header.getFieldNamesCollection();
-        assertThat(names, contains("Expect", "RaNdOm", "Accept-Charset", "foo-bar"));
-        assertTrue(names.contains("expect"));
-        assertTrue(names.contains("Expect"));
-        assertTrue(names.contains("random"));
-        assertTrue(names.contains("accept-charset"));
-        assertTrue(names.contains("Accept-Charset"));
-        assertTrue(names.contains("foo-bar"));
-        assertTrue(names.contains("Foo-Bar"));
     }
 }

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
@@ -1496,7 +1496,6 @@ public class HttpFieldsTest
     public void testRandomAccess()
     {
         HttpFields.Mutable mutable = HttpFields.build();
-        assertThat(mutable.asMappedAccess(), sameInstance(mutable));
 
         mutable.add("expect", "100")
             .add("RaNdOm", "value")

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
@@ -25,6 +25,7 @@ import java.util.ListIterator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -354,16 +355,27 @@ public class HttpFieldsTest
         assertThat(header.get("EXPECT"), is("100"));
         assertThat(header.get("eXpEcT"), is("100"));
         assertThat(header.get(HttpHeader.EXPECT), is("100"));
+        assertTrue(header.contains("expect"));
+        assertTrue(header.contains("Expect"));
+        assertTrue(header.contains("EXPECT"));
+        assertTrue(header.contains("eXpEcT"));
 
         assertThat(header.get("random"), is("value"));
         assertThat(header.get("Random"), is("value"));
         assertThat(header.get("RANDOM"), is("value"));
         assertThat(header.get("rAnDoM"), is("value"));
         assertThat(header.get("RaNdOm"), is("value"));
+        assertTrue(header.contains("random"));
+        assertTrue(header.contains("Random"));
+        assertTrue(header.contains("RANDOM"));
+        assertTrue(header.contains("rAnDoM"));
+        assertTrue(header.contains("RaNdOm"));
 
         assertThat(header.get("Accept-Charset"), is("UTF-8"));
         assertThat(header.get("accept-charset"), is("UTF-8"));
         assertThat(header.get(HttpHeader.ACCEPT_CHARSET), is("UTF-8"));
+        assertTrue(header.contains("Accept-Charset"));
+        assertTrue(header.contains("accept-charset"));
 
         assertThat(header.getValuesList("Accept-Charset"), contains("UTF-8", "UTF-16"));
         assertThat(header.getValuesList("accept-charset"), contains("UTF-8", "UTF-16"));
@@ -373,9 +385,19 @@ public class HttpFieldsTest
         assertThat(header.get("Foo-Bar"), is("one"));
         assertThat(header.getValuesList("foo-bar"), contains("one", "two"));
         assertThat(header.getValuesList("Foo-Bar"), contains("one", "two"));
+        assertTrue(header.contains("foo-bar"));
+        assertTrue(header.contains("Foo-Bar"));
 
         // We know the order of the set is deterministic
-        assertThat(header.getFieldNamesCollection(), contains("expect", "RaNdOm", "Accept-Charset", "foo-bar"));
+        Set<String> names = header.getFieldNamesCollection();
+        assertThat(names, contains("expect", "RaNdOm", "Accept-Charset", "foo-bar"));
+        assertTrue(names.contains("expect"));
+        assertTrue(names.contains("Expect"));
+        assertTrue(names.contains("random"));
+        assertTrue(names.contains("accept-charset"));
+        assertTrue(names.contains("Accept-Charset"));
+        assertTrue(names.contains("foo-bar"));
+        assertTrue(names.contains("Foo-Bar"));
     }
 
     @ParameterizedTest
@@ -1492,16 +1514,27 @@ public class HttpFieldsTest
         assertThat(header.get("EXPECT"), is("100"));
         assertThat(header.get("eXpEcT"), is("100"));
         assertThat(header.get(HttpHeader.EXPECT), is("100"));
+        assertTrue(header.contains("expect"));
+        assertTrue(header.contains("Expect"));
+        assertTrue(header.contains("EXPECT"));
+        assertTrue(header.contains("eXpEcT"));
 
         assertThat(header.get("random"), is("value"));
         assertThat(header.get("Random"), is("value"));
         assertThat(header.get("RANDOM"), is("value"));
         assertThat(header.get("rAnDoM"), is("value"));
         assertThat(header.get("RaNdOm"), is("value"));
+        assertTrue(header.contains("random"));
+        assertTrue(header.contains("Random"));
+        assertTrue(header.contains("RANDOM"));
+        assertTrue(header.contains("rAnDoM"));
+        assertTrue(header.contains("RaNdOm"));
 
         assertThat(header.get("Accept-Charset"), is("UTF-8"));
         assertThat(header.get("accept-charset"), is("UTF-8"));
         assertThat(header.get(HttpHeader.ACCEPT_CHARSET), is("UTF-8"));
+        assertTrue(header.contains("Accept-Charset"));
+        assertTrue(header.contains("accept-charset"));
 
         assertThat(header.getValuesList("Accept-Charset"), contains("UTF-8", "UTF-16"));
         assertThat(header.getValuesList("accept-charset"), contains("UTF-8", "UTF-16"));
@@ -1511,8 +1544,18 @@ public class HttpFieldsTest
         assertThat(header.get("Foo-Bar"), is("one"));
         assertThat(header.getValuesList("foo-bar"), contains("one", "two"));
         assertThat(header.getValuesList("Foo-Bar"), contains("one", "two"));
+        assertTrue(header.contains("foo-bar"));
+        assertTrue(header.contains("Foo-Bar"));
 
         // We know the order of the set is deterministic
-        assertThat(header.getFieldNamesCollection(), contains("Expect", "RaNdOm", "Accept-Charset", "foo-bar"));
+        Set<String> names = header.getFieldNamesCollection();
+        assertThat(names, contains("Expect", "RaNdOm", "Accept-Charset", "foo-bar"));
+        assertTrue(names.contains("expect"));
+        assertTrue(names.contains("Expect"));
+        assertTrue(names.contains("random"));
+        assertTrue(names.contains("accept-charset"));
+        assertTrue(names.contains("Accept-Charset"));
+        assertTrue(names.contains("foo-bar"));
+        assertTrue(names.contains("Foo-Bar"));
     }
 }

--- a/tests/jetty-jmh/src/main/java/org/eclipse/jetty/server/jmh/HashMapVsEnumMapBenchmark.java
+++ b/tests/jetty-jmh/src/main/java/org/eclipse/jetty/server/jmh/HashMapVsEnumMapBenchmark.java
@@ -1,0 +1,108 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.server.jmh;
+
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State(Scope.Thread)
+@BenchmarkMode(Mode.Throughput)
+@Fork(1)
+@Warmup(iterations = 6, time = 2000, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 3, time = 2000, timeUnit = TimeUnit.MILLISECONDS)
+public class HashMapVsEnumMapBenchmark
+{
+    private static final HttpHeader[] HEADERS = HttpHeader.values();
+    private static final String[] HEADER_NAMES = {
+        "Content-Type", "Content-Length", "User-Agent", "Accept", "Authorization"
+    };
+
+    @Benchmark
+    @OperationsPerInvocation(5)
+    public long testHashMapBuildAndLookup()
+    {
+        // Build the HashMap
+        Map<String, String> hashMap = new HashMap<>();
+        hashMap.put("Content-Type", "application/json");
+        hashMap.put("Content-Length", "123");
+        hashMap.put("User-Agent", "JMH Benchmark");
+        hashMap.put("Accept", "application/json");
+        hashMap.put("Authorization", "Bearer token");
+
+        // Perform lookups
+        long result = 0;
+        for (String header : HEADER_NAMES)
+        {
+            result ^= hashMap.get(header).hashCode();
+        }
+        return result;
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(5)
+    public long testEnumMapBuildAndLookup()
+    {
+        // Build the EnumMap
+        Map<HttpHeader, String> enumMap = new EnumMap<>(HttpHeader.class);
+        enumMap.put(HttpHeader.CONTENT_TYPE, "application/json");
+        enumMap.put(HttpHeader.CONTENT_LENGTH, "123");
+        enumMap.put(HttpHeader.USER_AGENT, "JMH Benchmark");
+        enumMap.put(HttpHeader.ACCEPT, "application/json");
+        enumMap.put(HttpHeader.AUTHORIZATION, "Bearer token");
+
+        // Perform lookups
+        long result = 0;
+        for (HttpHeader header : HEADERS)
+        {
+            result ^= enumMap.get(header).hashCode();
+        }
+        return result;
+    }
+
+    public enum HttpHeader
+    {
+        CONTENT_TYPE,
+        CONTENT_LENGTH,
+        USER_AGENT,
+        ACCEPT,
+        AUTHORIZATION
+    }
+
+    public static void main(String[] args) throws RunnerException
+    {
+        Options opt = new OptionsBuilder()
+            .include(HashMapVsEnumMapBenchmark.class.getSimpleName())
+            // .addProfiler(GCProfiler.class)
+            .forks(1)
+            .build();
+
+        new Runner(opt).run();
+    }
+}


### PR DESCRIPTION
This is an experiment towards fix #11811 with regards to the extra comments received on #11823

It provides an optional random access implementation and fixes the issue that the name set returned is not case sensitive.

Another approach could be to always create the EnumMap when an immutable HttpFields is created and only do the iteration lookup on fields that are not  known HttpHeaders