### PR TITLE
Ensure expired Set-Cookie not present on push as per spec

### DIFF
--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletApiRequest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletApiRequest.java
@@ -795,7 +795,8 @@ public class ServletApiRequest implements HttpServletRequest
                     }
                     continue;
                 }
-                cookies.add(httpCookie);
+                else
+                    cookies.add(httpCookie);
             }
         }
 

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletApiRequest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletApiRequest.java
@@ -796,7 +796,9 @@ public class ServletApiRequest implements HttpServletRequest
                     continue;
                 }
                 else
-                    cookies.add(httpCookie);
+                {
+                     cookies.add(httpCookie);
+                }
             }
         }
 


### PR DESCRIPTION
According to the tck, we need to ensure that an expired cookie that is created during the handling of a request is never present on server push.  See  https://github.com/jetty/jetty.project/issues/11931#issuecomment-2180190672.

This PR just ensures that such a cookie will never be given to the push builder.