### PR TITLE
Add response to debug log event in HttpSender#failRequest()

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpSender.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpSender.java
@@ -208,7 +208,7 @@ public abstract class HttpSender
             return false;
 
         if (LOG.isDebugEnabled())
-            LOG.debug("Request failure {}", exchange.getRequest(), failure);
+            LOG.debug("Request failure {}, response {}", exchange.getRequest(), exchange.getResponse(), failure);
 
         // Mark atomically the request as completed, with respect
         // to concurrency between request success and request failure.


### PR DESCRIPTION
While debugging a random failure in a large and complex test suite of mine, I found it helpful to be able to see in one log event the response and its status code matched up with the request. In my case, I could see that my failure was related to processing taking place during an "Expect 100" exchange.
