### PR TITLE
Fix #11902 undeprecate addHiddenClasses(Attributes, String...)

### DIFF
--- a/jetty-core/jetty-ee/src/main/java/org/eclipse/jetty/ee/WebAppClassLoading.java
+++ b/jetty-core/jetty-ee/src/main/java/org/eclipse/jetty/ee/WebAppClassLoading.java
@@ -169,9 +169,7 @@ public class WebAppClassLoading
      * Add a hidden (server) Class pattern to use for all WebAppContexts of a given {@link Server}.
      * @param attributes The {@link Attributes} instance to add classes to
      * @param patterns the patterns to use
-     * @deprecated use {@link #addHiddenClasses(Server, String...)} instead
      */
-    @Deprecated (since = "12.0.9", forRemoval = true)
     public static void addHiddenClasses(Attributes attributes, String... patterns)
     {
         if (patterns != null && patterns.length > 0)


### PR DESCRIPTION
Fixes #11902

Due to the current implementation of the JettyXmlConfiguration favouring methods with interface args, this means that the deprecated method `addHiddenClasses` method is in fact always called, leading to this log line during jetty startup:

2024-06-09 13:09:20,602 - WARN [org.eclipse.jetty.xml.XmlConfiguration:800] - Deprecated method public static void org.eclipse.jetty.ee.WebAppClassLoading.addHiddenClasses(org.eclipse.jetty.util.Attributes,java.lang.String[]) in file:///opt/jetty/etc/jetty-ee-webapp.xml

The real fix is to modify `JettyXmlConfiguration` to change the ordering in which it considers the methods to apply, and  #11895 has been opened for that. That fix is risky, so therefore, the quickest route to removing this unnessary log line is to simply undeprecate the method.