### PR TITLE
Version in the documentation title

### DIFF
--- a/documentation/jetty/modules/ROOT/pages/index.adoc
+++ b/documentation/jetty/modules/ROOT/pages/index.adoc
@@ -11,7 +11,7 @@
 // ========================================================================
 //
 
-= Eclipse Jetty
+= {page-component-title} {page-version}
 
 This section of the site contains the documentation for {page-component-title} {page-version}.
 


### PR DESCRIPTION
This change puts the version number in the root page of the documentation, which should make it appear in the left menu.

If this is the correct approach, this needs to be back ported to 10 & 11.