### PR TITLE
Remove buffer from pool on write failure

### DIFF
--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -604,8 +604,8 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
         @Override
         public boolean remove()
         {
-            super.release();
-            return _removed.compareAndSet(false, true);
+            _removed.compareAndSet(false, true);
+            return super.release();
         }
     }
 
@@ -634,9 +634,8 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
         @Override
         public boolean remove()
         {
-            boolean removed = ArrayByteBufferPool.this.remove(_bucket, _entry);
-            super.release();
-            return removed;
+            ArrayByteBufferPool.this.remove(_bucket, _entry);
+            return super.release();
         }
 
         private int use()

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -790,6 +790,29 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
                 }
             }
 
+            @Override
+            public boolean remove()
+            {
+                try
+                {
+                    boolean released = super.remove();
+                    if (released)
+                    {
+                        buffers.remove(this);
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("released {}", this);
+                    }
+                    releaseStacks.add(new Throwable());
+                    return released;
+                }
+                catch (IllegalStateException e)
+                {
+                    buffers.add(this);
+                    overReleaseStacks.add(new Throwable());
+                    throw e;
+                }
+            }
+
             public String dump()
             {
                 StringWriter w = new StringWriter();

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -800,7 +800,7 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
                     {
                         buffers.remove(this);
                         if (LOG.isDebugEnabled())
-                            LOG.debug("released {}", this);
+                            LOG.debug("removed {}", this);
                     }
                     releaseStacks.add(new Throwable());
                     return released;

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferPool.java
@@ -58,6 +58,17 @@ public interface ByteBufferPool
     RetainableByteBuffer acquire(int size, boolean direct);
 
     /**
+     * Remove a buffer from the pool.
+     * <p>Calling this method includes an implicit release of the buffer.</p>
+     * @param buffer The buffer to be removed from the pool
+     * @return {@code true} if the buffer can be removed.
+     */
+    default boolean remove(RetainableByteBuffer buffer)
+    {
+        return false;
+    }
+
+    /**
      * <p>Removes all {@link RetainableByteBuffer#isRetained() non-retained}
      * pooled instances from this pool.</p>
      */
@@ -84,6 +95,12 @@ public interface ByteBufferPool
         public RetainableByteBuffer acquire(int size, boolean direct)
         {
             return getWrapped().acquire(size, direct);
+        }
+
+        @Override
+        public boolean remove(RetainableByteBuffer buffer)
+        {
+            return getWrapped().remove(buffer);
         }
 
         @Override

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferPool.java
@@ -59,6 +59,20 @@ public interface ByteBufferPool
     RetainableByteBuffer acquire(int size, boolean direct);
 
     /**
+     * {@link RetainableByteBuffer#release() Release} the buffer in a way that will remove it from any pool that it may be in.
+     * If the buffer is not in a pool, calling this method is equivalent to calling {@link RetainableByteBuffer#release()}.
+     * Calling this method satisfies any contract that requires a call to {@link RetainableByteBuffer#release()}.
+     * @return {@code true} if a call to {@link RetainableByteBuffer#release()} would have returned {@code true}.
+     * @see RetainableByteBuffer#release()
+     * @deprecated This API is experimental and may be removed in future releases
+     */
+    @Deprecated
+    default boolean removeAndRelease(RetainableByteBuffer buffer)
+    {
+        return buffer != null && buffer.release();
+    }
+
+    /**
      * <p>Removes all {@link RetainableByteBuffer#isRetained() non-retained}
      * pooled instances from this pool.</p>
      */

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferPool.java
@@ -59,17 +59,6 @@ public interface ByteBufferPool
     RetainableByteBuffer acquire(int size, boolean direct);
 
     /**
-     * Remove a buffer from the pool.
-     * <p>Calling this method includes an implicit release of the buffer.</p>
-     * @param buffer The buffer to be removed from the pool
-     * @return {@code true} if the buffer can be removed.
-     */
-    default boolean remove(RetainableByteBuffer buffer)
-    {
-        return false;
-    }
-
-    /**
      * <p>Removes all {@link RetainableByteBuffer#isRetained() non-retained}
      * pooled instances from this pool.</p>
      */
@@ -96,12 +85,6 @@ public interface ByteBufferPool
         public RetainableByteBuffer acquire(int size, boolean direct)
         {
             return getWrapped().acquire(size, direct);
-        }
-
-        @Override
-        public boolean remove(RetainableByteBuffer buffer)
-        {
-            return getWrapped().remove(buffer);
         }
 
         @Override

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/RetainableByteBuffer.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/RetainableByteBuffer.java
@@ -160,13 +160,15 @@ public interface RetainableByteBuffer extends Retainable
     }
 
     /**
-     * {@link #release() Release} the buffer in a way that will remove it from any pool that it may be in..
-     * @return {@code true} if the buffer can be removed.
+     * {@link #release() Release} the buffer in a way that will remove it from any pool that it may be in.
+     * If the buffer is not in a pool, calling this method is equivalent to calling {@link #release()}.
+     * Calling this method satisfies any contract that requires a call to {@link #release()}.
+     * @return {@code true} if a call to {@link #release()} would have returned {@code true}.
+     * @see #release()
      */
     default boolean remove()
     {
-        release();
-        return false;
+        return release();
     }
 
     /**

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/RetainableByteBuffer.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/RetainableByteBuffer.java
@@ -160,18 +160,6 @@ public interface RetainableByteBuffer extends Retainable
     }
 
     /**
-     * {@link #release() Release} the buffer in a way that will remove it from any pool that it may be in.
-     * If the buffer is not in a pool, calling this method is equivalent to calling {@link #release()}.
-     * Calling this method satisfies any contract that requires a call to {@link #release()}.
-     * @return {@code true} if a call to {@link #release()} would have returned {@code true}.
-     * @see #release()
-     */
-    default boolean remove()
-    {
-        return release();
-    }
-
-    /**
      * A wrapper for {@link RetainableByteBuffer} instances
      */
     class Wrapper extends Retainable.Wrapper implements RetainableByteBuffer
@@ -226,12 +214,6 @@ public interface RetainableByteBuffer extends Retainable
         public void clear()
         {
             getWrapped().clear();
-        }
-
-        @Override
-        public boolean remove()
-        {
-            return getWrapped().remove();
         }
     }
 }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/RetainableByteBuffer.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/RetainableByteBuffer.java
@@ -160,6 +160,16 @@ public interface RetainableByteBuffer extends Retainable
     }
 
     /**
+     * {@link #release() Release} the buffer in a way that will remove it from any pool that it may be in..
+     * @return {@code true} if the buffer can be removed.
+     */
+    default boolean remove()
+    {
+        release();
+        return false;
+    }
+
+    /**
      * A wrapper for {@link RetainableByteBuffer} instances
      */
     class Wrapper extends Retainable.Wrapper implements RetainableByteBuffer
@@ -214,6 +224,12 @@ public interface RetainableByteBuffer extends Retainable
         public void clear()
         {
             getWrapped().clear();
+        }
+
+        @Override
+        public boolean remove()
+        {
+            return getWrapped().remove();
         }
     }
 }

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
@@ -470,9 +470,9 @@ public class ArrayByteBufferPoolTest
         retained1 = pool.acquire(1024, false);
         retained1.retain();
 
-        assertTrue(pool.remove(reserved1));
-        assertTrue(pool.remove(acquired1));
-        assertTrue(pool.remove(retained1));
+        assertTrue(reserved1.remove());
+        assertTrue(acquired1.remove());
+        assertTrue(retained1.remove());
 
         retained1.release();
 

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
@@ -472,9 +472,8 @@ public class ArrayByteBufferPoolTest
 
         assertTrue(reserved1.remove());
         assertTrue(acquired1.remove());
-        assertTrue(retained1.remove());
-
-        retained1.release();
+        assertFalse(retained1.remove());
+        assertTrue(retained1.release());
 
         assertThat(pool.getHeapByteBufferCount(), is(2L));
         assertTrue(reserved0.release());

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
@@ -447,7 +447,7 @@ public class ArrayByteBufferPoolTest
     }
 
     @Test
-    public void testRemove()
+    public void testRemoveAndRelease()
     {
         ArrayByteBufferPool pool = new ArrayByteBufferPool();
 
@@ -470,9 +470,9 @@ public class ArrayByteBufferPoolTest
         retained1 = pool.acquire(1024, false);
         retained1.retain();
 
-        assertTrue(reserved1.remove());
-        assertTrue(acquired1.remove());
-        assertFalse(retained1.remove());
+        assertTrue(pool.removeAndRelease(reserved1));
+        assertTrue(pool.removeAndRelease(acquired1));
+        assertFalse(pool.removeAndRelease(retained1));
         assertTrue(retained1.release());
 
         assertThat(pool.getHeapByteBufferCount(), is(2L));

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ErrorHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ErrorHandler.java
@@ -258,7 +258,7 @@ public class ErrorHandler implements Request.Handler
         catch (Throwable x)
         {
             if (buffer != null)
-                request.getComponents().getByteBufferPool().remove(buffer);
+                buffer.remove();
             throw x;
         }
     }

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
@@ -583,6 +583,8 @@ public class HttpOutput extends ServletOutputStream implements Runnable
 
     private RetainableByteBuffer lockedAcquireBuffer()
     {
+        assert _channelState.isLockHeldByCurrentThread();
+
         boolean useOutputDirectByteBuffers = _servletChannel.getConnectionMetaData().getHttpConfiguration().isUseOutputDirectByteBuffers();
 
         if (_aggregate == null)
@@ -595,6 +597,8 @@ public class HttpOutput extends ServletOutputStream implements Runnable
 
     private void lockedReleaseBuffer(boolean failure)
     {
+        assert _channelState.isLockHeldByCurrentThread();
+
         if (_aggregate != null)
         {
             if (failure && _pool != null)

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
@@ -222,7 +222,7 @@ public class HttpOutput extends ServletOutputStream implements Runnable
                 _state = State.CLOSED;
                 closedCallback = _closedCallback;
                 _closedCallback = null;
-                releaseBuffer();
+                releaseBuffer(failure != null);
                 wake = updateApiState(failure);
             }
             else if (_state == State.CLOSE)
@@ -444,7 +444,7 @@ public class HttpOutput extends ServletOutputStream implements Runnable
         try (AutoLock l = _channelState.lock())
         {
             _state = State.CLOSED;
-            releaseBuffer();
+            releaseBuffer(failure != null);
         }
     }
 
@@ -589,11 +589,14 @@ public class HttpOutput extends ServletOutputStream implements Runnable
         return _aggregate;
     }
 
-    private void releaseBuffer()
+    private void releaseBuffer(boolean failure)
     {
         if (_aggregate != null)
         {
-            _aggregate.release();
+            if (failure)
+                _servletChannel.getRequest().getComponents().getByteBufferPool().remove(_aggregate);
+            else
+                _aggregate.release();
             _aggregate = null;
         }
     }
@@ -1265,6 +1268,7 @@ public class HttpOutput extends ServletOutputStream implements Runnable
     {
         try (AutoLock l = _channelState.lock())
         {
+            releaseBuffer(_state != State.CLOSED);
             _state = State.OPEN;
             _apiState = ApiState.BLOCKING;
             _softClose = true; // Stay closed until next request
@@ -1273,7 +1277,6 @@ public class HttpOutput extends ServletOutputStream implements Runnable
             _commitSize = config.getOutputAggregationSize();
             if (_commitSize > _bufferSize)
                 _commitSize = _bufferSize;
-            releaseBuffer();
             _written = 0;
             _writeListener = null;
             _onError = null;

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
@@ -135,6 +135,7 @@ public class HttpOutput extends ServletOutputStream implements Runnable
     private long _written;
     private long _flushed;
     private long _firstByteNanoTime = -1;
+    private ByteBufferPool _pool;
     private RetainableByteBuffer _aggregate;
     private int _bufferSize;
     private int _commitSize;
@@ -222,7 +223,7 @@ public class HttpOutput extends ServletOutputStream implements Runnable
                 _state = State.CLOSED;
                 closedCallback = _closedCallback;
                 _closedCallback = null;
-                releaseBuffer(failure != null);
+                lockedReleaseBuffer(failure != null);
                 wake = updateApiState(failure);
             }
             else if (_state == State.CLOSE)
@@ -444,7 +445,7 @@ public class HttpOutput extends ServletOutputStream implements Runnable
         try (AutoLock l = _channelState.lock())
         {
             _state = State.CLOSED;
-            releaseBuffer(failure != null);
+            lockedReleaseBuffer(failure != null);
         }
     }
 
@@ -576,28 +577,32 @@ public class HttpOutput extends ServletOutputStream implements Runnable
     {
         try (AutoLock l = _channelState.lock())
         {
-            return acquireBuffer().getByteBuffer();
+            return lockedAcquireBuffer().getByteBuffer();
         }
     }
 
-    private RetainableByteBuffer acquireBuffer()
+    private RetainableByteBuffer lockedAcquireBuffer()
     {
         boolean useOutputDirectByteBuffers = _servletChannel.getConnectionMetaData().getHttpConfiguration().isUseOutputDirectByteBuffers();
-        ByteBufferPool pool = _servletChannel.getRequest().getComponents().getByteBufferPool();
+
         if (_aggregate == null)
-            _aggregate = pool.acquire(getBufferSize(), useOutputDirectByteBuffers);
+        {
+            _pool = _servletChannel.getRequest().getComponents().getByteBufferPool();
+            _aggregate = _pool.acquire(getBufferSize(), useOutputDirectByteBuffers);
+        }
         return _aggregate;
     }
 
-    private void releaseBuffer(boolean failure)
+    private void lockedReleaseBuffer(boolean failure)
     {
         if (_aggregate != null)
         {
-            if (failure)
-                _aggregate.remove();
+            if (failure && _pool != null)
+                _pool.removeAndRelease(_aggregate);
             else
                 _aggregate.release();
             _aggregate = null;
+            _pool = null;
         }
     }
 
@@ -760,7 +765,7 @@ public class HttpOutput extends ServletOutputStream implements Runnable
             // Should we aggregate?
             if (aggregate)
             {
-                acquireBuffer();
+                lockedAcquireBuffer();
                 int filled = BufferUtil.fill(_aggregate.getByteBuffer(), b, off, len);
 
                 // return if we are not complete, not full and filled all the content
@@ -965,7 +970,7 @@ public class HttpOutput extends ServletOutputStream implements Runnable
             }
             _written = written;
 
-            acquireBuffer();
+            lockedAcquireBuffer();
             BufferUtil.append(_aggregate.getByteBuffer(), (byte)b);
         }
 
@@ -1268,7 +1273,7 @@ public class HttpOutput extends ServletOutputStream implements Runnable
     {
         try (AutoLock l = _channelState.lock())
         {
-            releaseBuffer(_state != State.CLOSED);
+            lockedReleaseBuffer(_state != State.CLOSED);
             _state = State.OPEN;
             _apiState = ApiState.BLOCKING;
             _softClose = true; // Stay closed until next request

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
@@ -594,7 +594,7 @@ public class HttpOutput extends ServletOutputStream implements Runnable
         if (_aggregate != null)
         {
             if (failure)
-                _servletChannel.getRequest().getComponents().getByteBufferPool().remove(_aggregate);
+                _aggregate.remove();
             else
                 _aggregate.release();
             _aggregate = null;

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannelState.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannelState.java
@@ -227,6 +227,11 @@ public class ServletChannelState
         return _lock.lock();
     }
 
+    boolean isLockHeldByCurrentThread()
+    {
+        return _lock.isHeldByCurrentThread();
+    }
+
     public State getState()
     {
         try (AutoLock ignored = lock())

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannelState.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannelState.java
@@ -158,6 +158,11 @@ public class HttpChannelState
         return _lock.lock();
     }
 
+    boolean isLockHeldByCurrentThread()
+    {
+        return _lock.isHeldByCurrentThread();
+    }
+
     public State getState()
     {
         try (AutoLock l = lock())

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpOutput.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpOutput.java
@@ -650,6 +650,8 @@ public class HttpOutput extends ServletOutputStream implements Runnable
 
     private RetainableByteBuffer lockedAcquireBuffer()
     {
+        assert _channelState.isLockHeldByCurrentThread();
+
         if (_aggregate == null)
         {
             _pool = _channel.getByteBufferPool();
@@ -660,6 +662,8 @@ public class HttpOutput extends ServletOutputStream implements Runnable
 
     private void lockedReleaseBuffer(boolean failure)
     {
+        assert _channelState.isLockHeldByCurrentThread();
+
         if (_aggregate != null)
         {
             if (failure && _pool != null)


### PR DESCRIPTION
Fixes #11854 by removing buffers from the pool when failed during a write.
This is an alternative solution to #11876
