### PR TITLE
[9.4.x] Updating URL refs to jetty.org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,9 +14,9 @@ Developer resources
 --------------------
 Information regarding source code management, builds, coding standards, and more.
 
-- [https://www.eclipse.org/jetty/documentation/current/advanced-contributing.html](https://www.eclipse.org/jetty/documentation/current/advanced-contributing.html)
+- [https://jetty.org/docs/contribution-guide/index.html](https://jetty.org/docs/contribution-guide/index.html)
 
-The canonical Jetty git repository is located at [GitHub.](https://github.com/eclipse/jetty.project) Providing you have
+The canonical Jetty git repository is located at [GitHub.](https://github.com/jetty/jetty.project) Providing you have
 completed the contributors agreement mentioned below we will endeavor to pull your commit into Jetty proper.
 
 Eclipse Contributor Agreement

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,13 +43,13 @@ Search for bugs
 ----------------
 This project uses GitHub Issues to track ongoing development and issues.
 
-- [https://github.com/eclipse/jetty.project/issues](https://github.com/eclipse/jetty.project/issues)
+- [https://github.com/jetty/jetty.project/issues](https://github.com/jetty/jetty.project/issues)
 
 Create a new bug
 -----------------
 Be sure to search for existing bugs before you create another one. Remember that contributions are always welcome!
 
-- [https://github.com/eclipse/jetty.project/issues](https://github.com/eclipse/jetty.project/issues)
+- [https://github.com/jetty/jetty.project/issues](https://github.com/jetty/jetty.project/issues)
 
 Reporting Security Issues
 -----------------

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -2,7 +2,7 @@ Notices for Eclipse Jetty
 =========================
 This content is produced and maintained by the Eclipse Jetty project.
 
-Project home: https://www.eclipse.org/jetty/
+Project home: https://jetty.org/
 
 Trademarks
 ----------

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Documentation
 
 Project documentation is available on the Jetty Eclipse website.
 
-- [https://www.eclipse.org/jetty/documentation](https://www.eclipse.org/jetty/documentation)
+- [https://jetty.org/docs/](https://jetty.org/docs/)
 
 Building
 ========

--- a/aggregates/jetty-all-compact3/pom.xml
+++ b/aggregates/jetty-all-compact3/pom.xml
@@ -83,7 +83,7 @@
             <manifest></manifest>
             <manifestEntries>
               <mode>development</mode>
-              <url>https://eclipse.org/jetty</url>
+              <url>https://jetty.org/</url>
               <Built-By>${user.name}</Built-By>
               <package>org.eclipse.jetty</package>
               <Bundle-License>https://raw.githubusercontent.com/eclipse/jetty.project/master/NOTICE.txt</Bundle-License>

--- a/aggregates/jetty-websocket-all/pom.xml
+++ b/aggregates/jetty-websocket-all/pom.xml
@@ -65,7 +65,7 @@
                 <manifest></manifest>
                 <manifestEntries>
                   <mode>development</mode>
-                  <url>https://eclipse.org/jetty</url>
+                  <url>https://jetty.org/</url>
                   <Built-By>${user.name}</Built-By>
                   <package>org.eclipse.jetty</package>
                   <Bundle-License>https://raw.githubusercontent.com/eclipse/jetty.project/master/NOTICE.txt</Bundle-License>

--- a/apache-jsp/src/main/config/modules/apache-jsp.mod
+++ b/apache-jsp/src/main/config/modules/apache-jsp.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables use of the apache implementation of JSP

--- a/apache-jstl/src/main/config/modules/apache-jstl.mod
+++ b/apache-jstl/src/main/config/modules/apache-jstl.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables the apache version of JSTL

--- a/examples/async-rest/async-rest-webapp/src/main/webapp/WEB-INF/jetty-web.xml
+++ b/examples/async-rest/async-rest-webapp/src/main/webapp/WEB-INF/jetty-web.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!--
 This is the jetty specific web application configuration file.  When starting

--- a/examples/embedded/src/main/resources/exampleserver.xml
+++ b/examples/embedded/src/main/resources/exampleserver.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="ExampleServer" class="org.eclipse.jetty.server.Server">
 

--- a/examples/embedded/src/main/resources/fileserver.xml
+++ b/examples/embedded/src/main/resources/fileserver.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="FileServer" class="org.eclipse.jetty.server.Server">
 

--- a/examples/embedded/src/main/resources/jetty-otherserver.xml
+++ b/examples/embedded/src/main/resources/jetty-otherserver.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="OtherServer" class="org.eclipse.jetty.server.Server">
     <Set name="handler">

--- a/jetty-alpn/jetty-alpn-server/src/main/config/etc/jetty-alpn.xml
+++ b/jetty-alpn/jetty-alpn-server/src/main/config/etc/jetty-alpn.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="sslConnector" class="org.eclipse.jetty.server.ServerConnector">
 

--- a/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-available-false.mod
+++ b/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-available-false.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Provides ALPN support for JDK 8, using the Jetty ALPN Agent.

--- a/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-available-true.mod
+++ b/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn-impl/alpn-available-true.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Provides support for ALPN based on JDK 9+ APIs.

--- a/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn.mod
+++ b/jetty-alpn/jetty-alpn-server/src/main/config/modules/alpn.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables the ALPN (Application Layer Protocol Negotiation) TLS extension.

--- a/jetty-annotations/src/main/config/etc/jetty-annotations.xml
+++ b/jetty-annotations/src/main/config/etc/jetty-annotations.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <!-- =========================================================== -->

--- a/jetty-annotations/src/main/config/modules/annotations.mod
+++ b/jetty-annotations/src/main/config/modules/annotations.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables Annotation scanning for deployed webapplications.

--- a/jetty-bom/pom.xml
+++ b/jetty-bom/pom.xml
@@ -3,7 +3,7 @@
   <artifactId>jetty-bom</artifactId>
   <name>Jetty :: Bom</name>
   <description>Jetty BOM artifact</description>
-  <url>https://eclipse.org/jetty</url>
+  <url>https://jetty.org/</url>
   <packaging>pom</packaging>
 
   <parent>

--- a/jetty-cdi/src/main/config/etc/cdi/jetty-cdi.xml
+++ b/jetty-cdi/src/main/config/etc/cdi/jetty-cdi.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call name="setAttribute">

--- a/jetty-cdi/src/main/config/etc/cdi/jetty-cdi2.xml
+++ b/jetty-cdi/src/main/config/etc/cdi/jetty-cdi2.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Get class="org.eclipse.jetty.util.log.Log" name="rootLogger">

--- a/jetty-cdi/src/main/config/etc/cdi/jetty-web-cdi2.xml
+++ b/jetty-cdi/src/main/config/etc/cdi/jetty-web-cdi2.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Get name="serverClasspathPattern">

--- a/jetty-cdi/src/main/config/modules/cdi-decorate.mod
+++ b/jetty-cdi/src/main/config/modules/cdi-decorate.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Configures Jetty to use the "CdiDecoratingListener" as the default

--- a/jetty-cdi/src/main/config/modules/cdi-spi.mod
+++ b/jetty-cdi/src/main/config/modules/cdi-spi.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Configures Jetty to use the "CdiSpiDecorator" that calls the CDI SPI

--- a/jetty-cdi/src/main/config/modules/cdi.mod
+++ b/jetty-cdi/src/main/config/modules/cdi.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Support for CDI inside the webapp.

--- a/jetty-cdi/src/main/config/modules/cdi2.mod
+++ b/jetty-cdi/src/main/config/modules/cdi2.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Deprecated support for CDI integrations inside the webapp.

--- a/jetty-client/src/main/config/modules/client.mod
+++ b/jetty-client/src/main/config/modules/client.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Adds the Jetty HTTP client to the server classpath.

--- a/jetty-deploy/src/main/config/etc/jetty-decorate.xml
+++ b/jetty-deploy/src/main/config/etc/jetty-decorate.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Mixin the Weld / CDI classes to the class loader                -->

--- a/jetty-deploy/src/main/config/etc/jetty-deploy.xml
+++ b/jetty-deploy/src/main/config/etc/jetty-deploy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Create the deployment manager                                   -->

--- a/jetty-deploy/src/main/config/etc/jetty-web-decorate.xml
+++ b/jetty-deploy/src/main/config/etc/jetty-web-decorate.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext" id="context">
 

--- a/jetty-deploy/src/main/config/modules/decorate.mod
+++ b/jetty-deploy/src/main/config/modules/decorate.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Jetty setup to support Decoration of Listeners, Filters and Servlets within a deployed webapp.

--- a/jetty-deploy/src/main/config/modules/deploy.mod
+++ b/jetty-deploy/src/main/config/modules/deploy.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables webapplication deployment from the webapps directory.

--- a/jetty-deploy/src/main/config/modules/global-webapp-common.d/global-webapp-common.xml
+++ b/jetty-deploy/src/main/config/modules/global-webapp-common.d/global-webapp-common.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Ref refid="DeploymentManager">

--- a/jetty-deploy/src/main/config/modules/global-webapp-common.d/webapp-common.xml
+++ b/jetty-deploy/src/main/config/modules/global-webapp-common.d/webapp-common.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
 

--- a/jetty-deploy/src/main/config/modules/global-webapp-common.mod
+++ b/jetty-deploy/src/main/config/modules/global-webapp-common.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables Deployer to apply common configuration to all webapp deployments

--- a/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/DeploymentTempDirTest.java
+++ b/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/DeploymentTempDirTest.java
@@ -103,7 +103,7 @@ public class DeploymentTempDirTest
         Path warPath = MavenTestingUtils.getTestResourcePath("webapps/foo-webapp-1.war");
         String deploymentXml =
             "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
-            "<!DOCTYPE Configure PUBLIC \"-//Jetty//Configure//EN\" \"https://eclipse.dev/jetty/configure.dtd\">\n" +
+            "<!DOCTYPE Configure PUBLIC \"-//Jetty//Configure//EN\" \"https://jetty.org/configure.dtd\">\n" +
             "<Configure class=\"org.eclipse.jetty.webapp.WebAppContext\">\n" +
             "<Set name=\"war\">" + warPath + "</Set>\n" +
             "<Set name=\"tempDirectory\">" + tmpDir + "</Set>\n" +
@@ -146,7 +146,7 @@ public class DeploymentTempDirTest
         Path warPath = MavenTestingUtils.getTestResourcePath("webapps/foo-webapp-1.war");
         String deploymentXml =
             "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
-            "<!DOCTYPE Configure PUBLIC \"-//Jetty//Configure//EN\" \"https://eclipse.dev/jetty/configure.dtd\">\n" +
+            "<!DOCTYPE Configure PUBLIC \"-//Jetty//Configure//EN\" \"https://jetty.org/configure.dtd\">\n" +
             "<Configure class=\"org.eclipse.jetty.webapp.WebAppContext\">\n" +
             "<Set name=\"war\">" + warPath + "</Set>\n" +
             "<Set name=\"tempDirectory\">" + tmpDir + "</Set>\n" +

--- a/jetty-deploy/src/test/resources/binding-test-contexts-1.xml
+++ b/jetty-deploy/src/test/resources/binding-test-contexts-1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-deploy/src/test/resources/context-binding-test-1.xml
+++ b/jetty-deploy/src/test/resources/context-binding-test-1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://eclipse.dev/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
 
   <Call name="addServerClass">

--- a/jetty-deploy/src/test/resources/jetty-deploy-wars.xml
+++ b/jetty-deploy/src/test/resources/jetty-deploy-wars.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-deploy/src/test/resources/jetty-deploymgr-contexts.xml
+++ b/jetty-deploy/src/test/resources/jetty-deploymgr-contexts.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call name="addBean">

--- a/jetty-deploy/src/test/resources/jetty-http.xml
+++ b/jetty-deploy/src/test/resources/jetty-http.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->

--- a/jetty-deploy/src/test/resources/jetty.xml
+++ b/jetty-deploy/src/test/resources/jetty.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Documentation of this file format can be found at:              -->
-<!-- https://www.eclipse.org/jetty/documentation/current/        -->
+<!-- https://jetty.org/documentation/current/        -->
 <!--                                                                 -->
 <!-- Additional configuration files are available in $JETTY_HOME/etc -->
 <!-- and can be mixed in. See start.ini file for the default         -->

--- a/jetty-deploy/src/test/resources/webapps/badapp/badapp.xml
+++ b/jetty-deploy/src/test/resources/webapps/badapp/badapp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/badapp</Set>

--- a/jetty-deploy/src/test/resources/webapps/foo.xml
+++ b/jetty-deploy/src/test/resources/webapps/foo.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
     <Set name="contextPath">/foo</Set>
     <Set name="war">

--- a/jetty-distribution/src/main/resources/demo-base/webapps/ROOT/index.html
+++ b/jetty-distribution/src/main/resources/demo-base/webapps/ROOT/index.html
@@ -45,7 +45,7 @@
           <h2>information ...</h2>
             <ul>
                 <li><a href="https://www.eclipse.org/jetty/">Jetty Homepage</a></li>
-                <li><a href="https://www.eclipse.org/jetty/documentation/current/">Jetty Documentation</a></li>
+                <li><a href="https://jetty.org/docs/">Jetty Documentation</a></li>
                 <li><a href="/proxy/current/">Javadoc</a> (via transparent proxy)</li>
                 <li><a href="https://www.eclipse.org/jetty/powered">Jetty Powered</a></li>
             </ul>

--- a/jetty-distribution/src/main/resources/demo-base/webapps/example-moved.xml
+++ b/jetty-distribution/src/main/resources/demo-base/webapps/example-moved.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- Simple handler to redirect from old path to new -->
 <Configure class="org.eclipse.jetty.server.handler.MovedContextHandler">

--- a/jetty-distribution/src/main/resources/start.ini
+++ b/jetty-distribution/src/main/resources/start.ini
@@ -7,7 +7,7 @@
 # of making changes to this {jetty.home} directory.
 #
 # See documentation about {jetty.base} at
-# https://www.eclipse.org/jetty/documentation/current/startup.html
+# https://jetty.org/docs/9/startup.html
 #
 # A demo-base directory has been provided as an example of
 # this sort of setup.

--- a/jetty-documentation/pom.xml
+++ b/jetty-documentation/pom.xml
@@ -29,7 +29,7 @@
             <require>asciidoctor-diagram</require>
           </requires>
           <attributes>
-            <JDURL>http://www.eclipse.org/jetty/javadoc/jetty-9</JDURL>
+            <JDURL>https://jetty.org/javadoc/jetty-9</JDURL>
             <JXURL>http://download.eclipse.org/jetty/stable-9/xref</JXURL>
             <SRCDIR>${basedir}/..</SRCDIR>
             <GITBROWSEURL>https://github.com/eclipse/jetty.project/tree/jetty-9.4.x</GITBROWSEURL>

--- a/jetty-documentation/pom.xml
+++ b/jetty-documentation/pom.xml
@@ -32,8 +32,8 @@
             <JDURL>https://jetty.org/javadoc/jetty-9</JDURL>
             <JXURL>http://download.eclipse.org/jetty/stable-9/xref</JXURL>
             <SRCDIR>${basedir}/..</SRCDIR>
-            <GITBROWSEURL>https://github.com/eclipse/jetty.project/tree/jetty-9.4.x</GITBROWSEURL>
-            <GITDOCURL>https://github.com/eclipse/jetty.project/tree/jetty-9.4.x/jetty-documentation/src/main/asciidoc</GITDOCURL>
+            <GITBROWSEURL>https://github.com/jetty/jetty.project/tree/jetty-9.4.x</GITBROWSEURL>
+            <GITDOCURL>https://github.com/jetty/jetty.project/tree/jetty-9.4.x/jetty-documentation/src/main/asciidoc</GITDOCURL>
             <MVNCENTRAL>http://central.maven.org/maven2</MVNCENTRAL>
             <VERSION>${project.version}</VERSION>
             <TIMESTAMP>${maven.build.timestamp}</TIMESTAMP>

--- a/jetty-documentation/src/main/asciidoc/administration/runner/jetty-runner.adoc
+++ b/jetty-documentation/src/main/asciidoc/administration/runner/jetty-runner.adoc
@@ -73,7 +73,7 @@ The default Configuration Classes are:
 `org.eclipse.jetty.plus.webapp.PlusConfiguration`
 `org.eclipse.jetty.annotations.AnnotationConfiguration`
 
-You can learn more about implementing specific Configuration Classes link:https://www.eclipse.org/jetty/documentation/current/configuring-webapps.html#webapp-configurations[here.]
+You can learn more about implementing specific Configuration Classes link:https://jetty.org/docs/9/configuring-webapps.html#webapp-configurations[here.]
 
 ==== Deploying Multiple Contexts
 
@@ -251,7 +251,7 @@ Here's an example of configuring a single extra classes dir:
 [NOTE]
 ====
 When using the `--jar` and/or `--lib` arguments, by default these will *not* be inspected for `META-INF` information such as `META-INF/resources`, `META-INF/web-fragment.xml`, or `META-INF/taglib.tld`.
-If you require these jar files inspected you will need to define the link:https://www.eclipse.org/jetty/documentation/current/configuring-webapps.html#webapp-context-attributes[jar pattern in your context xml file].
+If you require these jar files inspected you will need to define the link:https://jetty.org/docs/9/configuring-webapps.html#webapp-context-attributes[jar pattern in your context xml file].
 Jetty-Runner automatically provides and appends a suitable pattern for jtsl taglibs (this pattern is different than the one in the standard Jetty distribution).
 ====
 ===== Gathering Statistics

--- a/jetty-documentation/src/main/asciidoc/administration/sessions/session-configuration-infinispan.adoc
+++ b/jetty-documentation/src/main/asciidoc/administration/sessions/session-configuration-infinispan.adoc
@@ -205,7 +205,7 @@ There are no configuration properties associated with this module.
 
 From jetty-9.4.13 onwards, we have changed the format of the serialized session when using a remote cache (ie using hotrod).
 Prior to release 9.4.13 we used the default Infinispan serialization, however this was not able to store sufficient information to allow jetty to properly deserialize session attributes in all circumstances.
-See issue https://github.com/eclipse/jetty.project/issues/2919 for more background.
+See issue https://github.com/jetty/jetty.project/issues/2919 for more background.
 
 We have provided a conversion program which will convert any sessions stored in Infinispan to the new format.
 [IMPORTANT]

--- a/jetty-documentation/src/main/asciidoc/configuring/security/jaas-support.adoc
+++ b/jetty-documentation/src/main/asciidoc/configuring/security/jaas-support.adoc
@@ -407,4 +407,4 @@ public class FooLoginModule extends AbstractLoginModule
 
 An example webapp using JAAS can be found in the Jetty GitHub repository:
 
-* link:{GITBROWSEURL}/tests/test-webapps/test-jaas-webapp[https://github.com/eclipse/jetty.project/tree/jetty-9.4.x/tests/test-webapps/test-jaas-webapp]
+* link:{GITBROWSEURL}/tests/test-webapps/test-jaas-webapp[https://github.com/jetty/jetty.project/tree/jetty-9.4.x/tests/test-webapps/test-jaas-webapp]

--- a/jetty-documentation/src/main/asciidoc/development/continuations/continuations-patterns.adoc
+++ b/jetty-documentation/src/main/asciidoc/development/continuations/continuations-patterns.adoc
@@ -104,7 +104,7 @@ If many responses are to be sent (e.g., a chat room), then writing one response 
 
 ==== Examples
 
-* The https://github.com/eclipse/jetty.project/blob/jetty-9.4.x/tests/test-webapps/test-jetty-webapp/src/main/java/com/acme/ChatServlet.java[ChatServlet example]
+* The https://github.com/jetty/jetty.project/blob/jetty-9.4.x/tests/test-webapps/test-jetty-webapp/src/main/java/com/acme/ChatServlet.java[ChatServlet example]
 shows how to make a chat room using Async Servlets.
 The same principles are applied to frameworks like http://cometd.org/[cometd] which provide an richer environment for such applications, based on Continuations.
 

--- a/jetty-documentation/src/main/asciidoc/quick-start/getting-started/jetty-running.adoc
+++ b/jetty-documentation/src/main/asciidoc/quick-start/getting-started/jetty-running.adoc
@@ -29,7 +29,7 @@ To start Jetty on the default port of 8080, run the following command:
 ----
 $ java -jar start.jar
 2017-09-20 15:45:11.986:INFO::main: Logging initialized @683ms to org.eclipse.jetty.util.log.StdErrLog
-2017-09-20 15:45:12.197:WARN:oejs.HomeBaseWarning:main: This instance of Jetty is not running from a separate {jetty.base} directory, this is not recommended.  See documentation at https://www.eclipse.org/jetty/documentation/current/startup.html
+2017-09-20 15:45:12.197:WARN:oejs.HomeBaseWarning:main: This instance of Jetty is not running from a separate {jetty.base} directory, this is not recommended.  See documentation at https://jetty.org/docs/9/startup.html
 2017-09-20 15:45:12.243:INFO:oejs.Server:main: {VERSION}
 2017-09-20 15:45:12.266:INFO:oejdp.ScanningAppProvider:main: Deployment monitor [file:///installs/repository/jetty/webapps/] at interval 1
 2017-09-20 15:45:12.298:INFO:oejs.AbstractConnector:main: Started ServerConnector@39c0f4a{HTTP/1.1,[http/1.1]}{0.0.0.0:8080}

--- a/jetty-documentation/src/main/asciidoc/reference/contributing/bugs.adoc
+++ b/jetty-documentation/src/main/asciidoc/reference/contributing/bugs.adoc
@@ -22,5 +22,5 @@
 As with any constantly evolving software project, there will be issues, features, and bugs.
 We want to know whats bugging you!
 
-File bugs as Issues in our Github repository http://github.com/eclipse/jetty.project[Issues at Github]
+File bugs as Issues in our Github repository http://github.com/jetty/jetty.project[Issues at Github]
 

--- a/jetty-documentation/src/main/asciidoc/reference/contributing/documentation.adoc
+++ b/jetty-documentation/src/main/asciidoc/reference/contributing/documentation.adoc
@@ -54,7 +54,7 @@ Clone the repository:
 
 [source, screen]
 ----
-$ git clone https://github.com/eclipse/jetty.project.git
+$ git clone https://github.com/jetty/jetty.project.git
 ----
 
 You will now have a local directory with all of jetty, including the jetty-documentation.
@@ -113,7 +113,7 @@ Obviously we can not allow anyone immediate access to this repository so you mus
 In English that means that you would go to the url of the documentation in github:
 
 ----
-https://github.com/eclipse/jetty.project
+https://github.com/jetty/jetty.project
 ----
 
 When you are on this page you will see a little button called 'Fork' which you can click and you will be taken back to your main page on github where you have a new repository.

--- a/jetty-documentation/src/main/asciidoc/reference/contributing/releasing-jetty.adoc
+++ b/jetty-documentation/src/main/asciidoc/reference/contributing/releasing-jetty.adoc
@@ -249,7 +249,7 @@ Make sure you follow the other examples and include the `rel="nofollow"` attribu
 
 [NOTE]
 ====
-There is a separate Jenkins build job that publishes documentation to https://www.eclipse.org/jetty/documentation/current triggered by a push of changed files to the jetty-documentation project.
+There is a separate Jenkins build job that publishes documentation to https://jetty.org/docs/ triggered by a push of changed files to the jetty-documentation project.
 If you commit your change to the <version> number from step 2, then these builds will use the same release version number.
 It is preferable if you _don't_ commit that version number change, or better yet, ensure that it is set to the next -SNAPSHOT version number for your jetty major release number.
 ====

--- a/jetty-documentation/src/main/asciidoc/reference/contributing/source-build.adoc
+++ b/jetty-documentation/src/main/asciidoc/reference/contributing/source-build.adoc
@@ -33,7 +33,7 @@ These are the URLs to the GIT repositories for the Jetty code.
 They are for people who are working on the Jetty project, as well as for people who are interested in examining or modifying the Jetty code for their own projects.
 
 Jetty Project Repository::
-  https://github.com/eclipse/jetty.project
+  https://github.com/jetty/jetty.project
 
 ===== Build and Project Infrastructure SCM URLs
 
@@ -58,7 +58,7 @@ Building Jetty should simply be a matter of changing into the relevant directory
 [source, screen]
 ----
 
-$ git clone https://github.com/eclipse/jetty.project.git
+$ git clone https://github.com/jetty/jetty.project.git
 $ cd jetty.project
 $ mvn install
 

--- a/jetty-documentation/src/main/asciidoc/reference/jetty-xml/jetty-xml-config.adoc
+++ b/jetty-documentation/src/main/asciidoc/reference/jetty-xml/jetty-xml-config.adoc
@@ -31,7 +31,7 @@
 
 Not all Jetty features are configured in `jetty.xml`.
 There are several optional configuration files that share the same format as `jetty.xml` and, if specified, concatenate to it.
-These configuration files are also stored in `$JETTY_HOME/etc/`, and examples of them are in http://github.com/eclipse/jetty.project/jetty-server/src/main/config/etc/[Github Repository].
+These configuration files are also stored in `$JETTY_HOME/etc/`, and examples of them are in http://github.com/jetty/jetty.project/jetty-server/src/main/config/etc/[Github Repository].
 The selection of which configuration files to use is controlled by `start.jar` and the process of merging configuration is described in xref:jetty-xml-usage[].
 
 [[root-element-jetty-xml]]

--- a/jetty-fcgi/fcgi-server/src/main/config/modules/fcgi.mod
+++ b/jetty-fcgi/fcgi-server/src/main/config/modules/fcgi.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Adds the FastCGI implementation to the classpath.
@@ -13,4 +13,4 @@ lib/fcgi/*.jar
 
 [ini-template]
 ## For configuration of FastCGI contexts, see
-## https://www.eclipse.org/jetty/documentation/current/fastcgi.html
+## https://jetty.org/docs/9/fastcgi.html

--- a/jetty-gcloud/jetty-gcloud-session-manager/src/main/config-template/etc/sessions/gcloud/session-store.xml
+++ b/jetty-gcloud/jetty-gcloud-session-manager/src/main/config-template/etc/sessions/gcloud/session-store.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-gcloud/jetty-gcloud-session-manager/src/main/config-template/modules/gcloud-datastore.mod
+++ b/jetty-gcloud/jetty-gcloud-session-manager/src/main/config-template/modules/gcloud-datastore.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables GCloud Datastore API and implementation

--- a/jetty-gcloud/jetty-gcloud-session-manager/src/main/config-template/modules/gcloud.mod
+++ b/jetty-gcloud/jetty-gcloud-session-manager/src/main/config-template/modules/gcloud.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Control GCloud API classpath

--- a/jetty-gcloud/jetty-gcloud-session-manager/src/main/config-template/modules/session-store-gcloud.mod
+++ b/jetty-gcloud/jetty-gcloud-session-manager/src/main/config-template/modules/session-store-gcloud.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables GCloudDatastore session management.

--- a/jetty-hazelcast/src/main/config/etc/sessions/hazelcast/default.xml
+++ b/jetty-hazelcast/src/main/config/etc/sessions/hazelcast/default.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-hazelcast/src/main/config/etc/sessions/hazelcast/remote.xml
+++ b/jetty-hazelcast/src/main/config/etc/sessions/hazelcast/remote.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-hazelcast/src/main/config/modules/session-store-hazelcast-embedded.mod
+++ b/jetty-hazelcast/src/main/config/modules/session-store-hazelcast-embedded.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables session data store in an embedded Hazelcast Map

--- a/jetty-hazelcast/src/main/config/modules/session-store-hazelcast-remote.mod
+++ b/jetty-hazelcast/src/main/config/modules/session-store-hazelcast-remote.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables session data store in a remote Hazelcast Map

--- a/jetty-home/src/main/resources/etc/jetty-setuid.xml
+++ b/jetty-home/src/main/resources/etc/jetty-setuid.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- ================================================================ -->
 <!-- Configure the Jetty SetUIDListener                                -->

--- a/jetty-home/src/main/resources/etc/jetty-started.xml
+++ b/jetty-home/src/main/resources/etc/jetty-started.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Mixin the Start FileNoticeLifeCycleListener                     -->

--- a/jetty-home/src/main/resources/etc/jetty-stop.xml
+++ b/jetty-home/src/main/resources/etc/jetty-stop.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Stop" class="org.eclipse.jetty.util.component.StopLifeCycle">
   <Arg><Ref refid="Server"/></Arg>

--- a/jetty-home/src/main/resources/modules/conscrypt.mod
+++ b/jetty-home/src/main/resources/modules/conscrypt.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Installs the Conscrypt JSSE provider

--- a/jetty-home/src/main/resources/modules/conscrypt/conscrypt.xml
+++ b/jetty-home/src/main/resources/modules/conscrypt/conscrypt.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 <Configure id="Conscrypt" class="org.conscrypt.OpenSSLProvider">
   <Call class="java.security.Security" name="addProvider">
     <Arg><Ref refid="Conscrypt"/></Arg>

--- a/jetty-home/src/main/resources/modules/hawtio.mod
+++ b/jetty-home/src/main/resources/modules/hawtio.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Deploys the Hawtio console as a webapplication.

--- a/jetty-home/src/main/resources/modules/hawtio/hawtio.xml
+++ b/jetty-home/src/main/resources/modules/hawtio/hawtio.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection">
   <Call name="addHandler">

--- a/jetty-home/src/main/resources/modules/jamon.mod
+++ b/jetty-home/src/main/resources/modules/jamon.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Deploys the JAMon webapplication

--- a/jetty-home/src/main/resources/modules/jamon/jamon.xml
+++ b/jetty-home/src/main/resources/modules/jamon/jamon.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Mixin the Jamon Handler                                         -->

--- a/jetty-home/src/main/resources/modules/jminix.mod
+++ b/jetty-home/src/main/resources/modules/jminix.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Deploys the Jminix JMX Console within the server

--- a/jetty-home/src/main/resources/modules/jminix/jminix.xml
+++ b/jetty-home/src/main/resources/modules/jminix/jminix.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
  
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call name="addBean">

--- a/jetty-home/src/main/resources/modules/jolokia.mod
+++ b/jetty-home/src/main/resources/modules/jolokia.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Deploys the Jolokia console as a web application.

--- a/jetty-home/src/main/resources/modules/jolokia/jolokia.xml
+++ b/jetty-home/src/main/resources/modules/jolokia/jolokia.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection">
   <Call name="addHandler">

--- a/jetty-home/src/main/resources/modules/jsp.mod
+++ b/jetty-home/src/main/resources/modules/jsp.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables JSP for all webapplications deployed on the server.

--- a/jetty-home/src/main/resources/modules/jstl.mod
+++ b/jetty-home/src/main/resources/modules/jstl.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables JSTL for all webapplications deployed on the server

--- a/jetty-home/src/main/resources/modules/setuid.mod
+++ b/jetty-home/src/main/resources/modules/setuid.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables the unix setUID configuration so that the server

--- a/jetty-home/src/main/resources/modules/stop.mod
+++ b/jetty-home/src/main/resources/modules/stop.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 This module causes jetty to stop immediately after starting. This is good for testing configuration and/or precompiling quickstart webapps

--- a/jetty-http2/http2-server/src/main/config/etc/jetty-http2.xml
+++ b/jetty-http2/http2-server/src/main/config/etc/jetty-http2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="sslConnector" class="org.eclipse.jetty.server.ServerConnector">
   <Call name="addConnectionFactory">

--- a/jetty-http2/http2-server/src/main/config/etc/jetty-http2c.xml
+++ b/jetty-http2/http2-server/src/main/config/etc/jetty-http2c.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="httpConnector" class="org.eclipse.jetty.server.ServerConnector">
   <Call name="addConnectionFactory">

--- a/jetty-http2/http2-server/src/main/config/modules/http2.mod
+++ b/jetty-http2/http2-server/src/main/config/modules/http2.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables HTTP2 protocol support on the TLS(SSL) Connector,

--- a/jetty-http2/http2-server/src/main/config/modules/http2c.mod
+++ b/jetty-http2/http2-server/src/main/config/modules/http2c.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables the HTTP2C protocol on the HTTP Connector

--- a/jetty-infinispan/infinispan-common/src/main/config/etc/sessions/infinispan/infinispan-common.xml
+++ b/jetty-infinispan/infinispan-common/src/main/config/etc/sessions/infinispan/infinispan-common.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   

--- a/jetty-infinispan/infinispan-embedded-query/src/main/config-template/etc/sessions/infinispan/infinispan-embedded-query.xml
+++ b/jetty-infinispan/infinispan-embedded-query/src/main/config-template/etc/sessions/infinispan/infinispan-embedded-query.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-infinispan/infinispan-embedded/src/main/config-template/etc/sessions/infinispan/infinispan-embedded.xml
+++ b/jetty-infinispan/infinispan-embedded/src/main/config-template/etc/sessions/infinispan/infinispan-embedded.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-infinispan/infinispan-remote-query/src/main/config-template/etc/sessions/infinispan/infinispan-remote-query.xml
+++ b/jetty-infinispan/infinispan-remote-query/src/main/config-template/etc/sessions/infinispan/infinispan-remote-query.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-infinispan/infinispan-remote/src/main/config-template/etc/sessions/infinispan/infinispan-remote.xml
+++ b/jetty-infinispan/infinispan-remote/src/main/config-template/etc/sessions/infinispan/infinispan-remote.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-jaas/src/main/config/etc/jetty-jaas.xml
+++ b/jetty-jaas/src/main/config/etc/jetty-jaas.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-jaas/src/main/config/modules/jaas.mod
+++ b/jetty-jaas/src/main/config/modules/jaas.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enable JAAS for deployed webapplications.

--- a/jetty-jaspi/src/main/config/modules/jaspi.mod
+++ b/jetty-jaspi/src/main/config/modules/jaspi.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enable JASPI authentication for deployed webapplications.

--- a/jetty-jmx/src/main/config/etc/jetty-jmx-remote.xml
+++ b/jetty-jmx/src/main/config/etc/jetty-jmx-remote.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <!-- =========================================================== -->

--- a/jetty-jmx/src/main/config/etc/jetty-jmx.xml
+++ b/jetty-jmx/src/main/config/etc/jetty-jmx.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-jmx/src/main/config/modules/jmx-remote.mod
+++ b/jetty-jmx/src/main/config/modules/jmx-remote.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables remote RMI access to JMX

--- a/jetty-jmx/src/main/config/modules/jmx.mod
+++ b/jetty-jmx/src/main/config/modules/jmx.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables JMX instrumentation for server beans and 

--- a/jetty-jndi/src/main/jndi-config/modules/jndi.mod
+++ b/jetty-jndi/src/main/jndi-config/modules/jndi.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Adds the Jetty JNDI implementation to the classpath.

--- a/jetty-jndi/src/main/jndi-config/modules/mail.mod
+++ b/jetty-jndi/src/main/jndi-config/modules/mail.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Adds the javax.mail implementation to the classpath.

--- a/jetty-jspc-maven-plugin/src/main/java/org/eclipse/jetty/jspc/plugin/JspcMojo.java
+++ b/jetty-jspc-maven-plugin/src/main/java/org/eclipse/jetty/jspc/plugin/JspcMojo.java
@@ -65,7 +65,7 @@ import org.eclipse.jetty.util.resource.Resource;
  * jsps, which will be the Eclipse java compiler.
  * <p>
  * See <a
- * href="https://www.eclipse.org/jetty/documentation/current/jetty-jspc-maven-plugin.html">Usage
+ * href="https://jetty.org/docs/9/jetty-jspc-maven-plugin.html">Usage
  * Guide</a> for instructions on using this plugin.
  * </p>
  * Runs jspc compiler to produce .java and .class files

--- a/jetty-jspc-maven-plugin/src/site/site.xml
+++ b/jetty-jspc-maven-plugin/src/site/site.xml
@@ -6,8 +6,8 @@
 
   <bannerLeft>
     <name>${project.name}</name>
-    <src>https://www.eclipse.org/jetty/images/jetty-logo-80x22.png</src>
-    <href>https://eclipse.org/jetty/</href>
+    <src>https://jetty.org/images/jetty-logo-80x22.png</src>
+    <href>https://jetty.org/</href>
   </bannerLeft>
   <bannerRight>
     <src>https://www.eclipse.org/eclipse.org-common/themes/solstice/public/images/logo/eclipse-426x100.png</src>

--- a/jetty-maven-plugin/src/it/jetty-cdi-run-forked/src/main/jetty/jetty-context.xml
+++ b/jetty-maven-plugin/src/it/jetty-cdi-run-forked/src/main/jetty/jetty-context.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"  encoding="ISO-8859-1"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"  encoding="ISO-8859-1"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- Weld needs access to some internal classes. Same configuration as "cdi2" module provides on server. -->
 

--- a/jetty-maven-plugin/src/it/jetty-cdi-run-forked/src/main/jetty/jetty.xml
+++ b/jetty-maven-plugin/src/it/jetty-cdi-run-forked/src/main/jetty/jetty.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">

--- a/jetty-maven-plugin/src/it/jetty-deploy-war-mojo-it/src/config/jetty.xml
+++ b/jetty-maven-plugin/src/it/jetty-deploy-war-mojo-it/src/config/jetty.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">

--- a/jetty-maven-plugin/src/it/jetty-maven-plugin-provided-module-dep/web/src/config/jetty.xml
+++ b/jetty-maven-plugin/src/it/jetty-maven-plugin-provided-module-dep/web/src/config/jetty.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">

--- a/jetty-maven-plugin/src/it/jetty-run-distro-mojo-it/jetty-simple-webapp/src/base/etc/test-jetty.xml
+++ b/jetty-maven-plugin/src/it/jetty-run-distro-mojo-it/jetty-simple-webapp/src/base/etc/test-jetty.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Ref refid="httpConnector">

--- a/jetty-maven-plugin/src/it/jetty-run-distro-mojo-it/jetty-simple-webapp/src/base/modules/testmod.mod
+++ b/jetty-maven-plugin/src/it/jetty-run-distro-mojo-it/jetty-simple-webapp/src/base/modules/testmod.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables test setup

--- a/jetty-maven-plugin/src/it/jetty-run-forked-mojo-it/jetty-simple-webapp/src/config/jetty.xml
+++ b/jetty-maven-plugin/src/it/jetty-run-forked-mojo-it/jetty-simple-webapp/src/config/jetty.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">

--- a/jetty-maven-plugin/src/it/jetty-run-mojo-it/jetty-simple-webapp/src/config/context.xml
+++ b/jetty-maven-plugin/src/it/jetty-run-mojo-it/jetty-simple-webapp/src/config/context.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
 

--- a/jetty-maven-plugin/src/it/jetty-run-mojo-it/jetty-simple-webapp/src/config/jetty.xml
+++ b/jetty-maven-plugin/src/it/jetty-run-mojo-it/jetty-simple-webapp/src/config/jetty.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">

--- a/jetty-maven-plugin/src/it/jetty-run-mojo-jar-scan-it/MyWebApp/src/config/context.xml
+++ b/jetty-maven-plugin/src/it/jetty-run-mojo-jar-scan-it/MyWebApp/src/config/context.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
 

--- a/jetty-maven-plugin/src/it/jetty-run-mojo-jar-scan-it/MyWebApp/src/config/jetty.xml
+++ b/jetty-maven-plugin/src/it/jetty-run-mojo-jar-scan-it/MyWebApp/src/config/jetty.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">

--- a/jetty-maven-plugin/src/it/jetty-run-mojo-jsp/src/config/jetty.xml
+++ b/jetty-maven-plugin/src/it/jetty-run-mojo-jsp/src/config/jetty.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">

--- a/jetty-maven-plugin/src/it/jetty-run-mojo-multi-module-single-war-it/webapp-war/src/config/jetty.xml
+++ b/jetty-maven-plugin/src/it/jetty-run-mojo-multi-module-single-war-it/webapp-war/src/config/jetty.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">

--- a/jetty-maven-plugin/src/it/jetty-run-war-exploded-mojo-it/jetty-simple-webapp/src/config/jetty.xml
+++ b/jetty-maven-plugin/src/it/jetty-run-war-exploded-mojo-it/jetty-simple-webapp/src/config/jetty.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">

--- a/jetty-maven-plugin/src/it/jetty-run-war-mojo-it/jetty-simple-webapp/src/config/jetty.xml
+++ b/jetty-maven-plugin/src/it/jetty-run-war-mojo-it/jetty-simple-webapp/src/config/jetty.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">

--- a/jetty-maven-plugin/src/it/jetty-start-mojo-it/jetty-simple-webapp/src/config/jetty.xml
+++ b/jetty-maven-plugin/src/it/jetty-start-mojo-it/jetty-simple-webapp/src/config/jetty.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">

--- a/jetty-maven-plugin/src/it/run-mojo-gwt-it/beer-server/src/config/jetty.xml
+++ b/jetty-maven-plugin/src/it/run-mojo-gwt-it/beer-server/src/config/jetty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://eclipse.dev/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">

--- a/jetty-maven-plugin/src/it/run-mojo-gwt-it/beer-server/src/main/jettyconf/context.xml
+++ b/jetty-maven-plugin/src/it/run-mojo-gwt-it/beer-server/src/main/jettyconf/context.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://eclipse.dev/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Call name="setInitParameter">

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyEffectiveWebXml.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyEffectiveWebXml.java
@@ -39,7 +39,7 @@ import org.eclipse.jetty.util.thread.QueuedThreadPool;
  * files. By default, the web.xml is generated to the console output only. Use the <b>effectiveWebXml</b> parameter
  * to provide a file name into which to save the output.
  *
- * See <a href="https://www.eclipse.org/jetty/documentation/">https://www.eclipse.org/jetty/documentation</a> for more information on this and other jetty plugins.
+ * See <a href="https://jetty.org/docs/">https://jetty.org/docs/</a> for more information on this and other jetty plugins.
  *
  * Runs jetty on the unassembled webapp to generate the effective web.xml
  */

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyRunDistro.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyRunDistro.java
@@ -78,7 +78,7 @@ import org.eclipse.jetty.util.resource.Resource;
  *
  * This goal does NOT support the <b>scanIntervalSeconds</b> parameter: the webapp will be deployed only once.
  *
- * See <a href="https://www.eclipse.org/jetty/documentation/">https://www.eclipse.org/jetty/documentation</a> for more information on this and other jetty plugins.
+ * See <a href="https://jetty.org/docs/">https://jetty.org/docs/</a> for more information on this and other jetty plugins.
  *
  * Runs unassembled webapp in a locally installed jetty distro
  */

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyRunForkedMojo.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyRunForkedMojo.java
@@ -62,7 +62,7 @@ import org.eclipse.jetty.util.thread.QueuedThreadPool;
  * By setting the configuration element <b>waitForChild</b> to <b>false</b>, the plugin will terminate after having forked the jetty process. In this case
  * you can use the <b>jetty:stop</b> goal to terminate the process.
  * <p>
- * See <a href="https://www.eclipse.org/jetty/documentation/">https://www.eclipse.org/jetty/documentation</a> for more information on this and other jetty plugins.
+ * See <a href="https://jetty.org/docs/">https://jetty.org/docs/</a> for more information on this and other jetty plugins.
  *
  * Runs Jetty in forked JVM on an unassembled webapp
  */

--- a/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyRunMojo.java
+++ b/jetty-maven-plugin/src/main/java/org/eclipse/jetty/maven/plugin/JettyRunMojo.java
@@ -61,7 +61,7 @@ import org.eclipse.jetty.webapp.WebAppContext;
  * You may also specify the location of a jetty.xml file whose contents will be applied before any plugin configuration.
  * This can be used, for example, to deploy a static webapp that is not part of your maven build.
  * <p>
- * There is a <a href="https://www.eclipse.org/jetty/documentation/current/maven-and-jetty.html">reference guide</a> to the configuration parameters for this plugin.
+ * There is a <a href="https://jetty.org/docs/9/maven-and-jetty.html">reference guide</a> to the configuration parameters for this plugin.
  *
  * Runs jetty directly from a maven project
  */

--- a/jetty-maven-plugin/src/main/resources/jetty-maven.xml
+++ b/jetty-maven-plugin/src/main/resources/jetty-maven.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
    <Call name="addLifeCycleListener">

--- a/jetty-maven-plugin/src/main/resources/maven.mod
+++ b/jetty-maven-plugin/src/main/resources/maven.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables an unassembled maven webapp to run in a jetty distro

--- a/jetty-maven-plugin/src/main/resources/maven.xml
+++ b/jetty-maven-plugin/src/main/resources/maven.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="wac" class="org.eclipse.jetty.maven.plugin.JettyWebAppContext">
 

--- a/jetty-maven-plugin/src/site/site.xml
+++ b/jetty-maven-plugin/src/site/site.xml
@@ -6,8 +6,8 @@
 
   <bannerLeft>
     <name>${project.name}</name>
-    <src>https://www.eclipse.org/jetty/images/jetty-logo-80x22.png</src>
-    <href>https://eclipse.org/jetty/</href>
+    <src>https://jetty.org/images/jetty-logo-80x22.png</src>
+    <href>https://jetty.org/</href>
   </bannerLeft>
   <bannerRight>
     <src>https://www.eclipse.org/eclipse.org-common/themes/solstice/public/images/logo/eclipse-426x100.png</src>

--- a/jetty-memcached/jetty-memcached-sessions/src/main/config/etc/sessions/session-data-cache/xmemcached.xml
+++ b/jetty-memcached/jetty-memcached-sessions/src/main/config/etc/sessions/session-data-cache/xmemcached.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
     <New id="sessionDataMapFactory" class="org.eclipse.jetty.memcached.session.MemcachedSessionDataMapFactory">

--- a/jetty-memcached/jetty-memcached-sessions/src/main/config/modules/sessions/session-data-cache/xmemcached.mod
+++ b/jetty-memcached/jetty-memcached-sessions/src/main/config/modules/sessions/session-data-cache/xmemcached.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Memcache cache for SessionData

--- a/jetty-nosql/src/main/config/etc/sessions/mongo/session-store-by-address.xml
+++ b/jetty-nosql/src/main/config/etc/sessions/mongo/session-store-by-address.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-nosql/src/main/config/etc/sessions/mongo/session-store-by-uri.xml
+++ b/jetty-nosql/src/main/config/etc/sessions/mongo/session-store-by-uri.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-nosql/src/main/config/modules/session-store-mongo.mod
+++ b/jetty-nosql/src/main/config/modules/session-store-mongo.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables NoSql session management with a MongoDB driver.

--- a/jetty-nosql/src/main/config/modules/sessions/mongo/address.mod
+++ b/jetty-nosql/src/main/config/modules/sessions/mongo/address.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Server/port address connections for session storage

--- a/jetty-nosql/src/main/config/modules/sessions/mongo/uri.mod
+++ b/jetty-nosql/src/main/config/modules/sessions/mongo/uri.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 MongoURI connections for session storage

--- a/jetty-openid/src/main/config/etc/jetty-openid.xml
+++ b/jetty-openid/src/main/config/etc/jetty-openid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Get id="ThreadPool" name="threadPool"/>
   <New id="HttpClient" class="org.eclipse.jetty.client.HttpClient">

--- a/jetty-openid/src/main/config/modules/openid.mod
+++ b/jetty-openid/src/main/config/modules/openid.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Adds OpenId Connect authentication to the server.

--- a/jetty-openid/src/main/config/modules/openid/openid-baseloginservice.xml
+++ b/jetty-openid/src/main/config/modules/openid/openid-baseloginservice.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 <Configure>
   <!-- Optional code to configure the base LoginService used by the OpenIdLoginService
   <New id="BaseLoginService" class="org.eclipse.jetty.security.HashLoginService">

--- a/jetty-osgi/jetty-osgi-boot/jettyhome/etc/jetty-deploy.xml
+++ b/jetty-osgi/jetty-osgi-boot/jettyhome/etc/jetty-deploy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-osgi/jetty-osgi-boot/jettyhome/etc/jetty-http.xml
+++ b/jetty-osgi/jetty-osgi-boot/jettyhome/etc/jetty-http.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->

--- a/jetty-osgi/jetty-osgi-boot/jettyhome/etc/jetty.xml
+++ b/jetty-osgi/jetty-osgi-boot/jettyhome/etc/jetty.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 
 <!-- =============================================================== -->
 <!-- Configure the Jetty Server                                      -->
 <!--                                                                 -->
 <!-- Documentation of this file format can be found at:              -->
-<!-- https://www.eclipse.org/jetty/documentation/current/        -->
+<!-- https://jetty.org/documentation/current/        -->
 <!-- =============================================================== -->
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">

--- a/jetty-osgi/jetty-osgi-httpservice/contexts/httpservice.xml
+++ b/jetty-osgi/jetty-osgi-httpservice/contexts/httpservice.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 <Configure class="org.eclipse.jetty.servlet.ServletContextHandler">
   <!-- this configures the servlet session manager -->
   <Set name="SessionHandler">

--- a/jetty-osgi/test-jetty-osgi-context/src/main/context/acme.xml
+++ b/jetty-osgi/test-jetty-osgi-context/src/main/context/acme.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.server.handler.ContextHandler">
 

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-alpn.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-alpn.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="sslConnector" class="org.eclipse.jetty.server.ServerConnector">
 

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-deploy.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-deploy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http-boot-context-as-service.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http-boot-context-as-service.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http-boot-webapp-as-service.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http-boot-webapp-as-service.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http-boot-with-annotations.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http-boot-with-annotations.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http-boot-with-javax-websocket.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http-boot-with-javax-websocket.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http-boot-with-jsp.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http-boot-with-jsp.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http-boot-with-resources.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http-boot-with-resources.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http-boot-with-websocket.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http-boot-with-websocket.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http2-jdk9.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http2-jdk9.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure an HTTP2 on the ssl connector.                       -->

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http2.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http2.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure an HTTP2 on the ssl connector.                       -->

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-https.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-https.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure an HTTPS connector.                                  -->

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-ssl.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-ssl.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- ============================================================= -->
 <!-- Base SSL configuration                                        -->

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-testrealm.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-testrealm.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-" "https://jetty.org/configure_9_3.dtd">
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
     <!-- =========================================================== -->
     <!-- Configure Authentication Login Service                      -->

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 
 <!-- =============================================================== -->
 <!-- Configure the Jetty Server                                      -->
 <!--                                                                 -->
 <!-- Documentation of this file format can be found at:              -->
-<!-- https://www.eclipse.org/jetty/documentation/current/        -->
+<!-- https://jetty.org/documentation/current/        -->
 <!-- =============================================================== -->
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">

--- a/jetty-plus/src/main/plus-config/etc/jetty-plus.xml
+++ b/jetty-plus/src/main/plus-config/etc/jetty-plus.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure extended support for webapps                          -->

--- a/jetty-plus/src/main/plus-config/modules/plus.mod
+++ b/jetty-plus/src/main/plus-config/modules/plus.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables JNDI and resource injection for webapplications 

--- a/jetty-plus/src/main/plus-config/modules/transactions.mod
+++ b/jetty-plus/src/main/plus-config/modules/transactions.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Puts javax.transaction api on the classpath  

--- a/jetty-proxy/src/main/config/etc/jetty-proxy.xml
+++ b/jetty-proxy/src/main/config/etc/jetty-proxy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-proxy/src/main/config/modules/proxy.mod
+++ b/jetty-proxy/src/main/config/modules/proxy.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enable the Jetty Proxy, that allows the server to act

--- a/jetty-quickstart/src/main/config/etc/example-quickstart.xml
+++ b/jetty-quickstart/src/main/config/etc/example-quickstart.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"  encoding="ISO-8859-1"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"  encoding="ISO-8859-1"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- An example context XML for a quickstart webapp
 A quick started webapp has all the jar scanning and fragment resolution done in a 

--- a/jetty-quickstart/src/main/config/modules/quickstart.mod
+++ b/jetty-quickstart/src/main/config/modules/quickstart.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables the Jetty Quickstart module for rapid

--- a/jetty-rewrite/src/main/config/etc/jetty-rewrite-customizer.xml
+++ b/jetty-rewrite/src/main/config/etc/jetty-rewrite-customizer.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 <Configure id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
   <!-- =========================================================== -->
   <!-- configure rewrite rule container as a customizer            -->

--- a/jetty-rewrite/src/main/config/etc/jetty-rewrite.xml
+++ b/jetty-rewrite/src/main/config/etc/jetty-rewrite.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-rewrite/src/main/config/etc/rewrite-compactpath.xml
+++ b/jetty-rewrite/src/main/config/etc/rewrite-compactpath.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 <Configure id="Rewrite" class="org.eclipse.jetty.rewrite.handler.RuleContainer">
   <Call name="addRule">
     <Arg>

--- a/jetty-rewrite/src/main/config/modules/rewrite-compactpath.mod
+++ b/jetty-rewrite/src/main/config/modules/rewrite-compactpath.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Add a rule to the rewrite module to compact paths so that double slashes

--- a/jetty-rewrite/src/main/config/modules/rewrite-customizer.mod
+++ b/jetty-rewrite/src/main/config/modules/rewrite-customizer.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables a rewrite Rules container as a request customizer on

--- a/jetty-rewrite/src/main/config/modules/rewrite.mod
+++ b/jetty-rewrite/src/main/config/modules/rewrite.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables the jetty-rewrite handler.  Specific rewrite

--- a/jetty-rewrite/src/test/resources/org.mortbay.jetty.rewrite.handler/jetty-rewrite.xml
+++ b/jetty-rewrite/src/test/resources/org.mortbay.jetty.rewrite.handler/jetty-rewrite.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure the Jetty Server                                      -->

--- a/jetty-runner/src/main/java/org/eclipse/jetty/runner/Runner.java
+++ b/jetty-runner/src/main/java/org/eclipse/jetty/runner/Runner.java
@@ -544,7 +544,7 @@ public class Runner
     {
         System.err.println("WARNING: jetty-runner is deprecated.");
         System.err.println("         See Jetty Documentation for startup options");
-        System.err.println("         https://www.eclipse.org/jetty/documentation/");
+        System.err.println("         https://jetty.org/docs/");
 
         Runner runner = new Runner();
 

--- a/jetty-security/src/main/config/modules/security.mod
+++ b/jetty-security/src/main/config/modules/security.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Adds servlet standard security handling to the classpath.

--- a/jetty-server/src/main/config/etc/home-base-warning.xml
+++ b/jetty-server/src/main/config/etc/home-base-warning.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- ============================================================= -->
 <!-- Display a Warning Message if {jetty.home} == {jetty.base}     -->

--- a/jetty-server/src/main/config/etc/jetty-acceptratelimit.xml
+++ b/jetty-server/src/main/config/etc/jetty-acceptratelimit.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call name="addBean">
     <Arg>

--- a/jetty-server/src/main/config/etc/jetty-bytebufferpool-logarithmic.xml
+++ b/jetty-server/src/main/config/etc/jetty-bytebufferpool-logarithmic.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 <Configure>
   <New id="byteBufferPool" class="org.eclipse.jetty.io.LogarithmicArrayByteBufferPool">
     <Arg type="int"><Property name="jetty.byteBufferPool.minCapacity" default="0"/></Arg>

--- a/jetty-server/src/main/config/etc/jetty-bytebufferpool.xml
+++ b/jetty-server/src/main/config/etc/jetty-bytebufferpool.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 <Configure>
   <New id="byteBufferPool" class="org.eclipse.jetty.io.ArrayByteBufferPool">
     <Arg type="int"><Property name="jetty.byteBufferPool.minCapacity" default="0"/></Arg>

--- a/jetty-server/src/main/config/etc/jetty-connectionlimit.xml
+++ b/jetty-server/src/main/config/etc/jetty-connectionlimit.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call name="addBean">
     <Arg>

--- a/jetty-server/src/main/config/etc/jetty-customrequestlog.xml
+++ b/jetty-server/src/main/config/etc/jetty-customrequestlog.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure the Jetty Request Log                                 -->

--- a/jetty-server/src/main/config/etc/jetty-debug.xml
+++ b/jetty-server/src/main/config/etc/jetty-debug.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- The DebugListener                                               -->

--- a/jetty-server/src/main/config/etc/jetty-debuglog.xml
+++ b/jetty-server/src/main/config/etc/jetty-debuglog.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- The DebugHandler                                                -->

--- a/jetty-server/src/main/config/etc/jetty-gzip.xml
+++ b/jetty-server/src/main/config/etc/jetty-gzip.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Mixin the GZIP Handler                                          -->

--- a/jetty-server/src/main/config/etc/jetty-http-forwarded.xml
+++ b/jetty-server/src/main/config/etc/jetty-http-forwarded.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 <Configure id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
   <Call name="addCustomizer">
     <Arg>

--- a/jetty-server/src/main/config/etc/jetty-http.xml
+++ b/jetty-server/src/main/config/etc/jetty-http.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->

--- a/jetty-server/src/main/config/etc/jetty-https.xml
+++ b/jetty-server/src/main/config/etc/jetty-https.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure an HTTPS connector.                                  -->

--- a/jetty-server/src/main/config/etc/jetty-ipaccess.xml
+++ b/jetty-server/src/main/config/etc/jetty-ipaccess.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- The IP Access Handler                                           -->

--- a/jetty-server/src/main/config/etc/jetty-lowresources.xml
+++ b/jetty-server/src/main/config/etc/jetty-lowresources.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Mixin the Low Resources Monitor                                 -->

--- a/jetty-server/src/main/config/etc/jetty-proxy-protocol-ssl.xml
+++ b/jetty-server/src/main/config/etc/jetty-proxy-protocol-ssl.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="sslConnector" class="org.eclipse.jetty.server.ServerConnector">
   <Call name="addFirstConnectionFactory">

--- a/jetty-server/src/main/config/etc/jetty-proxy-protocol.xml
+++ b/jetty-server/src/main/config/etc/jetty-proxy-protocol.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="httpConnector" class="org.eclipse.jetty.server.ServerConnector">
   <Call name="addFirstConnectionFactory">

--- a/jetty-server/src/main/config/etc/jetty-requestlog.xml
+++ b/jetty-server/src/main/config/etc/jetty-requestlog.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure the Jetty Request Log                                 -->

--- a/jetty-server/src/main/config/etc/jetty-ssl-context-reload.xml
+++ b/jetty-server/src/main/config/etc/jetty-ssl-context-reload.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call name="addBean">

--- a/jetty-server/src/main/config/etc/jetty-ssl-context.xml
+++ b/jetty-server/src/main/config/etc/jetty-ssl-context.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- ============================================================= -->
 <!-- SSL ContextFactory configuration                              -->
@@ -6,7 +6,7 @@
 
 <!-- 
   To configure Includes / Excludes for Cipher Suites or Protocols see tweak-ssl.xml example at 
-     https://www.eclipse.org/jetty/documentation/current/configuring-ssl.html#configuring-sslcontextfactory-cipherSuites
+     https://jetty.org/documentation/current/configuring-ssl.html#configuring-sslcontextfactory-cipherSuites
 -->
 
 <Configure id="sslContextFactory" class="org.eclipse.jetty.util.ssl.SslContextFactory$Server">

--- a/jetty-server/src/main/config/etc/jetty-ssl.xml
+++ b/jetty-server/src/main/config/etc/jetty-ssl.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- ============================================================= -->
 <!-- Base SSL configuration                                        -->

--- a/jetty-server/src/main/config/etc/jetty-stats.xml
+++ b/jetty-server/src/main/config/etc/jetty-stats.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Mixin the Statistics Handler                                    -->

--- a/jetty-server/src/main/config/etc/jetty-threadlimit.xml
+++ b/jetty-server/src/main/config/etc/jetty-threadlimit.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Mixin the Thread Limit Handler to the entire server             -->

--- a/jetty-server/src/main/config/etc/jetty-threadpool.xml
+++ b/jetty-server/src/main/config/etc/jetty-threadpool.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure>
   <!-- =========================================================== -->

--- a/jetty-server/src/main/config/etc/jetty.xml
+++ b/jetty-server/src/main/config/etc/jetty.xml
@@ -1,8 +1,8 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Documentation of this file format can be found at:              -->
-<!-- https://www.eclipse.org/jetty/documentation/current/            -->
+<!-- https://jetty.org/documentation/current/            -->
 <!--                                                                 -->
 <!-- Additional configuration files are available in $JETTY_HOME/etc -->
 <!-- and can be mixed in. See start.ini file for the default         -->

--- a/jetty-server/src/main/config/etc/sessions/file/session-store.xml
+++ b/jetty-server/src/main/config/etc/sessions/file/session-store.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-server/src/main/config/etc/sessions/id-manager.xml
+++ b/jetty-server/src/main/config/etc/sessions/id-manager.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-server/src/main/config/etc/sessions/jdbc/datasource.xml
+++ b/jetty-server/src/main/config/etc/sessions/jdbc/datasource.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-server/src/main/config/etc/sessions/jdbc/driver.xml
+++ b/jetty-server/src/main/config/etc/sessions/jdbc/driver.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-server/src/main/config/etc/sessions/jdbc/session-store.xml
+++ b/jetty-server/src/main/config/etc/sessions/jdbc/session-store.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-server/src/main/config/etc/sessions/session-cache-hash.xml
+++ b/jetty-server/src/main/config/etc/sessions/session-cache-hash.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-server/src/main/config/etc/sessions/session-cache-null.xml
+++ b/jetty-server/src/main/config/etc/sessions/session-cache-null.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-server/src/main/config/etc/sessions/session-data-cache/session-caching-store.xml
+++ b/jetty-server/src/main/config/etc/sessions/session-data-cache/session-caching-store.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-server/src/main/config/modules/acceptratelimit.mod
+++ b/jetty-server/src/main/config/modules/acceptratelimit.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enable a server wide accept rate limit

--- a/jetty-server/src/main/config/modules/bytebufferpool-logarithmic.mod
+++ b/jetty-server/src/main/config/modules/bytebufferpool-logarithmic.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Configures the ByteBufferPool used by ServerConnectors whose bucket sizes increase exponentially instead of linearly.

--- a/jetty-server/src/main/config/modules/bytebufferpool.mod
+++ b/jetty-server/src/main/config/modules/bytebufferpool.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Configures the ByteBufferPool used by ServerConnectors.

--- a/jetty-server/src/main/config/modules/connectionlimit.mod
+++ b/jetty-server/src/main/config/modules/connectionlimit.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enable a server wide connection limit

--- a/jetty-server/src/main/config/modules/continuation.mod
+++ b/jetty-server/src/main/config/modules/continuation.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables support for Continuation style asynchronous

--- a/jetty-server/src/main/config/modules/customrequestlog.mod
+++ b/jetty-server/src/main/config/modules/customrequestlog.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables a format string style request log.

--- a/jetty-server/src/main/config/modules/debug.mod
+++ b/jetty-server/src/main/config/modules/debug.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables the DebugListener to generate additional 

--- a/jetty-server/src/main/config/modules/debuglog.mod
+++ b/jetty-server/src/main/config/modules/debuglog.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Deprecated Debug Log using the DebugHandle.

--- a/jetty-server/src/main/config/modules/ext.mod
+++ b/jetty-server/src/main/config/modules/ext.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Adds all jar files discovered in $JETTY_HOME/lib/ext

--- a/jetty-server/src/main/config/modules/gzip.mod
+++ b/jetty-server/src/main/config/modules/gzip.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enable GzipHandler for dynamic gzip compression

--- a/jetty-server/src/main/config/modules/home-base-warning.mod
+++ b/jetty-server/src/main/config/modules/home-base-warning.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Generates a warning that server has been run from $JETTY_HOME

--- a/jetty-server/src/main/config/modules/http-forwarded.mod
+++ b/jetty-server/src/main/config/modules/http-forwarded.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Adds a forwarded request customizer to the HTTP Connector

--- a/jetty-server/src/main/config/modules/http.mod
+++ b/jetty-server/src/main/config/modules/http.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables an HTTP connector on the server.

--- a/jetty-server/src/main/config/modules/https.mod
+++ b/jetty-server/src/main/config/modules/https.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Adds HTTPS protocol support to the TLS(SSL) Connector

--- a/jetty-server/src/main/config/modules/inetaccess.mod
+++ b/jetty-server/src/main/config/modules/inetaccess.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enable the InetAccessHandler to apply a include/exclude

--- a/jetty-server/src/main/config/modules/inetaccess/jetty-inetaccess.xml
+++ b/jetty-server/src/main/config/modules/inetaccess/jetty-inetaccess.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call name="insertHandler">

--- a/jetty-server/src/main/config/modules/ipaccess.mod
+++ b/jetty-server/src/main/config/modules/ipaccess.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enable the ipaccess handler to apply a white/black list

--- a/jetty-server/src/main/config/modules/jdbc.mod
+++ b/jetty-server/src/main/config/modules/jdbc.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [jpms]
 add-modules: java.sql

--- a/jetty-server/src/main/config/modules/jvm.mod
+++ b/jetty-server/src/main/config/modules/jvm.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 A noop module that creates an ini template useful for

--- a/jetty-server/src/main/config/modules/logback-access.mod
+++ b/jetty-server/src/main/config/modules/logback-access.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables logback request log.

--- a/jetty-server/src/main/config/modules/logback-access/jetty-logback-access.xml
+++ b/jetty-server/src/main/config/modules/logback-access/jetty-logback-access.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure the Logback Request Log                               -->

--- a/jetty-server/src/main/config/modules/lowresources.mod
+++ b/jetty-server/src/main/config/modules/lowresources.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables a low resource monitor on the server

--- a/jetty-server/src/main/config/modules/proxy-protocol-ssl.mod
+++ b/jetty-server/src/main/config/modules/proxy-protocol-ssl.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables the Proxy Protocol on the TLS(SSL) Connector.

--- a/jetty-server/src/main/config/modules/proxy-protocol.mod
+++ b/jetty-server/src/main/config/modules/proxy-protocol.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables the Proxy Protocol on the HTTP Connector.

--- a/jetty-server/src/main/config/modules/requestlog.mod
+++ b/jetty-server/src/main/config/modules/requestlog.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables a NCSA style request log.

--- a/jetty-server/src/main/config/modules/resources.mod
+++ b/jetty-server/src/main/config/modules/resources.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Adds the $JETTY_HOME/resources and/or $JETTY_BASE/resources

--- a/jetty-server/src/main/config/modules/server.mod
+++ b/jetty-server/src/main/config/modules/server.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables the core Jetty server on the classpath.

--- a/jetty-server/src/main/config/modules/session-cache-hash.mod
+++ b/jetty-server/src/main/config/modules/session-cache-hash.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enable first level session cache. If this module is not enabled, sessions will

--- a/jetty-server/src/main/config/modules/session-cache-null.mod
+++ b/jetty-server/src/main/config/modules/session-cache-null.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 A trivial SessionCache that does not actually cache sessions.

--- a/jetty-server/src/main/config/modules/session-store-cache.mod
+++ b/jetty-server/src/main/config/modules/session-store-cache.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables caching of SessionData in front of a SessionDataStore.

--- a/jetty-server/src/main/config/modules/session-store-file.mod
+++ b/jetty-server/src/main/config/modules/session-store-file.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables session persistent storage in files.

--- a/jetty-server/src/main/config/modules/session-store-jdbc.mod
+++ b/jetty-server/src/main/config/modules/session-store-jdbc.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables JDBC persistent/distributed session storage.

--- a/jetty-server/src/main/config/modules/sessions.mod
+++ b/jetty-server/src/main/config/modules/sessions.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 The session management. By enabling this module, it allows 

--- a/jetty-server/src/main/config/modules/sessions/jdbc/datasource.mod
+++ b/jetty-server/src/main/config/modules/sessions/jdbc/datasource.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 JDBC Datasource connections for session storage

--- a/jetty-server/src/main/config/modules/sessions/jdbc/driver.mod
+++ b/jetty-server/src/main/config/modules/sessions/jdbc/driver.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 JDBC Driver connections for session storage

--- a/jetty-server/src/main/config/modules/ssl-reload.mod
+++ b/jetty-server/src/main/config/modules/ssl-reload.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables the SSL keystore to be reloaded after any changes are detected on the file system.

--- a/jetty-server/src/main/config/modules/ssl.mod
+++ b/jetty-server/src/main/config/modules/ssl.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables a TLS(SSL) Connector on the server.
@@ -124,7 +124,7 @@ basehome:modules/ssl/keystore|etc/keystore
 # jetty.sslContext.useCipherSuitesOrder=true
 
 ## To configure Includes / Excludes for Cipher Suites or Protocols see tweak-ssl.xml example at
-## https://www.eclipse.org/jetty/documentation/current/configuring-ssl.html#configuring-sslcontextfactory-cipherSuites
+## https://jetty.org/docs/9/configuring-ssl.html#configuring-sslcontextfactory-cipherSuites
 
 ## Set the size of the SslSession cache
 # jetty.sslContext.sslSessionCacheSize=-1

--- a/jetty-server/src/main/config/modules/stats.mod
+++ b/jetty-server/src/main/config/modules/stats.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enable detailed statistics collection for the server,

--- a/jetty-server/src/main/config/modules/threadpool.mod
+++ b/jetty-server/src/main/config/modules/threadpool.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables the Server thread pool.

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HomeBaseWarning.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HomeBaseWarning.java
@@ -68,7 +68,7 @@ public class HomeBaseWarning
         {
             StringBuilder warn = new StringBuilder();
             warn.append("This instance of Jetty is not running from a separate {jetty.base} directory");
-            warn.append(", this is not recommended.  See documentation at https://www.eclipse.org/jetty/documentation/current/startup.html");
+            warn.append(", this is not recommended.  See documentation at https://jetty.org/docs/9/startup.html");
             LOG.warn("{}", warn.toString());
         }
     }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/DefaultHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/DefaultHandler.java
@@ -190,8 +190,8 @@ public class DefaultHandler extends AbstractHandler
             }
 
             writer.append("</tbody></table><hr/>\n");
-            writer.append("<a href=\"https://eclipse.org/jetty\"><img alt=\"icon\" src=\"/favicon.ico\"/></a>&nbsp;");
-            writer.append("<a href=\"https://eclipse.org/jetty\">Powered by Eclipse Jetty:// Server</a><hr/>\n");
+            writer.append("<a href=\"https://jetty.org/\"><img alt=\"icon\" src=\"/favicon.ico\"/></a>&nbsp;");
+            writer.append("<a href=\"https://jetty.org/\">Powered by Eclipse Jetty:// Server</a><hr/>\n");
             writer.append("</body>\n</html>\n");
             writer.flush();
             byte[] content = outputStream.toByteArray();

--- a/jetty-servlet/src/main/config/modules/servlet.mod
+++ b/jetty-servlet/src/main/config/modules/servlet.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables standard Servlet handling.

--- a/jetty-servlets/src/main/config/modules/servlets.mod
+++ b/jetty-servlets/src/main/config/modules/servlets.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Puts a collection of jetty utility servlets and filters

--- a/jetty-spring/src/main/config/modules/spring.mod
+++ b/jetty-spring/src/main/config/modules/spring.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enable spring configuration processing so all jetty style 

--- a/jetty-start/src/main/resources/org/eclipse/jetty/start/usage.txt
+++ b/jetty-start/src/main/resources/org/eclipse/jetty/start/usage.txt
@@ -74,7 +74,7 @@ Debug and Start Logging:
   --debug          Enable debug output of the startup procedure.
                    Note: this does not setup debug for Jetty itself.
                    If you want debug for Jetty, configure your logging.
-                   https://www.eclipse.org/jetty/documentation/
+                   https://jetty.org/docs/
 
   --start-log-file=<filename>
                    A filename, relative to ${jetty.base}, where all startup
@@ -264,4 +264,4 @@ Defaults:
     5) <jetty-dir>/start.d/*.ini
 
 For more information on startup, see the online documentation at
-    https://www.eclipse.org/jetty/documentation/
+    https://jetty.org/docs/

--- a/jetty-start/src/test/resources/bogus.xml
+++ b/jetty-start/src/test/resources/bogus.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://eclipse.dev/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 <Configure />

--- a/jetty-start/src/test/resources/dist-home/modules/main.mod
+++ b/jetty-start/src/test/resources/dist-home/modules/main.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Example of a module

--- a/jetty-unixsocket/src/main/config-template/etc/jetty-unixsocket-forwarded.xml
+++ b/jetty-unixsocket/src/main/config-template/etc/jetty-unixsocket-forwarded.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="unixSocketHttpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
   <Call name="addCustomizer">

--- a/jetty-unixsocket/src/main/config-template/etc/jetty-unixsocket-http.xml
+++ b/jetty-unixsocket/src/main/config-template/etc/jetty-unixsocket-http.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="unixSocketConnector" class="org.eclipse.jetty.unixsocket.UnixSocketConnector">
   <Call name="addConnectionFactory">

--- a/jetty-unixsocket/src/main/config-template/etc/jetty-unixsocket-http2c.xml
+++ b/jetty-unixsocket/src/main/config-template/etc/jetty-unixsocket-http2c.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="unixSocketConnector" class="org.eclipse.jetty.unixsocket.UnixSocketConnector">
   <Call name="addConnectionFactory">

--- a/jetty-unixsocket/src/main/config-template/etc/jetty-unixsocket-proxy-protocol.xml
+++ b/jetty-unixsocket/src/main/config-template/etc/jetty-unixsocket-proxy-protocol.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="unixSocketConnector" class="org.eclipse.jetty.unixsocket.UnixSocketConnector">
   <Call name="addFirstConnectionFactory">

--- a/jetty-unixsocket/src/main/config-template/etc/jetty-unixsocket-secure.xml
+++ b/jetty-unixsocket/src/main/config-template/etc/jetty-unixsocket-secure.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="unixSocketHttpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
   <Call name="addCustomizer">

--- a/jetty-unixsocket/src/main/config-template/etc/jetty-unixsocket.xml
+++ b/jetty-unixsocket/src/main/config-template/etc/jetty-unixsocket.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="unixSocketHttpConfig" class="org.eclipse.jetty.server.HttpConfiguration">

--- a/jetty-unixsocket/src/main/config-template/modules/unixsocket-forwarded.mod
+++ b/jetty-unixsocket/src/main/config-template/modules/unixsocket-forwarded.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Adds a forwarded request customizer to the HTTP configuration used

--- a/jetty-unixsocket/src/main/config-template/modules/unixsocket-http.mod
+++ b/jetty-unixsocket/src/main/config-template/modules/unixsocket-http.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Adds an HTTP protocol support to the Unix Domain Socket connector.

--- a/jetty-unixsocket/src/main/config-template/modules/unixsocket-http2c.mod
+++ b/jetty-unixsocket/src/main/config-template/modules/unixsocket-http2c.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Adds an HTTP2C connetion factory to the Unix Domain Socket Connector

--- a/jetty-unixsocket/src/main/config-template/modules/unixsocket-prefix.mod
+++ b/jetty-unixsocket/src/main/config-template/modules/unixsocket-prefix.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables a Unix Domain Socket Connector that can receive

--- a/jetty-unixsocket/src/main/config-template/modules/unixsocket-proxy-protocol.mod
+++ b/jetty-unixsocket/src/main/config-template/modules/unixsocket-proxy-protocol.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enables the proxy protocol on the Unix Domain Socket Connector 

--- a/jetty-unixsocket/src/main/config-template/modules/unixsocket-secure.mod
+++ b/jetty-unixsocket/src/main/config-template/modules/unixsocket-secure.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enable a secure request customizer on the HTTP Configuration

--- a/jetty-util/src/main/config/etc/console-capture.xml
+++ b/jetty-util/src/main/config/etc/console-capture.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="logging" class="org.eclipse.jetty.util.log.Log">
     <New id="ServerLog" class="java.io.PrintStream">

--- a/jetty-util/src/main/config/modules/console-capture.mod
+++ b/jetty-util/src/main/config/modules/console-capture.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Redirects JVMs console stderr and stdout to a log file,

--- a/jetty-util/src/main/config/modules/jcl-slf4j.mod
+++ b/jetty-util/src/main/config/modules/jcl-slf4j.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Provides a Java Commons Logging (JCL) binding to SLF4J logging. 

--- a/jetty-util/src/main/config/modules/jul-impl.mod
+++ b/jetty-util/src/main/config/modules/jul-impl.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Configures the Java Util Logging mechanism

--- a/jetty-util/src/main/config/modules/jul-slf4j.mod
+++ b/jetty-util/src/main/config/modules/jul-slf4j.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Provides a Java Util Logging binding to SLF4J logging.

--- a/jetty-util/src/main/config/modules/log4j-impl.mod
+++ b/jetty-util/src/main/config/modules/log4j-impl.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Provides a Log4j v1.2 API and implementation.  

--- a/jetty-util/src/main/config/modules/log4j2-api.mod
+++ b/jetty-util/src/main/config/modules/log4j2-api.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Provides the Log4j v2 API

--- a/jetty-util/src/main/config/modules/log4j2-impl.mod
+++ b/jetty-util/src/main/config/modules/log4j2-impl.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Provides a Log4j v2 implementation. 

--- a/jetty-util/src/main/config/modules/log4j2-slf4j.mod
+++ b/jetty-util/src/main/config/modules/log4j2-slf4j.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Provides a Log4j v2 binding to SLF4J logging.  

--- a/jetty-util/src/main/config/modules/logback-impl.mod
+++ b/jetty-util/src/main/config/modules/logback-impl.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Provides the logback core implementation

--- a/jetty-util/src/main/config/modules/logging-jetty.mod
+++ b/jetty-util/src/main/config/modules/logging-jetty.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Configure jetty logging mechanism.

--- a/jetty-util/src/main/config/modules/logging-jul.mod
+++ b/jetty-util/src/main/config/modules/logging-jul.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Configure jetty logging to use Java Util Logging (jul)

--- a/jetty-util/src/main/config/modules/logging-log4j.mod
+++ b/jetty-util/src/main/config/modules/logging-log4j.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Configure jetty logging to use Log4j Logging

--- a/jetty-util/src/main/config/modules/logging-log4j2.mod
+++ b/jetty-util/src/main/config/modules/logging-log4j2.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Configure jetty logging to use log4j version 2

--- a/jetty-util/src/main/config/modules/logging-logback.mod
+++ b/jetty-util/src/main/config/modules/logging-logback.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Configure jetty logging to use Logback Logging. 

--- a/jetty-util/src/main/config/modules/logging-slf4j.mod
+++ b/jetty-util/src/main/config/modules/logging-slf4j.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Configure jetty logging to use slf4j.

--- a/jetty-util/src/main/config/modules/slf4j-api.mod
+++ b/jetty-util/src/main/config/modules/slf4j-api.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Provides SLF4J API.  Requires a slf4j implementation (eg slf4j-simple-impl)

--- a/jetty-util/src/main/config/modules/slf4j-jul.mod
+++ b/jetty-util/src/main/config/modules/slf4j-jul.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Provides a SLF4J binding to Java Util Logging (JUL) logging.

--- a/jetty-util/src/main/config/modules/slf4j-log4j.mod
+++ b/jetty-util/src/main/config/modules/slf4j-log4j.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Provides a SLF4J binding to the Log4j v1.2 API logging.

--- a/jetty-util/src/main/config/modules/slf4j-log4j2.mod
+++ b/jetty-util/src/main/config/modules/slf4j-log4j2.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Provides a SLF4J binding to Log4j v2 logging.

--- a/jetty-util/src/main/config/modules/slf4j-logback.mod
+++ b/jetty-util/src/main/config/modules/slf4j-logback.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Provides a SLF4J binding to Logback logging.

--- a/jetty-util/src/main/config/modules/slf4j-simple-impl.mod
+++ b/jetty-util/src/main/config/modules/slf4j-simple-impl.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Provides SLF4J simple logging implementation.

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Jetty.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Jetty.java
@@ -72,7 +72,7 @@ public class Jetty
         else
             VERSION = System.getProperty("jetty.version", __buildProperties.getProperty("version", "9.4.z-SNAPSHOT"));
 
-        POWERED_BY = "<a href=\"https://eclipse.org/jetty\">Powered by Jetty:// " + VERSION + "</a>";
+        POWERED_BY = "<a href=\"https://jetty.org/\">Powered by Jetty:// " + VERSION + "</a>";
 
         // Show warning when RC# or M# is in version string
         STABLE = !VERSION.matches("^.*\\.(RC|M)[0-9]+$");

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/RolloverFileOutputStreamTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/RolloverFileOutputStreamTest.java
@@ -83,7 +83,7 @@ public class RolloverFileOutputStreamTest
     }
 
     /**
-     * <a href="Issue #1507">https://github.com/eclipse/jetty.project/issues/1507</a>
+     * <a href="Issue #1507">https://github.com/jetty/jetty.project/issues/1507</a>
      */
     @Test
     public void testMidnightRolloverCalcPDTIssue1507()

--- a/jetty-webapp/src/main/config/etc/jetty-webapp.xml
+++ b/jetty-webapp/src/main/config/etc/jetty-webapp.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call class="org.eclipse.jetty.webapp.WebAppContext" name="addSystemClasses">

--- a/jetty-webapp/src/main/config/modules/webapp.mod
+++ b/jetty-webapp/src/main/config/modules/webapp.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Adds support for servlet specification webapplication to the server

--- a/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebAppContext.java
+++ b/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebAppContext.java
@@ -689,7 +689,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
      *
      * @param classOrPackage A pattern.
      * @see #setServerClasses(String[])
-     * @see <a href="https://www.eclipse.org/jetty/documentation/current/jetty-classloading.html">Jetty Documentation: Classloading</a>
+     * @see <a href="https://jetty.org/docs/9/jetty-classloading.html">Jetty Documentation: Classloading</a>
      * @deprecated Use {@link #getServerClasspathPattern()}.{@link ClasspathPattern#add(String)}
      */
     @Deprecated
@@ -743,7 +743,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
      *
      * @param classOrPackage A pattern.
      * @see #setSystemClasses(String[])
-     * @see <a href="https://www.eclipse.org/jetty/documentation/current/jetty-classloading.html">Jetty Documentation: Classloading</a>
+     * @see <a href="https://jetty.org/docs/9/jetty-classloading.html">Jetty Documentation: Classloading</a>
      * @deprecated Use {@link #getSystemClasspathPattern()}.{@link ClasspathPattern#add(String)}
      */
     @Deprecated

--- a/jetty-websocket/javax-websocket-client-impl/src/test/resources/examples/jetty-websocket-httpclient.xml
+++ b/jetty-websocket/javax-websocket-client-impl/src/test/resources/examples/jetty-websocket-httpclient.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.client.HttpClient">
   <Arg>

--- a/jetty-websocket/javax-websocket-server-impl/src/main/config/modules/websocket.mod
+++ b/jetty-websocket/javax-websocket-server-impl/src/main/config/modules/websocket.mod
@@ -1,4 +1,4 @@
-# DO NOT EDIT - See: https://www.eclipse.org/jetty/documentation/current/startup-modules.html
+# DO NOT EDIT - See: https://jetty.org/docs/9/startup-modules.html
 
 [description]
 Enable websockets for deployed web applications

--- a/jetty-websocket/websocket-client/src/test/resources/httpclient/simple/jetty-websocket-httpclient.xml
+++ b/jetty-websocket/websocket-client/src/test/resources/httpclient/simple/jetty-websocket-httpclient.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.client.HttpClient">
   <Arg>

--- a/jetty-websocket/websocket-common/src/test/java/org/eclipse/jetty/websocket/common/WebSocketRemoteEndpointTest.java
+++ b/jetty-websocket/websocket-common/src/test/java/org/eclipse/jetty/websocket/common/WebSocketRemoteEndpointTest.java
@@ -91,7 +91,7 @@ public class WebSocketRemoteEndpointTest
     /**
      * Ensure that WebSocketRemoteEndpoint honors the correct order of websocket frames.
      *
-     * @see <a href="https://github.com/eclipse/jetty.project/issues/2491">eclipse/jetty.project#2491</a>
+     * @see <a href="https://github.com/jetty/jetty.project/issues/2491">eclipse/jetty.project#2491</a>
      */
     @Test
     public void testLargeSmallText(TestInfo testInfo) throws ExecutionException, InterruptedException

--- a/jetty-websocket/websocket-common/src/test/java/org/eclipse/jetty/websocket/common/extensions/FragmentExtensionTest.java
+++ b/jetty-websocket/websocket-common/src/test/java/org/eclipse/jetty/websocket/common/extensions/FragmentExtensionTest.java
@@ -330,7 +330,7 @@ public class FragmentExtensionTest
     /**
      * Ensure that FragmentExtension honors the correct order of websocket frames.
      *
-     * @see <a href="https://github.com/eclipse/jetty.project/issues/2491">eclipse/jetty.project#2491</a>
+     * @see <a href="https://github.com/jetty/jetty.project/issues/2491">eclipse/jetty.project#2491</a>
      */
     @Test
     public void testLargeSmallTextAlternating() throws Exception

--- a/jetty-websocket/websocket-common/src/test/java/org/eclipse/jetty/websocket/common/io/FrameFlusherTest.java
+++ b/jetty-websocket/websocket-common/src/test/java/org/eclipse/jetty/websocket/common/io/FrameFlusherTest.java
@@ -90,7 +90,7 @@ public class FrameFlusherTest
     /**
      * Ensure that FrameFlusher honors the correct order of websocket frames.
      *
-     * @see <a href="https://github.com/eclipse/jetty.project/issues/2491">eclipse/jetty.project#2491</a>
+     * @see <a href="https://github.com/jetty/jetty.project/issues/2491">eclipse/jetty.project#2491</a>
      */
     @Test
     public void testLargeSmallText() throws ExecutionException, InterruptedException

--- a/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
+++ b/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
@@ -1970,8 +1970,8 @@ public class XmlConfiguration
 
             // Register all variations of DOCTYPE entity references for Config 9.3
             String[] schemes = {"http", "https"};
-            String[] hosts = {"www.eclipse.org", "eclipse.org", "www.eclipse.dev", "eclipse.dev"};
-            String[] paths = {"/jetty/configure.dtd", "/jetty/configure_9_3.dtd"};
+            String[] hosts = {"www.eclipse.org/jetty", "eclipse.org/jetty", "www.eclipse.dev/jetty", "eclipse.dev/jetty", "jetty.org"};
+            String[] paths = {"/configure.dtd", "/configure_9_3.dtd"};
 
             for (String scheme : schemes)
             {

--- a/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
+++ b/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
@@ -1742,16 +1742,16 @@ public class XmlConfigurationTest
         List<Arguments> ids = new ArrayList<>();
 
         String[] schemes = {"http", "https"};
-        String[] hosts = {"eclipse.org", "www.eclipse.org", "eclipse.dev", "www.eclipse.dev"};
-        String[] paths = {"/jetty/configure.dtd", "/jetty/configure_9_3.dtd"};
+        String[] hostAndContexts = {"eclipse.org/jetty", "www.eclipse.org/jetty", "eclipse.dev/jetty", "www.eclipse.dev/jetty", "jetty.org"};
+        String[] dtdNames = {"/configure.dtd", "/configure_9_3.dtd"};
 
         for (String scheme: schemes)
         {
-            for (String host: hosts)
+            for (String hostAndContext: hostAndContexts)
             {
-                for (String path: paths)
+                for (String dtdName: dtdNames)
                 {
-                    ids.add(Arguments.of(String.format("%s://%s%s", scheme, host, path)));
+                    ids.add(Arguments.of(String.format("%s://%s%s", scheme, hostAndContext, dtdName)));
                 }
             }
         }

--- a/jetty-xml/src/test/resources/org/eclipse/jetty/xml/configureWithAttr.xml
+++ b/jetty-xml/src/test/resources/org/eclipse/jetty/xml/configureWithAttr.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.xml.TestConfiguration">
   <Arg name="name">name</Arg>

--- a/jetty-xml/src/test/resources/org/eclipse/jetty/xml/configureWithElements.xml
+++ b/jetty-xml/src/test/resources/org/eclipse/jetty/xml/configureWithElements.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.xml.TestConfiguration">
   <Arg name="name">name</Arg>

--- a/jetty-xml/src/test/resources/org/eclipse/jetty/xml/mortbay.xml
+++ b/jetty-xml/src/test/resources/org/eclipse/jetty/xml/mortbay.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 <Configure class="java.lang.Object"></Configure>

--- a/pom.xml
+++ b/pom.xml
@@ -167,9 +167,9 @@
   </licenses>
 
   <scm>
-    <connection>scm:git:https://github.com/eclipse/jetty.project.git</connection>
+    <connection>scm:git:https://github.com/jetty/jetty.project.git</connection>
     <developerConnection>scm:git:git@github.com:eclipse/jetty.project.git</developerConnection>
-    <url>https://github.com/eclipse/jetty.project</url>
+    <url>https://github.com/jetty/jetty.project</url>
   </scm>
 
   <modules>
@@ -1748,7 +1748,7 @@
 
   <issueManagement>
     <system>github</system>
-    <url>https://github.com/eclipse/jetty.project/issues</url>
+    <url>https://github.com/jetty/jetty.project/issues</url>
   </issueManagement>
 
   <mailingLists>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <name>Jetty :: Project</name>
   <description>The Eclipse Jetty Project</description>
   <packaging>pom</packaging>
-  <url>https://eclipse.org/jetty</url>
+  <url>https://jetty.org/</url>
   <inceptionYear>1995</inceptionYear>
 
   <properties>
@@ -16,7 +16,7 @@
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
     <maven.compiler.createMissingPackageInfoClass>false</maven.compiler.createMissingPackageInfoClass>
-    <jetty.url>https://eclipse.org/jetty</jetty.url>
+    <jetty.url>https://jetty.org/</jetty.url>
     <jmhjar.name>benchmarks</jmhjar.name>
     <jpms-module-name>${bundle-symbolic-name}</jpms-module-name>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DemoBaseTests.java
+++ b/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DemoBaseTests.java
@@ -172,11 +172,10 @@ public class DemoBaseTests extends AbstractDistributionTest
             assertTrue(run.awaitConsoleLogsFor("Started @", 10, TimeUnit.SECONDS));
 
             startHttpClient(true);
-            ContentResponse response = client.GET("http://localhost:" + httpPort + "/proxy/current/");
+            ContentResponse response = client.GET("http://localhost:" + httpPort + "/proxy/jetty-12/index.html");
             assertEquals(HttpStatus.OK_200, response.getStatus());
             String body = response.getContentAsString();
-            assertThat("Expecting APIdoc contents", body, containsString("All&nbsp;Classes"));
-            assertThat("Expecting APIdoc contents", body, containsString("<title>Overview (Jetty :: Project 9."));
+            assertThat("Expecting APIdoc contents", body, containsString("<title>Overview (Eclipse Jetty API Doc"));
         }
     }
 

--- a/tests/test-distribution/src/test/resources/badapp/badapp_throwonunavailable_false.xml
+++ b/tests/test-distribution/src/test/resources/badapp/badapp_throwonunavailable_false.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/badapp</Set>

--- a/tests/test-distribution/src/test/resources/badapp/badapp_throwonunavailable_true.xml
+++ b/tests/test-distribution/src/test/resources/badapp/badapp_throwonunavailable_true.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/badapp</Set>

--- a/tests/test-distribution/src/test/resources/test-realm.xml
+++ b/tests/test-distribution/src/test/resources/test-realm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-" "https://jetty.org/configure_9_3.dtd">
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
     <!-- =========================================================== -->
     <!-- Configure Authentication Login Service                      -->

--- a/tests/test-integration/src/test/java/org/eclipse/jetty/test/DeploymentErrorInitializer.java
+++ b/tests/test-integration/src/test/java/org/eclipse/jetty/test/DeploymentErrorInitializer.java
@@ -26,7 +26,7 @@ import javax.servlet.ServletException;
 /**
  * A SCI that tosses an Error to intentionally to cause issues with the DeploymentManager
  *
- * @see <a href="https://github.com/eclipse/jetty.project/issues/1602">Issue #1602</a>
+ * @see <a href="https://github.com/jetty/jetty.project/issues/1602">Issue #1602</a>
  */
 public class DeploymentErrorInitializer implements ServletContainerInitializer
 {

--- a/tests/test-integration/src/test/resources/DefaultHandler.xml
+++ b/tests/test-integration/src/test/resources/DefaultHandler.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure the Jetty Server                                      -->

--- a/tests/test-integration/src/test/resources/NIOHttp.xml
+++ b/tests/test-integration/src/test/resources/NIOHttp.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/tests/test-integration/src/test/resources/NIOHttps.xml
+++ b/tests/test-integration/src/test/resources/NIOHttps.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/tests/test-integration/src/test/resources/RFC2616Base.xml
+++ b/tests/test-integration/src/test/resources/RFC2616Base.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure the Jetty Server                                      -->

--- a/tests/test-integration/src/test/resources/RFC2616_Filters.xml
+++ b/tests/test-integration/src/test/resources/RFC2616_Filters.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/tests/test-integration/src/test/resources/RFC2616_Redirects.xml
+++ b/tests/test-integration/src/test/resources/RFC2616_Redirects.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <!-- =========================================================== -->

--- a/tests/test-integration/src/test/resources/docroots/deployerror/badapp-unavailable-false.xml
+++ b/tests/test-integration/src/test/resources/docroots/deployerror/badapp-unavailable-false.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/badapp-uaf</Set>

--- a/tests/test-integration/src/test/resources/docroots/deployerror/badapp.xml
+++ b/tests/test-integration/src/test/resources/docroots/deployerror/badapp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/badapp</Set>

--- a/tests/test-integration/src/test/resources/ssl.xml
+++ b/tests/test-integration/src/test/resources/ssl.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://eclipse.dev/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 <Configure id="sslContextFactory" class="org.eclipse.jetty.util.ssl.SslContextFactory$Server">
   <Set name="KeyStorePath"><Property name="jetty.home" default="." />/<Property name="jetty.sslContext.keyStorePath" default="keystore"/></Set>
   <Set name="KeyStorePassword"><Property name="jetty.sslContext.keyStorePassword" default="OBF:1vny1zlo1x8e1vnw1vn61x8g1zlu1vn4"/></Set>

--- a/tests/test-integration/src/test/resources/webapp-contexts/RFC2616/rfc2616-webapp.xml
+++ b/tests/test-integration/src/test/resources/webapp-contexts/RFC2616/rfc2616-webapp.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/rfc2616-webapp</Set>
   <Set name="war"><Property name="test.webapps" default="." />/test-webapp-rfc2616.war</Set>

--- a/tests/test-quickstart/src/test/resources/test-jndi.xml
+++ b/tests/test-quickstart/src/test/resources/test-jndi.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure the test-jndi webapp                                  -->

--- a/tests/test-quickstart/src/test/resources/test-spec.xml
+++ b/tests/test-quickstart/src/test/resources/test-spec.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id='wac' class="org.eclipse.jetty.webapp.WebAppContext">
 

--- a/tests/test-quickstart/src/test/resources/test.xml
+++ b/tests/test-quickstart/src/test/resources/test.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"  encoding="ISO-8859-1"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"  encoding="ISO-8859-1"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- ==================================================================
 Configure and deploy the test web application in $(jetty.home)/webapps/test

--- a/tests/test-webapps/test-jaas-webapp/src/main/config/demo-base/webapps/test-jaas.xml
+++ b/tests/test-webapps/test-jaas-webapp/src/main/config/demo-base/webapps/test-jaas.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure the test-jaas webapp                                  -->

--- a/tests/test-webapps/test-jaas-webapp/src/main/webapp/WEB-INF/jetty-web.xml
+++ b/tests/test-webapps/test-jaas-webapp/src/main/webapp/WEB-INF/jetty-web.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Get class="org.eclipse.jetty.util.log.Log" name="rootLogger">

--- a/tests/test-webapps/test-jaas-webapp/src/main/webapp/index.html
+++ b/tests/test-webapps/test-jaas-webapp/src/main/webapp/index.html
@@ -34,7 +34,7 @@ href="https://github.com/jetty/jetty.project/tree/jetty-9.4.x/tests/test-webapps
   <p>
       This demo uses a simple login module that stores its configuration in a properties file. There are other types of login
       module provided with the jetty distro. For full information, please refer to the
-      <a href="https://www.eclipse.org/jetty/documentation/current/">Jetty 9 documentation</a>.
+      <a href="https://jetty.org/docs/9/">Jetty 9 documentation</a>.
   </p>
 
   <hr/>

--- a/tests/test-webapps/test-jaas-webapp/src/main/webapp/index.html
+++ b/tests/test-webapps/test-jaas-webapp/src/main/webapp/index.html
@@ -24,7 +24,7 @@
   $JETTY_BASE/start.ini file. The Jetty demo-base already has JAAS enabled in its start.ini file.  </p>
 
 <p>The full source of this demonstration is available <a
-href="https://github.com/eclipse/jetty.project/tree/jetty-9.4.x/tests/test-webapps/test-jaas-webapp">here</a>.</p>
+href="https://github.com/jetty/jetty.project/tree/jetty-9.4.x/tests/test-webapps/test-jaas-webapp">here</a>.</p>
 
   <h2>Using the Demo</h2>
   <P>

--- a/tests/test-webapps/test-jetty-webapp/src/main/assembly/embedded-jetty-web-for-webbundle.xml
+++ b/tests/test-webapps/test-jetty-webapp/src/main/assembly/embedded-jetty-web-for-webbundle.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- ==================================================================
 Configure and deploy the test web application in $(jetty.home)/webapps/test

--- a/tests/test-webapps/test-jetty-webapp/src/main/config/demo-base/etc/demo-rewrite-rules.xml
+++ b/tests/test-webapps/test-jetty-webapp/src/main/config/demo-base/etc/demo-rewrite-rules.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure the demos                                             -->

--- a/tests/test-webapps/test-jetty-webapp/src/main/config/demo-base/etc/test-realm.xml
+++ b/tests/test-webapps/test-jetty-webapp/src/main/config/demo-base/etc/test-realm.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
     <!-- =========================================================== -->
     <!-- Configure Authentication Login Service                      -->

--- a/tests/test-webapps/test-jetty-webapp/src/main/config/demo-base/webapps/test.xml
+++ b/tests/test-webapps/test-jetty-webapp/src/main/config/demo-base/webapps/test.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- ==================================================================
 Configure and deploy the test web application in $(jetty.home)/webapps/test

--- a/tests/test-webapps/test-jetty-webapp/src/main/webapp/WEB-INF/jetty-web.xml
+++ b/tests/test-webapps/test-jetty-webapp/src/main/webapp/WEB-INF/jetty-web.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!--
 This is the jetty specific web application configuration file.  When starting

--- a/tests/test-webapps/test-jetty-webapp/src/main/webapp/index.html
+++ b/tests/test-webapps/test-jetty-webapp/src/main/webapp/index.html
@@ -58,7 +58,7 @@ It is configured as a jetty base directory in $JETTY_HOME/demo_base.
 <h2>Useful links:</h2>
   <ul>
       <li><a
-              href="https://github.com/eclipse/jetty.project/tree/jetty-9.4.x/tests/test-webapps/test-jetty-webapp">Source
+              href="https://github.com/jetty/jetty.project/tree/jetty-9.4.x/tests/test-webapps/test-jetty-webapp">Source
           tree of this webapp</a></li>
       <li><a href="https://www.eclipse.org/jetty/">Jetty project home</a></li>
       <li><a href="https://www.eclipse.org/jetty/documentation/current/">Documentation</a></li>

--- a/tests/test-webapps/test-jetty-webapp/src/main/webapp/index.html
+++ b/tests/test-webapps/test-jetty-webapp/src/main/webapp/index.html
@@ -61,7 +61,7 @@ It is configured as a jetty base directory in $JETTY_HOME/demo_base.
               href="https://github.com/jetty/jetty.project/tree/jetty-9.4.x/tests/test-webapps/test-jetty-webapp">Source
           tree of this webapp</a></li>
       <li><a href="https://www.eclipse.org/jetty/">Jetty project home</a></li>
-      <li><a href="https://www.eclipse.org/jetty/documentation/current/">Documentation</a></li>
+      <li><a href="https://jetty.org/docs/">Documentation</a></li>
       <li><a href="https://webtide.com">Commercial Support</a></li>
   </ul>
 </p>

--- a/tests/test-webapps/test-jetty-webapp/src/main/webapp/remote.html
+++ b/tests/test-webapps/test-jetty-webapp/src/main/webapp/remote.html
@@ -11,7 +11,7 @@
     This is the Test webapp for the Jetty 9 HTTP Server and Servlet Container.
     For more information about Jetty, please visit our
     <a href="https://www.eclipse.org/jetty/">website</a>
-    or <a href="https://www.eclipse.org/jetty/documentation/current/">documentation</a>.
+    or <a href="https://jetty.org/docs/">documentation</a>.
     Commercial support for Jetty is available via <a href="http://www.webtide.com">webtide</a>.
 </p>
 <p>

--- a/tests/test-webapps/test-jndi-webapp/src/main/templates/jetty-test-jndi-header.xml
+++ b/tests/test-webapps/test-jndi-webapp/src/main/templates/jetty-test-jndi-header.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure the test-jndi webapp                                  -->

--- a/tests/test-webapps/test-jndi-webapp/src/main/templates/plugin-context-header.xml
+++ b/tests/test-webapps/test-jndi-webapp/src/main/templates/plugin-context-header.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure the test-jndi webapp                                  -->

--- a/tests/test-webapps/test-jndi-webapp/src/main/webapp/WEB-INF/jetty-env.xml
+++ b/tests/test-webapps/test-jndi-webapp/src/main/webapp/WEB-INF/jetty-env.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id='wac' class="org.eclipse.jetty.webapp.WebAppContext">
 

--- a/tests/test-webapps/test-jndi-webapp/src/main/webapp/WEB-INF/jetty-web.xml
+++ b/tests/test-webapps/test-jndi-webapp/src/main/webapp/WEB-INF/jetty-web.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Get class="org.eclipse.jetty.util.log.Log" name="rootLogger">

--- a/tests/test-webapps/test-jndi-webapp/src/main/webapp/index.html
+++ b/tests/test-webapps/test-jndi-webapp/src/main/webapp/index.html
@@ -27,7 +27,7 @@ This example shows how to configure and lookup resources such as DataSources, a 
   </p>
   <p>This will create a $JETTY_BASE/start.d/jndi.ini file to enable and parameterise JNDI.  If the --add-to-start option instead, then the same initialisation will be appended to the
   $JETTY_BASE/start.ini file instead. The jetty demo-base already has JNDI enabled in the start.ini file and some mock resources included.  </p>
-<p>The full source of this demonstration is available <a href="https://github.com/eclipse/jetty.project/tree/jetty-9.4.x/tests/test-webapps/test-jndi-webapp">here</a>.</p>
+<p>The full source of this demonstration is available <a href="https://github.com/jetty/jetty.project/tree/jetty-9.4.x/tests/test-webapps/test-jndi-webapp">here</a>.</p>
 
 
 <h2>Execution</h2>

--- a/tests/test-webapps/test-owb-cdi-webapp/src/main/webapp/WEB-INF/jetty-env.xml
+++ b/tests/test-webapps/test-owb-cdi-webapp/src/main/webapp/WEB-INF/jetty-env.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="webAppCtx" class="org.eclipse.jetty.webapp.WebAppContext">
   <New id="BeanManager" class="org.eclipse.jetty.plus.jndi.Resource">

--- a/tests/test-webapps/test-owb-cdi-webapp/src/main/webapp/WEB-INF/jetty-web-owb.xml
+++ b/tests/test-webapps/test-owb-cdi-webapp/src/main/webapp/WEB-INF/jetty-web-owb.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://eclipse.dev/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="wac" class="org.eclipse.jetty.webapp.WebAppContext">
   <!-- Rename this file to jetty-web.xml if the cdi-spi module is not used-->

--- a/tests/test-webapps/test-proxy-webapp/src/main/webapp/WEB-INF/jetty-web.xml
+++ b/tests/test-webapps/test-proxy-webapp/src/main/webapp/WEB-INF/jetty-web.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/proxy</Set>

--- a/tests/test-webapps/test-proxy-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/tests/test-webapps/test-proxy-webapp/src/main/webapp/WEB-INF/web.xml
@@ -8,11 +8,11 @@
     <servlet-class>org.eclipse.jetty.proxy.ProxyServlet$Transparent</servlet-class>
     <init-param>
       <param-name>proxyTo</param-name>
-      <param-value>https://jetty.org/javadoc/jetty-9/index.html?overview-summary.html</param-value>
+      <param-value>https://javadoc.jetty.org/</param-value>
     </init-param>
     <init-param>
       <param-name>hostHeader</param-name>
-      <param-value>eclipse.dev</param-value>
+      <param-value>javadoc.jetty.org</param-value>
     </init-param>
     <load-on-startup>1</load-on-startup>
     <async-supported>true</async-supported>
@@ -20,7 +20,7 @@
 
   <servlet-mapping>
     <servlet-name>JavadocTransparentProxy</servlet-name>
-    <url-pattern>/current/*</url-pattern>
+    <url-pattern>/*</url-pattern>
   </servlet-mapping>
 
 </web-app>

--- a/tests/test-webapps/test-proxy-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/tests/test-webapps/test-proxy-webapp/src/main/webapp/WEB-INF/web.xml
@@ -8,7 +8,7 @@
     <servlet-class>org.eclipse.jetty.proxy.ProxyServlet$Transparent</servlet-class>
     <init-param>
       <param-name>proxyTo</param-name>
-      <param-value>https://eclipse.dev/jetty/javadoc/jetty-9/index.html?overview-summary.html</param-value>
+      <param-value>https://jetty.org/javadoc/jetty-9/index.html?overview-summary.html</param-value>
     </init-param>
     <init-param>
       <param-name>hostHeader</param-name>

--- a/tests/test-webapps/test-proxy-webapp/src/test/java/org/eclipse/jetty/ProxyWebAppTest.java
+++ b/tests/test-webapps/test-proxy-webapp/src/test/java/org/eclipse/jetty/ProxyWebAppTest.java
@@ -81,7 +81,7 @@ public class ProxyWebAppTest
     @Tag("external")
     public void testProxyRequest() throws InterruptedException, ExecutionException, TimeoutException
     {
-        ContentResponse response = client.newRequest(server.getURI().resolve("/proxy/current/"))
+        ContentResponse response = client.newRequest(server.getURI().resolve("/proxy/jetty-12/index.html"))
             .followRedirects(false)
             .send();
 
@@ -92,7 +92,6 @@ public class ProxyWebAppTest
         assertThat("response status", response.getStatus(), is(HttpStatus.OK_200));
         // Expecting a Javadoc / APIDoc response - look for something unique for APIdoc.
         String body = response.getContentAsString();
-        assertThat(body, containsString("All&nbsp;Classes"));
-        assertThat(body, containsString("<title>Overview (Jetty :: Project 9."));
+        assertThat(body, containsString("<title>Overview (Eclipse Jetty API Doc"));
     }
 }

--- a/tests/test-webapps/test-servlet-spec/test-spec-webapp/src/main/templates/annotations-context-header.xml
+++ b/tests/test-webapps/test-servlet-spec/test-spec-webapp/src/main/templates/annotations-context-header.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 
 <!-- =============================================================== -->

--- a/tests/test-webapps/test-servlet-spec/test-spec-webapp/src/main/templates/plugin-context-header.xml
+++ b/tests/test-webapps/test-servlet-spec/test-spec-webapp/src/main/templates/plugin-context-header.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 
 <!-- =============================================================== -->

--- a/tests/test-webapps/test-servlet-spec/test-spec-webapp/src/main/webapp/WEB-INF/jetty-env.xml
+++ b/tests/test-webapps/test-servlet-spec/test-spec-webapp/src/main/webapp/WEB-INF/jetty-env.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id='wac' class="org.eclipse.jetty.webapp.WebAppContext">
 

--- a/tests/test-webapps/test-servlet-spec/test-spec-webapp/src/main/webapp/WEB-INF/jetty-web.xml
+++ b/tests/test-webapps/test-servlet-spec/test-spec-webapp/src/main/webapp/WEB-INF/jetty-web.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Get class="org.eclipse.jetty.util.log.Log" name="rootLogger">

--- a/tests/test-webapps/test-servlet-spec/test-spec-webapp/src/main/webapp/index.html
+++ b/tests/test-webapps/test-servlet-spec/test-spec-webapp/src/main/webapp/index.html
@@ -21,7 +21,7 @@ This example tests some aspects of the servlet 3.1 specification:<ul>
 <li>servlet container initializers.
 <li>multi-part upload support.
 </ul>
-The source repository for this test is available <a href="https://github.com/eclipse/jetty.project/tree/jetty-9.4.x/tests/test-webapps/test-servlet-spec/test-spec-webapp">here</a>.
+The source repository for this test is available <a href="https://github.com/jetty/jetty.project/tree/jetty-9.4.x/tests/test-webapps/test-servlet-spec/test-spec-webapp">here</a>.
 </p>
 
 <h3>Test Servlet 2.5/3.0 Annotations, Fragments and Initializers</h3>

--- a/tests/test-webapps/test-servlet-spec/test-spec-webapp/src/test/jetty-plugin-env.xml
+++ b/tests/test-webapps/test-servlet-spec/test-spec-webapp/src/test/jetty-plugin-env.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id='wac' class="org.eclipse.jetty.webapp.WebAppContext">
 

--- a/tests/test-webapps/test-websocket-client-provided-webapp/src/main/resources/jetty-websocket-httpclient.xml
+++ b/tests/test-webapps/test-websocket-client-provided-webapp/src/main/resources/jetty-websocket-httpclient.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.client.HttpClient">
   <Arg>

--- a/tests/test-webapps/test-weld-cdi-webapp/src/main/webapp/WEB-INF/jetty-env.xml
+++ b/tests/test-webapps/test-weld-cdi-webapp/src/main/webapp/WEB-INF/jetty-env.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="webAppCtx" class="org.eclipse.jetty.webapp.WebAppContext">
   <New id="BeanManager" class="org.eclipse.jetty.plus.jndi.Resource">


### PR DESCRIPTION
All URL refs.

* DTD refs in XMLConfiguration
* Maven poms
* Documentation
* HTML
* Github references (to new `github.com/jetty/jetty.project` location)