### PR TITLE
Servlet 61 cookie fixes

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CookieCompliance.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CookieCompliance.java
@@ -99,7 +99,12 @@ public class CookieCompliance implements ComplianceViolation.Mode
         /**
          * Allow spaces within values without quotes.
          */
-        SPACE_IN_VALUES("https://www.rfc-editor.org/rfc/rfc6265#section-5.2", "Space in value");
+        SPACE_IN_VALUES("https://www.rfc-editor.org/rfc/rfc6265#section-5.2", "Space in value"),
+
+        /**
+         * Maintain quotes around values .
+         */
+        MAINTAIN_QUOTES("https://www.rfc-editor.org/rfc/rfc6265#section-4.1.1", "Quotes are part of the cookie value");
 
         private final String url;
         private final String description;
@@ -143,9 +148,23 @@ public class CookieCompliance implements ComplianceViolation.Mode
     );
 
     /**
+     * <p>A CookieCompliance mode that enforces <a href="https://tools.ietf.org/html/rfc6265">RFC 6265</a> compliance,
+     * but allows:</p>
+     * <ul>
+     * <li>{@link Violation#INVALID_COOKIES}</li>
+     * <li>{@link Violation#OPTIONAL_WHITE_SPACE}</li>
+     * <li>{@link Violation#SPACE_IN_VALUES}</li>
+     * <li>{@link Violation#MAINTAIN_QUOTES}</li>
+     * </ul>
+     */
+    public static final CookieCompliance RFC6265_QUOTED = new CookieCompliance("RFC6265_QUOTED", of(
+        Violation.INVALID_COOKIES, Violation.OPTIONAL_WHITE_SPACE, Violation.SPACE_IN_VALUES, Violation.MAINTAIN_QUOTES)
+    );
+
+    /**
      * A CookieCompliance mode that enforces <a href="https://tools.ietf.org/html/rfc6265">RFC 6265</a> compliance.
      */
-    public static final CookieCompliance RFC6265_STRICT = new CookieCompliance("RFC6265_STRICT", noneOf(Violation.class));
+    public static final CookieCompliance RFC6265_STRICT = new CookieCompliance("RFC6265_STRICT", of(Violation.MAINTAIN_QUOTES));
 
     /**
      * <p>A CookieCompliance mode that enforces <a href="https://tools.ietf.org/html/rfc6265">RFC 6265</a> compliance,
@@ -176,13 +195,14 @@ public class CookieCompliance implements ComplianceViolation.Mode
      * <li>{@link Violation#BAD_QUOTES}</li>
      * <li>{@link Violation#COMMA_NOT_VALID_OCTET}</li>
      * <li>{@link Violation#RESERVED_NAMES_NOT_DOLLAR_PREFIXED}</li>
+     * <li>{@link Violation#MAINTAIN_QUOTES}</li>
      * </ul>
      */
     public static final CookieCompliance RFC2965 = new CookieCompliance("RFC2965", complementOf(of(
-        Violation.BAD_QUOTES, Violation.COMMA_NOT_VALID_OCTET, Violation.RESERVED_NAMES_NOT_DOLLAR_PREFIXED)
+        Violation.BAD_QUOTES, Violation.COMMA_NOT_VALID_OCTET, Violation.RESERVED_NAMES_NOT_DOLLAR_PREFIXED, Violation.MAINTAIN_QUOTES)
     ));
 
-    private static final List<CookieCompliance> KNOWN_MODES = Arrays.asList(RFC6265, RFC6265_STRICT, RFC6265_LEGACY, RFC2965, RFC2965_LEGACY);
+    private static final List<CookieCompliance> KNOWN_MODES = Arrays.asList(RFC6265, RFC6265_QUOTED, RFC6265_STRICT, RFC6265_LEGACY, RFC2965, RFC2965_LEGACY);
     private static final AtomicInteger __custom = new AtomicInteger();
 
     public static CookieCompliance valueOf(String name)

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CookieCompliance.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CookieCompliance.java
@@ -102,9 +102,9 @@ public class CookieCompliance implements ComplianceViolation.Mode
         SPACE_IN_VALUES("https://www.rfc-editor.org/rfc/rfc6265#section-5.2", "Space in value"),
 
         /**
-         * Maintain quotes around values .
+         * Allows quotes to be stripped from values.
          */
-        MAINTAIN_QUOTES("https://www.rfc-editor.org/rfc/rfc6265#section-4.1.1", "Quotes are part of the cookie value");
+        STRIPPED_QUOTES("https://www.rfc-editor.org/rfc/rfc6265#section-4.1.1", "Strip quotes from the cookie value");
 
         private final String url;
         private final String description;
@@ -141,10 +141,11 @@ public class CookieCompliance implements ComplianceViolation.Mode
      * <li>{@link Violation#INVALID_COOKIES}</li>
      * <li>{@link Violation#OPTIONAL_WHITE_SPACE}</li>
      * <li>{@link Violation#SPACE_IN_VALUES}</li>
+     * <li>{@link Violation#STRIPPED_QUOTES}</li>
      * </ul>
      */
     public static final CookieCompliance RFC6265 = new CookieCompliance("RFC6265", of(
-        Violation.INVALID_COOKIES, Violation.OPTIONAL_WHITE_SPACE, Violation.SPACE_IN_VALUES)
+        Violation.INVALID_COOKIES, Violation.OPTIONAL_WHITE_SPACE, Violation.SPACE_IN_VALUES, Violation.STRIPPED_QUOTES)
     );
 
     /**
@@ -154,17 +155,16 @@ public class CookieCompliance implements ComplianceViolation.Mode
      * <li>{@link Violation#INVALID_COOKIES}</li>
      * <li>{@link Violation#OPTIONAL_WHITE_SPACE}</li>
      * <li>{@link Violation#SPACE_IN_VALUES}</li>
-     * <li>{@link Violation#MAINTAIN_QUOTES}</li>
      * </ul>
      */
     public static final CookieCompliance RFC6265_QUOTED = new CookieCompliance("RFC6265_QUOTED", of(
-        Violation.INVALID_COOKIES, Violation.OPTIONAL_WHITE_SPACE, Violation.SPACE_IN_VALUES, Violation.MAINTAIN_QUOTES)
+        Violation.INVALID_COOKIES, Violation.OPTIONAL_WHITE_SPACE, Violation.SPACE_IN_VALUES)
     );
 
     /**
      * A CookieCompliance mode that enforces <a href="https://tools.ietf.org/html/rfc6265">RFC 6265</a> compliance.
      */
-    public static final CookieCompliance RFC6265_STRICT = new CookieCompliance("RFC6265_STRICT", of(Violation.MAINTAIN_QUOTES));
+    public static final CookieCompliance RFC6265_STRICT = new CookieCompliance("RFC6265_STRICT", noneOf(Violation.class));
 
     /**
      * <p>A CookieCompliance mode that enforces <a href="https://tools.ietf.org/html/rfc6265">RFC 6265</a> compliance,
@@ -195,11 +195,10 @@ public class CookieCompliance implements ComplianceViolation.Mode
      * <li>{@link Violation#BAD_QUOTES}</li>
      * <li>{@link Violation#COMMA_NOT_VALID_OCTET}</li>
      * <li>{@link Violation#RESERVED_NAMES_NOT_DOLLAR_PREFIXED}</li>
-     * <li>{@link Violation#MAINTAIN_QUOTES}</li>
      * </ul>
      */
     public static final CookieCompliance RFC2965 = new CookieCompliance("RFC2965", complementOf(of(
-        Violation.BAD_QUOTES, Violation.COMMA_NOT_VALID_OCTET, Violation.RESERVED_NAMES_NOT_DOLLAR_PREFIXED, Violation.MAINTAIN_QUOTES)
+        Violation.BAD_QUOTES, Violation.COMMA_NOT_VALID_OCTET, Violation.RESERVED_NAMES_NOT_DOLLAR_PREFIXED)
     ));
 
     private static final List<CookieCompliance> KNOWN_MODES = Arrays.asList(RFC6265, RFC6265_QUOTED, RFC6265_STRICT, RFC6265_LEGACY, RFC2965, RFC2965_LEGACY);

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
@@ -128,7 +128,7 @@ public interface HttpCookie
      */
     default boolean isSecure()
     {
-        return Boolean.parseBoolean(getAttributes().get(SECURE_ATTRIBUTE));
+        return isSetToNotFalse(SECURE_ATTRIBUTE);
     }
 
     /**
@@ -146,7 +146,7 @@ public interface HttpCookie
      */
     default boolean isHttpOnly()
     {
-        return Boolean.parseBoolean(getAttributes().get(HTTP_ONLY_ATTRIBUTE));
+        return isSetToNotFalse(HTTP_ONLY_ATTRIBUTE);
     }
 
     /**
@@ -155,8 +155,13 @@ public interface HttpCookie
      */
     default boolean isPartitioned()
     {
-        String partitioned = getAttributes().get(PARTITIONED_ATTRIBUTE);
-        return partitioned != null && !StringUtil.asciiEqualsIgnoreCase("false", partitioned);
+        return isSetToNotFalse(PARTITIONED_ATTRIBUTE);
+    }
+
+    private boolean isSetToNotFalse(String attribute)
+    {
+        String value = getAttributes().get(attribute);
+        return value != null && !StringUtil.asciiEqualsIgnoreCase("false", value);
     }
 
     /**

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import java.util.TreeMap;
 
 import org.eclipse.jetty.util.Index;
+import org.eclipse.jetty.util.StringUtil;
 
 /**
  * <p>Implementation of RFC6265 HTTP Cookies (with fallback support for RFC2965).</p>
@@ -154,7 +155,8 @@ public interface HttpCookie
      */
     default boolean isPartitioned()
     {
-        return Boolean.parseBoolean(getAttributes().get(PARTITIONED_ATTRIBUTE));
+        String partitioned = getAttributes().get(PARTITIONED_ATTRIBUTE);
+        return partitioned != null && !StringUtil.asciiEqualsIgnoreCase("false", partitioned);
     }
 
     /**

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/RFC6265CookieParser.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/RFC6265CookieParser.java
@@ -23,10 +23,10 @@ import static org.eclipse.jetty.http.CookieCompliance.Violation.COMMA_NOT_VALID_
 import static org.eclipse.jetty.http.CookieCompliance.Violation.COMMA_SEPARATOR;
 import static org.eclipse.jetty.http.CookieCompliance.Violation.ESCAPE_IN_QUOTES;
 import static org.eclipse.jetty.http.CookieCompliance.Violation.INVALID_COOKIES;
-import static org.eclipse.jetty.http.CookieCompliance.Violation.MAINTAIN_QUOTES;
 import static org.eclipse.jetty.http.CookieCompliance.Violation.OPTIONAL_WHITE_SPACE;
 import static org.eclipse.jetty.http.CookieCompliance.Violation.SPACE_IN_VALUES;
 import static org.eclipse.jetty.http.CookieCompliance.Violation.SPECIAL_CHARS_IN_QUOTES;
+import static org.eclipse.jetty.http.CookieCompliance.Violation.STRIPPED_QUOTES;
 
 /**
  * Cookie parser
@@ -195,7 +195,7 @@ public class RFC6265CookieParser implements CookieParser
                     string.setLength(0);
                     if (c == '"')
                     {
-                        if (_complianceMode.allows(MAINTAIN_QUOTES))
+                        if (!_complianceMode.allows(STRIPPED_QUOTES))
                             string.append(c);
                         state = State.IN_QUOTED_VALUE;
                     }
@@ -279,14 +279,14 @@ public class RFC6265CookieParser implements CookieParser
                 case IN_QUOTED_VALUE:
                     if (c == '"')
                     {
-                        if (_complianceMode.allows(MAINTAIN_QUOTES))
+                        if (_complianceMode.allows(STRIPPED_QUOTES))
                         {
-                            string.append(c);
                             value = string.toString();
-                            reportComplianceViolation(MAINTAIN_QUOTES, value);
+                            reportComplianceViolation(STRIPPED_QUOTES, value);
                         }
                         else
                         {
+                            string.append(c);
                             value = string.toString();
                         }
                         state = State.AFTER_QUOTED_VALUE;

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/RFC6265CookieParser.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/RFC6265CookieParser.java
@@ -23,6 +23,7 @@ import static org.eclipse.jetty.http.CookieCompliance.Violation.COMMA_NOT_VALID_
 import static org.eclipse.jetty.http.CookieCompliance.Violation.COMMA_SEPARATOR;
 import static org.eclipse.jetty.http.CookieCompliance.Violation.ESCAPE_IN_QUOTES;
 import static org.eclipse.jetty.http.CookieCompliance.Violation.INVALID_COOKIES;
+import static org.eclipse.jetty.http.CookieCompliance.Violation.MAINTAIN_QUOTES;
 import static org.eclipse.jetty.http.CookieCompliance.Violation.OPTIONAL_WHITE_SPACE;
 import static org.eclipse.jetty.http.CookieCompliance.Violation.SPACE_IN_VALUES;
 import static org.eclipse.jetty.http.CookieCompliance.Violation.SPECIAL_CHARS_IN_QUOTES;
@@ -194,6 +195,8 @@ public class RFC6265CookieParser implements CookieParser
                     string.setLength(0);
                     if (c == '"')
                     {
+                        if (_complianceMode.allows(MAINTAIN_QUOTES))
+                            string.append(c);
                         state = State.IN_QUOTED_VALUE;
                     }
                     else if (c == ';')
@@ -276,7 +279,16 @@ public class RFC6265CookieParser implements CookieParser
                 case IN_QUOTED_VALUE:
                     if (c == '"')
                     {
-                        value = string.toString();
+                        if (_complianceMode.allows(MAINTAIN_QUOTES))
+                        {
+                            string.append(c);
+                            value = string.toString();
+                            reportComplianceViolation(MAINTAIN_QUOTES, value);
+                        }
+                        else
+                        {
+                            value = string.toString();
+                        }
                         state = State.AFTER_QUOTED_VALUE;
                     }
                     else if (c == '\\' && _complianceMode.allows(ESCAPE_IN_QUOTES))

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/RFC6265CookieParserTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/RFC6265CookieParserTest.java
@@ -41,8 +41,8 @@ public class RFC6265CookieParserTest
 
         assertThat("Cookies.length", cookies.size(), is(1));
         assertCookie("Cookies[0]", cookies.get(0), "Customer", "WILE_E_COYOTE", 1, "/acme");
-        // There are 2 attributes, so 2 violations.
-        assertThat(parser.violations.size(), is(2));
+        // There are 2 attributes, so 2 violations, plus 3 violations for stripping quotes.
+        assertThat(parser.violations.size(), is(2 + 3));
 
         // Same test with RFC6265.
         parser = new TestCookieParser(CookieCompliance.RFC6265);
@@ -52,8 +52,8 @@ public class RFC6265CookieParserTest
         assertCookie("Cookies[1]", cookies.get(1), "Customer", "WILE_E_COYOTE", 0, null);
         assertCookie("Cookies[2]", cookies.get(2), "$Path", "/acme", 0, null);
 
-        // Normal cookies with attributes, so no violations
-        assertThat(parser.violations.size(), is(0));
+        // Normal cookies with attributes, so just 3 violations for stripping quotes
+        assertThat(parser.violations.size(), is(3));
 
         // Same again, but allow attributes which are ignored
         parser = new TestCookieParser(CookieCompliance.from("RFC6265,ATTRIBUTES"));
@@ -61,8 +61,8 @@ public class RFC6265CookieParserTest
         assertThat("Cookies.length", cookies.size(), is(1));
         assertCookie("Cookies[0]", cookies.get(0), "Customer", "WILE_E_COYOTE", 0, null);
 
-        // There are 2 attributes that are seen as violations
-        assertThat(parser.violations.size(), is(2));
+        // There are 2 attributes, so 2 violations, plus 3 violations for stripping quotes.
+        assertThat(parser.violations.size(), is(2 + 3));
 
         // Same again, but allow attributes which are not ignored
         parser = new TestCookieParser(CookieCompliance.from("RFC6265,ATTRIBUTE_VALUES"));
@@ -70,8 +70,8 @@ public class RFC6265CookieParserTest
         assertThat("Cookies.length", cookies.size(), is(1));
         assertCookie("Cookies[0]", cookies.get(0), "Customer", "WILE_E_COYOTE", 1, "/acme");
 
-        // There are 2 attributes that are seen as violations
-        assertThat(parser.violations.size(), is(2));
+        // There are 2 attributes, so 2 violations, plus 3 violations for stripping quotes.
+        assertThat(parser.violations.size(), is(2 + 3));
 
         // Same test, but with RFC 6265 strict.
         parser = new TestCookieParser(CookieCompliance.RFC6265_STRICT);
@@ -81,8 +81,8 @@ public class RFC6265CookieParserTest
         assertCookie("Cookies[1]", cookies.get(1), "Customer", "\"WILE_E_COYOTE\"", 0, null);
         assertCookie("Cookies[2]", cookies.get(2), "$Path", "\"/acme\"", 0, null);
 
-        // Three violations for each of the maintained quotes
-        assertThat(parser.violations.size(), is(3));
+        // No violations for the maintained quotes
+        assertThat(parser.violations.size(), is(0));
     }
 
     /**

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/RFC6265CookieParserTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/RFC6265CookieParserTest.java
@@ -309,6 +309,10 @@ public class RFC6265CookieParserTest
         cookies = parseCookieHeaders(CookieCompliance.RFC6265_QUOTED, rawCookie);
         assertThat("Cookies.length", cookies.length, is(1));
         assertCookie("Cookies[0]", cookies[0], "A", "\"quotedValue\"", 0, null);
+
+        cookies = parseCookieHeaders(CookieCompliance.RFC6265_STRICT, rawCookie);
+        assertThat("Cookies.length", cookies.length, is(1));
+        assertCookie("Cookies[0]", cookies[0], "A", "\"quotedValue\"", 0, null);
     }
 
     @Test

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ConnectionMetaData.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ConnectionMetaData.java
@@ -52,9 +52,7 @@ public interface ConnectionMetaData extends Attributes
 
     /**
      * @return whether the functionality of pushing resources is supported
-     * @deprecated in favour of 103 Early Hints
      */
-    @Deprecated(since = "12.0.1")
     default boolean isPushSupported()
     {
         return false;

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpCookieUtils.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpCookieUtils.java
@@ -253,8 +253,11 @@ public final class HttpCookieUtils
             else
                 builder.append(HttpCookie.formatExpires(Instant.now().plusSeconds(maxAge)));
 
-            builder.append("; Max-Age=");
-            builder.append(maxAge);
+            if (maxAge > 0)
+            {
+                builder.append("; Max-Age=");
+                builder.append(maxAge);
+            }
         }
 
         // add the other fields

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpCookieUtils.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpCookieUtils.java
@@ -107,16 +107,16 @@ public final class HttpCookieUtils
 
     public static String getSetCookie(HttpCookie httpCookie, CookieCompliance compliance)
     {
-        if (compliance == null || CookieCompliance.RFC6265_LEGACY.compliesWith(compliance))
-            return getRFC6265SetCookie(httpCookie);
-        return getRFC2965SetCookie(httpCookie);
+        if (compliance != null && compliance.getName().contains("RFC2965"))
+            return getRFC2965SetCookie(httpCookie);
+        return getRFC6265SetCookie(httpCookie);
     }
 
     public static String getRFC2965SetCookie(HttpCookie httpCookie)
     {
         // Check arguments
         String name = httpCookie.getName();
-        if (name == null || name.length() == 0)
+        if (name == null || name.isEmpty())
             throw new IllegalArgumentException("Invalid cookie name");
 
         StringBuilder builder = new StringBuilder();
@@ -130,11 +130,11 @@ public final class HttpCookieUtils
 
         // Look for domain and path fields and check if they need to be quoted.
         String domain = httpCookie.getDomain();
-        boolean hasDomain = domain != null && domain.length() > 0;
+        boolean hasDomain = domain != null && !domain.isEmpty();
         boolean quoteDomain = hasDomain && isQuoteNeeded(domain);
 
         String path = httpCookie.getPath();
-        boolean hasPath = path != null && path.length() > 0;
+        boolean hasPath = path != null && !path.isEmpty();
         boolean quotePath = hasPath && isQuoteNeeded(path);
 
         // Upgrade the version if we have a comment or we need to quote value/path/domain or if they were already quoted
@@ -210,7 +210,7 @@ public final class HttpCookieUtils
     {
         // Check arguments
         String name = httpCookie.getName();
-        if (name == null || name.length() == 0)
+        if (name == null || name.isEmpty())
             throw new IllegalArgumentException("Bad cookie name");
 
         try
@@ -234,12 +234,12 @@ public final class HttpCookieUtils
 
         // Append path
         String path = httpCookie.getPath();
-        if (path != null && path.length() > 0)
+        if (path != null && !path.isEmpty())
             builder.append("; Path=").append(path);
 
         // Append domain
         String domain = httpCookie.getDomain();
-        if (domain != null && domain.length() > 0)
+        if (domain != null && !domain.isEmpty())
             builder.append("; Domain=").append(domain);
 
         // Handle max-age and/or expires
@@ -309,7 +309,7 @@ public final class HttpCookieUtils
      */
     private static boolean isQuoteNeeded(String text)
     {
-        if (text == null || text.length() == 0)
+        if (text == null || text.isEmpty())
             return true;
 
         if (QuotedStringTokenizer.isQuoted(text))

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpCookieUtils.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpCookieUtils.java
@@ -27,6 +27,7 @@ import org.eclipse.jetty.http.Syntax;
 import org.eclipse.jetty.util.Attributes;
 import org.eclipse.jetty.util.Index;
 import org.eclipse.jetty.util.QuotedStringTokenizer;
+import org.eclipse.jetty.util.StringUtil;
 
 /**
  * <p>Utility methods for server-side HTTP cookie handling.</p>
@@ -291,8 +292,9 @@ public final class HttpCookieUtils
         {
             if (KNOWN_ATTRIBUTES.contains(e.getKey()))
                 continue;
-            builder.append("; ").append(e.getKey()).append("=");
-            builder.append(e.getValue());
+            builder.append("; ").append(e.getKey());
+            if (StringUtil.isNotBlank(e.getValue()))
+                builder.append("=").append(e.getValue());
         }
 
         return builder.toString();

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpCookieTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpCookieTest.java
@@ -155,6 +155,9 @@ public class HttpCookieTest
         httpCookie = HttpCookie.from("everything", "value", Map.of(HttpCookie.DOMAIN_ATTRIBUTE, "domain", HttpCookie.PATH_ATTRIBUTE, "path", HttpCookie.MAX_AGE_ATTRIBUTE, Long.toString(0), HttpCookie.HTTP_ONLY_ATTRIBUTE, Boolean.toString(true), HttpCookie.SECURE_ATTRIBUTE, Boolean.toString(true), HttpCookie.SAME_SITE_ATTRIBUTE, SameSite.STRICT.getAttributeValue()));
         assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Strict", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
 
+        httpCookie = HttpCookie.from("everything", "value", Map.of(HttpCookie.DOMAIN_ATTRIBUTE, "domain", HttpCookie.PATH_ATTRIBUTE, "path", HttpCookie.MAX_AGE_ATTRIBUTE, Long.toString(0), HttpCookie.HTTP_ONLY_ATTRIBUTE, Boolean.toString(true), HttpCookie.SECURE_ATTRIBUTE, Boolean.toString(true), HttpCookie.SAME_SITE_ATTRIBUTE, SameSite.STRICT.getAttributeValue(), HttpCookie.PARTITIONED_ATTRIBUTE, ""));
+        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; Partitioned; SameSite=Strict", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
+
         httpCookie = HttpCookie.from("everything", "value", Map.of(HttpCookie.DOMAIN_ATTRIBUTE, "domain", HttpCookie.PATH_ATTRIBUTE, "path", HttpCookie.MAX_AGE_ATTRIBUTE, Long.toString(0), HttpCookie.HTTP_ONLY_ATTRIBUTE, Boolean.toString(true), HttpCookie.SECURE_ATTRIBUTE, Boolean.toString(true), HttpCookie.SAME_SITE_ATTRIBUTE, SameSite.STRICT.getAttributeValue(), HttpCookie.PARTITIONED_ATTRIBUTE, Boolean.toString(true)));
         assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; Partitioned; SameSite=Strict", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
 

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpCookieTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpCookieTest.java
@@ -93,7 +93,7 @@ public class HttpCookieTest
     }
 
     @Test
-    public void testSetRFC2965Cookie() throws Exception
+    public void testSetRFC2965Cookie()
     {
         HttpCookie httpCookie;
 
@@ -162,10 +162,12 @@ public class HttpCookieTest
         assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; Partitioned; SameSite=Strict", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
 
         httpCookie = HttpCookie.from("everything", "value", Map.of(HttpCookie.DOMAIN_ATTRIBUTE, "domain", HttpCookie.PATH_ATTRIBUTE, "path", HttpCookie.MAX_AGE_ATTRIBUTE, Long.toString(1), HttpCookie.HTTP_ONLY_ATTRIBUTE, Boolean.toString(true), HttpCookie.SECURE_ATTRIBUTE, Boolean.toString(true), HttpCookie.SAME_SITE_ATTRIBUTE, SameSite.STRICT.getAttributeValue(), HttpCookie.PARTITIONED_ATTRIBUTE, Boolean.toString(true)));
-
         String rfc6265SetCookie = HttpCookieUtils.getRFC6265SetCookie(httpCookie);
         assertThat(rfc6265SetCookie, startsWith("everything=value; Path=path; Domain=domain; Expires="));
         assertThat(rfc6265SetCookie, endsWith(" GMT; Max-Age=1; Secure; HttpOnly; Partitioned; SameSite=Strict"));
+
+        httpCookie = HttpCookie.from("everything", "value", -1, Map.of(HttpCookie.DOMAIN_ATTRIBUTE, "domain", HttpCookie.PATH_ATTRIBUTE, "path", HttpCookie.MAX_AGE_ATTRIBUTE, Long.toString(0), HttpCookie.HTTP_ONLY_ATTRIBUTE, Boolean.toString(true), HttpCookie.SECURE_ATTRIBUTE, Boolean.toString(true), "Other", "attribute", "Single", ""));
+        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; Other=attribute; Single", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
     }
 
     public static Stream<String> rfc6265BadNameSource()

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpCookieTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpCookieTest.java
@@ -29,8 +29,10 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.equalToIgnoringCase;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -127,7 +129,7 @@ public class HttpCookieTest
     }
 
     @Test
-    public void testSetRFC6265Cookie() throws Exception
+    public void testSetRFC6265Cookie()
     {
         HttpCookie httpCookie;
 
@@ -139,22 +141,28 @@ public class HttpCookieTest
 
         //test cookies with same name, domain and path
         httpCookie = HttpCookie.from("everything", "something", -1, Map.of(HttpCookie.DOMAIN_ATTRIBUTE, "domain", HttpCookie.PATH_ATTRIBUTE, "path", HttpCookie.MAX_AGE_ATTRIBUTE, Long.toString(0), HttpCookie.HTTP_ONLY_ATTRIBUTE, Boolean.toString(true), HttpCookie.SECURE_ATTRIBUTE, Boolean.toString(true)));
-        assertEquals("everything=something; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Secure; HttpOnly", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
+        assertEquals("everything=something; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
 
         httpCookie = HttpCookie.from("everything", "value", -1, Map.of(HttpCookie.DOMAIN_ATTRIBUTE, "domain", HttpCookie.PATH_ATTRIBUTE, "path", HttpCookie.MAX_AGE_ATTRIBUTE, Long.toString(0), HttpCookie.HTTP_ONLY_ATTRIBUTE, Boolean.toString(true), HttpCookie.SECURE_ATTRIBUTE, Boolean.toString(true)));
-        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Secure; HttpOnly", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
+        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
 
         httpCookie = HttpCookie.from("everything", "value", Map.of(HttpCookie.DOMAIN_ATTRIBUTE, "domain", HttpCookie.PATH_ATTRIBUTE, "path", HttpCookie.MAX_AGE_ATTRIBUTE, Long.toString(0), HttpCookie.HTTP_ONLY_ATTRIBUTE, Boolean.toString(true), HttpCookie.SECURE_ATTRIBUTE, Boolean.toString(true), HttpCookie.SAME_SITE_ATTRIBUTE, SameSite.NONE.getAttributeValue()));
-        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Secure; HttpOnly; SameSite=None", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
+        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=None", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
 
         httpCookie = HttpCookie.from("everything", "value", Map.of(HttpCookie.DOMAIN_ATTRIBUTE, "domain", HttpCookie.PATH_ATTRIBUTE, "path", HttpCookie.MAX_AGE_ATTRIBUTE, Long.toString(0), HttpCookie.HTTP_ONLY_ATTRIBUTE, Boolean.toString(true), HttpCookie.SECURE_ATTRIBUTE, Boolean.toString(true), HttpCookie.SAME_SITE_ATTRIBUTE, SameSite.LAX.getAttributeValue()));
-        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Secure; HttpOnly; SameSite=Lax", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
+        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
 
         httpCookie = HttpCookie.from("everything", "value", Map.of(HttpCookie.DOMAIN_ATTRIBUTE, "domain", HttpCookie.PATH_ATTRIBUTE, "path", HttpCookie.MAX_AGE_ATTRIBUTE, Long.toString(0), HttpCookie.HTTP_ONLY_ATTRIBUTE, Boolean.toString(true), HttpCookie.SECURE_ATTRIBUTE, Boolean.toString(true), HttpCookie.SAME_SITE_ATTRIBUTE, SameSite.STRICT.getAttributeValue()));
-        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Secure; HttpOnly; SameSite=Strict", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
+        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Strict", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
 
         httpCookie = HttpCookie.from("everything", "value", Map.of(HttpCookie.DOMAIN_ATTRIBUTE, "domain", HttpCookie.PATH_ATTRIBUTE, "path", HttpCookie.MAX_AGE_ATTRIBUTE, Long.toString(0), HttpCookie.HTTP_ONLY_ATTRIBUTE, Boolean.toString(true), HttpCookie.SECURE_ATTRIBUTE, Boolean.toString(true), HttpCookie.SAME_SITE_ATTRIBUTE, SameSite.STRICT.getAttributeValue(), HttpCookie.PARTITIONED_ATTRIBUTE, Boolean.toString(true)));
-        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Secure; HttpOnly; Partitioned; SameSite=Strict", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
+        assertEquals("everything=value; Path=path; Domain=domain; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; Partitioned; SameSite=Strict", HttpCookieUtils.getRFC6265SetCookie(httpCookie));
+
+        httpCookie = HttpCookie.from("everything", "value", Map.of(HttpCookie.DOMAIN_ATTRIBUTE, "domain", HttpCookie.PATH_ATTRIBUTE, "path", HttpCookie.MAX_AGE_ATTRIBUTE, Long.toString(1), HttpCookie.HTTP_ONLY_ATTRIBUTE, Boolean.toString(true), HttpCookie.SECURE_ATTRIBUTE, Boolean.toString(true), HttpCookie.SAME_SITE_ATTRIBUTE, SameSite.STRICT.getAttributeValue(), HttpCookie.PARTITIONED_ATTRIBUTE, Boolean.toString(true)));
+
+        String rfc6265SetCookie = HttpCookieUtils.getRFC6265SetCookie(httpCookie);
+        assertThat(rfc6265SetCookie, startsWith("everything=value; Path=path; Domain=domain; Expires="));
+        assertThat(rfc6265SetCookie, endsWith(" GMT; Max-Age=1; Secure; HttpOnly; Partitioned; SameSite=Strict"));
     }
 
     public static Stream<String> rfc6265BadNameSource()

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ServerHttpCookieTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ServerHttpCookieTest.java
@@ -123,7 +123,7 @@ public class ServerHttpCookieTest
 
             // bad characters
             Arguments.of(RFC6265_STRICT, "Cookie: name=va\\ue", 400, null, List.of("400", "Bad Cookie value").toArray(new String[0])),
-            Arguments.of(RFC6265_STRICT, "Cookie: name=\"value\"", 200, "Version=", List.of("[name=value]").toArray(new String[0])),
+            Arguments.of(RFC6265_STRICT, "Cookie: name=\"value\"", 200, "Version=", List.of("[name=\"value\"]").toArray(new String[0])),
             Arguments.of(RFC6265_STRICT, "Cookie: name=\"value;other=extra\"", 400, null, List.of("400", "Bad Cookie quoted value").toArray(new String[0])),
             Arguments.of(RFC6265, "Cookie: name=\"value;other=extra\"", 200, "name=value", null),
             Arguments.of(RFC6265_LEGACY, "Cookie: name=\"value;other=extra\"", 200, null, List.of("[name=value;other=extra]").toArray(new String[0])),
@@ -167,13 +167,12 @@ public class ServerHttpCookieTest
             Arguments.of(RFC6265_LEGACY, "name=value", "name=value"),
             Arguments.of(RFC2965, "name=value", "name=value"),
             Arguments.of(RFC2965_LEGACY, "name=value", "name=value"),
-
+            Arguments.of(CookieCompliance.from("0"), "name=value;$version=1;$path=/path;$domain=domain", "name=value; Path=/path; Domain=domain"),
             Arguments.of(RFC6265_STRICT, "name=value;$version=1;$path=/path;$domain=domain", "name=value; Path=/path; Domain=domain"),
             Arguments.of(RFC6265, "name=value;$version=1;$path=/path;$domain=domain", "name=value; Path=/path; Domain=domain"),
             Arguments.of(RFC6265_LEGACY, "name=value;$version=1;$path=/path;$domain=domain", "name=value; Path=/path; Domain=domain"),
             Arguments.of(RFC2965, "name=value;$version=1;$path=/path;$domain=domain", "name=value;Version=1;Domain=domain;Path=/path"),
             Arguments.of(RFC2965_LEGACY, "name=value;$version=1;$path=/path;$domain=domain", "name=value;Version=1;Domain=domain;Path=/path"),
-
             Arguments.of(RFC6265, "name=value", "name=value")
             );
     }

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ServletRequestListenerTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ServletRequestListenerTest.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import jakarta.servlet.AsyncContext;
@@ -31,6 +32,7 @@ import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.awaitility.Awaitility;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.ee10.servlet.security.ConstraintMapping;
@@ -108,6 +110,7 @@ public class ServletRequestListenerTest
         assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
         assertThat(response.getContentAsString(), equalTo("success"));
 
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).pollInterval(10, TimeUnit.MILLISECONDS).until(() -> _events.contains("requestDestroyed /"));
         assertEvents("requestInitialized /", "doFilter /", "REQUEST /", "doFilter /", "FORWARD /", "requestDestroyed /");
     }
 
@@ -135,6 +138,7 @@ public class ServletRequestListenerTest
         assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
         assertThat(response.getContentAsString(), equalTo("success"));
 
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).pollInterval(10, TimeUnit.MILLISECONDS).until(() -> _events.contains("requestDestroyed /"));
         assertEvents("requestInitialized /", "doFilter /", "REQUEST /", "doFilter /", "INCLUDE /", "requestDestroyed /");
     }
 
@@ -165,6 +169,7 @@ public class ServletRequestListenerTest
         assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
         assertThat(response.getContentAsString(), equalTo("success"));
 
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).pollInterval(10, TimeUnit.MILLISECONDS).until(() -> _events.contains("requestDestroyed /"));
         assertEvents("requestInitialized /", "doFilter /", "REQUEST /", "requestDestroyed /",
             "requestInitialized /", "doFilter /", "ASYNC /", "requestDestroyed /");
     }
@@ -201,6 +206,7 @@ public class ServletRequestListenerTest
         assertThat(response.getStatus(), equalTo(HttpStatus.INTERNAL_SERVER_ERROR_500));
         assertThat(response.getContentAsString(), equalTo("error handled"));
 
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).pollInterval(10, TimeUnit.MILLISECONDS).until(() -> _events.contains("requestDestroyed /"));
         assertEvents("requestInitialized /", "doFilter /", "REQUEST /", "requestDestroyed /",
             "requestInitialized /", "doFilter /error", "ERROR /error", "requestDestroyed /");
     }
@@ -240,6 +246,7 @@ public class ServletRequestListenerTest
         assertThat(response.getStatus(), equalTo(HttpStatus.INTERNAL_SERVER_ERROR_500));
         assertThat(response.getContentAsString(), equalTo("error handled"));
 
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).pollInterval(10, TimeUnit.MILLISECONDS).until(() -> _events.contains("errorHandler"));
         assertEvents("requestInitialized /", "doFilter /", "REQUEST /", "requestDestroyed /", "errorHandler");
     }
 
@@ -270,6 +277,7 @@ public class ServletRequestListenerTest
         ContentResponse response = _httpClient.GET("http://localhost:" + _connector.getLocalPort());
         assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
         assertThat(response.getContentAsString(), equalTo("from servlet"));
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).pollInterval(10, TimeUnit.MILLISECONDS).until(() -> _events.contains("requestDestroyed /"));
         assertEvents("requestInitialized /", "doFilter /", "REQUEST /", "requestDestroyed /");
 
         response = _httpClient.GET("http://localhost:" + _connector.getLocalPort() + "/authed");

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/PushedResourcesTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/PushedResourcesTest.java
@@ -18,6 +18,7 @@ import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -25,9 +26,11 @@ import org.eclipse.jetty.client.BufferingResponseListener;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.Result;
 import org.eclipse.jetty.http.HttpStatus;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -53,19 +56,31 @@ public class PushedResourcesTest extends AbstractTest
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
             {
+                Cookie cookie0 = new Cookie("C0", "v0");
+                cookie0.setMaxAge(0);
+                response.addCookie(cookie0);
+                Cookie cookie1 = new Cookie("C1", "v1");
+                response.addCookie(cookie1);
+
                 String target = request.getRequestURI();
                 if (target.equals(path1))
                 {
+                    assertThat(request.getHeader("H1"), Matchers.equalTo("V1"));
+                    assertThat(request.getHeader("Cookie"), Matchers.equalTo("C1=v1"));
                     response.getOutputStream().write(pushBytes1);
                 }
                 else if (target.equals(path2))
                 {
+                    assertThat(request.getHeader("H1"), Matchers.nullValue());
+                    assertThat(request.getHeader("Cookie"), Matchers.equalTo("C1=v1"));
                     response.getOutputStream().write(pushBytes2);
                 }
                 else
                 {
+                    assertThat(request.getHeader("Cookie"), Matchers.equalTo("C0=toBeRemoved"));
                     request.newPushBuilder()
                         .path(path1)
+                        .addHeader("H1", "V1")
                         .push();
                     request.newPushBuilder()
                         .path(path2)
@@ -78,6 +93,7 @@ public class PushedResourcesTest extends AbstractTest
         CountDownLatch latch1 = new CountDownLatch(1);
         CountDownLatch latch2 = new CountDownLatch(1);
         ContentResponse response = client.newRequest(newURI(transport))
+            .headers(h -> h.add("Cookie", "C0=toBeRemoved"))
             .onPush((mainRequest, pushedRequest) -> new BufferingResponseListener()
             {
                 @Override

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletApiRequest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletApiRequest.java
@@ -23,12 +23,15 @@ import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
 import java.security.Principal;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -761,37 +764,54 @@ public class ServletApiRequest implements HttpServletRequest
             referrer += "?" + query;
         pushHeaders.put(HttpHeader.REFERER, referrer);
 
-        StringBuilder cookieBuilder = new StringBuilder();
-        Cookie[] cookies = getCookies();
-        if (cookies != null)
-        {
-            for (Cookie cookie : cookies)
-            {
-                if (!cookieBuilder.isEmpty())
-                    cookieBuilder.append("; ");
-                cookieBuilder.append(cookie.getName()).append("=").append(cookie.getValue());
-            }
-        }
+        Cookie[] existing = getCookies();
+        List<Object> cookies = new ArrayList<>();
+        if (existing != null && existing.length > 0)
+            cookies.addAll(Arrays.asList(existing));
+
         // Any Set-Cookie in the response should be present in the push.
         for (HttpField field : _servletContextRequest.getServletContextResponse().getHeaders())
         {
             HttpHeader header = field.getHeader();
             if (header == HttpHeader.SET_COOKIE || header == HttpHeader.SET_COOKIE2)
             {
-                HttpCookie httpCookie;
-                if (field instanceof HttpCookieUtils.SetCookieHttpField set)
-                    httpCookie = set.getHttpCookie();
-                else
-                    httpCookie = SET_COOKIE_PARSER.parse(field.getValue());
-                if (httpCookie == null || httpCookie.isExpired())
+                HttpCookie httpCookie = (field instanceof HttpCookieUtils.SetCookieHttpField set)
+                    ? set.getHttpCookie()
+                    : SET_COOKIE_PARSER.parse(field.getValue());
+
+                if (httpCookie == null)
                     continue;
-                if (!cookieBuilder.isEmpty())
-                    cookieBuilder.append("; ");
-                cookieBuilder.append(httpCookie.getName()).append("=").append(httpCookie.getValue());
+
+                if (httpCookie.isExpired())
+                {
+                    for (Iterator<Object> i = cookies.iterator(); i.hasNext();)
+                    {
+                        Object o = i.next();
+                        if (o instanceof Cookie cookie && cookie.getName().equals(httpCookie.getName()))
+                            i.remove();
+                        else if (o instanceof HttpCookie cookie && cookie.getName().equals(httpCookie.getName()))
+                            i.remove();
+                    }
+                    continue;
+                }
+                cookies.add(httpCookie);
             }
         }
-        if (!cookieBuilder.isEmpty())
+
+        if (!cookies.isEmpty())
+        {
+            StringBuilder cookieBuilder = new StringBuilder();
+            for (Object o : cookies)
+            {
+                if (!cookieBuilder.isEmpty())
+                    cookieBuilder.append("; ");
+                if (o instanceof Cookie cookie)
+                    cookieBuilder.append(cookie.getName()).append("=").append(cookie.getValue());
+                else if (o instanceof HttpCookie httpCookie)
+                    cookieBuilder.append(httpCookie.getName()).append("=").append(httpCookie.getValue());
+            }
             pushHeaders.put(HttpHeader.COOKIE, cookieBuilder.toString());
+        }
 
         String sessionId;
         HttpSession httpSession = getSession(false);

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/ServletRequestListenerTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/ServletRequestListenerTest.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import jakarta.servlet.AsyncContext;
@@ -31,6 +32,7 @@ import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.awaitility.Awaitility;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.ee11.servlet.security.ConstraintMapping;
@@ -108,6 +110,7 @@ public class ServletRequestListenerTest
         assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
         assertThat(response.getContentAsString(), equalTo("success"));
 
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).pollInterval(10, TimeUnit.MILLISECONDS).until(() -> _events.contains("requestDestroyed /"));
         assertEvents("requestInitialized /", "doFilter /", "REQUEST /", "doFilter /", "FORWARD /", "requestDestroyed /");
     }
 
@@ -135,6 +138,7 @@ public class ServletRequestListenerTest
         assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
         assertThat(response.getContentAsString(), equalTo("success"));
 
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).pollInterval(10, TimeUnit.MILLISECONDS).until(() -> _events.contains("requestDestroyed /"));
         assertEvents("requestInitialized /", "doFilter /", "REQUEST /", "doFilter /", "INCLUDE /", "requestDestroyed /");
     }
 
@@ -165,6 +169,7 @@ public class ServletRequestListenerTest
         assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
         assertThat(response.getContentAsString(), equalTo("success"));
 
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).pollInterval(10, TimeUnit.MILLISECONDS).until(() -> _events.contains("requestDestroyed /"));
         assertEvents("requestInitialized /", "doFilter /", "REQUEST /", "requestDestroyed /",
             "requestInitialized /", "doFilter /", "ASYNC /", "requestDestroyed /");
     }
@@ -201,6 +206,7 @@ public class ServletRequestListenerTest
         assertThat(response.getStatus(), equalTo(HttpStatus.INTERNAL_SERVER_ERROR_500));
         assertThat(response.getContentAsString(), equalTo("error handled"));
 
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).pollInterval(10, TimeUnit.MILLISECONDS).until(() -> _events.contains("requestDestroyed /"));
         assertEvents("requestInitialized /", "doFilter /", "REQUEST /", "requestDestroyed /",
             "requestInitialized /", "doFilter /error", "ERROR /error", "requestDestroyed /");
     }
@@ -240,6 +246,7 @@ public class ServletRequestListenerTest
         assertThat(response.getStatus(), equalTo(HttpStatus.INTERNAL_SERVER_ERROR_500));
         assertThat(response.getContentAsString(), equalTo("error handled"));
 
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).pollInterval(10, TimeUnit.MILLISECONDS).until(() -> _events.contains("errorHandler"));
         assertEvents("requestInitialized /", "doFilter /", "REQUEST /", "requestDestroyed /", "errorHandler");
     }
 
@@ -270,6 +277,7 @@ public class ServletRequestListenerTest
         ContentResponse response = _httpClient.GET("http://localhost:" + _connector.getLocalPort());
         assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
         assertThat(response.getContentAsString(), equalTo("from servlet"));
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).pollInterval(10, TimeUnit.MILLISECONDS).until(() -> _events.contains("requestDestroyed /"));
         assertEvents("requestInitialized /", "doFilter /", "REQUEST /", "requestDestroyed /");
 
         response = _httpClient.GET("http://localhost:" + _connector.getLocalPort() + "/authed");

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/PushedResourcesTest.java
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/PushedResourcesTest.java
@@ -18,6 +18,7 @@ import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -25,9 +26,11 @@ import org.eclipse.jetty.client.BufferingResponseListener;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.Result;
 import org.eclipse.jetty.http.HttpStatus;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -53,19 +56,31 @@ public class PushedResourcesTest extends AbstractTest
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
             {
+                Cookie cookie0 = new Cookie("C0", "v0");
+                cookie0.setMaxAge(0);
+                response.addCookie(cookie0);
+                Cookie cookie1 = new Cookie("C1", "v1");
+                response.addCookie(cookie1);
+
                 String target = request.getRequestURI();
                 if (target.equals(path1))
                 {
+                    assertThat(request.getHeader("H1"), Matchers.equalTo("V1"));
+                    assertThat(request.getHeader("Cookie"), Matchers.equalTo("C1=v1"));
                     response.getOutputStream().write(pushBytes1);
                 }
                 else if (target.equals(path2))
                 {
+                    assertThat(request.getHeader("H1"), Matchers.nullValue());
+                    assertThat(request.getHeader("Cookie"), Matchers.equalTo("C1=v1"));
                     response.getOutputStream().write(pushBytes2);
                 }
                 else
                 {
+                    assertThat(request.getHeader("Cookie"), Matchers.equalTo("C0=toBeRemoved"));
                     request.newPushBuilder()
                         .path(path1)
+                        .addHeader("H1", "V1")
                         .push();
                     request.newPushBuilder()
                         .path(path2)
@@ -78,6 +93,7 @@ public class PushedResourcesTest extends AbstractTest
         CountDownLatch latch1 = new CountDownLatch(1);
         CountDownLatch latch2 = new CountDownLatch(1);
         ContentResponse response = client.newRequest(newURI(transport))
+            .headers(h -> h.add("Cookie", "C0=toBeRemoved"))
             .onPush((mainRequest, pushedRequest) -> new BufferingResponseListener()
             {
                 @Override


### PR DESCRIPTION
Fix #11934 Servlet 6.1 cookies:
 + don't send a max-age=0
 + treat any non null non "false" attribute value as a true
 + don't send = for empty cookie attribute values
 + added compliance mode MAINTAIN_QUOTES to keep the quotes as part of the cookie value.  Added mode RFC6265_QUOTED that includes this violation
