### PR TITLE
Issue #12000 - use URIUtil::toURI instead of URI::create in MavenWebAppContext

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -1892,15 +1892,18 @@ public final class URIUtil
     }
 
     /**
-     * <p>Convert a String into a URI suitable for use as a Resource.</p>
+     * <p>Convert a String into a URI in a sane way.</p>
      *
-     * @param resource If the string starts with one of the ALLOWED_SCHEMES, then it is assumed to be a
-     * representation of a {@link URI}, otherwise it is treated as a {@link Path}.
+     * <p>
+     *     This exits to take an end user provided String and make a usable URI out of it.
+     *     It is capable of dealing with paths that have spaces, windows slashes, windows UNC references,
+     *     relative paths, absolute paths, and much more.
+     * </p>
+     *
+     * @param resource If the string starts with a recognized scheme, then it is assumed to be a representation
+     * of a {@link URI}, otherwise it is treated as a {@link Path} (which is then converted to a URI)
      * @return The {@link URI} form of the resource.
-     * @deprecated This method is currently resolving relative paths against the current directory, which is a mechanism
-     * that should be implemented by a {@link ResourceFactory}.   All calls to this method need to be reviewed.
      */
-    @Deprecated(since = "12.0.8")
     public static URI toURI(String resource)
     {
         Objects.requireNonNull(resource);

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -1900,19 +1900,19 @@ public final class URIUtil
      *     relative paths, absolute paths, and much more.
      * </p>
      *
-     * @param resource If the string starts with a recognized scheme, then it is assumed to be a representation
+     * @param reference If the reference string starts with a recognized scheme, then it is assumed to be a representation
      * of a {@link URI}, otherwise it is treated as a {@link Path} (which is then converted to a URI)
-     * @return The {@link URI} form of the resource.
+     * @return The {@link URI} form of the input string.
      */
-    public static URI toURI(String resource)
+    public static URI toURI(String reference)
     {
-        Objects.requireNonNull(resource);
+        Objects.requireNonNull(reference);
 
-        if (URIUtil.hasScheme(resource))
+        if (URIUtil.hasScheme(reference))
         {
             try
             {
-                URI uri = new URI(resource);
+                URI uri = new URI(reference);
 
                 if (ResourceFactory.isSupported(uri))
                     return correctURI(uri);
@@ -1923,7 +1923,7 @@ public final class URIUtil
                     // Input is a possible Windows path disguised as a URI "D:/path/to/resource.txt".
                     try
                     {
-                        return toURI(Paths.get(resource).toUri().toASCIIString());
+                        return toURI(Path.of(reference).toUri().toASCIIString());
                     }
                     catch (InvalidPathException x)
                     {
@@ -1949,7 +1949,7 @@ public final class URIUtil
         // Treat it as a Path, as that's all we have left to investigate.
         try
         {
-            return toURI(Paths.get(resource).toUri().toASCIIString());
+            return toURI(Path.of(reference).toUri().toASCIIString());
         }
         catch (InvalidPathException x)
         {
@@ -1960,7 +1960,7 @@ public final class URIUtil
         // a URI or a File Path.  The cause is usually due to bad input (eg:
         // characters that are not supported by file system)
         if (LOG.isDebugEnabled())
-            LOG.debug("Input string cannot be converted to URI \"{}\"", resource);
+            LOG.debug("Input string cannot be converted to URI \"{}\"", reference);
         throw new IllegalArgumentException("Cannot be converted to URI");
     }
 

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
@@ -1086,6 +1086,7 @@ public class URIUtilTest
         else
         {
             // URI (and unix) format (relative)
+            args.add(Arguments.of("/path/that has spaces/foo.jar", "file:///path/that%20has%20spaces/foo.jar"));
             args.add(Arguments.of("/path/to/foo.jar", "file:///path/to/foo.jar"));
             args.add(Arguments.of("/path/to/bogus.txt", "file:///path/to/bogus.txt"));
         }

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/invoker.properties
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = test -e

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/jetty-simple-base/pom.xml
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/jetty-simple-base/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.jetty.ee10.its.jetty-start-mojo-it</groupId>
+    <artifactId>jetty-simple-project</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>jetty-simple-base</artifactId>
+  <packaging>jar</packaging>
+
+  <name>EE10 :: Simple :: Base</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-perf-helper</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/jetty-simple-base/src/main/java/org/eclipse/jetty/its/jetty_start_mojo_it/Counter.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/jetty-simple-base/src/main/java/org/eclipse/jetty/its/jetty_start_mojo_it/Counter.java
@@ -1,0 +1,38 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.its.jetty_start_mojo_it;
+
+@SuppressWarnings("serial")
+public class Counter implements java.io.Serializable
+{
+    int counter = 0;
+    String last;
+
+    public int getCount()
+    {
+        counter++;
+        return counter;
+    }
+
+    public void setLast(String uri)
+    {
+        last = uri;
+    }
+
+    public String getLast()
+    {
+        return last;
+    }
+}
+

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/jetty-simple-base/src/main/java/org/eclipse/jetty/its/jetty_start_mojo_it/HelloServlet.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/jetty-simple-base/src/main/java/org/eclipse/jetty/its/jetty_start_mojo_it/HelloServlet.java
@@ -1,0 +1,40 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.its.jetty_start_mojo_it;
+
+import java.io.IOException;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ *
+ */
+@WebServlet("/hello")
+public class HelloServlet
+    extends HttpServlet
+{
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+        throws ServletException, IOException
+    {
+        String who = req.getParameter("name");
+
+        resp.getWriter().write("Hello " + (who == null ? "unknown" : who));
+    }
+}

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/jetty-simple-base/src/main/java/org/eclipse/jetty/its/jetty_start_mojo_it/PingServlet.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/jetty-simple-base/src/main/java/org/eclipse/jetty/its/jetty_start_mojo_it/PingServlet.java
@@ -1,0 +1,35 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.its.jetty_start_mojo_it;
+
+import java.io.IOException;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class PingServlet
+    extends HttpServlet
+{
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+        throws ServletException, IOException
+    {
+        String who = req.getParameter("name");
+
+        resp.getWriter().write("pong " + (who == null ? "unknown" : who));
+    }
+}

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/jetty-simple-base/src/main/resources/META-INF/web-fragment.xml
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/jetty-simple-base/src/main/resources/META-INF/web-fragment.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<web-fragment
+    xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-fragment_3_1.xsd"
+    version="3.1">
+
+  <name>FragmentA</name>
+
+  <ordering>
+    <after><others/></after>
+  </ordering>
+
+  <servlet>
+    <servlet-name>Ping</servlet-name>
+    <servlet-class>org.eclipse.jetty.its.jetty_start_mojo_it.PingServlet</servlet-class>
+    <init-param>
+      <param-name>extra1</param-name><param-value>123</param-value>
+    </init-param>
+    <init-param>
+      <param-name>extra2</param-name><param-value>345</param-value>
+    </init-param>
+  </servlet>
+
+  <servlet-mapping>
+    <servlet-name>Ping</servlet-name>
+    <url-pattern>/ping</url-pattern>
+  </servlet-mapping>
+
+
+</web-fragment>

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/jetty-simple-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/jetty-simple-webapp/pom.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.jetty.ee10.its.jetty-start-mojo-it</groupId>
+    <artifactId>jetty-simple-project</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>jetty-simple-webapp</artifactId>
+  <packaging>war</packaging>
+
+  <name>EE10 :: Simple :: WebApp</name>
+
+  <properties>
+    <jetty.port.file>${project.build.directory}/jetty-start-port.txt</jetty.port.file>
+  </properties>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.eclipse.jetty.ee10.its.jetty-start-mojo-it</groupId>
+      <artifactId>jetty-simple-base</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-servlet</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-maven-plugin</artifactId>
+      <classifier>tests</classifier>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-war-plugin</artifactId>
+          <configuration>
+            <failOnMissingWebXml>false</failOnMissingWebXml>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>IntegrationTest*.java</include>
+          </includes>
+          <systemPropertyVariables>
+            <jetty.port.file>${jetty.port.file}</jetty.port.file>
+            <context.path>/setbycontextxml</context.path>
+            <pingServlet>true</pingServlet>
+            <helloServlet>true</helloServlet>
+            <contentCheck>Counter accessed 1 times.</contentCheck>
+            <pathToCheck>/jsp/bean1.jsp</pathToCheck>
+            <maven.it.name>${project.groupId}:${project.artifactId}</maven.it.name>
+          </systemPropertyVariables>
+          <dependenciesToScan>
+            <dependency>org.eclipse.jetty.ee10:jetty-ee10-maven-plugin</dependency>
+          </dependenciesToScan>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>start-jetty</id>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>start</goal>
+            </goals>
+            <configuration>
+              <contextXml>${basedir}/src/config/context.xml</contextXml>
+              <systemProperties>
+                  <jetty.port.file>${jetty.port.file}</jetty.port.file>
+                  <jetty.deployMode>EMBED</jetty.deployMode>
+              </systemProperties>
+              <jettyXmls>
+                  <jettyXml>${basedir}/src/config/jetty.xml</jettyXml>
+              </jettyXmls>
+              <loginServices>
+                  <loginService implementation="org.eclipse.jetty.security.HashLoginService">
+                      <name>Test Realm</name>
+                      <config implementation="org.eclipse.jetty.maven.MavenResource">
+                          <resourceAsString>${basedir}/src/config/realm.properties</resourceAsString>
+                      </config>
+                  </loginService>
+              </loginServices>
+              <webApp>
+                <jettyEnvXml>${basedir}/src/config/jetty-env.xml</jettyEnvXml>
+                <resourceBases>
+                  <resourceBase>${basedir}/src/main/webapp</resourceBase>
+                </resourceBases>
+              </webApp>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/jetty-simple-webapp/src/config/context.xml
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/jetty-simple-webapp/src/config/context.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+
+<Configure class="org.eclipse.jetty.ee10.webapp.WebAppContext">
+
+  <Set name="contextPath">/setbycontextxml</Set>
+
+</Configure>

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/jetty-simple-webapp/src/config/jetty-env.xml
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/jetty-simple-webapp/src/config/jetty-env.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://eclipse.dev/jetty/configure_10_0.dtd">
+<Configure id='wac' class="org.eclipse.jetty.ee10.webapp.WebAppContext">
+
+  <!-- Add an EnvEntry only valid for this webapp               -->
+  <New id="foo"  class="org.eclipse.jetty.plus.jndi.EnvEntry">
+    <Arg><Ref refid='wac'/></Arg>
+    <Arg>fooBoolean</Arg>
+    <Arg type="java.lang.Double">100</Arg>
+    <Arg type="boolean">true</Arg>
+  </New>
+</Configure>

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/jetty-simple-webapp/src/config/jetty.xml
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/jetty-simple-webapp/src/config/jetty.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
+
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+  <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+    <Set name="secureScheme">https</Set>
+    <Set name="securePort"><Property name="jetty.secure.port" default="8443" /></Set>
+    <Set name="outputBufferSize">32768</Set>
+    <Set name="requestHeaderSize">8192</Set>
+    <Set name="responseHeaderSize">8192</Set>
+    <Set name="headerCacheSize">1024</Set>
+  </New>
+
+  <Call name="addConnector">
+    <Arg>
+      <New class="org.eclipse.jetty.server.ServerConnector">
+        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="factories">
+          <Array type="org.eclipse.jetty.server.ConnectionFactory">
+            <Item>
+              <New class="org.eclipse.jetty.server.HttpConnectionFactory">
+                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+              </New>
+            </Item>
+          </Array>
+        </Arg>
+        <Call name="addEventListener">
+          <Arg>
+            <New class="org.eclipse.jetty.maven.ServerConnectorListener">
+              <Set name="fileName"><Property name="jetty.port.file" default="port.txt"/></Set>
+            </New>
+          </Arg>
+        </Call>
+        <Set name="host" property="jetty.host"/>
+        <Set name="port" property="jetty.port"/>
+        <Set name="idleTimeout">30000</Set>
+      </New>
+    </Arg>
+  </Call>
+</Configure>

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/jetty-simple-webapp/src/config/realm.properties
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/jetty-simple-webapp/src/config/realm.properties
@@ -1,0 +1,6 @@
+jetty: MD5:164c88b302622e17050af52c89945d44,user
+admin: CRYPT:adpexzg3FUZAk,server-administrator,content-administrator,admin
+other: OBF:1xmk1w261u9r1w1c1xmq,user
+plain: plain,user
+user: password,user
+

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/jetty-simple-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/jetty-simple-webapp/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
+  <display-name>Jetty Simple Webapp run-mojo-it</display-name>
+
+   <security-constraint>
+    <web-resource-collection>
+      <web-resource-name>Any Authenticated User</web-resource-name>
+      <url-pattern>/auth/*</url-pattern>
+    </web-resource-collection>
+    <auth-constraint>
+      <role-name>*</role-name>
+    </auth-constraint>
+  </security-constraint>
+
+  <login-config>
+    <auth-method>FORM</auth-method>
+    <realm-name>Test Realm</realm-name>
+    <form-login-config>
+       <form-login-page>/logon.html?param=test</form-login-page>
+       <form-error-page>/logonError.html?param=test</form-error-page>
+    </form-login-config>
+  </login-config>
+
+</web-app>

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/jetty-simple-webapp/src/main/webapp/auth/index.html
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/jetty-simple-webapp/src/main/webapp/auth/index.html
@@ -1,0 +1,3 @@
+<html>
+    <h1>Authenticated</h1>
+</html>

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/jetty-simple-webapp/src/main/webapp/jsp/bean1.jsp
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/jetty-simple-webapp/src/main/webapp/jsp/bean1.jsp
@@ -1,0 +1,13 @@
+<html>
+<%@ page session="true"%>
+<body>
+<jsp:useBean id='counter' scope='session' class='org.eclipse.jetty.its.jetty_start_mojo_it.Counter' type="org.eclipse.jetty.its.jetty_start_mojo_it.Counter" />
+
+<h1>JSP1.2 Beans: 1</h1>
+
+Counter accessed <jsp:getProperty name="counter" property="count"/> times.<br/>
+Counter last accessed by <jsp:getProperty name="counter" property="last"/><br/>
+<jsp:setProperty name="counter" property="last" value="<%= request.getRequestURI()%>"/>
+
+</body>
+</html>

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/jetty-simple-webapp/src/main/webapp/logon.html
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/jetty-simple-webapp/src/main/webapp/logon.html
@@ -1,0 +1,20 @@
+<html>
+<h1>FORM Authentication demo</h1>
+<form method="POST" action="j_security_check">
+    <table border="0" cellspacing="2" cellpadding="1">
+        <tr>
+            <td>Username:</td>
+            <td><input size="12" value="" name="j_username" maxlength="25" type="text"></td>
+        </tr>
+        <tr>
+            <td>Password:</td>
+            <td><input size="12" value="" name="j_password" maxlength="25" type="password"></td>
+        </tr>
+        <tr>
+            <td colspan="2" align="center">
+                <input name="submit" type="submit" value="Login">
+            </td>
+        </tr>
+    </table>
+</form>
+</html>

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/jetty-simple-webapp/src/main/webapp/logonError.html
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/jetty-simple-webapp/src/main/webapp/logonError.html
@@ -1,0 +1,4 @@
+<html>
+<h1>Authentication ERROR</h1>
+Username, password or role incorrect.
+</html>

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/pom.xml
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.jetty.ee10.its</groupId>
+    <artifactId>it-parent-pom</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.eclipse.jetty.ee10.its.jetty-start-mojo-it</groupId>
+  <artifactId>jetty-simple-project</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>EE10 :: Simple</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <java.version>1.8</java.version>
+    <jetty.version>@project.version@</jetty.version>
+  </properties>
+
+  <modules>
+    <module>jetty-simple-base</module>
+    <module>jetty-simple-webapp</module>
+  </modules>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee10.its.jetty-start-mojo-it</groupId>
+        <artifactId>jetty-simple-base</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+</project>

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/postbuild.groovy
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/it/jetty-start with spaces mojo-it/postbuild.groovy
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+File buildLog = new File( basedir, 'build.log' )
+assert buildLog.text.contains( 'Started Server' )
+assert buildLog.text.contains( 'Running org.eclipse.jetty.ee10.maven.plugin.it.IntegrationTestGetContent')
+assert buildLog.text.contains( 'pingServlet ok')
+assert buildLog.text.contains( 'helloServlet')

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/MavenWebAppContext.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/MavenWebAppContext.java
@@ -231,7 +231,7 @@ public class MavenWebAppContext extends WebAppContext
             // This is a user provided list of configurations.
             // We have to assume that mounting can happen.
             List<URI> uris = Stream.of(resourceBases)
-                .map(URI::create)
+                .map(URIUtil::toURI)
                 .toList();
 
             setBaseResource(this.getResourceFactory().newResource(uris));

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/MavenWebAppContext.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/MavenWebAppContext.java
@@ -233,7 +233,7 @@ public class MavenWebAppContext extends WebAppContext
             // This is a user provided list of configurations.
             // We have to assume that mounting can happen.
             List<URI> uris = Stream.of(resourceBases)
-                .map(URI::create)
+                .map(URIUtil::toURI)
                 .toList();
             Resource r = ResourceFactory.of(this).newResource(uris);
 


### PR DESCRIPTION
Restore `URIUtil.toURI(String)`, properly javadoc it, and use it where end-user provided Strings are given.
Include maven-plugin IT test that replicates reported issue.

Fixes #12000