### PR TITLE
Servlet 6.1 Cookie fixes

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CookieCompliance.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CookieCompliance.java
@@ -99,7 +99,12 @@ public class CookieCompliance implements ComplianceViolation.Mode
         /**
          * Allow spaces within values without quotes.
          */
-        SPACE_IN_VALUES("https://www.rfc-editor.org/rfc/rfc6265#section-5.2", "Space in value");
+        SPACE_IN_VALUES("https://www.rfc-editor.org/rfc/rfc6265#section-5.2", "Space in value"),
+
+        /**
+         * Maintain quotes around values .
+         */
+        MAINTAIN_QUOTES("https://www.rfc-editor.org/rfc/rfc6265#section-4.1.1", "Quotes are part of the cookie value");
 
         private final String url;
         private final String description;
@@ -143,9 +148,23 @@ public class CookieCompliance implements ComplianceViolation.Mode
     );
 
     /**
+     * <p>A CookieCompliance mode that enforces <a href="https://tools.ietf.org/html/rfc6265">RFC 6265</a> compliance,
+     * but allows:</p>
+     * <ul>
+     * <li>{@link Violation#INVALID_COOKIES}</li>
+     * <li>{@link Violation#OPTIONAL_WHITE_SPACE}</li>
+     * <li>{@link Violation#SPACE_IN_VALUES}</li>
+     * <li>{@link Violation#MAINTAIN_QUOTES}</li>
+     * </ul>
+     */
+    public static final CookieCompliance RFC6265_QUOTED = new CookieCompliance("RFC6265_QUOTED", of(
+        Violation.INVALID_COOKIES, Violation.OPTIONAL_WHITE_SPACE, Violation.SPACE_IN_VALUES, Violation.MAINTAIN_QUOTES)
+    );
+
+    /**
      * A CookieCompliance mode that enforces <a href="https://tools.ietf.org/html/rfc6265">RFC 6265</a> compliance.
      */
-    public static final CookieCompliance RFC6265_STRICT = new CookieCompliance("RFC6265_STRICT", noneOf(Violation.class));
+    public static final CookieCompliance RFC6265_STRICT = new CookieCompliance("RFC6265_STRICT", of(Violation.MAINTAIN_QUOTES));
 
     /**
      * <p>A CookieCompliance mode that enforces <a href="https://tools.ietf.org/html/rfc6265">RFC 6265</a> compliance,
@@ -176,13 +195,14 @@ public class CookieCompliance implements ComplianceViolation.Mode
      * <li>{@link Violation#BAD_QUOTES}</li>
      * <li>{@link Violation#COMMA_NOT_VALID_OCTET}</li>
      * <li>{@link Violation#RESERVED_NAMES_NOT_DOLLAR_PREFIXED}</li>
+     * <li>{@link Violation#MAINTAIN_QUOTES}</li>
      * </ul>
      */
     public static final CookieCompliance RFC2965 = new CookieCompliance("RFC2965", complementOf(of(
-        Violation.BAD_QUOTES, Violation.COMMA_NOT_VALID_OCTET, Violation.RESERVED_NAMES_NOT_DOLLAR_PREFIXED)
+        Violation.BAD_QUOTES, Violation.COMMA_NOT_VALID_OCTET, Violation.RESERVED_NAMES_NOT_DOLLAR_PREFIXED, Violation.MAINTAIN_QUOTES)
     ));
 
-    private static final List<CookieCompliance> KNOWN_MODES = Arrays.asList(RFC6265, RFC6265_STRICT, RFC6265_LEGACY, RFC2965, RFC2965_LEGACY);
+    private static final List<CookieCompliance> KNOWN_MODES = Arrays.asList(RFC6265, RFC6265_QUOTED, RFC6265_STRICT, RFC6265_LEGACY, RFC2965, RFC2965_LEGACY);
     private static final AtomicInteger __custom = new AtomicInteger();
 
     public static CookieCompliance valueOf(String name)

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
@@ -128,7 +128,7 @@ public interface HttpCookie
      */
     default boolean isSecure()
     {
-        return Boolean.parseBoolean(getAttributes().get(SECURE_ATTRIBUTE));
+        return isSetToNotFalse(SECURE_ATTRIBUTE);
     }
 
     /**
@@ -146,7 +146,7 @@ public interface HttpCookie
      */
     default boolean isHttpOnly()
     {
-        return Boolean.parseBoolean(getAttributes().get(HTTP_ONLY_ATTRIBUTE));
+        return isSetToNotFalse(HTTP_ONLY_ATTRIBUTE);
     }
 
     /**
@@ -155,8 +155,13 @@ public interface HttpCookie
      */
     default boolean isPartitioned()
     {
-        String partitioned = getAttributes().get(PARTITIONED_ATTRIBUTE);
-        return partitioned != null && !StringUtil.asciiEqualsIgnoreCase("false", partitioned);
+        return isSetToNotFalse(PARTITIONED_ATTRIBUTE);
+    }
+
+    private boolean isSetToNotFalse(String attribute)
+    {
+        String value = getAttributes().get(attribute);
+        return value != null && !StringUtil.asciiEqualsIgnoreCase("false", value);
     }
 
     /**

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import java.util.TreeMap;
 
 import org.eclipse.jetty.util.Index;
+import org.eclipse.jetty.util.StringUtil;
 
 /**
  * <p>Implementation of RFC6265 HTTP Cookies (with fallback support for RFC2965).</p>
@@ -154,7 +155,8 @@ public interface HttpCookie
      */
     default boolean isPartitioned()
     {
-        return Boolean.parseBoolean(getAttributes().get(PARTITIONED_ATTRIBUTE));
+        String partitioned = getAttributes().get(PARTITIONED_ATTRIBUTE);
+        return partitioned != null && !StringUtil.asciiEqualsIgnoreCase("false", partitioned);
     }
 
     /**

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/RFC6265CookieParser.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/RFC6265CookieParser.java
@@ -23,6 +23,7 @@ import static org.eclipse.jetty.http.CookieCompliance.Violation.COMMA_NOT_VALID_
 import static org.eclipse.jetty.http.CookieCompliance.Violation.COMMA_SEPARATOR;
 import static org.eclipse.jetty.http.CookieCompliance.Violation.ESCAPE_IN_QUOTES;
 import static org.eclipse.jetty.http.CookieCompliance.Violation.INVALID_COOKIES;
+import static org.eclipse.jetty.http.CookieCompliance.Violation.MAINTAIN_QUOTES;
 import static org.eclipse.jetty.http.CookieCompliance.Violation.OPTIONAL_WHITE_SPACE;
 import static org.eclipse.jetty.http.CookieCompliance.Violation.SPACE_IN_VALUES;
 import static org.eclipse.jetty.http.CookieCompliance.Violation.SPECIAL_CHARS_IN_QUOTES;
@@ -194,6 +195,8 @@ public class RFC6265CookieParser implements CookieParser
                     string.setLength(0);
                     if (c == '"')
                     {
+                        if (_complianceMode.allows(MAINTAIN_QUOTES))
+                            string.append(c);
                         state = State.IN_QUOTED_VALUE;
                     }
                     else if (c == ';')
@@ -276,7 +279,16 @@ public class RFC6265CookieParser implements CookieParser
                 case IN_QUOTED_VALUE:
                     if (c == '"')
                     {
-                        value = string.toString();
+                        if (_complianceMode.allows(MAINTAIN_QUOTES))
+                        {
+                            string.append(c);
+                            value = string.toString();
+                            reportComplianceViolation(MAINTAIN_QUOTES, value);
+                        }
+                        else
+                        {
+                            value = string.toString();
+                        }
                         state = State.AFTER_QUOTED_VALUE;
                     }
                     else if (c == '\\' && _complianceMode.allows(ESCAPE_IN_QUOTES))

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpCookieUtils.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpCookieUtils.java
@@ -253,8 +253,11 @@ public final class HttpCookieUtils
             else
                 builder.append(HttpCookie.formatExpires(Instant.now().plusSeconds(maxAge)));
 
-            builder.append("; Max-Age=");
-            builder.append(maxAge);
+            if (maxAge > 0)
+            {
+                builder.append("; Max-Age=");
+                builder.append(maxAge);
+            }
         }
 
         // add the other fields

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpCookieUtils.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpCookieUtils.java
@@ -27,6 +27,7 @@ import org.eclipse.jetty.http.Syntax;
 import org.eclipse.jetty.util.Attributes;
 import org.eclipse.jetty.util.Index;
 import org.eclipse.jetty.util.QuotedStringTokenizer;
+import org.eclipse.jetty.util.StringUtil;
 
 /**
  * <p>Utility methods for server-side HTTP cookie handling.</p>
@@ -291,8 +292,9 @@ public final class HttpCookieUtils
         {
             if (KNOWN_ATTRIBUTES.contains(e.getKey()))
                 continue;
-            builder.append("; ").append(e.getKey()).append("=");
-            builder.append(e.getValue());
+            builder.append("; ").append(e.getKey());
+            if (StringUtil.isNotBlank(e.getValue()))
+                builder.append("=").append(e.getValue());
         }
 
         return builder.toString();

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpCookieTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpCookieTest.java
@@ -155,6 +155,9 @@ public class HttpCookieTest
         httpCookie = HttpCookie.from("everything", "value", Map.of(HttpCookie.DOMAIN_ATTRIBUTE, "domain", HttpCookie.PATH_ATTRIBUTE, "path", HttpCookie.MAX_AGE_ATTRIBUTE, Long.toString(0), HttpCookie.HTTP_ONLY_ATTRIBUTE, Boolean.toString(true), HttpCookie.SECURE_ATTRIBUTE, Boolean.toString(true), HttpCookie.SAME_SITE_ATTRIBUTE, SameSite.STRICT.getAttributeValue()));
         assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Strict", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
 
+        httpCookie = HttpCookie.from("everything", "value", Map.of(HttpCookie.DOMAIN_ATTRIBUTE, "domain", HttpCookie.PATH_ATTRIBUTE, "path", HttpCookie.MAX_AGE_ATTRIBUTE, Long.toString(0), HttpCookie.HTTP_ONLY_ATTRIBUTE, Boolean.toString(true), HttpCookie.SECURE_ATTRIBUTE, Boolean.toString(true), HttpCookie.SAME_SITE_ATTRIBUTE, SameSite.STRICT.getAttributeValue(), HttpCookie.PARTITIONED_ATTRIBUTE, ""));
+        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; Partitioned; SameSite=Strict", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
+
         httpCookie = HttpCookie.from("everything", "value", Map.of(HttpCookie.DOMAIN_ATTRIBUTE, "domain", HttpCookie.PATH_ATTRIBUTE, "path", HttpCookie.MAX_AGE_ATTRIBUTE, Long.toString(0), HttpCookie.HTTP_ONLY_ATTRIBUTE, Boolean.toString(true), HttpCookie.SECURE_ATTRIBUTE, Boolean.toString(true), HttpCookie.SAME_SITE_ATTRIBUTE, SameSite.STRICT.getAttributeValue(), HttpCookie.PARTITIONED_ATTRIBUTE, Boolean.toString(true)));
         assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; Partitioned; SameSite=Strict", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
 

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpCookieTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpCookieTest.java
@@ -93,7 +93,7 @@ public class HttpCookieTest
     }
 
     @Test
-    public void testSetRFC2965Cookie() throws Exception
+    public void testSetRFC2965Cookie()
     {
         HttpCookie httpCookie;
 
@@ -162,10 +162,12 @@ public class HttpCookieTest
         assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; Partitioned; SameSite=Strict", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
 
         httpCookie = HttpCookie.from("everything", "value", Map.of(HttpCookie.DOMAIN_ATTRIBUTE, "domain", HttpCookie.PATH_ATTRIBUTE, "path", HttpCookie.MAX_AGE_ATTRIBUTE, Long.toString(1), HttpCookie.HTTP_ONLY_ATTRIBUTE, Boolean.toString(true), HttpCookie.SECURE_ATTRIBUTE, Boolean.toString(true), HttpCookie.SAME_SITE_ATTRIBUTE, SameSite.STRICT.getAttributeValue(), HttpCookie.PARTITIONED_ATTRIBUTE, Boolean.toString(true)));
-
         String rfc6265SetCookie = HttpCookieUtils.getRFC6265SetCookie(httpCookie);
         assertThat(rfc6265SetCookie, startsWith("everything=value; Path=path; Domain=domain; Expires="));
         assertThat(rfc6265SetCookie, endsWith(" GMT; Max-Age=1; Secure; HttpOnly; Partitioned; SameSite=Strict"));
+
+        httpCookie = HttpCookie.from("everything", "value", -1, Map.of(HttpCookie.DOMAIN_ATTRIBUTE, "domain", HttpCookie.PATH_ATTRIBUTE, "path", HttpCookie.MAX_AGE_ATTRIBUTE, Long.toString(0), HttpCookie.HTTP_ONLY_ATTRIBUTE, Boolean.toString(true), HttpCookie.SECURE_ATTRIBUTE, Boolean.toString(true), "Other", "attribute", "Single", ""));
+        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; Other=attribute; Single", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
     }
 
     public static Stream<String> rfc6265BadNameSource()

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpCookieTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpCookieTest.java
@@ -29,8 +29,10 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.equalToIgnoringCase;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -127,7 +129,7 @@ public class HttpCookieTest
     }
 
     @Test
-    public void testSetRFC6265Cookie() throws Exception
+    public void testSetRFC6265Cookie()
     {
         HttpCookie httpCookie;
 
@@ -139,22 +141,28 @@ public class HttpCookieTest
 
         //test cookies with same name, domain and path
         httpCookie = HttpCookie.from("everything", "something", -1, Map.of(HttpCookie.DOMAIN_ATTRIBUTE, "domain", HttpCookie.PATH_ATTRIBUTE, "path", HttpCookie.MAX_AGE_ATTRIBUTE, Long.toString(0), HttpCookie.HTTP_ONLY_ATTRIBUTE, Boolean.toString(true), HttpCookie.SECURE_ATTRIBUTE, Boolean.toString(true)));
-        assertEquals("everything=something; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Secure; HttpOnly", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
+        assertEquals("everything=something; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
 
         httpCookie = HttpCookie.from("everything", "value", -1, Map.of(HttpCookie.DOMAIN_ATTRIBUTE, "domain", HttpCookie.PATH_ATTRIBUTE, "path", HttpCookie.MAX_AGE_ATTRIBUTE, Long.toString(0), HttpCookie.HTTP_ONLY_ATTRIBUTE, Boolean.toString(true), HttpCookie.SECURE_ATTRIBUTE, Boolean.toString(true)));
-        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Secure; HttpOnly", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
+        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
 
         httpCookie = HttpCookie.from("everything", "value", Map.of(HttpCookie.DOMAIN_ATTRIBUTE, "domain", HttpCookie.PATH_ATTRIBUTE, "path", HttpCookie.MAX_AGE_ATTRIBUTE, Long.toString(0), HttpCookie.HTTP_ONLY_ATTRIBUTE, Boolean.toString(true), HttpCookie.SECURE_ATTRIBUTE, Boolean.toString(true), HttpCookie.SAME_SITE_ATTRIBUTE, SameSite.NONE.getAttributeValue()));
-        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Secure; HttpOnly; SameSite=None", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
+        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=None", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
 
         httpCookie = HttpCookie.from("everything", "value", Map.of(HttpCookie.DOMAIN_ATTRIBUTE, "domain", HttpCookie.PATH_ATTRIBUTE, "path", HttpCookie.MAX_AGE_ATTRIBUTE, Long.toString(0), HttpCookie.HTTP_ONLY_ATTRIBUTE, Boolean.toString(true), HttpCookie.SECURE_ATTRIBUTE, Boolean.toString(true), HttpCookie.SAME_SITE_ATTRIBUTE, SameSite.LAX.getAttributeValue()));
-        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Secure; HttpOnly; SameSite=Lax", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
+        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
 
         httpCookie = HttpCookie.from("everything", "value", Map.of(HttpCookie.DOMAIN_ATTRIBUTE, "domain", HttpCookie.PATH_ATTRIBUTE, "path", HttpCookie.MAX_AGE_ATTRIBUTE, Long.toString(0), HttpCookie.HTTP_ONLY_ATTRIBUTE, Boolean.toString(true), HttpCookie.SECURE_ATTRIBUTE, Boolean.toString(true), HttpCookie.SAME_SITE_ATTRIBUTE, SameSite.STRICT.getAttributeValue()));
-        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Secure; HttpOnly; SameSite=Strict", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
+        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Strict", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
 
         httpCookie = HttpCookie.from("everything", "value", Map.of(HttpCookie.DOMAIN_ATTRIBUTE, "domain", HttpCookie.PATH_ATTRIBUTE, "path", HttpCookie.MAX_AGE_ATTRIBUTE, Long.toString(0), HttpCookie.HTTP_ONLY_ATTRIBUTE, Boolean.toString(true), HttpCookie.SECURE_ATTRIBUTE, Boolean.toString(true), HttpCookie.SAME_SITE_ATTRIBUTE, SameSite.STRICT.getAttributeValue(), HttpCookie.PARTITIONED_ATTRIBUTE, Boolean.toString(true)));
-        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Secure; HttpOnly; Partitioned; SameSite=Strict", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
+        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; Partitioned; SameSite=Strict", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
+
+        httpCookie = HttpCookie.from("everything", "value", Map.of(HttpCookie.DOMAIN_ATTRIBUTE, "domain", HttpCookie.PATH_ATTRIBUTE, "path", HttpCookie.MAX_AGE_ATTRIBUTE, Long.toString(1), HttpCookie.HTTP_ONLY_ATTRIBUTE, Boolean.toString(true), HttpCookie.SECURE_ATTRIBUTE, Boolean.toString(true), HttpCookie.SAME_SITE_ATTRIBUTE, SameSite.STRICT.getAttributeValue(), HttpCookie.PARTITIONED_ATTRIBUTE, Boolean.toString(true)));
+
+        String rfc6265SetCookie = HttpCookieUtils.getRFC6265SetCookie(httpCookie);
+        assertThat(rfc6265SetCookie, startsWith("everything=value; Path=path; Domain=domain; Expires="));
+        assertThat(rfc6265SetCookie, endsWith(" GMT; Max-Age=1; Secure; HttpOnly; Partitioned; SameSite=Strict"));
     }
 
     public static Stream<String> rfc6265BadNameSource()


### PR DESCRIPTION
Support a violation to include the quotes as part of the value.
Never send a set-cookie with 0 max-age
Treat any non null non "false" attribute value as true
Don't set equals sign for attributes with empty value