### PR TITLE
Jetty 12.0.x xmlconfig prefers interfaces

### DIFF
--- a/jetty-core/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
+++ b/jetty-core/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
@@ -122,7 +122,7 @@ public class XmlConfiguration
      * interfaces or the Object class, return -1 if only t2 is the Object class or an
      * interface.
      */
-    public static int compare(Class<?> t1, Class<?> t2)
+    private static int compare(Class<?> t1, Class<?> t2)
     {
         if (t1 == Object.class)
         {
@@ -1033,7 +1033,6 @@ public class XmlConfiguration
 
                 try
                 {
-                    System.err.println("Invoking: " + method);
                     return invokeMethod(method, obj, arguments);
                 }
                 catch (IllegalAccessException | IllegalArgumentException e)

--- a/jetty-core/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
+++ b/jetty-core/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
@@ -1007,6 +1007,7 @@ public class XmlConfiguration
 
                 try
                 {
+                    System.err.println("Invoking: " + method);
                     return invokeMethod(method, obj, arguments);
                 }
                 catch (IllegalAccessException | IllegalArgumentException e)

--- a/jetty-core/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
+++ b/jetty-core/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
@@ -110,6 +110,32 @@ public class XmlConfiguration
         .toList();
     private static final Pool<ConfigurationParser> __parsers =
         new ConcurrentPool<>(ConcurrentPool.StrategyType.THREAD_ID, Math.min(8, Runtime.getRuntime().availableProcessors()));
+
+    /**
+     * Order two classes to prefer a non Object type as the highest ranking, followed by
+     * an interface type. Where both are the Object type, or both are an interface they
+     * are considered equal.
+     *
+     * @param t1 the first class to compare
+     * @param t2 the second class to compare
+     * @return 1 if t1 is a non Object class or an interface type, return 0 if both are
+     * interfaces or the Object class, return -1 if only t2 is the Object class or an
+     * interface.
+     */
+    public static int compare(Class<?> t1, Class<?> t2)
+    {
+        if (t1 == Object.class)
+        {
+            if (t2 == Object.class)
+                return 0;
+            return 1;
+        }
+        if (t2 == Object.class)
+            return -1;
+
+        return Boolean.compare(t1.isInterface(), t2.isInterface());
+    }
+
     public static final Comparator<Executable> EXECUTABLE_COMPARATOR = (e1, e2) ->
     {
         // Favour methods with less parameters
@@ -135,8 +161,8 @@ public class XmlConfiguration
                         compare = Boolean.compare(t2.isPrimitive(), t1.isPrimitive());
                         if (compare == 0)
                         {
-                            // prefer interfaces
-                            compare = Boolean.compare(t2.isInterface(), t1.isInterface());
+                            // prefer (non Object.class) classes over interfaces
+                            compare = compare(t1, t2);
 
                             if (compare == 0)
                             {

--- a/jetty-core/jetty-xml/src/test/java/org/eclipse/jetty/xml/ExampleConfiguration.java
+++ b/jetty-core/jetty-xml/src/test/java/org/eclipse/jetty/xml/ExampleConfiguration.java
@@ -36,6 +36,9 @@ public class ExampleConfiguration extends HashMap<String, Object>
     public int testInt;
     public URL url;
     public static boolean called = false;
+
+    public static boolean calledWithClass = false;
+
     public Object[] oa;
     public int[] ia;
     public int testField1;
@@ -48,6 +51,16 @@ public class ExampleConfiguration extends HashMap<String, Object>
     private ConstructorArgTestClass constructorArgTestClass;
     public Map map;
     public Double number;
+
+    public interface TestInterface
+    {
+
+    }
+
+    public static class TestImpl implements TestInterface
+    {
+
+    }
 
     public ExampleConfiguration()
     {
@@ -129,6 +142,17 @@ public class ExampleConfiguration extends HashMap<String, Object>
     public static void callStatic()
     {
         called = true;
+    }
+
+    public static void callStaticWithVarArgs(TestInterface i, String... strings)
+    {
+        called = true;
+    }
+
+    public static void callStaticWithVarArgs(TestImpl i, String... strings)
+    {
+        called = true;
+        calledWithClass = true;
     }
 
     public void call(Object[] oa)

--- a/jetty-core/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
+++ b/jetty-core/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
@@ -218,6 +218,11 @@ public class XmlConfigurationTest
         Map<String, String> concurrentMap = (Map<String, String>)configuration.getIdMap().get("concurrentMap");
         assertThat(concurrentMap, instanceOf(ConcurrentMap.class));
         assertEquals(concurrentMap.get("KEY"), "ITEM");
+
+        if ("org/eclipse/jetty/xml/configureWithElements.xml".equals(configure))
+        {
+            System.err.println("Static call with TestImpl: " + ExampleConfiguration.calledWithClass);
+        }
     }
 
     @ParameterizedTest

--- a/jetty-core/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
+++ b/jetty-core/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
@@ -816,11 +816,11 @@ public class XmlConfigurationTest
         assertThat(methods, Matchers.contains(
             TestOrder.class.getMethod("call"),
             TestOrder.class.getMethod("call", int.class),
-            TestOrder.class.getMethod("call", Abc.class),
-            TestOrder.class.getMethod("call", Aaa.class),
             TestOrder.class.getMethod("call", String.class),
             TestOrder.class.getMethod("call", Bbb.class),
             TestOrder.class.getMethod("call", Ccc.class),
+            TestOrder.class.getMethod("call", Abc.class),
+            TestOrder.class.getMethod("call", Aaa.class),
             TestOrder.class.getMethod("call", Object.class),
             TestOrder.class.getMethod("call", String[].class),
             TestOrder.class.getMethod("call", String.class, String[].class)
@@ -2117,21 +2117,29 @@ public class XmlConfigurationTest
         aaa(null);
         bbb(null);
         ccc(null);
-
-        Stream.of(XmlConfigurationTest.class.getMethods())
-            .filter(m -> m.getName().length() == 3)
-            .filter(m -> !m.getName().equals("foo"))
-            .sorted(EXECUTABLE_COMPARATOR)
-            .map(Executable::toGenericString)
-            .forEach(System.out::println);
+        Logger slf4jLogger = LoggerFactory.getLogger(XmlConfiguration.class);
+        if (slf4jLogger.isDebugEnabled())
+        {
+            Stream.of(XmlConfigurationTest.class.getMethods())
+                .filter(m -> m.getName().length() == 3)
+                .filter(m -> !m.getName().equals("foo"))
+                .sorted(EXECUTABLE_COMPARATOR)
+                .map(Executable::toGenericString)
+                .forEach(System.out::println);
+        }
 
         List<Method> methods = Arrays.asList(Arrays.stream(XmlConfigurationTest.class.getMethods())
             .filter(m -> m.getName().length() == 3)
+            .sorted(EXECUTABLE_COMPARATOR)
             .toArray(Method[]::new));
 
         // The implementor must also ensure that the relation is transitive: ((compare(x, y)>0) && (compare(y, z)>0)) implies compare(x, z)>0
         assertThat(EXECUTABLE_COMPARATOR.compare(methods.get(0), methods.get(1)), is(EXECUTABLE_COMPARATOR.compare(methods.get(1), methods.get(2))));
         assertThat(EXECUTABLE_COMPARATOR.compare(methods.get(0), methods.get(1)), is(EXECUTABLE_COMPARATOR.compare(methods.get(0), methods.get(2))));
+        // Test that it is als reflexive
+        assertThat(EXECUTABLE_COMPARATOR.compare(methods.get(0), methods.get(1)), is(-EXECUTABLE_COMPARATOR.compare(methods.get(1), methods.get(0))));
+        assertThat(EXECUTABLE_COMPARATOR.compare(methods.get(0), methods.get(2)), is(-EXECUTABLE_COMPARATOR.compare(methods.get(2), methods.get(0))));
+        assertThat(EXECUTABLE_COMPARATOR.compare(methods.get(1), methods.get(2)), is(-EXECUTABLE_COMPARATOR.compare(methods.get(2), methods.get(1))));
     }
 
     public void aaa(Aaa ignored)
@@ -2170,15 +2178,21 @@ public class XmlConfigurationTest
             .sorted(EXECUTABLE_COMPARATOR)
             .map(Executable::toGenericString)
             .collect(Collectors.toList());
-        orderedMethodIds.forEach(System.out::println);
+
+        Logger slf4jLogger = LoggerFactory.getLogger(XmlConfiguration.class);
+        if (slf4jLogger.isDebugEnabled())
+        {
+            orderedMethodIds.forEach(System.out::println);
+        }
+
         String[] expectedOrder = {
-            "public void org.eclipse.jetty.xml.XmlConfigurationTest$FooObj.foo()", // favor fewer args
-            "public void org.eclipse.jetty.xml.XmlConfigurationTest$FooObj.foo(int)", // favor primitives over non-primitives
-            "public void org.eclipse.jetty.xml.XmlConfigurationTest$FooObj.foo(java.time.temporal.Temporal)", // favor over Instant
-            "public int org.eclipse.jetty.xml.XmlConfigurationTest$FooObj.foo(java.lang.String)",
+            "public void org.eclipse.jetty.xml.XmlConfigurationTest$FooObj.foo()", // favour fewer args
+            "public void org.eclipse.jetty.xml.XmlConfigurationTest$FooObj.foo(int)", // favour primitives over non-primitives
+            "public int org.eclipse.jetty.xml.XmlConfigurationTest$FooObj.foo(java.lang.String)", //favour classes over interfaces
             "public java.util.Locale org.eclipse.jetty.xml.XmlConfigurationTest$FooObj.foo(java.nio.charset.Charset)",
             "public void org.eclipse.jetty.xml.XmlConfigurationTest$FooObj.foo(java.time.Instant)",
             "public void org.eclipse.jetty.xml.XmlConfigurationTest$FooObj.foo(java.util.Locale)",
+            "public void org.eclipse.jetty.xml.XmlConfigurationTest$FooObj.foo(java.time.temporal.Temporal)",
             "public void org.eclipse.jetty.xml.XmlConfigurationTest$FooObj.foo(int,java.lang.String)",
             "public void org.eclipse.jetty.xml.XmlConfigurationTest$FooObj.foo(java.lang.String,int)",
             "public void org.eclipse.jetty.xml.XmlConfigurationTest$FooObj.foo(int,java.lang.String,java.lang.String)",

--- a/jetty-core/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
+++ b/jetty-core/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
@@ -786,6 +786,10 @@ public class XmlConfigurationTest
         {
         }
 
+        public void call(Ddd ddd)
+        {
+        }
+
         public void call(Abc abc)
         {
         }
@@ -813,9 +817,11 @@ public class XmlConfigurationTest
         List<Method> methods = Arrays.stream(TestOrder.class.getMethods()).filter(m -> "call".equals(m.getName())).collect(Collectors.toList());
         Collections.shuffle(methods);
         methods.sort(EXECUTABLE_COMPARATOR);
+
         assertThat(methods, Matchers.contains(
             TestOrder.class.getMethod("call"),
             TestOrder.class.getMethod("call", int.class),
+            TestOrder.class.getMethod("call", Ddd.class), //more derived than String, Bbb or Ccc
             TestOrder.class.getMethod("call", String.class),
             TestOrder.class.getMethod("call", Bbb.class),
             TestOrder.class.getMethod("call", Ccc.class),
@@ -2170,6 +2176,31 @@ public class XmlConfigurationTest
     {
     }
 
+    public abstract static class Ddd extends Ccc
+    {
+    }
+
+    @Test
+    public void testClassBeforeInterface()
+    {
+        List<String> orderedMethodIds = Stream.of(Example.class.getMethods())
+            .filter(m -> m.getName().equals("foo"))
+            .sorted(EXECUTABLE_COMPARATOR)
+            .map(Executable::toGenericString)
+            .collect(Collectors.toList());
+        orderedMethodIds.stream().forEach(System.err::println);
+
+        String[] expectedOrder = {
+            "public void org.eclipse.jetty.xml.XmlConfigurationTest$Example.foo()",
+            "public void org.eclipse.jetty.xml.XmlConfigurationTest$Example.foo(int)",
+            "public void org.eclipse.jetty.xml.XmlConfigurationTest$Example.foo(java.lang.Integer)",
+            "public int org.eclipse.jetty.xml.XmlConfigurationTest$Example.foo(java.lang.String)",
+            "public int org.eclipse.jetty.xml.XmlConfigurationTest$Example.foo(java.lang.CharSequence)"
+        };
+
+        assertThat(orderedMethodIds, contains(expectedOrder));
+    }
+
     @Test
     public void testFooExecutableComparator()
     {
@@ -2189,10 +2220,11 @@ public class XmlConfigurationTest
             "public void org.eclipse.jetty.xml.XmlConfigurationTest$FooObj.foo()", // favour fewer args
             "public void org.eclipse.jetty.xml.XmlConfigurationTest$FooObj.foo(int)", // favour primitives over non-primitives
             "public int org.eclipse.jetty.xml.XmlConfigurationTest$FooObj.foo(java.lang.String)", //favour classes over interfaces
-            "public java.util.Locale org.eclipse.jetty.xml.XmlConfigurationTest$FooObj.foo(java.nio.charset.Charset)",
-            "public void org.eclipse.jetty.xml.XmlConfigurationTest$FooObj.foo(java.time.Instant)",
-            "public void org.eclipse.jetty.xml.XmlConfigurationTest$FooObj.foo(java.util.Locale)",
-            "public void org.eclipse.jetty.xml.XmlConfigurationTest$FooObj.foo(java.time.temporal.Temporal)",
+            "public java.util.Locale org.eclipse.jetty.xml.XmlConfigurationTest$FooObj.foo(java.nio.charset.Charset)", //derived abstract class
+            "public void org.eclipse.jetty.xml.XmlConfigurationTest$FooObj.foo(java.time.Instant)", //class
+            "public void org.eclipse.jetty.xml.XmlConfigurationTest$FooObj.foo(java.util.Locale)", ///class
+            "public void org.eclipse.jetty.xml.XmlConfigurationTest$FooObj.foo(java.time.temporal.Temporal)", //derived interface
+            "public int org.eclipse.jetty.xml.XmlConfigurationTest$FooObj.foo(java.lang.CharSequence)", //interface
             "public void org.eclipse.jetty.xml.XmlConfigurationTest$FooObj.foo(int,java.lang.String)",
             "public void org.eclipse.jetty.xml.XmlConfigurationTest$FooObj.foo(java.lang.String,int)",
             "public void org.eclipse.jetty.xml.XmlConfigurationTest$FooObj.foo(int,java.lang.String,java.lang.String)",
@@ -2205,6 +2237,11 @@ public class XmlConfigurationTest
     {
         public void foo()
         {
+        }
+
+        public int foo(CharSequence sequence)
+        {
+            return -99;
         }
 
         public int foo(String name)
@@ -2247,6 +2284,31 @@ public class XmlConfigurationTest
 
         public void foo(int id, String name, String description, Object value)
         {
+        }
+    }
+
+    public static class Example
+    {
+        public void foo()
+        {
+        }
+
+        public void foo(Integer i)
+        {
+        }
+
+        public void foo(int id)
+        {
+        }
+
+        public int foo(CharSequence sequence)
+        {
+            return 0;
+        }
+
+        public int foo(String string)
+        {
+            return -1;
         }
     }
 }

--- a/jetty-core/jetty-xml/src/test/resources/org/eclipse/jetty/xml/configureWithElements.xml
+++ b/jetty-core/jetty-xml/src/test/resources/org/eclipse/jetty/xml/configureWithElements.xml
@@ -137,6 +137,19 @@
     <Class>org.eclipse.jetty.xml.ExampleConfiguration</Class>
   </Call>
 
+   <Call class="org.eclipse.jetty.xml.ExampleConfiguration" name="callStaticWithVarArgs">
+    <Arg>
+      <New class="org.eclipse.jetty.xml.ExampleConfiguration$TestImpl"/>
+    </Arg>
+    <Arg>
+      <Array type="java.lang.String">
+        <Item>A</Item>
+        <Item>B</Item>
+        <Item>C</Item>
+      </Array>
+    </Arg>
+  </Call>
+
   <Call>
     <Name>call</Name>
     <Arg><Array type="java.lang.Object">


### PR DESCRIPTION
Fixes #11895.

Tentative fix to improve ordering of method matches so that:

* methods with fewer args are preferred
* methods with primitive args are preferred
* methods with non-varargs are preferred
* methods with class args (that are not the Object.class) are preferred
* methods with interface args or class args preference the most derived type