### PR TITLE
Fix warnings during jetty-ee9-servlet tests

### DIFF
--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/CacheControlHeaderTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/CacheControlHeaderTest.java
@@ -95,7 +95,7 @@ public class CacheControlHeaderTest
         servletHolder.setServlet(new DefaultServlet());
         servletHolder.setInitParameter("cacheControl", "max-age=3600,public");
         Path resBase = MavenTestingUtils.getTargetPath("test-classes/contextResources");
-        servletHolder.setInitParameter("resourceBase", resBase.toFile().toURI().toASCIIString());
+        servletHolder.setInitParameter("baseResource", resBase.toFile().toURI().toASCIIString());
         context.addServlet(servletHolder, "/*");
         if (forceFilter)
         {

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/DefaultServletRangesTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/DefaultServletRangesTest.java
@@ -66,7 +66,7 @@ public class DefaultServletRangesTest
 
         ServletHolder defholder = context.addServlet(DefaultServlet.class, "/");
         defholder.setInitParameter("acceptRanges", "true");
-        defholder.setInitParameter("resourceBase", resBasePath);
+        defholder.setInitParameter("baseResource", resBasePath);
 
         server.start();
     }

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/DefaultServletTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/DefaultServletTest.java
@@ -295,7 +295,7 @@ public class DefaultServletTest
             defholder.setInitParameter("redirectWelcome", "false");
             defholder.setInitParameter("gzip", "false");
 
-            defholder.setInitParameter("resourceBase", resBasePath);
+            defholder.setInitParameter("baseResource", resBasePath);
         });
 
         String req1 = "GET /context/one/deep/ HTTP/1.0\n\n";
@@ -335,7 +335,7 @@ public class DefaultServletTest
             context.setClassLoader(extraClassLoader);
 
             ServletHolder defholder = context.addServlet(DefaultServlet.class, "/extra/*");
-            defholder.setInitParameter("resourceBase", extraResourceBaseString);
+            defholder.setInitParameter("baseResource", extraResourceBaseString);
             defholder.setInitParameter("pathInfoOnly", "true");
             defholder.setInitParameter("dirAllowed", "true");
             defholder.setInitParameter("redirectWelcome", "false");
@@ -800,7 +800,7 @@ public class DefaultServletTest
         startServer((context) ->
         {
             ServletHolder altholder = context.addServlet(DefaultServlet.class, "/alt/*");
-            altholder.setInitParameter("resourceBase", altRoot.toUri().toASCIIString());
+            altholder.setInitParameter("baseResource", altRoot.toUri().toASCIIString());
             altholder.setInitParameter("pathInfoOnly", "true");
             altholder.setInitParameter("dirAllowed", "false");
             altholder.setInitParameter("redirectWelcome", "false");
@@ -808,7 +808,7 @@ public class DefaultServletTest
             altholder.setInitParameter("gzip", "false");
 
             ServletHolder otherholder = context.addServlet(DefaultServlet.class, "/other/*");
-            otherholder.setInitParameter("resourceBase", altRoot.toUri().toASCIIString());
+            otherholder.setInitParameter("baseResource", altRoot.toUri().toASCIIString());
             otherholder.setInitParameter("pathInfoOnly", "true");
             otherholder.setInitParameter("dirAllowed", "true");
             otherholder.setInitParameter("redirectWelcome", "false");
@@ -927,7 +927,7 @@ public class DefaultServletTest
         startServer((context) ->
         {
             ServletHolder defholder = context.addServlet(DefaultServlet.class, "/alt/*");
-            defholder.setInitParameter("resourceBase", altRoot.toUri().toASCIIString());
+            defholder.setInitParameter("baseResource", altRoot.toUri().toASCIIString());
             defholder.setInitParameter("dirAllowed", "false");
             defholder.setInitParameter("redirectWelcome", "false");
             defholder.setInitParameter("welcomeServlets", "true");
@@ -2237,7 +2237,7 @@ public class DefaultServletTest
         {
             ServletHolder defholder = context.addServlet(DefaultServlet.class, "/");
             defholder.setInitParameter("precompressed", "true");
-            defholder.setInitParameter("resourceBase", docRoot.toString());
+            defholder.setInitParameter("baseResource", docRoot.toString());
         });
 
         String rawResponse;
@@ -2290,7 +2290,7 @@ public class DefaultServletTest
         {
             ServletHolder defholder = context.addServlet(DefaultServlet.class, "/");
             defholder.setInitParameter("precompressed", "bzip2=.bz2,gzip=.gz,br=.br");
-            defholder.setInitParameter("resourceBase", docRoot.toString());
+            defholder.setInitParameter("baseResource", docRoot.toString());
         });
 
         String rawResponse;
@@ -2330,7 +2330,7 @@ public class DefaultServletTest
         {
             connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration().setUriCompliance(UriCompliance.UNSAFE);
             ServletHolder defholder = context.addServlet(DefaultServlet.class, "/");
-            defholder.setInitParameter("resourceBase", docRoot.toFile().getAbsolutePath());
+            defholder.setInitParameter("baseResource", docRoot.toFile().getAbsolutePath());
         });
 
         try (StacklessLogging ignore = new StacklessLogging(ResourceService.class))

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ServletRequestLogTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ServletRequestLogTest.java
@@ -366,6 +366,7 @@ public class ServletRequestLogTest
         server.setConnectors(new Connector[]{connector});
 
         ErrorHandler errorHandler = new ErrorHandler();
+        errorHandler.setServer(server);
         server.addBean(errorHandler);
 
         // First the behavior as defined in etc/jetty.xml


### PR DESCRIPTION
Just a small cleanup of WARN output during `jetty-ee9-servlet` tests.