### PR TITLE
Fix async callback failure leading to `IllegalArgumentException` in `SocketChannel.write()`

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/InputStreamResponseListener.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/InputStreamResponseListener.java
@@ -98,6 +98,10 @@ public class InputStreamResponseListener implements Listener
     @Override
     public void onContent(Response response, Content.Chunk chunk, Runnable demander)
     {
+        // Call onContent(Response, ByteBuffer) as ContentListener is implemented,
+        // so it is expected that this variant is called.
+        onContent(response, chunk.getByteBuffer());
+
         if (!chunk.hasRemaining())
         {
             if (LOG.isDebugEnabled())

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ErrorHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ErrorHandler.java
@@ -579,18 +579,31 @@ public class ErrorHandler implements Request.Handler
      * when calling {@link Response#write(boolean, ByteBuffer, Callback)} to wrap the passed in {@link Callback}
      * so that the {@link RetainableByteBuffer} used can be released.
      */
-    private static class WriteErrorCallback extends Callback.Nested
+    private static class WriteErrorCallback extends Callback.CancelableCallback
     {
+        private final Callback _callback;
         private final Retainable _retainable;
 
         public WriteErrorCallback(Callback callback, Retainable retainable)
         {
-            super(callback);
+            _callback = callback;
             _retainable = retainable;
         }
 
         @Override
-        public void completed()
+        protected void onSuccess()
+        {
+            _callback.succeeded();
+        }
+
+        @Override
+        protected void onFailure(Throwable cause)
+        {
+            _callback.failed(cause);
+        }
+
+        @Override
+        protected void onComplete(Throwable cause)
         {
             _retainable.release();
         }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -1147,7 +1147,7 @@ public class HttpChannelState implements HttpChannel, Components
                 _writeFailure = x;
             else
                 ExceptionUtil.addSuppressedIfNotAssociated(_writeFailure, x);
-            return () -> HttpChannelState.failed(writeCallback, x);
+            return () -> HttpChannelState.cancel(writeCallback, x);
         }
 
         public long getContentBytesWritten()
@@ -1929,6 +1929,19 @@ public class HttpChannelState implements HttpChannel, Components
         try
         {
             callback.failed(failure);
+        }
+        catch (Throwable t)
+        {
+            ExceptionUtil.addSuppressedIfNotAssociated(t, failure);
+            throw t;
+        }
+    }
+
+    private static void cancel(Callback callback, Throwable failure)
+    {
+        try
+        {
+            Callback.CancelableCallback.cancel(callback, failure);
         }
         catch (Throwable t)
         {

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ReadWriteFailuresTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ReadWriteFailuresTest.java
@@ -188,7 +188,7 @@ public class ReadWriteFailuresTest
                 Callback.Completable completable2 = new Callback.Completable();
                 Content.Sink.write(response, true, "hello world", completable2);
                 Throwable writeFailure2 = assertThrows(ExecutionException.class, () -> completable2.get(5, TimeUnit.SECONDS)).getCause();
-                assertSame(writeFailure1, writeFailure2);
+                assertSame(writeFailure1.getCause(), writeFailure2);
 
                 latch.countDown();
 

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
@@ -222,7 +222,6 @@ public class HttpOutput extends ServletOutputStream implements Runnable
                 _state = State.CLOSED;
                 closedCallback = _closedCallback;
                 _closedCallback = null;
-                releaseBuffer();
                 wake = updateApiState(failure);
             }
             else if (_state == State.CLOSE)
@@ -1744,18 +1743,24 @@ public class HttpOutput extends ServletOutputStream implements Runnable
         }
     }
 
-    private class WriteCompleteCB implements Callback
+    private class WriteCompleteCB extends Callback.CancelableCallback
     {
         @Override
-        public void succeeded()
+        protected void onSuccess()
         {
             onWriteComplete(true, null);
         }
 
         @Override
-        public void failed(Throwable x)
+        protected void onFailure(Throwable cause)
         {
-            onWriteComplete(true, x);
+            onWriteComplete(true, cause);
+        }
+
+        @Override
+        protected void onComplete(Throwable cause)
+        {
+            releaseBuffer();
         }
 
         @Override

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/ServerTimeoutsTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/ServerTimeoutsTest.java
@@ -264,7 +264,7 @@ public class ServerTimeoutsTest extends AbstractTest
                     @Override
                     public void onError(Throwable failure)
                     {
-                        if (failure instanceof TimeoutException)
+                        if (failure.getCause() instanceof TimeoutException)
                             handlerLatch.countDown();
 
                         asyncContext.complete();


### PR DESCRIPTION
Prototype fix for #11854


This is a slightly modified version of [the original proposal](https://github.com/jetty/jetty.project/issues/11854#issuecomment-2138462780) that does not require any modification to the `Callback` interface: introduce a new `CancelableCallback` class with a static `cancel(Callback, Throwable)` helper that actually calls `failed()` on the callback but not before wrapping the given throwable with a private, maker one that is then detected by the `CancelableCallback.failed()` implementation to discriminate between canceling and failing logic.