### PR TITLE
[10.0.x] Updating URL refs to jetty.org

### DIFF
--- a/.github/ISSUE_TEMPLATE/enhancement-template.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-template.md
@@ -8,7 +8,7 @@ labels: Enhancement
 ---
 
 **Jetty version(s)**
-_[Jetty 9.x is now at End of Community Support](https://github.com/eclipse/jetty.project/issues/7958)_
+_[Jetty 9.x is now at End of Community Support](https://github.com/jetty/jetty.project/issues/7958)_
 
 **Enhancement Description**
 

--- a/.github/ISSUE_TEMPLATE/issue-template.md
+++ b/.github/ISSUE_TEMPLATE/issue-template.md
@@ -8,7 +8,7 @@ labels: Bug
 ---
 
 **Jetty version(s)**
-<!--[Jetty 9.x is now at End of Community Support](https://github.com/eclipse/jetty.project/issues/7958) -->
+<!--[Jetty 9.x is now at End of Community Support](https://github.com/jetty/jetty.project/issues/7958) -->
 
 **Jetty Environment**
 <!-- Applicable for jetty-12 only, choose: core, ee8, ee9, ee10 -->

--- a/.github/ISSUE_TEMPLATE/release-template.md
+++ b/.github/ISSUE_TEMPLATE/release-template.md
@@ -16,18 +16,18 @@ This release process will produce releases:
 - [x] Create the release(s) issue.
 - [ ] Update the target Jetty version(s) in the issue.  
 - [ ] Update the target release date in the issue.
-- [ ] Link this issue to the target [GitHub Project(s)](https://github.com/eclipse/jetty.project/projects).
+- [ ] Link this issue to the target [GitHub Project(s)](https://github.com/jetty/jetty.project/projects).
 - [ ] Assign this issue to a "release manager".
-- [ ] Review [draft security advisories](https://github.com/eclipse/jetty.project/security/advisories). Ensure that issues are created and assigned to GitHub Projects to capture any advisories that will be announced.
-- [ ] Update [GitHub Project(s)](https://github.com/eclipse/jetty.project/projects)
+- [ ] Review [draft security advisories](https://github.com/jetty/jetty.project/security/advisories). Ensure that issues are created and assigned to GitHub Projects to capture any advisories that will be announced.
+- [ ] Update [GitHub Project(s)](https://github.com/jetty/jetty.project/projects)
   + [ ] Create new project for the next releases (not this release).
   + [ ] Ensure new project is public (not private)
-  + [ ] Freeze the target [GitHub Project(s)](https://github.com/eclipse/jetty.project/projects) by editing their names to "Jetty X.Y.Z FROZEN"
-  + [ ] Review the issues/PRs assigned to the target [GitHub Project(s)](https://github.com/eclipse/jetty.project/projects).  Any tasks that are not-yet-started are moved to next releases.
-- [ ] Review dependabot status. [Manually](https://github.com/eclipse/jetty.project/network/updates) run dependabot if needed and review resulting PRs for inclusion.
+  + [ ] Freeze the target [GitHub Project(s)](https://github.com/jetty/jetty.project/projects) by editing their names to "Jetty X.Y.Z FROZEN"
+  + [ ] Review the issues/PRs assigned to the target [GitHub Project(s)](https://github.com/jetty/jetty.project/projects).  Any tasks that are not-yet-started are moved to next releases.
+- [ ] Review dependabot status. [Manually](https://github.com/jetty/jetty.project/network/updates) run dependabot if needed and review resulting PRs for inclusion.
       Such updates should only be included in the week before a release if there is a compelling security or stability reason to do so.
 - [ ] Wait 24 hours from last change to the issues/PRs included in FROZEN GitHub Project(s).
-- [ ] Verify target [project(s)](https://github.com/eclipse/jetty.project/projects) are complete.
+- [ ] Verify target [project(s)](https://github.com/jetty/jetty.project/projects) are complete.
 - [ ] Verify that branch `jetty-10.0.x` is merged to branch `jetty-11.0.x`.
 - [ ] Assign issue to "build manager", who will stage the releases.
   + [ ] Create and use branches `release/<ver>` to perform version specific release work from.
@@ -35,9 +35,9 @@ This release process will produce releases:
   + [ ] Stage 9.4 release with Java 11.
   + [ ] Stage 10 release with Java 21.
   + [ ] Stage 11 release with Java 21.
-  + [ ] Push release branches `release/<ver>` to to https://github.com/eclipse/jetty.project
-  + [ ] Push release tags `jetty-<ver>` to https://github.com/eclipse/jetty.project
-  + [ ] Edit a draft release (for each Jetty release) in GitHub (https://github.com/eclipse/jetty.project/releases). Content is generated with the "changelog tool".
+  + [ ] Push release branches `release/<ver>` to to https://github.com/jetty/jetty.project
+  + [ ] Push release tags `jetty-<ver>` to https://github.com/jetty/jetty.project
+  + [ ] Edit a draft release (for each Jetty release) in GitHub (https://github.com/jetty/jetty.project/releases). Content is generated with the "changelog tool".
 - [ ] Assign issue to "test manager", who will oversee the testing of the staged releases.
   + [ ] Test [CometD](https://github.com/cometd/cometd).
   + [ ] Test [Reactive HttpClient](https://github.com/jetty-project/jetty-reactive-httpclient).
@@ -58,7 +58,7 @@ This release process will produce releases:
   + [ ] Update (or check) documentation page(s) are updated.
 - [ ] Publish GitHub Releases.
 - [ ] Prepare release announcement for mailing lists.
-- [ ] Publish any [security advisories](https://github.com/eclipse/jetty.project/security/advisories).
+- [ ] Publish any [security advisories](https://github.com/jetty/jetty.project/security/advisories).
   + [ ] Edit `VERSION.txt` to include any actual CVE number next to correspondent issue.
   + [ ] Edit any issues for CVEs in github with their CVE number
 - [ ] Notify downstream maintainers.

--- a/.github/ISSUE_TEMPLATE/release-template.md
+++ b/.github/ISSUE_TEMPLATE/release-template.md
@@ -42,7 +42,7 @@ This release process will produce releases:
   + [ ] Test [CometD](https://github.com/cometd/cometd).
   + [ ] Test [Reactive HttpClient](https://github.com/jetty-project/jetty-reactive-httpclient).
   + [ ] Test [Load Generator](https://github.com/jetty-project/jetty-load-generator).
-  + [ ] Test [Jetty Docker images](https://github.com/eclipse/jetty.docker).
+  + [ ] Test [Jetty Docker images](https://github.com/jetty/jetty.docker).
   + [ ] Test other [Jetty OSS integrations](https://jenkins.webtide.net/job/external_oss).
   + [ ] Check [TCK CI](https://jenkins.webtide.net/job/tck).
   + [ ] Test sponsored integrations.
@@ -53,7 +53,7 @@ This release process will produce releases:
 - [ ] Promote staged releases.
 - [ ] Merge release branches back to main branches and delete release branches.
 - [ ] Verify release existence in Maven Central by triggering the Jenkins builds of CometD.
-- [ ] Update Jetty versions on the website ( follow instructions in [jetty.website](https://github.com/eclipse/jetty.website/blob/master/README.md) ).
+- [ ] Update Jetty versions on the website (follow instructions in [jetty.website](https://github.com/jetty/jetty.website/blob/master/README.md) ).
   + [ ] Update (or check) [Download](https://jetty.org/download.html) page is updated.
   + [ ] Update (or check) documentation page(s) are updated.
 - [ ] Publish GitHub Releases.

--- a/.github/ISSUE_TEMPLATE/release-template.md
+++ b/.github/ISSUE_TEMPLATE/release-template.md
@@ -53,8 +53,8 @@ This release process will produce releases:
 - [ ] Promote staged releases.
 - [ ] Merge release branches back to main branches and delete release branches.
 - [ ] Verify release existence in Maven Central by triggering the Jenkins builds of CometD.
-- [ ] Update Jetty versions on the website ( follow instructions in [jetty-website](https://github.com/eclipse/jetty-website/blob/master/README.md) ).
-  + [ ] Update (or check) [Download](https://eclipse.dev/jetty/download.php) page is updated.
+- [ ] Update Jetty versions on the website ( follow instructions in [jetty.website](https://github.com/eclipse/jetty.website/blob/master/README.md) ).
+  + [ ] Update (or check) [Download](https://jetty.org/download.html) page is updated.
   + [ ] Update (or check) documentation page(s) are updated.
 - [ ] Publish GitHub Releases.
 - [ ] Prepare release announcement for mailing lists.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Information regarding source code management, builds, coding standards, and more
 
 - [https://eclipse.dev/jetty/documentation/](https://eclipse.dev/jetty/documentation/)
 
-The canonical Jetty git repository is located at [GitHub.](https://github.com/eclipse/jetty.project) Providing you have
+The canonical Jetty git repository is located at [GitHub.](https://github.com/jetty/jetty.project) Providing you have
 completed the contributors agreement mentioned below we will endeavor to pull your commit into Jetty proper.
 
 Eclipse Contributor Agreement
@@ -43,13 +43,13 @@ Search for bugs
 ----------------
 This project uses GitHub Issues to track ongoing development and issues.
 
-- [https://github.com/eclipse/jetty.project/issues](https://github.com/eclipse/jetty.project/issues)
+- [https://github.com/jetty/jetty.project/issues](https://github.com/jetty/jetty.project/issues)
 
 Create a new bug
 -----------------
 Be sure to search for existing bugs before you create another one. Remember that contributions are always welcome!
 
-- [https://github.com/eclipse/jetty.project/issues](https://github.com/eclipse/jetty.project/issues)
+- [https://github.com/jetty/jetty.project/issues](https://github.com/jetty/jetty.project/issues)
 
 Reporting Security Issues
 -----------------

--- a/Jenkinsfile-autobahn
+++ b/Jenkinsfile-autobahn
@@ -18,7 +18,7 @@ pipeline {
   stages {
     stage("Checkout Jetty Branch") {
       steps {
-        git url: 'https://github.com/eclipse/jetty.project/', branch: '${JETTY_BRANCH}'
+        git url: 'https://github.com/jetty/jetty.project/', branch: '${JETTY_BRANCH}'
       }
     }
     stage( "Build / Test - JDK11" ) {

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-All [stable versions](https://eclipse.dev/jetty/download.php) of jetty are actively supported for security issues. [Deprecated versions](https://eclipse.dev/jetty/download.php) may be supported for serious security issues or on a commercial support basis.
+All [stable versions](https://jetty.org/download.html) of jetty are actively supported for security issues. [Deprecated versions](https://jetty.org/download.html) may be supported for serious security issues or on a commercial support basis.
 
 ## Reporting a Vulnerability
 

--- a/demos/demo-async-rest/demo-async-rest-webapp/src/main/webapp/WEB-INF/jetty-web.xml
+++ b/demos/demo-async-rest/demo-async-rest-webapp/src/main/webapp/WEB-INF/jetty-web.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!--
 This is the jetty specific web application configuration file.  When starting

--- a/demos/demo-async-rest/demo-async-rest-webapp/src/main/webapp/index.html
+++ b/demos/demo-async-rest/demo-async-rest-webapp/src/main/webapp/index.html
@@ -9,7 +9,7 @@
 <body>
     <div class="topnav">
       <a class="menu" href="http://localhost:8080/">Demo Home</a>
-      <a class="menu" href="https://github.com/eclipse/jetty.project/tree/jetty-10.0.x/demos/demo-async-rest">Source</a>
+      <a class="menu" href="https://github.com/jetty/jetty.project/tree/jetty-10.0.x/demos/demo-async-rest">Source</a>
       <a class="menu" href="https://eclipse.dev/jetty/">Jetty Project Home</a>
       <a class="menu" href="https://eclipse.dev/jetty/documentation/">Documentation</a>
       <a class="menu" href="https://webtide.com">Commercial Support</a>

--- a/demos/demo-async-rest/demo-async-rest-webapp/src/main/webapp/index.html
+++ b/demos/demo-async-rest/demo-async-rest-webapp/src/main/webapp/index.html
@@ -55,7 +55,7 @@
     </p>
 
     <div class="footer">
-      <center><a href="https://www.eclipse.org/jetty"><img style="border:0" src="small_powered_by.gif"/></a></center>
+      <center><a href="https://jetty.org"><img style="border:0" src="small_powered_by.gif"/></a></center>
     </div>
 
 </body>

--- a/demos/demo-jaas-webapp/src/main/config/modules/demo.d/demo-jaas.xml
+++ b/demos/demo-jaas-webapp/src/main/config/modules/demo.d/demo-jaas.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure the demo-jaas webapp                                  -->

--- a/demos/demo-jaas-webapp/src/main/webapp/WEB-INF/jetty-web.xml
+++ b/demos/demo-jaas-webapp/src/main/webapp/WEB-INF/jetty-web.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Get name="servletContext">

--- a/demos/demo-jaas-webapp/src/main/webapp/index.html
+++ b/demos/demo-jaas-webapp/src/main/webapp/index.html
@@ -9,7 +9,7 @@
 <body>
     <div class="topnav">
       <a class="menu" href="http://localhost:8080/">Demo Home</a>
-      <a class="menu" href="https://github.com/eclipse/jetty.project/tree/jetty-10.0.x/demos/demo-jaas-webapp">Source</a>
+      <a class="menu" href="https://github.com/jetty/jetty.project/tree/jetty-10.0.x/demos/demo-jaas-webapp">Source</a>
       <a class="menu" href="https://eclipse.dev/jetty/">Jetty Project Home</a>
       <a class="menu" href="https://eclipse.dev/jetty/documentation/">Documentation</a>
       <a class="menu" href="https://webtide.com">Commercial Support</a>

--- a/demos/demo-jaas-webapp/src/main/webapp/index.html
+++ b/demos/demo-jaas-webapp/src/main/webapp/index.html
@@ -45,7 +45,7 @@
    </div>
 
   <div class="footer">
-    <center><a href="https://www.eclipse.org/jetty"><img style="border:0" src="small_powered_by.gif"/></a></center>
+    <center><a href="https://jetty.org"><img style="border:0" src="small_powered_by.gif"/></a></center>
   </div>
 
 </body>

--- a/demos/demo-jaas-webapp/src/main/webapp/login.html
+++ b/demos/demo-jaas-webapp/src/main/webapp/login.html
@@ -28,7 +28,7 @@
    </div>
 
    <div class="footer">
-      <center><a href="https://www.eclipse.org/jetty"><img style="border:0" src="small_powered_by.gif"/></a></center>
+      <center><a href="https://jetty.org"><img style="border:0" src="small_powered_by.gif"/></a></center>
    </div>
 
 </body>

--- a/demos/demo-jaas-webapp/src/main/webapp/login.html
+++ b/demos/demo-jaas-webapp/src/main/webapp/login.html
@@ -6,7 +6,7 @@
 <body>
     <div class="topnav">
       <a class="menu" href="http://localhost:8080/">Demo Home</a>
-      <a class="menu" href="https://github.com/eclipse/jetty.project/tree/jetty-10.0.x/demos/demo-jaas-webapp">Source</a>
+      <a class="menu" href="https://github.com/jetty/jetty.project/tree/jetty-10.0.x/demos/demo-jaas-webapp">Source</a>
       <a class="menu" href="https://eclipse.dev/jetty/">Jetty Project Home</a>
       <a class="menu" href="https://eclipse.dev/jetty/documentation/">Documentation</a>
       <a class="menu" href="https://webtide.com">Commercial Support</a>

--- a/demos/demo-jetty-webapp/src/main/assembly/embedded-jetty-web-for-webbundle.xml
+++ b/demos/demo-jetty-webapp/src/main/assembly/embedded-jetty-web-for-webbundle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ==================================================================
 Configure and deploy the test web application in $(jetty.home)/webapps/test

--- a/demos/demo-jetty-webapp/src/main/config/modules/demo.d/demo-jetty.xml
+++ b/demos/demo-jetty-webapp/src/main/config/modules/demo.d/demo-jetty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ==================================================================
 Configure and deploy the test web application

--- a/demos/demo-jetty-webapp/src/main/config/modules/demo.d/demo-moved-context.xml
+++ b/demos/demo-jetty-webapp/src/main/config/modules/demo.d/demo-moved-context.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- Simple handler to redirect from old path to new -->
 <Configure class="org.eclipse.jetty.server.handler.MovedContextHandler">

--- a/demos/demo-jetty-webapp/src/main/config/modules/demo.d/demo-rewrite-rules.xml
+++ b/demos/demo-jetty-webapp/src/main/config/modules/demo.d/demo-rewrite-rules.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure the demos                                             -->

--- a/demos/demo-jetty-webapp/src/main/webapp/WEB-INF/jetty-web.xml
+++ b/demos/demo-jetty-webapp/src/main/webapp/WEB-INF/jetty-web.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!--
 This is the jetty specific web application configuration file.  When starting

--- a/demos/demo-jetty-webapp/src/main/webapp/auth.html
+++ b/demos/demo-jetty-webapp/src/main/webapp/auth.html
@@ -9,7 +9,7 @@
 
     <div class="topnav">
       <a class="menu" href="http://localhost:8080/">Demo Home</a>
-      <a class="menu" href="https://github.com/eclipse/jetty.project/tree/jetty-10.0.x/demos/demo-jetty-webapp">Source</a>
+      <a class="menu" href="https://github.com/jetty/jetty.project/tree/jetty-10.0.x/demos/demo-jetty-webapp">Source</a>
       <a class="menu" href="https://eclipse.dev/jetty/">Jetty Project Home</a>
       <a class="menu" href="https://eclipse.dev/jetty/documentation/">Documentation</a>
       <a class="menu" href="https://webtide.com">Commercial Support</a>

--- a/demos/demo-jetty-webapp/src/main/webapp/auth.html
+++ b/demos/demo-jetty-webapp/src/main/webapp/auth.html
@@ -41,7 +41,7 @@
    </div>
 
    <div class="footer">
-      <center><a href="https://www.eclipse.org/jetty"><img style="border:0" src="small_powered_by.gif"/></a></center>
+      <center><a href="https://jetty.org"><img style="border:0" src="small_powered_by.gif"/></a></center>
    </div>
 </body>
 </html>

--- a/demos/demo-jetty-webapp/src/main/webapp/index.html
+++ b/demos/demo-jetty-webapp/src/main/webapp/index.html
@@ -66,7 +66,7 @@
     </div>
 
     <div class="footer">
-      <center><a href="https://www.eclipse.org/jetty"><img style="border:0" src="small_powered_by.gif"/></a></center>
+      <center><a href="https://jetty.org"><img style="border:0" src="small_powered_by.gif"/></a></center>
     </div>
 </body>
 </html>

--- a/demos/demo-jetty-webapp/src/main/webapp/index.html
+++ b/demos/demo-jetty-webapp/src/main/webapp/index.html
@@ -8,7 +8,7 @@
 <body>
     <div class="topnav">
       <a class="menu" href="http://localhost:8080/">Demo Home</a>
-      <a class="menu" href="https://github.com/eclipse/jetty.project/tree/jetty-10.0.x/demos/demo-jetty-webapp">Source</a>
+      <a class="menu" href="https://github.com/jetty/jetty.project/tree/jetty-10.0.x/demos/demo-jetty-webapp">Source</a>
       <a class="menu" href="https://eclipse.dev/jetty/">Jetty Project Home</a>
       <a class="menu" href="https://eclipse.dev/jetty/documentation/">Documentation</a>
       <a class="menu" href="https://webtide.com">Commercial Support</a>

--- a/demos/demo-jetty-webapp/src/main/webapp/remote.html
+++ b/demos/demo-jetty-webapp/src/main/webapp/remote.html
@@ -28,7 +28,7 @@
     </div>
 
     <div class="footer">
-      <center><a href="https://www.eclipse.org/jetty"><img style="border:0" src="small_powered_by.gif"/></a></center>
+      <center><a href="https://jetty.org"><img style="border:0" src="small_powered_by.gif"/></a></center>
     </div>
 
 </body>

--- a/demos/demo-jetty-webapp/src/main/webapp/remote.html
+++ b/demos/demo-jetty-webapp/src/main/webapp/remote.html
@@ -8,7 +8,7 @@
 <body>
     <div class="topnav">
       <a class="menu" href="http://localhost:8080/">Demo Home</a>
-      <a class="menu" href="https://github.com/eclipse/jetty.project/tree/jetty-10.0.x/demos/demo-jetty-webapp">Source</a>
+      <a class="menu" href="https://github.com/jetty/jetty.project/tree/jetty-10.0.x/demos/demo-jetty-webapp">Source</a>
       <a class="menu" href="https://eclipse.dev/jetty/">Jetty Project Home</a>
       <a class="menu" href="https://eclipse.dev/jetty/documentation/">Documentation</a>
       <a class="menu" href="https://webtide.com">Commercial Support</a>

--- a/demos/demo-jetty-webapp/src/main/webapp/rewrite/info.html
+++ b/demos/demo-jetty-webapp/src/main/webapp/rewrite/info.html
@@ -9,7 +9,7 @@
 <body>
     <div class="topnav">
       <a class="menu" href="http://localhost:8080/">Demo Home</a>
-      <a class="menu" href="https://github.com/eclipse/jetty.project/tree/jetty-10.0.x/demos/demo-jetty-webapp">Source</a>
+      <a class="menu" href="https://github.com/jetty/jetty.project/tree/jetty-10.0.x/demos/demo-jetty-webapp">Source</a>
       <a class="menu" href="https://eclipse.dev/jetty/">Jetty Project Home</a>
       <a class="menu" href="https://eclipse.dev/jetty/documentation/">Documentation</a>
       <a class="menu" href="https://webtide.com">Commercial Support</a>

--- a/demos/demo-jetty-webapp/src/main/webapp/rewrite/info.html
+++ b/demos/demo-jetty-webapp/src/main/webapp/rewrite/info.html
@@ -51,7 +51,7 @@
   </div>
 
   <div class="footer">
-    <center><a href="https://www.eclipse.org/jetty"><img style="border:0" src="../small_powered_by.gif"/></a></center>
+    <center><a href="https://jetty.org"><img style="border:0" src="../small_powered_by.gif"/></a></center>
   </div>
 
    

--- a/demos/demo-jndi-webapp/src/main/config/modules/demo.d/demo-jndi.xml
+++ b/demos/demo-jndi-webapp/src/main/config/modules/demo.d/demo-jndi.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure the test-jndi webapp                                  -->

--- a/demos/demo-jndi-webapp/src/main/templates/jetty-test-jndi-header.xml
+++ b/demos/demo-jndi-webapp/src/main/templates/jetty-test-jndi-header.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure the test-jndi webapp                                  -->

--- a/demos/demo-jndi-webapp/src/main/templates/plugin-context-header.xml
+++ b/demos/demo-jndi-webapp/src/main/templates/plugin-context-header.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure the test-jndi webapp                                  -->

--- a/demos/demo-jndi-webapp/src/main/webapp/WEB-INF/jetty-env.xml
+++ b/demos/demo-jndi-webapp/src/main/webapp/WEB-INF/jetty-env.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id='wac' class="org.eclipse.jetty.webapp.WebAppContext">
 

--- a/demos/demo-jndi-webapp/src/main/webapp/WEB-INF/jetty-web.xml
+++ b/demos/demo-jndi-webapp/src/main/webapp/WEB-INF/jetty-web.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Get name="servletContext">

--- a/demos/demo-jndi-webapp/src/main/webapp/index.html
+++ b/demos/demo-jndi-webapp/src/main/webapp/index.html
@@ -8,7 +8,7 @@
 <body>
     <div class="topnav">
       <a class="menu" href="http://localhost:8080/">Demo Home</a>
-      <a class="menu" href="https://github.com/eclipse/jetty.project/tree/jetty-10.0.x/demos/demo-jndi-webapp">Source</a>
+      <a class="menu" href="https://github.com/jetty/jetty.project/tree/jetty-10.0.x/demos/demo-jndi-webapp">Source</a>
       <a class="menu" href="https://eclipse.dev/jetty/">Jetty Project Home</a>
       <a class="menu" href="https://eclipse.dev/jetty/documentation/">Documentation</a>
       <a class="menu" href="https://webtide.com">Commercial Support</a>

--- a/demos/demo-jndi-webapp/src/main/webapp/index.html
+++ b/demos/demo-jndi-webapp/src/main/webapp/index.html
@@ -48,7 +48,7 @@
     </div>
 
     <div class="footer">
-      <center><a href="https://www.eclipse.org/jetty"><img style="border:0" src="small_powered_by.gif"/></a></center>
+      <center><a href="https://jetty.org"><img style="border:0" src="small_powered_by.gif"/></a></center>
     </div>
 
 

--- a/demos/demo-jsp-webapp/src/main/webapp/WEB-INF/jetty-web.xml
+++ b/demos/demo-jsp-webapp/src/main/webapp/WEB-INF/jetty-web.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Get name="servletContext">

--- a/demos/demo-jsp-webapp/src/main/webapp/index.jsp
+++ b/demos/demo-jsp-webapp/src/main/webapp/index.jsp
@@ -10,7 +10,7 @@
 
     <div class="topnav">
       <a class="menu" href="http://localhost:8080/">Demo Home</a>
-      <a class="menu" href="https://github.com/eclipse/jetty.project/tree/jetty-10.0.x/demos/demo-jsp-webapp">Source</a>
+      <a class="menu" href="https://github.com/jetty/jetty.project/tree/jetty-10.0.x/demos/demo-jsp-webapp">Source</a>
       <a class="menu" href="https://eclipse.dev/jetty/">Jetty Project Home</a>
       <a class="menu" href="https://eclipse.dev/jetty/documentation/">Documentation</a>
       <a class="menu" href="https://webtide.com">Commercial Support</a>

--- a/demos/demo-jsp-webapp/src/main/webapp/index.jsp
+++ b/demos/demo-jsp-webapp/src/main/webapp/index.jsp
@@ -39,7 +39,7 @@
     </div>
 
     <div class="footer">
-      <center><a href="https://www.eclipse.org/jetty"><img style="border:0" src="small_powered_by.gif"/></a></center>
+      <center><a href="https://jetty.org"><img style="border:0" src="small_powered_by.gif"/></a></center>
     </div>
 </body>
 </html>

--- a/demos/demo-proxy-webapp/src/main/webapp/WEB-INF/jetty-web.xml
+++ b/demos/demo-proxy-webapp/src/main/webapp/WEB-INF/jetty-web.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Get name="servletContext">

--- a/demos/demo-spec/demo-spec-webapp/src/main/config/modules/demo.d/demo-spec.xml
+++ b/demos/demo-spec/demo-spec-webapp/src/main/config/modules/demo.d/demo-spec.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="wac" class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/test-spec</Set>

--- a/demos/demo-spec/demo-spec-webapp/src/main/templates/annotations-context-header.xml
+++ b/demos/demo-spec/demo-spec-webapp/src/main/templates/annotations-context-header.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 
 <!-- =============================================================== -->

--- a/demos/demo-spec/demo-spec-webapp/src/main/templates/plugin-context-header.xml
+++ b/demos/demo-spec/demo-spec-webapp/src/main/templates/plugin-context-header.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 
 <!-- =============================================================== -->

--- a/demos/demo-spec/demo-spec-webapp/src/main/webapp/WEB-INF/jetty-env.xml
+++ b/demos/demo-spec/demo-spec-webapp/src/main/webapp/WEB-INF/jetty-env.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id='wac' class="org.eclipse.jetty.webapp.WebAppContext">
 

--- a/demos/demo-spec/demo-spec-webapp/src/main/webapp/WEB-INF/jetty-web.xml
+++ b/demos/demo-spec/demo-spec-webapp/src/main/webapp/WEB-INF/jetty-web.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Get name="servletContext">

--- a/demos/demo-spec/demo-spec-webapp/src/main/webapp/index.html
+++ b/demos/demo-spec/demo-spec-webapp/src/main/webapp/index.html
@@ -80,7 +80,7 @@
   </div>
 
   <div class="footer">
-    <center><a href="https://www.eclipse.org/jetty"><img style="border:0" src="small_powered_by.gif"/></a></center>
+    <center><a href="https://jetty.org"><img style="border:0" src="small_powered_by.gif"/></a></center>
   </div>
 </body>
 </html>

--- a/demos/demo-spec/demo-spec-webapp/src/main/webapp/index.html
+++ b/demos/demo-spec/demo-spec-webapp/src/main/webapp/index.html
@@ -8,7 +8,7 @@
 <body>
     <div class="topnav">
       <a class="menu" href="http://localhost:8080/">Demo Home</a>
-      <a class="menu" href="https://github.com/eclipse/jetty.project/tree/jetty-10.0.x/demos/demo-spec">Source</a>
+      <a class="menu" href="https://github.com/jetty/jetty.project/tree/jetty-10.0.x/demos/demo-spec">Source</a>
       <a class="menu" href="https://eclipse.dev/jetty/">Jetty Project Home</a>
       <a class="menu" href="https://eclipse.dev/jetty/documentation/">Documentation</a>
       <a class="menu" href="https://webtide.com">Commercial Support</a>

--- a/demos/demo-spec/demo-spec-webapp/src/test/jetty-plugin-env.xml
+++ b/demos/demo-spec/demo-spec-webapp/src/test/jetty-plugin-env.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id='wac' class="org.eclipse.jetty.webapp.WebAppContext">
 

--- a/demos/demo-template/src/main/resources/index.html
+++ b/demos/demo-template/src/main/resources/index.html
@@ -10,7 +10,7 @@
     <div class="topnav">
       <a class="menu" href="http://localhost:8080/">Demo Home</a>
       <!-- Change source to suit -->
-      <a class="menu" href="https://github.com/eclipse/jetty.project/tree/jetty-10.0.x/demos/XXX">Source</a>
+      <a class="menu" href="https://github.com/jetty/jetty.project/tree/jetty-10.0.x/demos/XXX">Source</a>
       <a class="menu" href="https://eclipse.dev/jetty/">Jetty Project Home</a>
       <a class="menu" href="https://eclipse.dev/jetty/documentation/">Documentation</a>
       <a class="menu" href="https://webtide.com">Commercial Support</a>

--- a/demos/demo-template/src/main/resources/index.html
+++ b/demos/demo-template/src/main/resources/index.html
@@ -29,7 +29,7 @@
     </div>
 
     <div class="footer">
-      <center><a href="https://www.eclipse.org/jetty"><img style="border:0" src="small_powered_by.gif"/></a></center>
+      <center><a href="https://jetty.org"><img style="border:0" src="small_powered_by.gif"/></a></center>
     </div>
 </body>
 </html>

--- a/demos/embedded/src/main/resources/exampleserver.xml
+++ b/demos/embedded/src/main/resources/exampleserver.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="ExampleServer" class="org.eclipse.jetty.server.Server">
 

--- a/demos/embedded/src/main/resources/fileserver.xml
+++ b/demos/embedded/src/main/resources/fileserver.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="FileServer" class="org.eclipse.jetty.server.Server">
 

--- a/documentation/jetty-documentation/src/main/asciidoc/old_docs/ant/jetty-ant.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/old_docs/ant/jetty-ant.adoc
@@ -32,7 +32,7 @@ Its purpose is to provide almost the same functionality as the Jetty plugin for 
 
 To set up your project for Ant to run Jetty, you need a Jetty distribution and the jetty-ant Jar:
 
-1.  https://eclipse.dev/jetty/download.php[Download] a Jetty distribution and unpack it in the local filesystem.
+1.  https://jetty.org/download.html[Download] a Jetty distribution and unpack it in the local filesystem.
 2.  https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-ant/[Get] the jetty-ant Jar.
 3.  Make a directory in your project called `jetty-lib/`.
 4.  Copy all of the Jars in your Jetty distribution's `lib` directory, and all its subdirectories, into your new `jetty-lib` dir.

--- a/documentation/jetty-documentation/src/main/asciidoc/old_docs/contexts/custom-error-pages.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/old_docs/contexts/custom-error-pages.adoc
@@ -72,7 +72,7 @@ Context files are normally located in `${jetty.base}/webapps/` (see `DeployerMan
 [source, xml, subs="{sub-order}"]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/test</Set>

--- a/documentation/jetty-documentation/src/main/asciidoc/old_docs/contributing/bugs.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/old_docs/contributing/bugs.adoc
@@ -17,5 +17,5 @@
 As with any constantly evolving software project, there will be issues, features, and bugs.
 We want to know whats bugging you!
 
-File bugs as Issues in our Github repository http://github.com/eclipse/jetty.project[Issues at Github]
+File bugs as Issues in our Github repository http://github.com/jetty/jetty.project[Issues at Github]
 

--- a/documentation/jetty-documentation/src/main/asciidoc/old_docs/contributing/documentation.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/old_docs/contributing/documentation.adoc
@@ -49,7 +49,7 @@ Clone the repository:
 
 [source, screen, subs="{sub-order}"]
 ....
-$ git clone https://github.com/eclipse/jetty.project.git
+$ git clone https://github.com/jetty/jetty.project.git
 ....
 
 You will now have a local directory with all of jetty, including the jetty-documentation.
@@ -109,7 +109,7 @@ Obviously we can not allow anyone immediate access to this repository so you mus
 In English that means that you would go to the url of the documentation in github:
 
 ....
-https://github.com/eclipse/jetty.project
+https://github.com/jetty/jetty.project
 ....
 
 When you are on this page you will see a little button called 'Fork' which you can click and you will be taken back to your main page on github where you have a new repository.

--- a/documentation/jetty-documentation/src/main/asciidoc/old_docs/contributing/releasing-jetty.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/old_docs/contributing/releasing-jetty.adoc
@@ -230,7 +230,7 @@ There are two git repositories you need to be aware of for releasing jetty-docum
 jetty-documentation::
 https://github.com/jetty-project/jetty-documentation
 jetty-website::
-http://git.eclipse.org/c/www.eclipse.org/jetty.git
+http://github.com/jetty/jetty.website
 
 Do the following steps to publish documentation for the release:
 

--- a/documentation/jetty-documentation/src/main/asciidoc/old_docs/contributing/source-build.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/old_docs/contributing/source-build.adoc
@@ -28,7 +28,7 @@ These are the URLs to the GIT repositories for the Jetty code.
 They are for people who are working on the Jetty project, as well as for people who are interested in examining or modifying the Jetty code for their own projects.
 
 Jetty Project Repository::
-  https://github.com/eclipse/jetty.project
+  https://github.com/jetty/jetty.project
 
 ===== Build and Project Infrastructure SCM URLs
 
@@ -53,7 +53,7 @@ Building Jetty should simply be a matter of changing into the relevant directory
 [source, screen, subs="{sub-order}"]
 ....
 
-$ git clone https://github.com/eclipse/jetty.project.git
+$ git clone https://github.com/jetty/jetty.project.git
 $ cd jetty.project
 $ mvn install
 

--- a/documentation/jetty-documentation/src/main/asciidoc/old_docs/deploying/configuring-specific-webapp-deployment.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/old_docs/deploying/configuring-specific-webapp-deployment.adoc
@@ -41,7 +41,7 @@ For example, here is a descriptor file that deploys the file `/opt/myapp/myapp.w
 [source, xml, subs="{sub-order}"]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/wiki</Set>
@@ -55,7 +55,7 @@ For example, if the system property is set to `myapp.home=/opt/myapp`, the previ
 [source, xml, subs="{sub-order}"]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/wiki</Set>
@@ -83,7 +83,7 @@ This can help make it clear that users should not make changes to the temporary 
 [source, xml, subs="{sub-order}"]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/wiki</Set>
@@ -99,7 +99,7 @@ However, since the `web.xml` for the web application is processed after the depl
 [source, xml, subs="{sub-order}"]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/wiki</Set>
@@ -120,7 +120,7 @@ This feature is useful when adding parameters or additional Servlet mappings wit
 [source, xml, subs="{sub-order}"]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/wiki</Set>
@@ -135,7 +135,7 @@ If the `web.xml` does not include a reference to this data source, an override d
 [source, xml, subs="{sub-order}"]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/wiki</Set>

--- a/documentation/jetty-documentation/src/main/asciidoc/old_docs/deploying/deployment-architecture.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/old_docs/deploying/deployment-architecture.adoc
@@ -99,7 +99,7 @@ In the standard Jetty Distribution, this is configured in the `${jetty.home}/etc
 [source, xml, subs="{sub-order}"]
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <Call name="addBean">

--- a/documentation/jetty-documentation/src/main/asciidoc/old_docs/deploying/deployment-processing-webapps.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/old_docs/deploying/deployment-processing-webapps.adoc
@@ -130,7 +130,7 @@ Let's see an example of how we would add in the Configurations for both JNDI _an
 [source, xml, subs="{sub-order}"]
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
 
@@ -162,7 +162,7 @@ They will then be applied to each `WebAppContext` deployed by the deployer:
 [source, xml, subs="{sub-order}"]
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
@@ -206,7 +206,7 @@ This example uses an xml file, in fact it is the `$JETTY_HOME/etc/jetty-plus.xml
 [source, xml, subs="{sub-order}"]
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
@@ -256,7 +256,7 @@ Here's an example from a context xml file (although as always, you could have ac
 [source, xml, subs="{sub-order}"]
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
 
@@ -282,7 +282,7 @@ Here's an example in a xml file of a pattern that matches any jar that starts wi
 [source, xml, subs="{sub-order}"]
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
 

--- a/documentation/jetty-documentation/src/main/asciidoc/old_docs/deploying/quickstart-webapp.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/old_docs/deploying/quickstart-webapp.adoc
@@ -100,7 +100,7 @@ Otherwise, create a context xml file with the following information (in addition
 [source, xml, subs="{sub-order}"]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 <Configure class="org.eclipse.jetty.quickstart.QuickStartWebApp">
   <Set name="autoPreconfigure">true</Set>
 </Configure>

--- a/documentation/jetty-documentation/src/main/asciidoc/old_docs/deploying/static-content-deployment.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/old_docs/deploying/static-content-deployment.adoc
@@ -20,7 +20,7 @@ Create a file called `scratch.xml` in the `${jetty.base}/webapps` directory and 
 [source, xml, subs="{sub-order}"]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 <Configure class="org.eclipse.jetty.server.handler.ContextHandler">
   <Set name="contextPath">/scratch</Set>
   <Set name="handler">

--- a/documentation/jetty-documentation/src/main/asciidoc/old_docs/extras/moved-context-handler.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/old_docs/extras/moved-context-handler.adoc
@@ -43,7 +43,7 @@ This is a permanent redirection, which also preserves `pathinfo` and query strin
 [source, xml, subs="{sub-order}"]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.server.handler.MovedContextHandler">
   <Set name="contextPath">/foo</Set>

--- a/documentation/jetty-documentation/src/main/asciidoc/old_docs/fastcgi/configuring-fastcgi.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/old_docs/fastcgi/configuring-fastcgi.adoc
@@ -44,7 +44,7 @@ Copy and paste the following content as `$JETTY_BASE/webapps/jetty-wordpress.xml
 [source, xml, subs="{sub-order}"]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 <Configure class="org.eclipse.jetty.servlet.ServletContextHandler">
 
     <New id="root" class="java.lang.String">

--- a/documentation/jetty-documentation/src/main/asciidoc/old_docs/frameworks/cdi.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/old_docs/frameworks/cdi.adoc
@@ -73,7 +73,7 @@ This module is equivalent to directly modifying the class path configuration wit
 [source.XML, xml]
 -------------------------------------------------------------
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://jetty.org/configure.dtd">
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
    <Call name="prependServerClass">
       <Arg>-org.eclipse.jetty.util.Decorator</Arg>

--- a/documentation/jetty-documentation/src/main/asciidoc/old_docs/frameworks/osgi.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/old_docs/frameworks/osgi.adoc
@@ -24,7 +24,7 @@ In addition, the infrastructure also supports the OSGi `HttpService` interface.
 
 All of the Jetty jars contain manifest entries appropriate to ensure that they can be deployed into an OSGi container as bundles.
 You will need to install some jetty jars into your OSGi container.
-You can always find the Jetty jars either in the Maven Central repository, or you can link:https://eclipse.dev/jetty/download.php[download] a distribution of Jetty.
+You can always find the Jetty jars either in the Maven Central repository, or you can link:https://jetty.org/download.html[download] a distribution of Jetty.
 Here's the absolute minimal set of Jetty jars:
 
 .Minimal Bundles
@@ -355,7 +355,7 @@ Here's an example of the contents of a `META-INF/jetty-webapp-context.xml` file:
 ----
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="defaultsDescriptor"><Property name="bundle.root"/>META-INF/webdefault.xml</Set>
@@ -796,7 +796,7 @@ To set the pattern, you will need to provide your own etc files - see the sectio
 [source, xml, subs="{sub-order}"]
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
     <Call name="addBean">
       <Arg>

--- a/documentation/jetty-documentation/src/main/asciidoc/old_docs/gettingstarted/configuring/what-to-configure.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/old_docs/gettingstarted/configuring/what-to-configure.adoc
@@ -140,7 +140,7 @@ The deployer discovers and hot deploys context IoC descriptors like the followin
 [source, xml, subs="{sub-order}"]
 ----
 <?xml version="1.0"  encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!--
   Configure a custom context for serving javadoc as static resources
@@ -199,7 +199,7 @@ To set the contextPath from within the WAR file, you can include a `WEB-INF/jett
 [source, xml, subs="{sub-order}"]
 ----
 <?xml version="1.0"  encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
     <Set name="contextPath">/contextpath</Set>
@@ -212,7 +212,7 @@ Instead of allowing the WAR file to be discovered by the deployer, an IoC XML fi
 [source, xml, subs="{sub-order}"]
 ----
 <?xml version="1.0"  encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="war"><SystemProperty name="jetty.home" default="."/>/webapps/test.war</Set>

--- a/documentation/jetty-documentation/src/main/asciidoc/old_docs/gettingstarted/getting-started/jetty-installing.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/old_docs/gettingstarted/getting-started/jetty-installing.adoc
@@ -19,7 +19,7 @@
 The standalone Jetty distribution is available for download from the Eclipse Foundation:
 ____
 *Jetty*
-https://eclipse.dev/jetty/download.php
+https://jetty.org/download.html
 ____
 
 It is available in both zip and gzip formats; download the one most appropriate for your system.

--- a/documentation/jetty-documentation/src/main/asciidoc/old_docs/jetty-xml/jetty-env-xml.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/old_docs/jetty-xml/jetty-env-xml.adoc
@@ -29,7 +29,7 @@ Jetty applies `jetty-env.xml` on a per-webapp basis, and configures an instance 
 ----
 
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
  ..
@@ -52,7 +52,7 @@ Place the `jetty-env.xml` file in your web application's WEB-INF folder.
 ----
 
  <?xml version="1.0"?>
- <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+ <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
  <Configure class="org.eclipse.jetty.webapp.WebAppContext">
 

--- a/documentation/jetty-documentation/src/main/asciidoc/old_docs/jetty-xml/jetty-web-xml-config.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/old_docs/jetty-xml/jetty-web-xml-config.adoc
@@ -28,7 +28,7 @@ For a more in-depth look at the syntax, see xref:jetty-xml-syntax[].
 [source, xml, subs="{sub-order}"]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
  ..

--- a/documentation/jetty-documentation/src/main/asciidoc/old_docs/jetty-xml/jetty-xml-config.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/old_docs/jetty-xml/jetty-xml-config.adoc
@@ -26,7 +26,7 @@
 
 Not all Jetty features are configured in `jetty.xml`.
 There are several optional configuration files that share the same format as `jetty.xml` and, if specified, concatenate to it.
-These configuration files are also stored in `$JETTY_HOME/etc/`, and examples of them are in http://github.com/eclipse/jetty.project/jetty-server/src/main/config/etc/[Github Repository].
+These configuration files are also stored in `$JETTY_HOME/etc/`, and examples of them are in http://github.com/jetty/jetty.project/jetty-server/src/main/config/etc/[Github Repository].
 The selection of which configuration files to use is controlled by `start.jar` and the process of merging configuration is described in xref:jetty-xml-usage[].
 
 [[root-element-jetty-xml]]

--- a/documentation/jetty-documentation/src/main/asciidoc/old_docs/jetty-xml/jetty-xml-config.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/old_docs/jetty-xml/jetty-xml-config.adoc
@@ -38,7 +38,7 @@ The selection of which configuration files to use is controlled by `start.jar` a
 ----
 
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
  ...

--- a/documentation/jetty-documentation/src/main/asciidoc/old_docs/security/jaas-support.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/old_docs/security/jaas-support.adoc
@@ -406,4 +406,4 @@ public class FooLoginModule extends AbstractLoginModule
 
 An example webapp using JAAS can be found in the Jetty GitHub repository:
 
-* link:{GITBROWSEURL}/tests/test-webapps/test-jaas-webapp[https://github.com/eclipse/jetty.project/tree/jetty-10.0.x/tests/test-webapps/test-jaas-webapp]
+* link:{GITBROWSEURL}/tests/test-webapps/test-jaas-webapp[https://github.com/jetty/jetty.project/tree/jetty-10.0.x/tests/test-webapps/test-jaas-webapp]

--- a/documentation/jetty-documentation/src/main/asciidoc/operations-guide/annotations/chapter.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/operations-guide/annotations/chapter.adoc
@@ -48,7 +48,7 @@ Here's an example context xml file that calls this method:
 [source,xml,subs=verbatim]
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext"> <1>
   <Set name="configurationDiscovered">false</Set> <2>
@@ -77,7 +77,7 @@ Here's an example from a context xml file that includes any jar whose name start
 [source,xml,subs=verbatim]
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext"> <1>
     <Call name="setAttribute"> <2>
@@ -108,7 +108,7 @@ Here's an example of a context xml file that sets a pattern that matches any jar
 [source,xml,subs=verbatim]
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext"> <1>
     <Call name="setAttribute">  <2>
@@ -174,7 +174,7 @@ Here's an example of setting the context attribute in a context xml file:
 [source,xml,subs=verbatim]
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext"> <1>
     <Call name="setAttribute">  <2>
@@ -205,7 +205,7 @@ Here is an example context xml file that ensures the `com.example.PrioritySCI` w
 [source,xml,subs=verbatim]
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext"> <1>
     <Call name="setAttribute">  <2>

--- a/documentation/jetty-documentation/src/main/asciidoc/operations-guide/begin/download.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/operations-guide/begin/download.adoc
@@ -14,7 +14,7 @@
 [[og-begin-download]]
 ==== Downloading Jetty
 
-The Eclipse Jetty distribution is available for download from link:https://eclipse.dev/jetty/download.php[]
+The Eclipse Jetty distribution is available for download from link:https://jetty.org/download.html[]
 
 The Eclipse Jetty distribution is available in both `zip` and `gzip` formats; download the one most appropriate for your system, typically `zip` for Windows and `gzip` for other operating systems.
 

--- a/documentation/jetty-documentation/src/main/asciidoc/operations-guide/deploy/deploy-extract-war.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/operations-guide/deploy/deploy-extract-war.adoc
@@ -24,7 +24,7 @@ If you do not want Jetty to extract the `+*.war+` files, you can disable this fe
 [source,xml,highlight=8]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/mywebapp</Set>

--- a/documentation/jetty-documentation/src/main/asciidoc/operations-guide/deploy/deploy-jetty.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/operations-guide/deploy/deploy-jetty.adoc
@@ -26,7 +26,7 @@ A simple Jetty context XML file, for example named `wiki.xml` is the following:
 [source,xml,subs=verbatim]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext"> <1>
   <Set name="contextPath">/wiki</Set> <2>
@@ -60,7 +60,7 @@ You can use the features of xref:og-xml[Jetty XML files] to avoid to hard-code f
 [source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/wiki</Set>

--- a/documentation/jetty-documentation/src/main/asciidoc/operations-guide/deploy/deploy-jndi.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/operations-guide/deploy/deploy-jndi.adoc
@@ -21,7 +21,7 @@ The JNDI entry must be _defined_ in a xref:og-jndi-xml[Jetty XML file], for exam
 [source,xml,subs=normal]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="wac" class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/mywebapp</Set>

--- a/documentation/jetty-documentation/src/main/asciidoc/operations-guide/deploy/deploy-override-webxml.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/operations-guide/deploy/deploy-override-webxml.adoc
@@ -22,7 +22,7 @@ This allows you to add host specific configuration or server specific configurat
 [source,xml,highlight=8]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/mywebapp</Set>

--- a/documentation/jetty-documentation/src/main/asciidoc/operations-guide/deploy/deploy-virtual-hosts.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/operations-guide/deploy/deploy-virtual-hosts.adoc
@@ -56,7 +56,7 @@ If you have a web application `mywebapp.war` you can configure its virtual hosts
 [source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/mywebapp</Set>
@@ -101,7 +101,7 @@ To achieve this, you simply use the same context path of `/` for each of your we
 [source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/</Set>
@@ -118,7 +118,7 @@ To achieve this, you simply use the same context path of `/` for each of your we
 [source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/</Set>
@@ -146,7 +146,7 @@ In this case, you want to xref:og-protocols[configure multiple connectors], each
 [source,xml,highlight=10]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/</Set>
@@ -163,7 +163,7 @@ In this case, you want to xref:og-protocols[configure multiple connectors], each
 [source,xml,highlight=10]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/</Set>

--- a/documentation/jetty-documentation/src/main/asciidoc/operations-guide/index.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/operations-guide/index.adoc
@@ -11,7 +11,7 @@
 // ========================================================================
 //
 
-:doctitle: link:https://eclipse.org/jetty[Eclipse Jetty]: Operations Guide
+:doctitle: link:https://jetty.org[Eclipse Jetty]: Operations Guide
 :toc-title: Operations Guide
 :idprefix: og-
 :docinfo: private-head

--- a/documentation/jetty-documentation/src/main/asciidoc/operations-guide/jaas/chapter.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/operations-guide/jaas/chapter.adoc
@@ -96,7 +96,7 @@ Here's an example of this type of XML file:
 [source,xml]
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call name="addBean">
     <Arg>
@@ -114,7 +114,7 @@ Here's an example of this type of XML file:
 [source,xml]
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="securityHandler">
     <New class="org.eclipse.jetty.security.ConstraintSecurityHandler">

--- a/documentation/jetty-documentation/src/main/asciidoc/operations-guide/jsp/chapter.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/operations-guide/jsp/chapter.adoc
@@ -195,7 +195,7 @@ Here's an example of using a context xml file to add in a pattern to match files
 [source,xml,subs=verbatim]
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext"> <!--1-->
     <Call name="setAttribute"> <!--2-->

--- a/documentation/jetty-documentation/src/main/asciidoc/operations-guide/modules/modules-custom.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/operations-guide/modules/modules-custom.adoc
@@ -43,7 +43,7 @@ Start with the custom Jetty XML file, `$JETTY_BASE/etc/custom-ssl.xml`:
 [source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 <Configure>
   <Ref refid="sslContextFactory"> <!--1-->
     <Set name="CipherComparator"> <!--2-->
@@ -159,7 +159,7 @@ Next, let's write the Jetty XML file that wires the auditing component to the `S
 [source,xml,subs=verbatim,options=nowrap]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 <Configure>
   <Ref refid="httpConnector"> <!--1-->
     <Call name="addBean"> <!--2-->

--- a/documentation/jetty-documentation/src/main/asciidoc/operations-guide/modules/modules.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/operations-guide/modules/modules.adoc
@@ -85,7 +85,7 @@ For example, a Jetty XML file that allocates Jetty's `QueuedThreadPool` could be
 .jetty-threadpool.xml
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 <Configure>
   <New id="threadPool" class="org.eclipse.jetty.util.thread.QueuedThreadPool">
     <Set name="maxThreads" type="int">
@@ -235,7 +235,7 @@ The `custom-server.xml` file is the following:
 [source,xml]
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 <Configure id="Server" class="com.acme.server.CustomJettyServer">
 </Configure>
 ----

--- a/documentation/jetty-documentation/src/main/asciidoc/operations-guide/protocols/protocols-ssl.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/operations-guide/protocols/protocols-ssl.adoc
@@ -59,7 +59,7 @@ You want to create the `$JETTY_BASE/etc/tls-config.xml` with the following templ
 [source,xml,subs=verbatim]
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <Ref refid="sslContextFactory">
@@ -85,7 +85,7 @@ To explicitly add the exclusion of TLSv1.0 and TLSv1.1 (that are also vulnerable
 [source,xml]
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <Ref refid="sslContextFactory">
@@ -110,7 +110,7 @@ You can precisely set the list of excluded ciphers, completely overriding Jetty'
 [source,xml]
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <Ref refid="sslContextFactory">

--- a/documentation/jetty-documentation/src/main/asciidoc/operations-guide/sessions/session-infinispan.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/operations-guide/sessions/session-infinispan.adoc
@@ -126,7 +126,7 @@ There are no configuration properties associated with this module.
 
 From Jetty-9.4.13 onwards, we have changed the format of the serialized session when using a remote cache (ie using hotrod).
 Prior to release 9.4.13 we used the default Infinispan serialization, however this was not able to store sufficient information to allow Jetty to properly deserialize session attributes in all circumstances.
-See issue link:https://github.com/eclipse/jetty.project/issues/2919[] for more background.
+See issue link:https://github.com/jetty/jetty.project/issues/2919[] for more background.
 
 We have provided a conversion program which will convert any sessions stored in Infinispan to the new format.
 

--- a/documentation/jetty-documentation/src/main/asciidoc/operations-guide/xml/xml-syntax.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/operations-guide/xml/xml-syntax.adoc
@@ -21,7 +21,7 @@ The Jetty XML elements define attributes such as `id`, `name`, `class`, etc. tha
 [source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <Get id="stderr" class="java.lang.System" name="err">
@@ -33,7 +33,7 @@ The Jetty XML elements define attributes such as `id`, `name`, `class`, etc. tha
 [source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <Get>
@@ -60,7 +60,7 @@ The following Jetty XML creates an empty `String` and assigns it the id `mystrin
 [source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="mystring" class="java.lang.String" />
 ----
@@ -88,7 +88,7 @@ The following example creates a minimal Jetty `Server`:
 [source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.server.Server">
   <Arg type="int">8080</Arg>
@@ -102,7 +102,7 @@ Arguments may also have a `name` attribute, which is matched with the correspond
 [source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.server.Server">
   <Arg name="port" type="int">8080</Arg>
@@ -122,7 +122,7 @@ The following example creates an `ArrayList`:
 [source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <New id="mylist" class="java.util.ArrayList">
@@ -149,7 +149,7 @@ Within element `<Call>` the return value, if the return type is not `void`, is i
 [source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <New class="java.util.ArrayList">
@@ -173,7 +173,7 @@ It is possible to call `static` methods by specifying the `class` attribute:
 [source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <Call id="myhost" name="getByName" class="java.net.InetAddress">
@@ -196,7 +196,7 @@ For example:
 [source,xml,subs=normal]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <Call class="java.util.concurrent.Executors" name="newSingleThreadScheduledExecutor">
@@ -225,7 +225,7 @@ If the JavaBean property is `foo` (or `Foo`), `<Get>` first attempts to invoke _
 [source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="server" class="org.eclipse.jetty.server.Server">
   <!-- Invokes getter method server.getVersion() -->
@@ -252,7 +252,7 @@ If the JavaBean property is `foo` (or `Foo`), `<Set>` first attempts to invoke _
 [source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="server" class="org.eclipse.jetty.server.Server">
   <!-- The value in the <Set> scope is the string "true" -->
@@ -277,7 +277,7 @@ The map entries are specified with a sequence of `<Entry>` elements, each with e
 [source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <Map class="java.util.concurrent.ConcurrentHashMap">
@@ -302,7 +302,7 @@ You can only specify the key value via the `name` attribute, so the key can only
 [source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <New class="java.util.Properties">
@@ -323,7 +323,7 @@ Element `<Array>` creates a new array, whose component type may be specified by 
 [source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <Array type="java.lang.Object">
@@ -347,7 +347,7 @@ You must give a unique `id` attribute to the objects you want to reference.
 [source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- The Jetty Server has id="server" -->
 <Configure id="server" class="org.eclipse.jetty.server.Server">
@@ -381,7 +381,7 @@ For example, you may want to configure the context path of your web application 
 [source,xml,subs=normal]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">
@@ -407,7 +407,7 @@ The following example creates a minimal Jetty `Server` that listens on a port sp
 [source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="server" class="org.eclipse.jetty.server.Server">
   <Arg type="int">
@@ -430,7 +430,7 @@ The following example creates a minimal Jetty `Server` that listens on a port sp
 [source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="server" class="org.eclipse.jetty.server.Server">
   <Arg type="int">
@@ -462,7 +462,7 @@ The following example illustrates how scopes work:
 [source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="server" class="org.eclipse.jetty.server.Server">
   <Arg type="int">8080</Arg>

--- a/documentation/jetty-documentation/src/main/asciidoc/programming-guide/index.adoc
+++ b/documentation/jetty-documentation/src/main/asciidoc/programming-guide/index.adoc
@@ -11,7 +11,7 @@
 // ========================================================================
 //
 
-:doctitle: link:https://eclipse.org/jetty[Eclipse Jetty]: Programming Guide
+:doctitle: link:https://jetty.org[Eclipse Jetty]: Programming Guide
 :toc-title: Jetty Programming Guide
 :idprefix: pg-
 :docinfo: private-head

--- a/documentation/jetty/modules/operations-guide/pages/annotations/index.adoc
+++ b/documentation/jetty/modules/operations-guide/pages/annotations/index.adoc
@@ -47,7 +47,7 @@ Here's an example context xml file that calls this method:
 [,xml,subs=verbatim]
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext"> <1>
   <Set name="configurationDiscovered">false</Set> <2>
@@ -76,7 +76,7 @@ Here's an example from a context xml file that includes any jar whose name start
 [,xml,subs=verbatim]
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext"> <1>
     <Call name="setAttribute"> <2>
@@ -107,7 +107,7 @@ Here's an example of a context xml file that sets a pattern that matches any jar
 [,xml,subs=verbatim]
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext"> <1>
     <Call name="setAttribute">  <2>
@@ -173,7 +173,7 @@ Here's an example of setting the context attribute in a context xml file:
 [,xml,subs=verbatim]
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext"> <1>
     <Call name="setAttribute">  <2>
@@ -204,7 +204,7 @@ Here is an example context xml file that ensures the `com.example.PrioritySCI` w
 [,xml,subs=verbatim]
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext"> <1>
     <Call name="setAttribute">  <2>

--- a/documentation/jetty/modules/operations-guide/pages/begin/index.adoc
+++ b/documentation/jetty/modules/operations-guide/pages/begin/index.adoc
@@ -56,7 +56,7 @@ Read the xref:arch/index.adoc[Jetty architecture section] for more information a
 [[download]]
 == Downloading Jetty
 
-The Eclipse Jetty distribution is available for download from https://eclipse.dev/jetty/download.php[]
+The Eclipse Jetty distribution is available for download from https://jetty.org/download.html[]
 
 The Eclipse Jetty distribution is available in both `zip` and `gzip` formats; download the one most appropriate for your system, typically `zip` for Windows and `gzip` for other operating systems.
 

--- a/documentation/jetty/modules/operations-guide/pages/deploy/index.adoc
+++ b/documentation/jetty/modules/operations-guide/pages/deploy/index.adoc
@@ -83,7 +83,7 @@ A simple Jetty context XML file, for example named `wiki.xml` is the following:
 [,xml,subs=verbatim]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext"> <1>
   <Set name="contextPath">/wiki</Set> <2>
@@ -117,7 +117,7 @@ You can use the features of xref:xml/index.adoc[Jetty XML files] to avoid to har
 [,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/wiki</Set>
@@ -141,7 +141,7 @@ The JNDI entry must be _defined_ in a xref:jndi/index.adoc#xml[Jetty XML file], 
 [,xml,subs=normal]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="wac" class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/mywebapp</Set>
@@ -215,7 +215,7 @@ If you have a web application `mywebapp.war` you can configure its virtual hosts
 [,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/mywebapp</Set>
@@ -260,7 +260,7 @@ To achieve this, you simply use the same context path of `/` for each of your we
 [,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/</Set>
@@ -277,7 +277,7 @@ To achieve this, you simply use the same context path of `/` for each of your we
 [,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/</Set>
@@ -305,7 +305,7 @@ In this case, you want to xref:protocols/index.adoc[configure multiple connector
 [,xml,highlight=10]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/</Set>
@@ -322,7 +322,7 @@ In this case, you want to xref:protocols/index.adoc[configure multiple connector
 [,xml,highlight=10]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/</Set>
@@ -357,7 +357,7 @@ If you do not want Jetty to extract the `+*.war+` files, you can disable this fe
 [,xml,highlight=8]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/mywebapp</Set>
@@ -377,7 +377,7 @@ This allows you to add host specific configuration or server specific configurat
 [,xml,highlight=8]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/mywebapp</Set>

--- a/documentation/jetty/modules/operations-guide/pages/jaas/index.adoc
+++ b/documentation/jetty/modules/operations-guide/pages/jaas/index.adoc
@@ -95,7 +95,7 @@ Here's an example of this type of XML file:
 [,xml]
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call name="addBean">
     <Arg>
@@ -113,7 +113,7 @@ Here's an example of this type of XML file:
 [,xml]
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="securityHandler">
     <New class="org.eclipse.jetty.security.ConstraintSecurityHandler">

--- a/documentation/jetty/modules/operations-guide/pages/jsf-taglibs/index.adoc
+++ b/documentation/jetty/modules/operations-guide/pages/jsf-taglibs/index.adoc
@@ -26,7 +26,7 @@ Here's an example of using a context xml file to add in a pattern to match files
 [,xml,subs=verbatim]
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext"> <!--1-->
     <Call name="setAttribute"> <!--2-->

--- a/documentation/jetty/modules/operations-guide/pages/modules/custom.adoc
+++ b/documentation/jetty/modules/operations-guide/pages/modules/custom.adoc
@@ -42,7 +42,7 @@ Start with the custom Jetty XML file, `$JETTY_BASE/etc/custom-ssl.xml`:
 [,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 <Configure>
   <Ref refid="sslContextFactory"> <!--1-->
     <Set name="CipherComparator"> <!--2-->
@@ -158,7 +158,7 @@ Next, let's write the Jetty XML file that wires the auditing component to the `S
 [,xml,subs=verbatim,options=nowrap]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 <Configure>
   <Ref refid="httpConnector"> <!--1-->
     <Call name="addBean"> <!--2-->

--- a/documentation/jetty/modules/operations-guide/pages/modules/index.adoc
+++ b/documentation/jetty/modules/operations-guide/pages/modules/index.adoc
@@ -84,7 +84,7 @@ For example, a Jetty XML file that allocates Jetty's `QueuedThreadPool` could be
 .jetty-threadpool.xml
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 <Configure>
   <New id="threadPool" class="org.eclipse.jetty.util.thread.QueuedThreadPool">
     <Set name="maxThreads" type="int">
@@ -234,7 +234,7 @@ The `custom-server.xml` file is the following:
 [,xml]
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 <Configure id="Server" class="com.acme.server.CustomJettyServer">
 </Configure>
 ----

--- a/documentation/jetty/modules/operations-guide/pages/protocols/index.adoc
+++ b/documentation/jetty/modules/operations-guide/pages/protocols/index.adoc
@@ -498,7 +498,7 @@ You want to create the `$JETTY_BASE/etc/tls-config.xml` with the following templ
 [,xml,subs=verbatim]
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <Ref refid="sslContextFactory">
@@ -524,7 +524,7 @@ To explicitly add the exclusion of TLSv1.0 and TLSv1.1 (that are also vulnerable
 [,xml]
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <Ref refid="sslContextFactory">
@@ -549,7 +549,7 @@ You can precisely set the list of excluded ciphers, completely overriding Jetty'
 [,xml]
 ----
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <Ref refid="sslContextFactory">

--- a/documentation/jetty/modules/operations-guide/pages/session/index.adoc
+++ b/documentation/jetty/modules/operations-guide/pages/session/index.adoc
@@ -604,7 +604,7 @@ There are no configuration properties associated with this module.
 
 From Jetty-9.4.13 onwards, we have changed the format of the serialized session when using a remote cache (ie using hotrod).
 Prior to release 9.4.13 we used the default Infinispan serialization, however this was not able to store sufficient information to allow Jetty to properly deserialize session attributes in all circumstances.
-See issue https://github.com/eclipse/jetty.project/issues/2919[] for more background.
+See issue https://github.com/jetty/jetty.project/issues/2919[] for more background.
 
 We have provided a conversion program which will convert any sessions stored in Infinispan to the new format.
 

--- a/documentation/jetty/modules/operations-guide/pages/xml/index.adoc
+++ b/documentation/jetty/modules/operations-guide/pages/xml/index.adoc
@@ -31,7 +31,7 @@ The Jetty XML elements define attributes such as `id`, `name`, `class`, etc. tha
 [,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <Get id="stderr" class="java.lang.System" name="err">
@@ -43,7 +43,7 @@ The Jetty XML elements define attributes such as `id`, `name`, `class`, etc. tha
 [,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <Get>
@@ -70,7 +70,7 @@ The following Jetty XML creates an empty `String` and assigns it the id `mystrin
 [,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="mystring" class="java.lang.String" />
 ----
@@ -98,7 +98,7 @@ The following example creates a minimal Jetty `Server`:
 [,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.server.Server">
   <Arg type="int">8080</Arg>
@@ -112,7 +112,7 @@ Arguments may also have a `name` attribute, which is matched with the correspond
 [,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.server.Server">
   <Arg name="port" type="int">8080</Arg>
@@ -132,7 +132,7 @@ The following example creates an `ArrayList`:
 [,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <New id="mylist" class="java.util.ArrayList">
@@ -159,7 +159,7 @@ Within element `<Call>` the return value, if the return type is not `void`, is i
 [,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <New class="java.util.ArrayList">
@@ -183,7 +183,7 @@ It is possible to call `static` methods by specifying the `class` attribute:
 [,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <Call id="myhost" name="getByName" class="java.net.InetAddress">
@@ -206,7 +206,7 @@ For example:
 [,xml,subs=normal]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <Call class="java.util.concurrent.Executors" name="newSingleThreadScheduledExecutor">
@@ -235,7 +235,7 @@ If the JavaBean property is `foo` (or `Foo`), `<Get>` first attempts to invoke _
 [,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="server" class="org.eclipse.jetty.server.Server">
   <!-- Invokes getter method server.getVersion() -->
@@ -262,7 +262,7 @@ If the JavaBean property is `foo` (or `Foo`), `<Set>` first attempts to invoke _
 [,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="server" class="org.eclipse.jetty.server.Server">
   <!-- The value in the <Set> scope is the string "true" -->
@@ -287,7 +287,7 @@ The map entries are specified with a sequence of `<Entry>` elements, each with e
 [,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <Map class="java.util.concurrent.ConcurrentHashMap">
@@ -312,7 +312,7 @@ You can only specify the key value via the `name` attribute, so the key can only
 [,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <New class="java.util.Properties">
@@ -333,7 +333,7 @@ Element `<Array>` creates a new array, whose component type may be specified by 
 [,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <Array type="java.lang.Object">
@@ -357,7 +357,7 @@ You must give a unique `id` attribute to the objects you want to reference.
 [,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- The Jetty Server has id="server" -->
 <Configure id="server" class="org.eclipse.jetty.server.Server">
@@ -391,7 +391,7 @@ For example, you may want to configure the context path of your web application 
 [,xml,subs=normal]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">
@@ -417,7 +417,7 @@ The following example creates a minimal Jetty `Server` that listens on a port sp
 [,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="server" class="org.eclipse.jetty.server.Server">
   <Arg type="int">
@@ -440,7 +440,7 @@ The following example creates a minimal Jetty `Server` that listens on a port sp
 [,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="server" class="org.eclipse.jetty.server.Server">
   <Arg type="int">
@@ -472,7 +472,7 @@ The following example illustrates how scopes work:
 [,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="server" class="org.eclipse.jetty.server.Server">
   <Arg type="int">8080</Arg>

--- a/jetty-alpn/jetty-alpn-server/src/main/config/etc/jetty-alpn.xml
+++ b/jetty-alpn/jetty-alpn-server/src/main/config/etc/jetty-alpn.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="sslConnector" class="org.eclipse.jetty.server.ServerConnector">
 

--- a/jetty-cdi/src/main/config/etc/cdi/jetty-cdi.xml
+++ b/jetty-cdi/src/main/config/etc/cdi/jetty-cdi.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call name="setAttribute">

--- a/jetty-deploy/src/main/config/etc/jetty-decorate.xml
+++ b/jetty-deploy/src/main/config/etc/jetty-decorate.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <!-- Bind the jetty-web-decorate.xml to every deployed webapp -->

--- a/jetty-deploy/src/main/config/etc/jetty-deploy.xml
+++ b/jetty-deploy/src/main/config/etc/jetty-deploy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- =============================================================== -->
 <!-- Create the deployment manager                                   -->

--- a/jetty-deploy/src/main/config/etc/jetty-web-decorate.xml
+++ b/jetty-deploy/src/main/config/etc/jetty-web-decorate.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext" id="context">
 

--- a/jetty-deploy/src/main/config/modules/global-webapp-common.d/global-webapp-common.xml
+++ b/jetty-deploy/src/main/config/modules/global-webapp-common.d/global-webapp-common.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Ref refid="DeploymentManager">

--- a/jetty-deploy/src/main/config/modules/global-webapp-common.d/webapp-common.xml
+++ b/jetty-deploy/src/main/config/modules/global-webapp-common.d/webapp-common.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
 

--- a/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/DeploymentTempDirTest.java
+++ b/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/DeploymentTempDirTest.java
@@ -101,7 +101,7 @@ public class DeploymentTempDirTest
     public void testTmpDirectory() throws Exception
     {
         Path warPath = MavenTestingUtils.getTestResourcePath("webapps/foo-webapp-1.war");
-        String deploymentXml = "<!DOCTYPE Configure PUBLIC \"-//Jetty//Configure//EN\" \"https://www.eclipse.org/jetty/configure_10_0.dtd\">\n" +
+        String deploymentXml = "<!DOCTYPE Configure PUBLIC \"-//Jetty//Configure//EN\" \"https://jetty.org/configure_10_0.dtd\">\n" +
             "<Configure class=\"org.eclipse.jetty.webapp.WebAppContext\">\n" +
             "<Set name=\"war\">" + warPath + "</Set>\n" +
             "<Set name=\"tempDirectory\">" + tmpDir + "</Set>\n" +
@@ -145,7 +145,7 @@ public class DeploymentTempDirTest
     public void testPersistentTmpDirectory() throws Exception
     {
         Path warPath = MavenTestingUtils.getTestResourcePath("webapps/foo-webapp-1.war");
-        String deploymentXml = "<!DOCTYPE Configure PUBLIC \"-//Jetty//Configure//EN\" \"https://www.eclipse.org/jetty/configure_10_0.dtd\">\n" +
+        String deploymentXml = "<!DOCTYPE Configure PUBLIC \"-//Jetty//Configure//EN\" \"https://jetty.org/configure_10_0.dtd\">\n" +
             "<Configure class=\"org.eclipse.jetty.webapp.WebAppContext\">\n" +
             "<Set name=\"war\">" + warPath + "</Set>\n" +
             "<Set name=\"tempDirectory\">" + tmpDir + "</Set>\n" +

--- a/jetty-deploy/src/test/resources/binding-test-contexts-1.xml
+++ b/jetty-deploy/src/test/resources/binding-test-contexts-1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-deploy/src/test/resources/context-binding-test-1.xml
+++ b/jetty-deploy/src/test/resources/context-binding-test-1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Call name="getServerClassMatcher">
     <Call name="include">

--- a/jetty-deploy/src/test/resources/jetty-deploy-wars.xml
+++ b/jetty-deploy/src/test/resources/jetty-deploy-wars.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-deploy/src/test/resources/jetty-deploymgr-contexts.xml
+++ b/jetty-deploy/src/test/resources/jetty-deploymgr-contexts.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call name="addBean">

--- a/jetty-deploy/src/test/resources/jetty-http.xml
+++ b/jetty-deploy/src/test/resources/jetty-http.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->

--- a/jetty-deploy/src/test/resources/jetty.xml
+++ b/jetty-deploy/src/test/resources/jetty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Documentation of this file format can be found at:              -->

--- a/jetty-deploy/src/test/resources/webapps/badapp/badapp.xml
+++ b/jetty-deploy/src/test/resources/webapps/badapp/badapp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/badapp</Set>

--- a/jetty-deploy/src/test/resources/webapps/foo.xml
+++ b/jetty-deploy/src/test/resources/webapps/foo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
     <Set name="contextPath">/foo</Set>
     <Set name="war">

--- a/jetty-gcloud/jetty-gcloud-session-manager/src/main/config-template/etc/sessions/gcloud/session-store.xml
+++ b/jetty-gcloud/jetty-gcloud-session-manager/src/main/config-template/etc/sessions/gcloud/session-store.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-hazelcast/src/main/config/etc/sessions/hazelcast/default.xml
+++ b/jetty-hazelcast/src/main/config/etc/sessions/hazelcast/default.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-hazelcast/src/main/config/etc/sessions/hazelcast/remote.xml
+++ b/jetty-hazelcast/src/main/config/etc/sessions/hazelcast/remote.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-home/src/main/resources/README.adoc
+++ b/jetty-home/src/main/resources/README.adoc
@@ -6,7 +6,7 @@ The link:https://eclipse.dev/jetty/[Eclipse Jetty] Project provides a:
 * Servlet Container
 * Java HTTP & WebSocket Client
 
-Jetty is available under an open source link:LICENSE.txt[LICENSE], and the full source code is available at link:https://github.com/eclipse/jetty.project[GitHub].
+Jetty is available under an open source link:LICENSE.txt[LICENSE], and the full source code is available at link:https://github.com/jetty/jetty.project[GitHub].
 
 The Jetty documentation is available at link:https://eclipse.dev/jetty/documentation/[].
 

--- a/jetty-home/src/main/resources/etc/jetty-halt.xml
+++ b/jetty-home/src/main/resources/etc/jetty-halt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call name="addEventListener">

--- a/jetty-home/src/main/resources/etc/jetty-setuid.xml
+++ b/jetty-home/src/main/resources/etc/jetty-setuid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- ================================================================ -->
 <!-- Configure the Jetty SetUIDListener                                -->

--- a/jetty-home/src/main/resources/etc/jetty-stop.xml
+++ b/jetty-home/src/main/resources/etc/jetty-stop.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Stop" class="org.eclipse.jetty.util.component.StopLifeCycle">
   <Arg><Ref refid="Server"/></Arg>

--- a/jetty-home/src/main/resources/modules/conscrypt/conscrypt.xml
+++ b/jetty-home/src/main/resources/modules/conscrypt/conscrypt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 <Configure id="Conscrypt" class="org.conscrypt.OpenSSLProvider">
   <Call class="java.security.Security" name="addProvider">
     <Arg><Ref refid="Conscrypt"/></Arg>

--- a/jetty-home/src/main/resources/modules/demo.d/demo-realm.xml
+++ b/jetty-home/src/main/resources/modules/demo.d/demo-realm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <!-- =========================================================== -->
   <!-- Configure Authentication Login Service                      -->

--- a/jetty-home/src/main/resources/modules/demo.d/root/index.html
+++ b/jetty-home/src/main/resources/modules/demo.d/root/index.html
@@ -61,7 +61,7 @@
           <h2>getting&nbsp;help</h2>
             <ul>
                 <li><a href="https://accounts.eclipse.org/mailing-list/jetty-users">Mailing lists @ eclipse</a></li>
-                <li><a href="https://github.com/eclipse/jetty.project">Source @ github</a></li>
+                <li><a href="https://github.com/jetty/jetty.project">Source @ github</a></li>
                 <li><a href="https://www.webtide.com/advice/">Developer Advice</a></li>
                 <li><a href="https://www.webtide.com/development">Custom Development</a></li>
                 <li><a href="https://www.webtide.com/support">Production support</a></li>

--- a/jetty-home/src/main/resources/modules/hawtio/hawtio.xml
+++ b/jetty-home/src/main/resources/modules/hawtio/hawtio.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection">
   <Call name="addHandler">

--- a/jetty-home/src/main/resources/modules/jamon/jamon.xml
+++ b/jetty-home/src/main/resources/modules/jamon/jamon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Mixin the Jamon Handler                                         -->

--- a/jetty-home/src/main/resources/modules/jolokia/jolokia.xml
+++ b/jetty-home/src/main/resources/modules/jolokia/jolokia.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection">
   <Call name="addHandler">

--- a/jetty-http2/http2-server/src/main/config/etc/jetty-http2.xml
+++ b/jetty-http2/http2-server/src/main/config/etc/jetty-http2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="sslConnector" class="org.eclipse.jetty.server.ServerConnector">
   <Call name="addConnectionFactory">

--- a/jetty-http2/http2-server/src/main/config/etc/jetty-http2c.xml
+++ b/jetty-http2/http2-server/src/main/config/etc/jetty-http2c.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="httpConnector" class="org.eclipse.jetty.server.ServerConnector">
   <Call name="addConnectionFactory">

--- a/jetty-http3/http3-server/src/main/config/etc/jetty-http3.xml
+++ b/jetty-http3/http3-server/src/main/config/etc/jetty-http3.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call name="addConnector">

--- a/jetty-infinispan/infinispan-common/src/main/config/etc/sessions/infinispan/infinispan-common.xml
+++ b/jetty-infinispan/infinispan-common/src/main/config/etc/sessions/infinispan/infinispan-common.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   

--- a/jetty-infinispan/infinispan-embedded-query/src/main/config-template/etc/sessions/infinispan/infinispan-embedded-query.xml
+++ b/jetty-infinispan/infinispan-embedded-query/src/main/config-template/etc/sessions/infinispan/infinispan-embedded-query.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-infinispan/infinispan-embedded/src/main/config-template/etc/sessions/infinispan/infinispan-embedded.xml
+++ b/jetty-infinispan/infinispan-embedded/src/main/config-template/etc/sessions/infinispan/infinispan-embedded.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-infinispan/infinispan-remote-query/src/main/config-template/etc/sessions/infinispan/infinispan-remote-query.xml
+++ b/jetty-infinispan/infinispan-remote-query/src/main/config-template/etc/sessions/infinispan/infinispan-remote-query.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-infinispan/infinispan-remote/src/main/config-template/etc/sessions/infinispan/infinispan-remote.xml
+++ b/jetty-infinispan/infinispan-remote/src/main/config-template/etc/sessions/infinispan/infinispan-remote.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-jaas/src/main/config/etc/jetty-jaas.xml
+++ b/jetty-jaas/src/main/config/etc/jetty-jaas.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-jaspi/src/main/config/etc/jaspi/jaspi-authmoduleconfig.xml
+++ b/jetty-jaspi/src/main/config/etc/jaspi/jaspi-authmoduleconfig.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <Call class="javax.security.auth.message.config.AuthConfigFactory" name="getFactory">

--- a/jetty-jaspi/src/main/config/etc/jaspi/jaspi-default.xml
+++ b/jetty-jaspi/src/main/config/etc/jaspi/jaspi-default.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-jaspi/src/main/config/etc/jaspi/jaspi-demo.xml
+++ b/jetty-jaspi/src/main/config/etc/jaspi/jaspi-demo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <Call class="javax.security.auth.message.config.AuthConfigFactory" name="getFactory">

--- a/jetty-jmx/src/main/config/etc/jetty-jmx-remote.xml
+++ b/jetty-jmx/src/main/config/etc/jetty-jmx-remote.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call name="addBean">

--- a/jetty-jmx/src/main/config/etc/jetty-jmx.xml
+++ b/jetty-jmx/src/main/config/etc/jetty-jmx.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-jmx/src/main/config/modules/jmx.d/jmx-remote-auth.xml
+++ b/jetty-jmx/src/main/config/modules/jmx.d/jmx-remote-auth.xml
@@ -19,7 +19,7 @@
   ~
   -->
 
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <Ref refid="JMXConnectorServer">

--- a/jetty-jmx/src/main/config/modules/jmx.d/jmx-remote-ssl.xml
+++ b/jetty-jmx/src/main/config/modules/jmx.d/jmx-remote-ssl.xml
@@ -19,7 +19,7 @@
   ~
   -->
 
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <Ref refid="JMXConnectorServer">

--- a/jetty-keystore/src/main/config/etc/jetty-test-keystore.xml
+++ b/jetty-keystore/src/main/config/etc/jetty-test-keystore.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call class="org.eclipse.jetty.keystore.KeystoreGenerator" name="generateTestKeystore">

--- a/jetty-maven-plugin/src/it/exclude-javax-annotation/src/config/jetty.xml
+++ b/jetty-maven-plugin/src/it/exclude-javax-annotation/src/config/jetty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">

--- a/jetty-maven-plugin/src/it/jetty-cdi-start-forked/src/main/jetty/jetty-context.xml
+++ b/jetty-maven-plugin/src/it/jetty-cdi-start-forked/src/main/jetty/jetty-context.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"  encoding="ISO-8859-1"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- Weld needs access to some internal classes. Same configuration as "cdi2" module provides on server. -->
 

--- a/jetty-maven-plugin/src/it/jetty-cdi-start-forked/src/main/jetty/jetty.xml
+++ b/jetty-maven-plugin/src/it/jetty-cdi-start-forked/src/main/jetty/jetty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">

--- a/jetty-maven-plugin/src/it/jetty-effective-web-xml-it/webapp-war/src/config/jetty.xml
+++ b/jetty-maven-plugin/src/it/jetty-effective-web-xml-it/webapp-war/src/config/jetty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">

--- a/jetty-maven-plugin/src/it/jetty-maven-plugin-provided-module-dep/web/src/config/jetty.xml
+++ b/jetty-maven-plugin/src/it/jetty-maven-plugin-provided-module-dep/web/src/config/jetty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">

--- a/jetty-maven-plugin/src/it/jetty-run-mojo-jar-scan-it/MyWebApp/src/config/context.xml
+++ b/jetty-maven-plugin/src/it/jetty-run-mojo-jar-scan-it/MyWebApp/src/config/context.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
 

--- a/jetty-maven-plugin/src/it/jetty-run-mojo-jar-scan-it/MyWebApp/src/config/jetty.xml
+++ b/jetty-maven-plugin/src/it/jetty-run-mojo-jar-scan-it/MyWebApp/src/config/jetty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">

--- a/jetty-maven-plugin/src/it/jetty-start-distro-mojo-it/jetty-simple-webapp/src/base/etc/test-jetty.xml
+++ b/jetty-maven-plugin/src/it/jetty-start-distro-mojo-it/jetty-simple-webapp/src/base/etc/test-jetty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Ref refid="httpConnector">

--- a/jetty-maven-plugin/src/it/jetty-start-forked-mojo-it/jetty-simple-webapp/src/config/jetty.xml
+++ b/jetty-maven-plugin/src/it/jetty-start-forked-mojo-it/jetty-simple-webapp/src/config/jetty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">

--- a/jetty-maven-plugin/src/it/jetty-start-gwt-it/beer-server/src/config/jetty.xml
+++ b/jetty-maven-plugin/src/it/jetty-start-gwt-it/beer-server/src/config/jetty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">

--- a/jetty-maven-plugin/src/it/jetty-start-gwt-it/beer-server/src/main/jettyconf/context.xml
+++ b/jetty-maven-plugin/src/it/jetty-start-gwt-it/beer-server/src/main/jettyconf/context.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Call name="setInitParameter">
     <Arg>org.eclipse.jetty.servlet.Default.useFileMappedBuffer</Arg>

--- a/jetty-maven-plugin/src/it/jetty-start-mojo-it/jetty-simple-webapp/src/config/context.xml
+++ b/jetty-maven-plugin/src/it/jetty-start-mojo-it/jetty-simple-webapp/src/config/context.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
 

--- a/jetty-maven-plugin/src/it/jetty-start-mojo-it/jetty-simple-webapp/src/config/jetty.xml
+++ b/jetty-maven-plugin/src/it/jetty-start-mojo-it/jetty-simple-webapp/src/config/jetty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">

--- a/jetty-maven-plugin/src/it/jetty-start-mojo-multi-module-single-war-it/webapp-war/src/config/jetty.xml
+++ b/jetty-maven-plugin/src/it/jetty-start-mojo-multi-module-single-war-it/webapp-war/src/config/jetty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">

--- a/jetty-maven-plugin/src/it/jetty-start-overlay-it/jetty-simple-webapp/src/config/context.xml
+++ b/jetty-maven-plugin/src/it/jetty-start-overlay-it/jetty-simple-webapp/src/config/context.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
 

--- a/jetty-maven-plugin/src/it/jetty-start-overlay-it/jetty-simple-webapp/src/config/jetty.xml
+++ b/jetty-maven-plugin/src/it/jetty-start-overlay-it/jetty-simple-webapp/src/config/jetty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">

--- a/jetty-maven-plugin/src/it/jetty-start-war-distro-mojo-it/jetty-simple-webapp/src/base/etc/test-jetty.xml
+++ b/jetty-maven-plugin/src/it/jetty-start-war-distro-mojo-it/jetty-simple-webapp/src/base/etc/test-jetty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Ref refid="httpConnector">

--- a/jetty-maven-plugin/src/it/jetty-start-war-forked-mojo-it/jetty-simple-webapp/src/config/jetty.xml
+++ b/jetty-maven-plugin/src/it/jetty-start-war-forked-mojo-it/jetty-simple-webapp/src/config/jetty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">

--- a/jetty-maven-plugin/src/it/jetty-start-war-mojo-it/src/config/jetty.xml
+++ b/jetty-maven-plugin/src/it/jetty-start-war-mojo-it/src/config/jetty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">

--- a/jetty-maven-plugin/src/main/resources/jetty-maven.xml
+++ b/jetty-maven-plugin/src/main/resources/jetty-maven.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
    <Call name="addEventListener">

--- a/jetty-maven-plugin/src/main/resources/maven.xml
+++ b/jetty-maven-plugin/src/main/resources/maven.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="wac" class="org.eclipse.jetty.maven.plugin.MavenWebAppContext">
 

--- a/jetty-maven-plugin/src/test/resources/embedder-context.xml
+++ b/jetty-maven-plugin/src/test/resources/embedder-context.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/embedder</Set>

--- a/jetty-maven-plugin/src/test/resources/embedder-jetty.xml
+++ b/jetty-maven-plugin/src/test/resources/embedder-jetty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
     <Set name="handler">

--- a/jetty-memcached/jetty-memcached-sessions/src/main/config/etc/sessions/session-data-cache/xmemcached.xml
+++ b/jetty-memcached/jetty-memcached-sessions/src/main/config/etc/sessions/session-data-cache/xmemcached.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
     <New id="sessionDataMapFactory" class="org.eclipse.jetty.memcached.session.MemcachedSessionDataMapFactory">

--- a/jetty-nosql/src/main/config/etc/sessions/mongo/session-store-by-address.xml
+++ b/jetty-nosql/src/main/config/etc/sessions/mongo/session-store-by-address.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-nosql/src/main/config/etc/sessions/mongo/session-store-by-uri.xml
+++ b/jetty-nosql/src/main/config/etc/sessions/mongo/session-store-by-uri.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-openid/src/main/config/etc/jetty-openid.xml
+++ b/jetty-openid/src/main/config/etc/jetty-openid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://jetty.org/configure_9_3.dtd">
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Get id="ThreadPool" name="threadPool"/>
   <New id="HttpClient" class="org.eclipse.jetty.client.HttpClient">

--- a/jetty-openid/src/main/config/modules/openid/openid-baseloginservice.xml
+++ b/jetty-openid/src/main/config/modules/openid/openid-baseloginservice.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://jetty.org/configure_9_3.dtd">
 <Configure>
   <!-- Optional code to configure the base LoginService used by the OpenIdLoginService
   <New id="BaseLoginService" class="org.eclipse.jetty.security.HashLoginService">

--- a/jetty-osgi/jetty-osgi-boot/jettyhome/etc/jetty-deploy.xml
+++ b/jetty-osgi/jetty-osgi-boot/jettyhome/etc/jetty-deploy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-osgi/jetty-osgi-boot/jettyhome/etc/jetty-http.xml
+++ b/jetty-osgi/jetty-osgi-boot/jettyhome/etc/jetty-http.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->

--- a/jetty-osgi/jetty-osgi-boot/jettyhome/etc/jetty.xml
+++ b/jetty-osgi/jetty-osgi-boot/jettyhome/etc/jetty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 
 <!-- =============================================================== -->

--- a/jetty-osgi/jetty-osgi-httpservice/contexts/httpservice.xml
+++ b/jetty-osgi/jetty-osgi-httpservice/contexts/httpservice.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 <Configure class="org.eclipse.jetty.servlet.ServletContextHandler">
   <!-- this configures the servlet session manager -->
   <Set name="SessionHandler">

--- a/jetty-osgi/test-jetty-osgi-context/src/main/context/acme.xml
+++ b/jetty-osgi/test-jetty-osgi-context/src/main/context/acme.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.server.handler.ContextHandler">
 

--- a/jetty-osgi/test-jetty-osgi/README.txt
+++ b/jetty-osgi/test-jetty-osgi/README.txt
@@ -143,7 +143,7 @@ If you've upgraded the jetty jar and that's all you've changed, then more than l
 Also, if you don't see any test failures with unresolved jar messages, then it's also a good indicator that the problem is with SpiFly versioning. Unfortunately, when the problem is a jvm/SpiFly versioning mismatch, the osgi paxexam environment doesn't output any good log messages. There is a java.lang.Error that is thrown from inside asm that the environment doesn't pass on in any useful fashion.
 
 To try and catch this error, you can modify the ServletInstanceWrapper at line 163 to catch Throwable instead of Exception:
-https://github.com/eclipse/jetty.project/blob/jetty-10.0.x/jetty-osgi/jetty-osgi-boot/src/main/java/org/eclipse/jetty/osgi/boot/internal/serverfactory/ServerInstanceWrapper.java#L163
+https://github.com/jetty/jetty.project/blob/jetty-10.0.x/jetty-osgi/jetty-osgi-boot/src/main/java/org/eclipse/jetty/osgi/boot/internal/serverfactory/ServerInstanceWrapper.java#L163
 
 When you do this, you get output like the following:
 

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-alpn.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-alpn.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="sslConnector" class="org.eclipse.jetty.server.ServerConnector">
 

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-deploy.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-deploy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http-boot-context-as-service.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http-boot-context-as-service.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http-boot-webapp-as-service.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http-boot-webapp-as-service.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http-boot-with-annotations.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http-boot-with-annotations.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http-boot-with-bundle.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http-boot-with-bundle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http-boot-with-javax-websocket.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http-boot-with-javax-websocket.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http-boot-with-jsp.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http-boot-with-jsp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http-boot-with-resources.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http-boot-with-resources.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://jetty.org/configure_9_3.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http-boot-with-websocket.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http-boot-with-websocket.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http2-jdk9.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http2-jdk9.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure an HTTP2 on the ssl connector.                       -->

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http2.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-http2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure an HTTP2 on the ssl connector.                       -->

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-https.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-https.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure an HTTPS connector.                                  -->

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-ssl.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-ssl.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Base SSL configuration                                        -->

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-testrealm.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-testrealm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
     <!-- =========================================================== -->
     <!-- Configure Authentication Login Service                      -->

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-with-custom-class.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty-with-custom-class.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 
 <!-- =============================================================== -->

--- a/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty.xml
+++ b/jetty-osgi/test-jetty-osgi/src/test/config/etc/jetty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 
 <!-- =============================================================== -->

--- a/jetty-proxy/src/main/config/etc/jetty-proxy.xml
+++ b/jetty-proxy/src/main/config/etc/jetty-proxy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-quickstart/src/main/config/etc/jetty-quickstart.xml
+++ b/jetty-quickstart/src/main/config/etc/jetty-quickstart.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call class="org.eclipse.jetty.quickstart.QuickStartConfiguration" name="configureMode">

--- a/jetty-quickstart/src/main/config/modules/jetty-quickstart.d/quickstart-webapp.xml
+++ b/jetty-quickstart/src/main/config/modules/jetty-quickstart.d/quickstart-webapp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Call name="setAttribute">

--- a/jetty-quickstart/src/test/resources/context.xml
+++ b/jetty-quickstart/src/test/resources/context.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ==================================================================
 Configure and deploy the test web application in $(jetty.home)/webapps/test

--- a/jetty-rewrite/src/main/config/etc/jetty-rewrite-customizer.xml
+++ b/jetty-rewrite/src/main/config/etc/jetty-rewrite-customizer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 <Configure id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
   <!-- =========================================================== -->
   <!-- configure rewrite rule container as a customizer            -->

--- a/jetty-rewrite/src/main/config/etc/jetty-rewrite.xml
+++ b/jetty-rewrite/src/main/config/etc/jetty-rewrite.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-rewrite/src/main/config/etc/rewrite-compactpath.xml
+++ b/jetty-rewrite/src/main/config/etc/rewrite-compactpath.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 <Configure id="Rewrite" class="org.eclipse.jetty.rewrite.handler.RuleContainer">
   <Call name="addRule">
     <Arg>

--- a/jetty-rewrite/src/main/config/modules/rewrite/rewrite-msie.xml
+++ b/jetty-rewrite/src/main/config/modules/rewrite/rewrite-msie.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 <Configure id="Rewrite" class="org.eclipse.jetty.rewrite.handler.RuleContainer">
   <Call name="addRule">
     <Arg>

--- a/jetty-rewrite/src/main/config/modules/rewrite/rewrite-rules.xml
+++ b/jetty-rewrite/src/main/config/modules/rewrite/rewrite-rules.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 <Configure id="Rewrite" class="org.eclipse.jetty.rewrite.handler.RuleContainer">
 
   <!-- protect favicon handling

--- a/jetty-rewrite/src/test/resources/org.mortbay.jetty.rewrite.handler/jetty-rewrite.xml
+++ b/jetty-rewrite/src/test/resources/org.mortbay.jetty.rewrite.handler/jetty-rewrite.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure the Jetty Server                                      -->

--- a/jetty-server/src/main/config/etc/home-base-warning.xml
+++ b/jetty-server/src/main/config/etc/home-base-warning.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Display a Warning Message if {jetty.home} == {jetty.base}     -->

--- a/jetty-server/src/main/config/etc/jetty-acceptratelimit.xml
+++ b/jetty-server/src/main/config/etc/jetty-acceptratelimit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call name="addBean">
     <Arg>

--- a/jetty-server/src/main/config/etc/jetty-bytebufferpool-logarithmic.xml
+++ b/jetty-server/src/main/config/etc/jetty-bytebufferpool-logarithmic.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://jetty.org/configure_10_0.dtd">
 <Configure>
   <New id="byteBufferPool" class="org.eclipse.jetty.io.LogarithmicArrayByteBufferPool">
     <Arg type="int"><Property name="jetty.byteBufferPool.minCapacity" default="0"/></Arg>

--- a/jetty-server/src/main/config/etc/jetty-bytebufferpool.xml
+++ b/jetty-server/src/main/config/etc/jetty-bytebufferpool.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 <Configure>
   <New id="byteBufferPool" class="org.eclipse.jetty.io.ArrayByteBufferPool">
     <Arg type="int"><Property name="jetty.byteBufferPool.minCapacity" default="0"/></Arg>

--- a/jetty-server/src/main/config/etc/jetty-connectionlimit.xml
+++ b/jetty-server/src/main/config/etc/jetty-connectionlimit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call name="addBean">
     <Arg>

--- a/jetty-server/src/main/config/etc/jetty-debug.xml
+++ b/jetty-server/src/main/config/etc/jetty-debug.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- =============================================================== -->
 <!-- The DebugListener                                               -->

--- a/jetty-server/src/main/config/etc/jetty-debuglog.xml
+++ b/jetty-server/src/main/config/etc/jetty-debuglog.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- =============================================================== -->
 <!-- The DebugHandler                                                -->

--- a/jetty-server/src/main/config/etc/jetty-gzip.xml
+++ b/jetty-server/src/main/config/etc/jetty-gzip.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- =============================================================== -->
 <!-- Mixin the GZIP Handler                                          -->

--- a/jetty-server/src/main/config/etc/jetty-http-forwarded.xml
+++ b/jetty-server/src/main/config/etc/jetty-http-forwarded.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 <Configure id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
   <Call name="addCustomizer">
     <Arg>

--- a/jetty-server/src/main/config/etc/jetty-http.xml
+++ b/jetty-server/src/main/config/etc/jetty-http.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->

--- a/jetty-server/src/main/config/etc/jetty-https.xml
+++ b/jetty-server/src/main/config/etc/jetty-https.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure an HTTPS connector.                                  -->

--- a/jetty-server/src/main/config/etc/jetty-lowresources.xml
+++ b/jetty-server/src/main/config/etc/jetty-lowresources.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- =============================================================== -->
 <!-- Mixin the Low Resources Monitor                                 -->

--- a/jetty-server/src/main/config/etc/jetty-proxy-protocol-ssl.xml
+++ b/jetty-server/src/main/config/etc/jetty-proxy-protocol-ssl.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="sslConnector" class="org.eclipse.jetty.server.ServerConnector">
   <Call name="addFirstConnectionFactory">

--- a/jetty-server/src/main/config/etc/jetty-proxy-protocol.xml
+++ b/jetty-server/src/main/config/etc/jetty-proxy-protocol.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="httpConnector" class="org.eclipse.jetty.server.ServerConnector">
   <Call name="addFirstConnectionFactory">

--- a/jetty-server/src/main/config/etc/jetty-requestlog.xml
+++ b/jetty-server/src/main/config/etc/jetty-requestlog.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure the Jetty Request Log                                 -->

--- a/jetty-server/src/main/config/etc/jetty-secure-redirect.xml
+++ b/jetty-server/src/main/config/etc/jetty-secure-redirect.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call name="insertHandler">

--- a/jetty-server/src/main/config/etc/jetty-ssl-context-reload.xml
+++ b/jetty-server/src/main/config/etc/jetty-ssl-context-reload.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call name="addBean">

--- a/jetty-server/src/main/config/etc/jetty-ssl-context.xml
+++ b/jetty-server/src/main/config/etc/jetty-ssl-context.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call name="addBean">

--- a/jetty-server/src/main/config/etc/jetty-ssl.xml
+++ b/jetty-server/src/main/config/etc/jetty-ssl.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Base SSL configuration                                        -->

--- a/jetty-server/src/main/config/etc/jetty-state.xml
+++ b/jetty-server/src/main/config/etc/jetty-state.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call name="addEventListener">

--- a/jetty-server/src/main/config/etc/jetty-stats.xml
+++ b/jetty-server/src/main/config/etc/jetty-stats.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- =============================================================== -->
 <!-- Mixin the Statistics Handler                                    -->

--- a/jetty-server/src/main/config/etc/jetty-threadlimit.xml
+++ b/jetty-server/src/main/config/etc/jetty-threadlimit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- =============================================================== -->
 <!-- Mixin the Thread Limit Handler to the entire server             -->

--- a/jetty-server/src/main/config/etc/jetty-threadpool-virtual-preview.xml
+++ b/jetty-server/src/main/config/etc/jetty-threadpool-virtual-preview.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <New id="threadPool" class="org.eclipse.jetty.util.thread.QueuedThreadPool">

--- a/jetty-server/src/main/config/etc/jetty-threadpool-virtual.xml
+++ b/jetty-server/src/main/config/etc/jetty-threadpool-virtual.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <New id="threadPool" class="org.eclipse.jetty.util.thread.QueuedThreadPool">

--- a/jetty-server/src/main/config/etc/jetty-threadpool.xml
+++ b/jetty-server/src/main/config/etc/jetty-threadpool.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <!-- =========================================================== -->

--- a/jetty-server/src/main/config/etc/jetty.xml
+++ b/jetty-server/src/main/config/etc/jetty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- =============================================================== -->
 <!-- Documentation of this file format can be found at:              -->

--- a/jetty-server/src/main/config/etc/sessions/file/session-store.xml
+++ b/jetty-server/src/main/config/etc/sessions/file/session-store.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-server/src/main/config/etc/sessions/id-manager.xml
+++ b/jetty-server/src/main/config/etc/sessions/id-manager.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <!-- ===================================================================== -->

--- a/jetty-server/src/main/config/etc/sessions/jdbc/datasource.xml
+++ b/jetty-server/src/main/config/etc/sessions/jdbc/datasource.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="databaseAdaptor" class="org.eclipse.jetty.server.session.DatabaseAdaptor">

--- a/jetty-server/src/main/config/etc/sessions/jdbc/driver.xml
+++ b/jetty-server/src/main/config/etc/sessions/jdbc/driver.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-server/src/main/config/etc/sessions/jdbc/session-store.xml
+++ b/jetty-server/src/main/config/etc/sessions/jdbc/session-store.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-server/src/main/config/etc/sessions/session-cache-hash.xml
+++ b/jetty-server/src/main/config/etc/sessions/session-cache-hash.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-server/src/main/config/etc/sessions/session-cache-null.xml
+++ b/jetty-server/src/main/config/etc/sessions/session-cache-null.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-server/src/main/config/etc/sessions/session-data-cache/session-caching-store.xml
+++ b/jetty-server/src/main/config/etc/sessions/session-data-cache/session-caching-store.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-server/src/main/config/etc/well-known.xml
+++ b/jetty-server/src/main/config/etc/well-known.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection">
   <Call id="resourceBase" name="resolvePath" class="org.eclipse.jetty.xml.XmlConfiguration">

--- a/jetty-server/src/main/config/modules/inetaccess/jetty-inetaccess.xml
+++ b/jetty-server/src/main/config/modules/inetaccess/jetty-inetaccess.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call name="insertHandler">

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/DefaultHandler.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/DefaultHandler.java
@@ -183,8 +183,8 @@ public class DefaultHandler extends AbstractHandler
             }
 
             writer.append("</tbody></table><hr/>\n");
-            writer.append("<a href=\"https://eclipse.org/jetty\"><img alt=\"icon\" src=\"/favicon.ico\"/></a>&nbsp;");
-            writer.append("<a href=\"https://eclipse.org/jetty\">Powered by Eclipse Jetty:// Server</a><hr/>\n");
+            writer.append("<a href=\"https://jetty.org\"><img alt=\"icon\" src=\"/favicon.ico\"/></a>&nbsp;");
+            writer.append("<a href=\"https://jetty.org\">Powered by Eclipse Jetty:// Server</a><hr/>\n");
             writer.append("</body>\n</html>\n");
             writer.flush();
             byte[] content = outputStream.toByteArray();

--- a/jetty-start/src/test/java/org/eclipse/jetty/start/fileinits/MavenLocalRepoFileInitializerTest.java
+++ b/jetty-start/src/test/java/org/eclipse/jetty/start/fileinits/MavenLocalRepoFileInitializerTest.java
@@ -75,7 +75,7 @@ public class MavenLocalRepoFileInitializerTest
     public void testGetCoordinateInvalidMaven()
     {
         MavenLocalRepoFileInitializer repo = new MavenLocalRepoFileInitializer(baseHome);
-        String ref = "maven://www.eclipse.org/jetty";
+        String ref = "maven://jetty.org";
         RuntimeException x = assertThrows(RuntimeException.class, () -> repo.getCoordinates(URI.create(ref)));
         assertThat(x.getMessage(), containsString("Not a valid maven:// uri"));
     }

--- a/jetty-start/src/test/resources/bogus.xml
+++ b/jetty-start/src/test/resources/bogus.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 <Configure />

--- a/jetty-unixdomain-server/src/main/config/etc/jetty-unixdomain-http.xml
+++ b/jetty-unixdomain-server/src/main/config/etc/jetty-unixdomain-http.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call name="addConnector">
     <Arg>

--- a/jetty-unixsocket/jetty-unixsocket-server/src/main/config-template/etc/jetty-unixsocket-forwarded.xml
+++ b/jetty-unixsocket/jetty-unixsocket-server/src/main/config-template/etc/jetty-unixsocket-forwarded.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="unixSocketHttpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
   <Call name="addCustomizer">

--- a/jetty-unixsocket/jetty-unixsocket-server/src/main/config-template/etc/jetty-unixsocket-http.xml
+++ b/jetty-unixsocket/jetty-unixsocket-server/src/main/config-template/etc/jetty-unixsocket-http.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="unixSocketConnector" class="org.eclipse.jetty.unixsocket.server.UnixSocketConnector">
   <Call name="addConnectionFactory">

--- a/jetty-unixsocket/jetty-unixsocket-server/src/main/config-template/etc/jetty-unixsocket-http2c.xml
+++ b/jetty-unixsocket/jetty-unixsocket-server/src/main/config-template/etc/jetty-unixsocket-http2c.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="unixSocketConnector" class="org.eclipse.jetty.unixsocket.server.UnixSocketConnector">
   <Call name="addConnectionFactory">

--- a/jetty-unixsocket/jetty-unixsocket-server/src/main/config-template/etc/jetty-unixsocket-proxy-protocol.xml
+++ b/jetty-unixsocket/jetty-unixsocket-server/src/main/config-template/etc/jetty-unixsocket-proxy-protocol.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="unixSocketConnector" class="org.eclipse.jetty.unixsocket.UnixSocketConnector">
   <Call name="addFirstConnectionFactory">

--- a/jetty-unixsocket/jetty-unixsocket-server/src/main/config-template/etc/jetty-unixsocket-secure.xml
+++ b/jetty-unixsocket/jetty-unixsocket-server/src/main/config-template/etc/jetty-unixsocket-secure.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="unixSocketHttpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
   <Call name="addCustomizer">

--- a/jetty-unixsocket/jetty-unixsocket-server/src/main/config-template/etc/jetty-unixsocket.xml
+++ b/jetty-unixsocket/jetty-unixsocket-server/src/main/config-template/etc/jetty-unixsocket.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="unixSocketHttpConfig" class="org.eclipse.jetty.server.HttpConfiguration">

--- a/jetty-util/src/main/config/etc/console-capture.xml
+++ b/jetty-util/src/main/config/etc/console-capture.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="logging">
   <New id="ServerLog" class="java.io.PrintStream">

--- a/jetty-util/src/main/config/etc/jetty-pid.xml
+++ b/jetty-util/src/main/config/etc/jetty-pid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <Call class="org.eclipse.jetty.util.PidFile" name="create">

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/Jetty.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/Jetty.java
@@ -67,7 +67,7 @@ public class Jetty
         else
             VERSION = System.getProperty("jetty.version", __buildProperties.getProperty("version", "10.0.z-SNAPSHOT"));
 
-        POWERED_BY = "<a href=\"https://eclipse.org/jetty\">Powered by Jetty:// " + VERSION + "</a>";
+        POWERED_BY = "<a href=\"https://jetty.org\">Powered by Jetty:// " + VERSION + "</a>";
 
         // Show warning when RC# or M# is in version string
         STABLE = !VERSION.matches("^.*\\.(RC|M)[0-9]+$");

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/RolloverFileOutputStreamTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/RolloverFileOutputStreamTest.java
@@ -81,7 +81,7 @@ public class RolloverFileOutputStreamTest
     }
 
     /**
-     * <a href="Issue #1507">https://github.com/eclipse/jetty.project/issues/1507</a>
+     * <a href="Issue #1507">https://github.com/jetty/jetty.project/issues/1507</a>
      */
     @Test
     public void testMidnightRolloverCalcPDTIssue1507()

--- a/jetty-webapp/src/main/config/etc/jetty-webapp.xml
+++ b/jetty-webapp/src/main/config/etc/jetty-webapp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call class="org.eclipse.jetty.webapp.WebAppContext" name="addSystemClasses">

--- a/jetty-websocket/websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/internal/FrameFlusherTest.java
+++ b/jetty-websocket/websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/internal/FrameFlusherTest.java
@@ -100,7 +100,7 @@ public class FrameFlusherTest
     /**
      * Ensure that FrameFlusher honors the correct order of websocket frames.
      *
-     * @see <a href="https://github.com/eclipse/jetty.project/issues/2491">eclipse/jetty.project#2491</a>
+     * @see <a href="https://github.com/jetty/jetty.project/issues/2491">eclipse/jetty.project#2491</a>
      */
     @Test
     public void testLargeSmallText() throws ExecutionException, InterruptedException

--- a/jetty-websocket/websocket-javax-client/src/test/resources/jetty-websocket-httpclient.xml
+++ b/jetty-websocket/websocket-javax-client/src/test/resources/jetty-websocket-httpclient.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.client.HttpClient">
   <Arg>

--- a/jetty-websocket/websocket-javax-tests/src/test/resources/jetty-websocket-httpclient.xml
+++ b/jetty-websocket/websocket-javax-tests/src/test/resources/jetty-websocket-httpclient.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 <Configure class="org.eclipse.jetty.client.HttpClient">
   <Call name="getAuthenticationStore">
     <Call name="addAuthentication">

--- a/jetty-websocket/websocket-javax-tests/src/test/resources/simple/jetty-websocket-httpclient.xml
+++ b/jetty-websocket/websocket-javax-tests/src/test/resources/simple/jetty-websocket-httpclient.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.client.HttpClient">
   <Arg>

--- a/jetty-xml/pom.xml
+++ b/jetty-xml/pom.xml
@@ -52,6 +52,14 @@
           <argLine>@{argLine} ${jetty.surefire.argLine} --add-reads org.eclipse.jetty.xml=org.eclipse.jetty.logging</argLine>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>8</source>
+          <target>8</target>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/jetty-xml/pom.xml
+++ b/jetty-xml/pom.xml
@@ -47,17 +47,17 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <argLine>@{argLine} ${jetty.surefire.argLine} --add-reads org.eclipse.jetty.xml=org.eclipse.jetty.logging</argLine>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <source>8</source>
           <target>8</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>@{argLine} ${jetty.surefire.argLine} --add-reads org.eclipse.jetty.xml=org.eclipse.jetty.logging</argLine>
         </configuration>
       </plugin>
     </plugins>

--- a/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
+++ b/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
@@ -1949,54 +1949,49 @@ public class XmlConfiguration
             _entry = entry;
 
             Class<?> klass = XmlConfiguration.class;
+
             URL config60 = klass.getResource("configure_6_0.dtd");
             URL config76 = klass.getResource("configure_7_6.dtd");
             URL config90 = klass.getResource("configure_9_0.dtd");
             URL config93 = klass.getResource("configure_9_3.dtd");
             URL config100 = klass.getResource("configure_10_0.dtd");
 
-            redirectEntity("configure.dtd", config93);
-            redirectEntity("configure_1_0.dtd", config60);
-            redirectEntity("configure_1_1.dtd", config60);
-            redirectEntity("configure_1_2.dtd", config60);
-            redirectEntity("configure_1_3.dtd", config60);
-            redirectEntity("configure_6_0.dtd", config60);
-            redirectEntity("configure_7_6.dtd", config76);
-            redirectEntity("configure_9_0.dtd", config90);
-            redirectEntity("configure_9_3.dtd", config93);
-            redirectEntity("configure_10_0.dtd", config100);
+            Map<String, URL> dtdRefMap = new HashMap<>();
+            dtdRefMap.put("configure.dtd", config93);
+            dtdRefMap.put("configure_1_0.dtd", config60);
+            dtdRefMap.put("configure_1_1.dtd", config60);
+            dtdRefMap.put("configure_1_2.dtd", config60);
+            dtdRefMap.put("configure_1_3.dtd", config60);
+            dtdRefMap.put("configure_6_0.dtd", config60);
+            dtdRefMap.put("configure_7_6.dtd", config76);
+            dtdRefMap.put("configure_9_0.dtd", config90);
+            dtdRefMap.put("configure_9_3.dtd", config93);
+            dtdRefMap.put("configure_10_0.dtd", config100);
 
-            redirectEntity("http://jetty.mortbay.org/configure.dtd", config93);
-            redirectEntity("http://jetty.eclipse.org/configure.dtd", config93);
-            redirectEntity("https://jetty.eclipse.org/configure.dtd", config93);
-            redirectEntity("http://www.eclipse.org/jetty/configure.dtd", config93);
-            redirectEntity("https://www.eclipse.org/jetty/configure.dtd", config93);
-            redirectEntity("http://eclipse.org/jetty/configure.dtd", config93);
-            redirectEntity("https://eclipse.org/jetty/configure.dtd", config93);
-            redirectEntity("http://www.eclipse.dev/jetty/configure.dtd", config93);
-            redirectEntity("https://www.eclipse.dev/jetty/configure.dtd", config93);
-            redirectEntity("http://eclipse.dev/jetty/configure.dtd", config93);
-            redirectEntity("https://eclipse.dev/jetty/configure.dtd", config93);
+            dtdRefMap.forEach(this::redirectEntity);
 
-            redirectEntity("http://jetty.mortbay.org/configure_9_3.dtd", config93);
-            redirectEntity("http://www.eclipse.org/jetty/configure_9_3.dtd", config93);
-            redirectEntity("https://www.eclipse.org/jetty/configure_9_3.dtd", config93);
-            redirectEntity("http://eclipse.org/jetty/configure_9_3.dtd", config93);
-            redirectEntity("https://eclipse.org/jetty/configure_9_3.dtd", config93);
-            redirectEntity("http://www.eclipse.dev/jetty/configure_9_3.dtd", config93);
-            redirectEntity("https://www.eclipse.dev/jetty/configure_9_3.dtd", config93);
-            redirectEntity("http://eclipse.dev/jetty/configure_9_3.dtd", config93);
-            redirectEntity("https://eclipse.dev/jetty/configure_9_3.dtd", config93);
+            // Register all variations of DOCTYPE entity references for Configure
+            List<String> schemes = List.of("http", "https");
+            List<String> contexts = List.of(
+                "jetty.mortbay.org",
+                "jetty.eclipse.org",
+                "www.eclipse.org/jetty",
+                "eclipse.org/jetty",
+                "www.eclipse.dev/jetty",
+                "eclipse.dev/jetty",
+                "jetty.org");
 
-            redirectEntity("http://www.eclipse.org/jetty/configure_10_0.dtd", config100);
-            redirectEntity("https://www.eclipse.org/jetty/configure_10_0.dtd", config100);
-            redirectEntity("http://eclipse.org/jetty/configure_10_0.dtd", config100);
-            redirectEntity("https://eclipse.org/jetty/configure_10_0.dtd", config100);
-            redirectEntity("http://www.eclipse.dev/jetty/configure_10_0.dtd", config100);
-            redirectEntity("https://www.eclipse.dev/jetty/configure_10_0.dtd", config100);
-            redirectEntity("http://eclipse.dev/jetty/configure_10_0.dtd", config100);
-            redirectEntity("https://eclipse.dev/jetty/configure_10_0.dtd", config100);
-
+            for (String scheme : schemes)
+            {
+                for (String context : contexts)
+                {
+                    dtdRefMap.forEach((dtdName, dtdUrl) ->
+                    {
+                        String refUrl = String.format("%s://%s/%s", scheme, context, dtdName);
+                        redirectEntity(refUrl, dtdUrl);
+                    });
+                }
+            }
             redirectEntity("-//Mort Bay Consulting//DTD Configure//EN", config100);
             redirectEntity("-//Jetty//Configure//EN", config100);
         }

--- a/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
+++ b/jetty-xml/src/test/java/org/eclipse/jetty/xml/XmlConfigurationTest.java
@@ -1894,16 +1894,16 @@ public class XmlConfigurationTest
         List<Arguments> ids = new ArrayList<>();
 
         String[] schemes = {"http", "https"};
-        String[] hosts = {"eclipse.org", "www.eclipse.org", "eclipse.dev", "www.eclipse.dev"};
-        String[] paths = {"/jetty/configure.dtd", "/jetty/configure_9_3.dtd", "/jetty/configure_10_0.dtd"};
+        String[] contexts = {"eclipse.org/jetty", "www.eclipse.org/jetty", "eclipse.dev/jetty", "www.eclipse.dev/jetty", "jetty.org"};
+        String[] paths = {"configure.dtd", "configure_9_3.dtd", "configure_10_0.dtd"};
 
         for (String scheme: schemes)
         {
-            for (String host: hosts)
+            for (String host: contexts)
             {
                 for (String path: paths)
                 {
-                    ids.add(Arguments.of(String.format("%s://%s%s", scheme, host, path)));
+                    ids.add(Arguments.of(String.format("%s://%s/%s", scheme, host, path)));
                 }
             }
         }

--- a/jetty-xml/src/test/resources/org/eclipse/jetty/xml/configureWithAttr.xml
+++ b/jetty-xml/src/test/resources/org/eclipse/jetty/xml/configureWithAttr.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure class="org.eclipse.jetty.xml.TestConfiguration">
   <Arg name="name">name</Arg>

--- a/jetty-xml/src/test/resources/org/eclipse/jetty/xml/configureWithElements.xml
+++ b/jetty-xml/src/test/resources/org/eclipse/jetty/xml/configureWithElements.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure>
   <Class>org.eclipse.jetty.xml.TestConfiguration</Class>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <packaging>pom</packaging>
   <name>Jetty :: Project</name>
   <description>The Eclipse Jetty Project</description>
-  <url>https://eclipse.dev/jetty</url>
+  <url>https://jetty.org</url>
   <inceptionYear>1995</inceptionYear>
 
   <organization>

--- a/tests/test-cdi/src/test/java/org/eclipse/jetty/cdi/tests/websocket/JavaxWebSocketCdiTest.java
+++ b/tests/test-cdi/src/test/java/org/eclipse/jetty/cdi/tests/websocket/JavaxWebSocketCdiTest.java
@@ -163,7 +163,7 @@ public class JavaxWebSocketCdiTest
     }
 
     @Test
-    @Disabled("See issue https://github.com/eclipse/jetty.project/issues/6174")
+    @Disabled("See issue https://github.com/jetty/jetty.project/issues/6174")
     public void testHttpSessionInjection() throws Exception
     {
         start((servletContext, wsContainer) -> wsContainer.addEndpoint(CdiHttpSessionSocket.class));

--- a/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -859,7 +859,7 @@ public class DistributionTests extends AbstractJettyHomeTest
             String message = "test-log-line";
             String xml = "" +
                 "<?xml version=\"1.0\"?>" +
-                "<!DOCTYPE Configure PUBLIC \"-//Jetty//Configure//EN\" \"https://www.eclipse.org/jetty/configure_10_0.dtd\">" +
+                "<!DOCTYPE Configure PUBLIC \"-//Jetty//Configure//EN\" \"https://jetty.org/configure_10_0.dtd\">" +
                 "<Configure>" +
                 "  <Call name=\"getLogger\" class=\"java.util.logging.Logger\">" +
                 "    <Arg>" + loggerName + "</Arg>" +
@@ -920,7 +920,7 @@ public class DistributionTests extends AbstractJettyHomeTest
             String nextProtocol = "fcgi/1.0";
             String xml = "" +
                 "<?xml version=\"1.0\"?>" +
-                "<!DOCTYPE Configure PUBLIC \"-//Jetty//Configure//EN\" \"https://www.eclipse.org/jetty/configure_10_0.dtd\">" +
+                "<!DOCTYPE Configure PUBLIC \"-//Jetty//Configure//EN\" \"https://jetty.org/configure_10_0.dtd\">" +
                 "<Configure id=\"sslConnector\" class=\"org.eclipse.jetty.server.ServerConnector\">" +
                 "  <Call name=\"addIfAbsentConnectionFactory\">" +
                 "    <Arg>" +

--- a/tests/test-distribution/src/test/resources/badapp/badapp_throwonunavailable_false.xml
+++ b/tests/test-distribution/src/test/resources/badapp/badapp_throwonunavailable_false.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/badapp</Set>

--- a/tests/test-distribution/src/test/resources/badapp/badapp_throwonunavailable_true.xml
+++ b/tests/test-distribution/src/test/resources/badapp/badapp_throwonunavailable_true.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/badapp</Set>

--- a/tests/test-distribution/src/test/resources/bases/spaces-with-conf/dir one/test1.xml
+++ b/tests/test-distribution/src/test/resources/bases/spaces-with-conf/dir one/test1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 </Configure>

--- a/tests/test-distribution/src/test/resources/bases/spaces-with-conf/dir two/test2.xml
+++ b/tests/test-distribution/src/test/resources/bases/spaces-with-conf/dir two/test2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 </Configure>

--- a/tests/test-distribution/src/test/resources/test-realm.xml
+++ b/tests/test-distribution/src/test/resources/test-realm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <!-- =========================================================== -->
   <!-- Configure Authentication Login Service                      -->

--- a/tests/test-integration/src/test/java/org/eclipse/jetty/test/DeploymentErrorInitializer.java
+++ b/tests/test-integration/src/test/java/org/eclipse/jetty/test/DeploymentErrorInitializer.java
@@ -21,7 +21,7 @@ import javax.servlet.ServletException;
 /**
  * A SCI that tosses an Error to intentionally to cause issues with the DeploymentManager
  *
- * @see <a href="https://github.com/eclipse/jetty.project/issues/1602">Issue #1602</a>
+ * @see <a href="https://github.com/jetty/jetty.project/issues/1602">Issue #1602</a>
  */
 public class DeploymentErrorInitializer implements ServletContainerInitializer
 {

--- a/tests/test-integration/src/test/resources/DefaultHandler.xml
+++ b/tests/test-integration/src/test/resources/DefaultHandler.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/tests/test-integration/src/test/resources/NIOHttp.xml
+++ b/tests/test-integration/src/test/resources/NIOHttp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/tests/test-integration/src/test/resources/NIOHttps.xml
+++ b/tests/test-integration/src/test/resources/NIOHttps.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
     <!-- =========================================================== -->

--- a/tests/test-integration/src/test/resources/RFC2616Base.xml
+++ b/tests/test-integration/src/test/resources/RFC2616Base.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure the Jetty Server                                      -->

--- a/tests/test-integration/src/test/resources/RFC2616_Filters.xml
+++ b/tests/test-integration/src/test/resources/RFC2616_Filters.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/tests/test-integration/src/test/resources/RFC2616_Redirects.xml
+++ b/tests/test-integration/src/test/resources/RFC2616_Redirects.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <!-- =========================================================== -->

--- a/tests/test-integration/src/test/resources/add-jetty-test-webapp.xml
+++ b/tests/test-integration/src/test/resources/add-jetty-test-webapp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Contexts" class="org.eclipse.jetty.server.handler.HandlerCollection">
   <Call name="addHandler">

--- a/tests/test-integration/src/test/resources/basic-server.xml
+++ b/tests/test-integration/src/test/resources/basic-server.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">

--- a/tests/test-integration/src/test/resources/deploy.xml
+++ b/tests/test-integration/src/test/resources/deploy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call name="addBean">

--- a/tests/test-integration/src/test/resources/docroots/deployerror/badapp-unavailable-false.xml
+++ b/tests/test-integration/src/test/resources/docroots/deployerror/badapp-unavailable-false.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/badapp-uaf</Set>

--- a/tests/test-integration/src/test/resources/docroots/deployerror/badapp.xml
+++ b/tests/test-integration/src/test/resources/docroots/deployerror/badapp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/badapp</Set>

--- a/tests/test-integration/src/test/resources/login-service.xml
+++ b/tests/test-integration/src/test/resources/login-service.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <!-- =========================================================== -->

--- a/tests/test-integration/src/test/resources/ssl.xml
+++ b/tests/test-integration/src/test/resources/ssl.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 <Configure id="sslContextFactory" class="org.eclipse.jetty.util.ssl.SslContextFactory$Server">
 
   <Set name="KeyStorePath"><Property name="jetty.sslContext.keyStorePath"/></Set>

--- a/tests/test-integration/src/test/resources/webapp-contexts/RFC2616/rfc2616-webapp.xml
+++ b/tests/test-integration/src/test/resources/webapp-contexts/RFC2616/rfc2616-webapp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath">/rfc2616-webapp</Set>
   <Set name="war"><Property name="test.webapps" default="." />/test-webapp-rfc2616.war</Set>

--- a/tests/test-quickstart/src/test/resources/test-jndi.xml
+++ b/tests/test-quickstart/src/test/resources/test-jndi.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure the test-jndi webapp                                  -->

--- a/tests/test-quickstart/src/test/resources/test-spec.xml
+++ b/tests/test-quickstart/src/test/resources/test-spec.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <Configure id='wac' class="org.eclipse.jetty.webapp.WebAppContext">
 

--- a/tests/test-quickstart/src/test/resources/test.xml
+++ b/tests/test-quickstart/src/test/resources/test.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"  encoding="ISO-8859-1"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
 
 <!-- ==================================================================
 Configure and deploy the test web application in $(jetty.home)/webapps/test

--- a/tests/test-webapps/test-owb-cdi-webapp/src/main/webapp/WEB-INF/jetty-env.xml
+++ b/tests/test-webapps/test-owb-cdi-webapp/src/main/webapp/WEB-INF/jetty-env.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://jetty.org/configure_9_3.dtd">
 
 <Configure id="webAppCtx" class="org.eclipse.jetty.webapp.WebAppContext">
   <!-- Enable OWB ServletContainerInitializer

--- a/tests/test-webapps/test-owb-cdi-webapp/src/main/webapp/WEB-INF/jetty-web-owb.xml
+++ b/tests/test-webapps/test-owb-cdi-webapp/src/main/webapp/WEB-INF/jetty-web-owb.xml
@@ -1,4 +1,4 @@
-<!DOCTYPE Configure PUBLIC "-//Mort Bay Consulting//DTD Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Mort Bay Consulting//DTD Configure//EN" "http://jetty.org/configure_9_3.dtd">
 
 <Configure id="wac" class="org.eclipse.jetty.webapp.WebAppContext">
   <!-- Rename this file to jetty-web.xml if the cdi-spi module is not used-->

--- a/tests/test-webapps/test-websocket-client-provided-webapp/src/main/resources/jetty-websocket-httpclient.xml
+++ b/tests/test-webapps/test-websocket-client-provided-webapp/src/main/resources/jetty-websocket-httpclient.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://jetty.org/configure_9_3.dtd">
 
 <Configure class="org.eclipse.jetty.client.HttpClient">
   <Arg>

--- a/tests/test-webapps/test-weld-cdi-webapp/src/main/webapp/WEB-INF/jetty-env.xml
+++ b/tests/test-webapps/test-weld-cdi-webapp/src/main/webapp/WEB-INF/jetty-env.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://jetty.org/configure_9_3.dtd">
 
 <Configure id="webAppCtx" class="org.eclipse.jetty.webapp.WebAppContext">
   <New id="BeanManager" class="org.eclipse.jetty.plus.jndi.Resource">


### PR DESCRIPTION
All URL refs.

* DTD refs in XMLConfiguration
* Maven poms
* Documentation
* HTML
* Github references (to new `github.com/jetty/jetty.project` location)