### PR TITLE
Issue #11941 - reduce logs for DistributionTests

### DIFF
--- a/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/ProcessWrapper.java
+++ b/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/ProcessWrapper.java
@@ -200,7 +200,7 @@ public class ProcessWrapper implements AutoCloseable
                 String line;
                 while ((line = reader.readLine()) != null)
                 {
-                    LOG.info(line);
+                    LOG.debug(line);
                     logs.add(line);
                 }
             }


### PR DESCRIPTION
closes #11941

Do not output full logs to console for the jetty-home tester.

This ProcessWrapper builds up the logs in `Queue<String> logs` which is tested to see if the logs contain the expected output.
So to reduce noise we can not log everything to console unless debug logging is enabled.

Alternatively we could add a configuration and only do this for specific tests.

