### PR TITLE
Fix #265 list licenses

### DIFF
--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/Main.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/Main.java
@@ -203,7 +203,7 @@ public class Main
     private static boolean isLicenseFile(JarEntry entry)
     {
         String name = entry.getName();
-        return name.matches("(?i)^(META-INF/)?LICENSE.*") || name.matches("(?i)^LICENSE.*");
+        return name.matches("(?i)^(META-INF/)?LICEN[SC]E.*") || name.matches("(?i)^LICEN[SC]E.*");
     }
 
     private String getLicenceFromFile(JarFile jarFile, JarEntry entry)

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/Main.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/Main.java
@@ -29,8 +29,14 @@ import java.net.SocketTimeoutException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 
 import org.eclipse.jetty.start.Props.Prop;
@@ -135,7 +141,7 @@ public class Main
         }).start();
     }
 
-    private void dumpClasspathWithVersions(String name, PrintStream out, Classpath classpath)
+    private void listClasspath(String name, PrintStream out, Classpath classpath)
     {
         StartLog.endStartLog();
         out.println();
@@ -154,8 +160,93 @@ public class Main
         int i = 0;
         for (Path element : classpath.getElements())
         {
-            out.printf("%2d: %24s | %s\n", i++, getVersion(element), baseHome.toShortForm(element));
+            String license = getLicenceFromJar(element);
+            if (license != null && !license.isEmpty())
+                out.printf("%2d: %24s | %s | %s\n", i++, getVersion(element), baseHome.toShortForm(element), license);
+            else
+                out.printf("%2d: %24s | %s\n", i++, getVersion(element), baseHome.toShortForm(element));
         }
+    }
+
+    private String getLicenceFromJar(Path jar)
+    {
+        if (!Files.exists(jar) || Files.isDirectory(jar) || !Files.isReadable(jar))
+            return null;
+        try
+        {
+            try (JarFile jarFile = new JarFile(jar.toFile()))
+            {
+                Manifest manifest = jarFile.getManifest();
+                if (manifest != null)
+                {
+                    String spdxLicense = manifest.getMainAttributes().getValue("SPDX-License-Identifier");
+                    if (spdxLicense != null)
+                        return spdxLicense;
+
+                    String bundleLicense = manifest.getMainAttributes().getValue("Bundle-License");
+                    if (bundleLicense != null)
+                        return bundleLicense;
+                }
+
+                Optional<String> license = jarFile.stream().filter(Main::isLicenseFile).map(e -> getLicenceFromFile(jarFile, e)).filter(Objects::nonNull).findFirst();
+                if (license.isPresent())
+                    return license.get();
+
+            }
+        }
+        catch (Throwable ignored)
+        {
+        }
+        return null;
+    }
+
+    private static boolean isLicenseFile(JarEntry entry)
+    {
+        String name = entry.getName();
+        return name.matches("(?i)^(META-INF/)?LICENSE.*") || name.matches("(?i)^LICENSE.*");
+    }
+
+    private String getLicenceFromFile(JarFile jarFile, JarEntry entry)
+    {
+        try
+        {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(jarFile.getInputStream(entry))))
+            {
+                String line;
+                StringBuilder licenseBuilder = new StringBuilder();
+                int nonEmptyLines = 0;
+
+                List<String> links = new ArrayList<>();
+
+                while ((line = reader.readLine()) != null)
+                {
+                    line = line.trim();
+                    if (!line.isEmpty())
+                    {
+                        if (line.contains("SPDX-License-Identifier:"))
+                            return line.substring(line.indexOf(':') + 1).trim();
+
+                        if (line.startsWith("http:") || line.startsWith("https:"))
+                            links.add(line);
+
+                        if (nonEmptyLines < 2)
+                        {
+                            licenseBuilder.append(line).append(" ");
+                            nonEmptyLines++;
+                        }
+                    }
+                }
+
+                if (!links.isEmpty())
+                    return links.stream().max(Comparator.comparingInt(String::length)).get();
+
+                return nonEmptyLines > 0 ? licenseBuilder.toString().trim() : null;
+            }
+        }
+        catch (Throwable ignored)
+        {
+        }
+        return null;
     }
 
     public BaseHome getBaseHome()
@@ -243,7 +334,7 @@ public class Main
         // Dump Jetty Properties
         jettyEnvironment.dumpProperties(out);
         // Dump Jetty Classpath
-        dumpClasspathWithVersions(jettyEnvironment.getName(), out, jettyEnvironment.getClasspath());
+        listClasspath(jettyEnvironment.getName(), out, jettyEnvironment.getClasspath());
         // Dump Jetty Resolved XMLs
         jettyEnvironment.dumpActiveXmls(out);
 
@@ -252,7 +343,7 @@ public class Main
             // Dump Properties
             environment.dumpProperties(out);
             // Dump Classpath
-            dumpClasspathWithVersions(environment.getName(), out, environment.getClasspath());
+            listClasspath(environment.getName(), out, environment.getClasspath());
             // Dump Resolved XMLs
             environment.dumpActiveXmls(out);
         }
@@ -400,7 +491,7 @@ public class Main
         // Show the version information and return
         if (args.isListClasspath())
         {
-            dumpClasspathWithVersions("Jetty", System.out, classpath);
+            listClasspath("Jetty", System.out, classpath);
         }
 
         // Show configuration

--- a/pom.xml
+++ b/pom.xml
@@ -1405,6 +1405,7 @@
               <manifestEntries>
                 <Implementation-Version>${project.version}</Implementation-Version>
                 <Implementation-Vendor>Eclipse Jetty Project</Implementation-Vendor>
+                <SPDX-License-Identifier>EPL-2.0 OR Apache-2.0</SPDX-License-Identifier>
                 <url>${jetty.url}</url>
               </manifestEntries>
             </archive>


### PR DESCRIPTION
List licenses in --list-classpath

Example output
```
Classpath: Jetty
----------------
Version Information on 268 entries in the classpath.
Note: order presented here is how they would appear on the classpath.
      changes to the --module=name command line options will be reflected here.
 0:         12.0.11-SNAPSHOT | ${jetty.home}/lib/jetty-alpn-java-server-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
 1:                    (dir) | ${jetty.base}/resources
 2:                   2.0.12 | ${jetty.home}/lib/logging/slf4j-api-2.0.12.jar | http://www.opensource.org/licenses/mit-license.php
 3:                    1.5.6 | ${jetty.base}/lib/logging/logback-classic-1.5.6.jar | http://www.eclipse.org/legal/epl-v10.html, http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
 4:                    1.5.6 | ${jetty.base}/lib/logging/logback-core-1.5.6.jar | http://www.eclipse.org/legal/epl-v10.html, http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
 5:                      9.7 | ${jetty.base}/lib/ext/asm-9.7.jar | BSD-3-Clause;link=https://asm.ow2.io/LICENSE.txt
 6:                      9.7 | ${jetty.base}/lib/ext/asm-analysis-9.7.jar | BSD-3-Clause;link=https://asm.ow2.io/LICENSE.txt
 7:                      9.7 | ${jetty.base}/lib/ext/asm-commons-9.7.jar | BSD-3-Clause;link=https://asm.ow2.io/LICENSE.txt
 8:                      9.7 | ${jetty.base}/lib/ext/asm-tree-9.7.jar | BSD-3-Clause;link=https://asm.ow2.io/LICENSE.txt
 9:                    1.3.5 | ${jetty.base}/lib/ext/jakarta.annotation-api-1.3.5.jar | http://www.eclipse.org/legal/epl-2.0, https://www.gnu.org/software/classpath/license.html
10:                    2.0.0 | ${jetty.base}/lib/ext/jakarta.annotation-api-2.0.0.jar | http://www.eclipse.org/legal/epl-2.0, https://www.gnu.org/software/classpath/license.html
11:                    2.1.1 | ${jetty.base}/lib/ext/jakarta.annotation-api-2.1.1.jar | http://www.eclipse.org/legal/epl-2.0, https://www.gnu.org/software/classpath/license.html
12:                    2.0.0 | ${jetty.base}/lib/ext/jakarta.authentication-api-2.0.0.jar | http://www.eclipse.org/legal/epl-2.0, https://www.gnu.org/software/classpath/license.html
13:                    3.0.0 | ${jetty.base}/lib/ext/jakarta.authentication-api-3.0.0.jar | http://www.eclipse.org/legal/epl-2.0, https://www.gnu.org/software/classpath/license.html
14:                    5.0.1 | ${jetty.base}/lib/ext/jakarta.el.jakarta.el-api-5.0.1.jar | https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt, https://www.gnu.org/software/classpath/license.html
15:                    3.0.1 | ${jetty.base}/lib/ext/jakarta.enterprise.cdi-api-3.0.1.jar | https://repository.jboss.org/licenses/apache-2.0.txt
16:                    4.0.1 | ${jetty.base}/lib/ext/jakarta.enterprise.cdi-api-4.0.1.jar | https://www.apache.org/licenses/LICENSE-2.0
17:                    4.0.1 | ${jetty.base}/lib/ext/jakarta.enterprise.lang-model-4.0.1.jar | https://repository.jboss.org/licenses/apache-2.0.txt
18:                      2.0 | ${jetty.base}/lib/ext/jakarta.inject-api-2.0.1.MR.jar | http://www.apache.org/licenses/LICENSE-2.0.txt
19:                    2.0.1 | ${jetty.base}/lib/ext/jakarta.interceptor-api-2.0.1.jar | http://www.eclipse.org/legal/epl-2.0, https://www.gnu.org/software/classpath/license.html
20:                    2.1.0 | ${jetty.base}/lib/ext/jakarta.interceptor-api-2.1.0.jar | http://www.eclipse.org/legal/epl-2.0, https://www.gnu.org/software/classpath/license.html
21:                    3.1.1 | ${jetty.base}/lib/ext/jakarta.servlet.jsp.jakarta.servlet.jsp-api-3.1.1.jar | https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt, https://www.gnu.org/software/classpath/license.html
22:                    1.2.7 | ${jetty.base}/lib/ext/jakarta.servlet.jsp.jstl.jakarta.servlet.jsp.jstl-api-1.2.7.jar | http://www.eclipse.org/legal/epl-2.0, https://www.gnu.org/software/classpath/license.html
23:                    2.0.0 | ${jetty.base}/lib/ext/jakarta.servlet.jsp.jstl.jakarta.servlet.jsp.jstl-api-2.0.0.jar | http://www.eclipse.org/legal/epl-2.0, https://www.gnu.org/software/classpath/license.html
24:                    3.0.0 | ${jetty.base}/lib/ext/jakarta.servlet.jsp.jstl.jakarta.servlet.jsp.jstl-api-3.0.0.jar | http://www.eclipse.org/legal/epl-2.0, https://www.gnu.org/software/classpath/license.html
25:                    6.0.0 | ${jetty.base}/lib/ext/jakarta.servlet-api-6.0.0.jar | http://www.eclipse.org/legal/epl-2.0, https://www.gnu.org/software/classpath/license.html
26:                    1.3.3 | ${jetty.base}/lib/ext/jakarta.transaction-api-1.3.3.jar | http://www.eclipse.org/legal/epl-2.0, https://www.gnu.org/software/classpath/license.html
27:                    2.0.1 | ${jetty.base}/lib/ext/jakarta.transaction-api-2.0.1.jar | http://www.eclipse.org/legal/epl-2.0, https://www.gnu.org/software/classpath/license.html
28:                    2.1.1 | ${jetty.base}/lib/ext/jakarta.websocket-api-2.1.1.jar | https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt, https://www.gnu.org/software/classpath/license.html
29:                    2.1.1 | ${jetty.base}/lib/ext/jakarta.websocket-client-api-2.1.1.jar | https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt, https://www.gnu.org/software/classpath/license.html
30:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-alpn-client-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
31:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-alpn-conscrypt-server-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
32:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-alpn-java-server-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
33:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-alpn-server-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
34:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-client-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
35:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-demo-handler-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
36:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-deploy-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
37:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee10-annotations-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
38:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee10-apache-jsp-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
39:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee10-cdi-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
40:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee10-fcgi-proxy-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
41:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee10-glassfish-jstl-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
42:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee10-jaspi-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
43:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee10-jndi-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
44:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee10-plus-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
45:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee10-proxy-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
46:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee10-quickstart-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
47:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee10-servlet-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
48:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee10-servlets-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
49:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee10-webapp-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
50:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee10-websocket-jakarta-client-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
51:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee10-websocket-jakarta-common-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
52:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee10-websocket-jakarta-server-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
53:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee10-websocket-jetty-client-webapp-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
54:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee10-websocket-jetty-server-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
55:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee10-websocket-servlet-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
56:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
57:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee8-annotations-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
58:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee8-apache-jsp-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
59:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee8-glassfish-jstl-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
60:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee8-jndi-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
61:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee8-nested-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
62:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee8-openid-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
63:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee8-plus-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
64:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee8-proxy-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
65:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee8-quickstart-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
66:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee8-security-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
67:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee8-servlet-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
68:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee8-servlets-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
69:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee8-webapp-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
70:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee8-websocket-javax-client-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
71:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee8-websocket-javax-common-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
72:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee8-websocket-javax-server-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
73:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee8-websocket-jetty-api-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
74:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee8-websocket-jetty-client-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
75:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee8-websocket-jetty-client-webapp-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
76:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee8-websocket-jetty-common-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
77:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee8-websocket-jetty-server-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
78:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee8-websocket-servlet-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
79:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee9-annotations-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
80:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee9-apache-jsp-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
81:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee9-cdi-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
82:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee9-fcgi-proxy-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
83:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee9-glassfish-jstl-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
84:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee9-jaspi-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
85:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee9-jndi-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
86:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee9-nested-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
87:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee9-openid-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
88:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee9-plus-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
89:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee9-proxy-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
90:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee9-quickstart-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
91:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee9-security-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
92:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee9-servlet-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
93:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee9-servlets-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
94:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee9-webapp-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
95:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee9-websocket-jakarta-client-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
96:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee9-websocket-jakarta-common-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
97:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee9-websocket-jakarta-server-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
98:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee9-websocket-jetty-api-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
99:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee9-websocket-jetty-client-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
100:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee9-websocket-jetty-client-webapp-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
101:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee9-websocket-jetty-common-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
102:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee9-websocket-jetty-server-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
103:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-ee9-websocket-servlet-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
104:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-fcgi-client-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
105:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-fcgi-proxy-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
106:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-fcgi-server-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
107:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-gcloud-session-manager-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
108:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-hazelcast-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
109:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-http-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
110:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-http2-common-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
111:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-http2-hpack-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
112:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-http2-server-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
113:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-http3-common-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
114:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-http3-qpack-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
115:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-http3-server-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
116:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-infinispan-common-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
117:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-infinispan-embedded-query-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
118:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-infinispan-remote-query-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
119:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-io-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
120:                    5.0.2 | ${jetty.base}/lib/ext/jetty-jakarta-servlet-api-5.0.2.jar | http://www.apache.org/licenses/LICENSE-2.0, http://www.eclipse.org/org/documents/epl-v10.php
121:                    2.0.0 | ${jetty.base}/lib/ext/jetty-jakarta-websocket-api-2.0.0.jar | http://www.apache.org/licenses/LICENSE-2.0, http://www.eclipse.org/org/documents/epl-v10.php
122:                    1.1.2 | ${jetty.base}/lib/ext/jetty-javax-websocket-api-1.1.2.jar | http://www.apache.org/licenses/LICENSE-2.0, http://www.eclipse.org/org/documents/epl-v10.php
123:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-jmx-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
124:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-jndi-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
125:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-keystore-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
126:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-memcached-sessions-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
127:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-nosql-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
128:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-openid-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
129:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-plus-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
130:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-proxy-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
131:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-quic-common-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
132:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-quic-quiche-common-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
133:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-quic-quiche-foreign-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
134:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-quic-quiche-jna-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
135:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-quic-server-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
136:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-rewrite-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
137:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-security-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
138:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-server-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
139:                    4.0.6 | ${jetty.base}/lib/ext/jetty-servlet-api-4.0.6.jar | http://www.apache.org/licenses/LICENSE-2.0, http://www.eclipse.org/org/documents/epl-v10.php
140:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-session-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
141:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-slf4j-impl-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
142:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-unixdomain-server-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
143:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-util-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
144:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-util-ajax-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
145:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-websocket-core-client-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
146:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-websocket-core-common-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
147:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-websocket-core-server-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
148:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-websocket-jetty-api-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
149:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-websocket-jetty-client-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
150:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-websocket-jetty-common-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
151:         12.0.11-SNAPSHOT | ${jetty.base}/lib/ext/jetty-xml-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
152:    3.37.0.v20240215-1558 | ${jetty.base}/lib/ext/org.eclipse.jdt.ecj-3.37.0.jar
153:                    2.0.0 | ${jetty.base}/lib/ext/org.glassfish.web.jakarta.servlet.jsp.jstl-2.0.0.jar | http://www.eclipse.org/legal/epl-2.0, https://www.gnu.org/software/classpath/license.html
154:                    3.0.1 | ${jetty.base}/lib/ext/org.glassfish.web.jakarta.servlet.jsp.jstl-3.0.1.jar | http://www.eclipse.org/legal/epl-2.0, https://www.gnu.org/software/classpath/license.html
155:                    1.2.5 | ${jetty.base}/lib/ext/org.glassfish.web.javax.servlet.jsp.jstl-1.2.5.jar | http://glassfish.dev.java.net/nonav/public/CDDL+GPL.html
156:                  10.0.27 | ${jetty.base}/lib/ext/org.mortbay.jasper.apache-el-10.0.27.jar | http://www.apache.org/licenses/LICENSE-2.0
157:                  10.1.25 | ${jetty.base}/lib/ext/org.mortbay.jasper.apache-el-10.1.25.jar | http://www.apache.org/licenses/LICENSE-2.0
158:                   9.0.90 | ${jetty.base}/lib/ext/org.mortbay.jasper.apache-el-9.0.90.jar | http://www.apache.org/licenses/LICENSE-2.0
159:                  10.0.27 | ${jetty.base}/lib/ext/org.mortbay.jasper.apache-jsp-10.0.27.jar | http://www.apache.org/licenses/LICENSE-2.0
160:                  10.1.25 | ${jetty.base}/lib/ext/org.mortbay.jasper.apache-jsp-10.1.25.jar | http://www.apache.org/licenses/LICENSE-2.0
161:                   9.0.90 | ${jetty.base}/lib/ext/org.mortbay.jasper.apache-jsp-9.0.90.jar | http://www.apache.org/licenses/LICENSE-2.0
162:                   2.0.12 | ${jetty.base}/lib/ext/slf4j-api-2.0.12.jar | http://www.opensource.org/licenses/mit-license.php
163:         12.0.11-SNAPSHOT | ${jetty.home}/lib/jetty-http-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
164:         12.0.11-SNAPSHOT | ${jetty.home}/lib/jetty-server-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
165:         12.0.11-SNAPSHOT | ${jetty.home}/lib/jetty-xml-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
166:         12.0.11-SNAPSHOT | ${jetty.home}/lib/jetty-util-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
167:         12.0.11-SNAPSHOT | ${jetty.home}/lib/jetty-io-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
168:         12.0.11-SNAPSHOT | ${jetty.home}/lib/jetty-keystore-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
169:                 1.78.1.0 | ${jetty.base}/lib/bouncycastle/bcpkix-jdk15to18-1.78.1.jar
170:                 1.78.1.0 | ${jetty.base}/lib/bouncycastle/bcprov-jdk15to18-1.78.1.jar
171:                 1.78.1.0 | ${jetty.base}/lib/bouncycastle/bcutil-jdk15to18-1.78.1.jar
172:         12.0.11-SNAPSHOT | ${jetty.home}/lib/jetty-alpn-server-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
173:         12.0.11-SNAPSHOT | ${jetty.home}/lib/jetty-client-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
174:         12.0.11-SNAPSHOT | ${jetty.home}/lib/jetty-alpn-client-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
175:         12.0.11-SNAPSHOT | ${jetty.home}/lib/jetty-security-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
176:         12.0.11-SNAPSHOT | ${jetty.home}/lib/jetty-deploy-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
177:         12.0.11-SNAPSHOT | ${jetty.home}/lib/http2/jetty-http2-common-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
178:         12.0.11-SNAPSHOT | ${jetty.home}/lib/http2/jetty-http2-hpack-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
179:         12.0.11-SNAPSHOT | ${jetty.home}/lib/http2/jetty-http2-server-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
180:         12.0.11-SNAPSHOT | ${jetty.home}/lib/jetty-session-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
181:         12.0.11-SNAPSHOT | ${jetty.home}/lib/jetty-ee-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
182:         12.0.11-SNAPSHOT | ${jetty.home}/lib/jetty-plus-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
183:         12.0.11-SNAPSHOT | ${jetty.home}/lib/jetty-jndi-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
184:         12.0.11-SNAPSHOT | ${jetty.home}/lib/jetty-rewrite-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
185:         12.0.11-SNAPSHOT | ${jetty.home}/lib/jetty-websocket-core-common-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
186:         12.0.11-SNAPSHOT | ${jetty.home}/lib/jetty-websocket-core-server-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
187:         12.0.11-SNAPSHOT | ${jetty.home}/lib/jetty-websocket-jetty-api-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
188:         12.0.11-SNAPSHOT | ${jetty.home}/lib/jetty-websocket-jetty-common-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
189:                     1.23 | ${jetty.base}/lib/gcloud/animal-sniffer-annotations-1.23.jar
190:                  4.1.1.4 | ${jetty.base}/lib/gcloud/annotations-4.1.1.4.jar
191:                   2.30.0 | ${jetty.base}/lib/gcloud/api-common-2.30.0.jar
192:                   1.10.4 | ${jetty.base}/lib/gcloud/auto-value-annotations-1.10.4.jar
193:                   3.42.0 | ${jetty.base}/lib/gcloud/checker-qual-3.42.0.jar | MIT
194:                   1.17.0 | ${jetty.base}/lib/gcloud/commons-codec-1.17.0.jar | https://www.apache.org/licenses/LICENSE-2.0.txt
195:                    2.5.2 | ${jetty.base}/lib/gcloud/conscrypt-openjdk-uber-2.5.2.jar
196:                   2.19.1 | ${jetty.base}/lib/gcloud/datastore-v1-proto-client-2.19.1.jar
197:                   2.27.1 | ${jetty.base}/lib/gcloud/error_prone_annotations-2.27.1.jar | "Apache 2.0";link="http://www.apache.org/licenses/LICENSE-2.0.txt"
198:                    1.0.2 | ${jetty.base}/lib/gcloud/failureaccess-1.0.2.jar | http://www.apache.org/licenses/LICENSE-2.0.txt
199:                   2.47.0 | ${jetty.base}/lib/gcloud/gax-2.47.0.jar
200:                   2.47.0 | ${jetty.base}/lib/gcloud/gax-grpc-2.47.0.jar
201:                   2.47.0 | ${jetty.base}/lib/gcloud/gax-httpjson-2.47.0.jar
202:                    2.4.0 | ${jetty.base}/lib/gcloud/google-api-client-2.4.0.jar | http://www.apache.org/licenses/LICENSE-2.0.txt
203:                   1.23.0 | ${jetty.base}/lib/gcloud/google-auth-library-credentials-1.23.0.jar
204:                   1.23.0 | ${jetty.base}/lib/gcloud/google-auth-library-oauth2-http-1.23.0.jar
205:                   2.37.0 | ${jetty.base}/lib/gcloud/google-cloud-core-2.37.0.jar
206:                   2.37.0 | ${jetty.base}/lib/gcloud/google-cloud-core-http-2.37.0.jar
207:                   2.19.1 | ${jetty.base}/lib/gcloud/google-cloud-datastore-2.19.1.jar
208:                   1.44.1 | ${jetty.base}/lib/gcloud/google-http-client-1.44.1.jar | http://www.apache.org/licenses/LICENSE-2.0.txt
209:                   1.44.1 | ${jetty.base}/lib/gcloud/google-http-client-apache-v2-1.44.1.jar | http://www.apache.org/licenses/LICENSE-2.0.txt
210:                   1.44.1 | ${jetty.base}/lib/gcloud/google-http-client-appengine-1.44.1.jar
211:                   1.44.1 | ${jetty.base}/lib/gcloud/google-http-client-gson-1.44.1.jar
212:                   1.44.1 | ${jetty.base}/lib/gcloud/google-http-client-jackson2-1.44.1.jar
213:                   1.44.1 | ${jetty.base}/lib/gcloud/google-http-client-protobuf-1.44.1.jar
214:                   1.35.0 | ${jetty.base}/lib/gcloud/google-oauth-client-1.35.0.jar | https://www.apache.org/licenses/LICENSE-2.0.txt
215:                   1.62.2 | ${jetty.base}/lib/gcloud/grpc-alts-1.62.2.jar
216:                   1.62.2 | ${jetty.base}/lib/gcloud/grpc-api-1.62.2.jar
217:                   1.62.2 | ${jetty.base}/lib/gcloud/grpc-auth-1.62.2.jar
218:                   1.62.2 | ${jetty.base}/lib/gcloud/grpc-context-1.62.2.jar
219:                   1.63.0 | ${jetty.base}/lib/gcloud/grpc-core-1.63.0.jar
220:                   1.62.2 | ${jetty.base}/lib/gcloud/grpc-googleapis-1.62.2.jar
221:                   2.19.1 | ${jetty.base}/lib/gcloud/grpc-google-cloud-datastore-admin-v1-2.19.1.jar
222:                   1.62.2 | ${jetty.base}/lib/gcloud/grpc-grpclb-1.62.2.jar
223:                   1.62.2 | ${jetty.base}/lib/gcloud/grpc-inprocess-1.62.2.jar
224:                   1.62.2 | ${jetty.base}/lib/gcloud/grpc-netty-shaded-1.62.2.jar | http://www.apache.org/licenses/LICENSE-2.0
225:                   1.62.2 | ${jetty.base}/lib/gcloud/grpc-protobuf-1.62.2.jar
226:                   1.62.2 | ${jetty.base}/lib/gcloud/grpc-protobuf-lite-1.62.2.jar
227:                   1.62.2 | ${jetty.base}/lib/gcloud/grpc-services-1.62.2.jar
228:                   1.62.2 | ${jetty.base}/lib/gcloud/grpc-stub-1.62.2.jar
229:                   1.62.2 | ${jetty.base}/lib/gcloud/grpc-util-1.62.2.jar
230:                   1.62.2 | ${jetty.base}/lib/gcloud/grpc-xds-1.62.2.jar
231:                   2.10.1 | ${jetty.base}/lib/gcloud/gson-2.10.1.jar | "Apache-2.0";link="https://www.apache.org/licenses/LICENSE-2.0.txt"
232:               33.1.0.jre | ${jetty.base}/lib/gcloud/guava-33.1.0-jre.jar | http://www.apache.org/licenses/LICENSE-2.0.txt
233:                   4.5.14 | ${jetty.base}/lib/gcloud/httpclient-4.5.14.jar | http://www.apache.org/licenses/LICENSE-2.0
234:                   4.4.16 | ${jetty.base}/lib/gcloud/httpcore-4.4.16.jar | http://www.apache.org/licenses/LICENSE-2.0
235:                    3.0.0 | ${jetty.base}/lib/gcloud/j2objc-annotations-3.0.0.jar
236:                   2.17.0 | ${jetty.base}/lib/gcloud/jackson-core-2.17.0.jar | https://www.apache.org/licenses/LICENSE-2.0.txt
237:                    3.0.2 | ${jetty.base}/lib/gcloud/jsr305-3.0.2.jar | http://www.apache.org/licenses/LICENSE-2.0.txt
238: 9999.0-empty-to-avoid-conflict-with-guava | ${jetty.base}/lib/gcloud/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
239:                   0.31.1 | ${jetty.base}/lib/gcloud/opencensus-api-0.31.1.jar
240:                   0.31.1 | ${jetty.base}/lib/gcloud/opencensus-contrib-http-util-0.31.1.jar
241:                    0.2.0 | ${jetty.base}/lib/gcloud/opencensus-proto-0.2.0.jar
242:                   1.37.0 | ${jetty.base}/lib/gcloud/opentelemetry-api-1.37.0.jar
243:                   1.37.0 | ${jetty.base}/lib/gcloud/opentelemetry-context-1.37.0.jar
244:                   0.27.0 | ${jetty.base}/lib/gcloud/perfmark-api-0.27.0.jar
245:                   3.25.3 | ${jetty.base}/lib/gcloud/protobuf-java-3.25.3.jar | https://opensource.org/licenses/BSD-3-Clause
246:                   3.25.3 | ${jetty.base}/lib/gcloud/protobuf-java-util-3.25.3.jar | https://opensource.org/licenses/BSD-3-Clause
247:                   2.19.1 | ${jetty.base}/lib/gcloud/proto-google-cloud-datastore-admin-v1-2.19.1.jar
248:                  0.110.1 | ${jetty.base}/lib/gcloud/proto-google-cloud-datastore-v1-0.110.1.jar
249:                   2.38.0 | ${jetty.base}/lib/gcloud/proto-google-common-protos-2.38.0.jar
250:                   1.33.0 | ${jetty.base}/lib/gcloud/proto-google-iam-v1-1.33.0.jar
251:         (none specified) | ${jetty.base}/lib/gcloud/re2j-1.7.jar
252:                   2.0.12 | ${jetty.base}/lib/gcloud/slf4j-api-2.0.12.jar | http://www.opensource.org/licenses/mit-license.php
253:                    1.6.9 | ${jetty.base}/lib/gcloud/threetenbp-1.6.9.jar | https://raw.githubusercontent.com/ThreeTen/threetenbp/main/LICENSE.txt
254:                   2.0.12 | ${jetty.base}/lib/logging/jcl-over-slf4j-2.0.12.jar | https://www.apache.org/licenses/LICENSE-2.0.txt
255:                   2.0.12 | ${jetty.base}/lib/logging/jul-to-slf4j-2.0.12.jar | http://www.opensource.org/licenses/mit-license.php
256:              5.14.0 (b0) | ${jetty.base}/lib/http3/jna-jpms-5.14.0.jar | Apache-2.0 OR LGPL-2.1
257:                   0.21.0 | ${jetty.base}/lib/http3/jetty-quiche-native-0.21.0.jar | Copyright (C) 1995-2021, Mort Bay Consulting Pty Ltd and others. All rights reserved.
258:         12.0.11-SNAPSHOT | ${jetty.home}/lib/http3/jetty-http3-common-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
259:         12.0.11-SNAPSHOT | ${jetty.home}/lib/http3/jetty-http3-qpack-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
260:         12.0.11-SNAPSHOT | ${jetty.home}/lib/http3/jetty-http3-server-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
261:         12.0.11-SNAPSHOT | ${jetty.home}/lib/http3/jetty-quic-common-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
262:         12.0.11-SNAPSHOT | ${jetty.home}/lib/http3/jetty-quic-quiche-common-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
263:         12.0.11-SNAPSHOT | ${jetty.home}/lib/http3/jetty-quic-quiche-foreign-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
264:         12.0.11-SNAPSHOT | ${jetty.home}/lib/http3/jetty-quic-quiche-jna-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
265:         12.0.11-SNAPSHOT | ${jetty.home}/lib/http3/jetty-quic-server-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
266:         12.0.11-SNAPSHOT | ${jetty.home}/lib/jetty-infinispan-remote-query-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
267:         12.0.11-SNAPSHOT | ${jetty.home}/lib/jetty-gcloud-session-manager-12.0.11-SNAPSHOT.jar | https://www.eclipse.org/legal/epl-2.0/, https://www.apache.org/licenses/LICENSE-2.0
```