### PR TITLE
Issue #11911 Fix documentation example for Request.getHttpUri

### DIFF
--- a/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/migration/ServletToHandlerDocs.java
+++ b/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/migration/ServletToHandlerDocs.java
@@ -27,6 +27,7 @@ import org.eclipse.jetty.http.HttpCookie;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.Trailers;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.server.Context;

--- a/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/migration/ServletToHandlerDocs.java
+++ b/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/migration/ServletToHandlerDocs.java
@@ -60,10 +60,10 @@ public class ServletToHandlerDocs
             //   - servletRequest.getProtocol();
             String protocol = request.getConnectionMetaData().getProtocol();
 
-            // Gets the full request URI.
+            // Gets the request URL.
             // Replaces:
             //   - servletRequest.getRequestURL();
-            String fullRequestURI = request.getHttpURI().asString();
+            StringBuffer requestURL = new StringBuffer(HttpURI.build(request.getHttpURI()).query(null).asString());
 
             // Gets the request context.
             // Replaces:

--- a/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/migration/ServletToHandlerDocs.java
+++ b/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/migration/ServletToHandlerDocs.java
@@ -64,7 +64,8 @@ public class ServletToHandlerDocs
             // Gets the request URL.
             // Replaces:
             //   - servletRequest.getRequestURL();
-            StringBuffer requestURL = new StringBuffer(HttpURI.build(request.getHttpURI()).query(null).asString());
+            HttpURI httpURI = HttpURI.build(request.getHttpURI().query(null));
+            StringBuffer requestURL = new StringBuffer(httpURI.asString());
 
             // Gets the request context.
             // Replaces:

--- a/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/migration/ServletToHandlerDocs.java
+++ b/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/migration/ServletToHandlerDocs.java
@@ -64,7 +64,7 @@ public class ServletToHandlerDocs
             // Gets the request URL.
             // Replaces:
             //   - servletRequest.getRequestURL();
-            HttpURI httpURI = HttpURI.build(request.getHttpURI().query(null));
+            HttpURI httpURI = HttpURI.build(request.getHttpURI()).query(null);
             StringBuffer requestURL = new StringBuffer(httpURI.asString());
 
             // Gets the request context.


### PR DESCRIPTION
Closes #11911

Migration documentation implies that `Request.getHttpURI()` is the jetty-12 substitute for `Request.getRequestURL()` in  prior versions, which is not strictly true. Clarified the code example.