### PR TITLE
Jetty 12.1.x tck error message

### DIFF
--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ErrorHandler.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ErrorHandler.java
@@ -73,6 +73,14 @@ public class ErrorHandler implements Request.Handler
         };
     }
 
+    private static Object getRequestErrorAttribute(HttpServletRequest request, String servletApiName, String jettyName)
+    {
+        Object o = request.getAttribute(servletApiName);
+        if (o == null)
+            o = request.getAttribute(jettyName);
+        return o;
+    }
+
     @Override
     public boolean handle(Request request, Response response, Callback callback) throws Exception
     {
@@ -126,7 +134,7 @@ public class ErrorHandler implements Request.Handler
             }
         }
 
-        String message = (String)request.getAttribute(Dispatcher.ERROR_MESSAGE);
+        String message = (String)getRequestErrorAttribute(httpServletRequest, Dispatcher.ERROR_MESSAGE, org.eclipse.jetty.server.handler.ErrorHandler.ERROR_MESSAGE);
         if (message == null)
             message = HttpStatus.getMessage(response.getStatus());
         generateAcceptableResponse(servletContextRequest, httpServletRequest, httpServletResponse, response.getStatus(), message);
@@ -416,7 +424,7 @@ public class ErrorHandler implements Request.Handler
         {
             htmlRow(writer, "SERVLET", request.getAttribute(Dispatcher.ERROR_SERVLET_NAME));
         }
-        Throwable cause = (Throwable)request.getAttribute(Dispatcher.ERROR_EXCEPTION);
+        Throwable cause = (Throwable)getRequestErrorAttribute(request, Dispatcher.ERROR_EXCEPTION, org.eclipse.jetty.server.handler.ErrorHandler.ERROR_EXCEPTION);
         while (cause != null)
         {
             htmlRow(writer, "CAUSED BY", cause);
@@ -451,7 +459,7 @@ public class ErrorHandler implements Request.Handler
         {
             writer.printf("SERVLET: %s%n", request.getAttribute(Dispatcher.ERROR_SERVLET_NAME));
         }
-        Throwable cause = (Throwable)request.getAttribute(Dispatcher.ERROR_EXCEPTION);
+        Throwable cause = (Throwable)getRequestErrorAttribute(request, Dispatcher.ERROR_EXCEPTION, org.eclipse.jetty.server.handler.ErrorHandler.ERROR_EXCEPTION);
         while (cause != null)
         {
             writer.printf("CAUSED BY %s%n", cause);
@@ -465,7 +473,7 @@ public class ErrorHandler implements Request.Handler
 
     protected void writeErrorJson(HttpServletRequest request, PrintWriter writer, int code, String message)
     {
-        Throwable cause = (Throwable)request.getAttribute(Dispatcher.ERROR_EXCEPTION);
+        Throwable cause = (Throwable)getRequestErrorAttribute(request, Dispatcher.ERROR_EXCEPTION, org.eclipse.jetty.server.handler.ErrorHandler.ERROR_EXCEPTION);
         Object servlet = request.getAttribute(Dispatcher.ERROR_SERVLET_NAME);
         Map<String, String> json = new HashMap<>();
 
@@ -490,7 +498,7 @@ public class ErrorHandler implements Request.Handler
 
     protected void writeErrorPageStacks(HttpServletRequest request, Writer writer) throws IOException
     {
-        Throwable th = (Throwable)request.getAttribute(RequestDispatcher.ERROR_EXCEPTION);
+        Throwable th = (Throwable)getRequestErrorAttribute(request, RequestDispatcher.ERROR_EXCEPTION, org.eclipse.jetty.server.handler.ErrorHandler.ERROR_EXCEPTION);
         if (th != null)
         {
             writer.write("<h3>Caused by:</h3><pre>");

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ErrorHandler.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ErrorHandler.java
@@ -73,11 +73,22 @@ public class ErrorHandler implements Request.Handler
         };
     }
 
-    private static Object getRequestErrorAttribute(HttpServletRequest request, String servletApiName, String jettyName)
+    /**
+     * Look up an attribute in the request that contains an exception message
+     * to use during an error dispatch. We first try the name of the attribute
+     * as defined by the servlet spec, falling back to checking a similar jetty
+     * core attribute name, if there is one.
+     *
+     * @param request the request from which to obtain the error attribute
+     * @param servletAttributeName the name of the attribute according to the servlet api
+     * @param jettyAttributeName the name of the attribute according to core jetty
+     * @return the exception message to use during the error dispatch or null
+     */
+    private static Object getRequestErrorAttribute(HttpServletRequest request, String servletAttributeName, String jettyAttributeName)
     {
-        Object o = request.getAttribute(servletApiName);
+        Object o = request.getAttribute(servletAttributeName);
         if (o == null)
-            o = request.getAttribute(jettyName);
+            o = request.getAttribute(jettyAttributeName);
         return o;
     }
 
@@ -134,6 +145,7 @@ public class ErrorHandler implements Request.Handler
             }
         }
 
+        //TODO we should refactor the servlet ErrorHandler to extend and use most of the core ErrorHandler to use the core error attributes
         String message = (String)getRequestErrorAttribute(httpServletRequest, Dispatcher.ERROR_MESSAGE, org.eclipse.jetty.server.handler.ErrorHandler.ERROR_MESSAGE);
         if (message == null)
             message = HttpStatus.getMessage(response.getStatus());


### PR DESCRIPTION
This PR fixes the output of ErrorHandler in accordance with TCK expectations. See https://github.com/jetty/jetty.project/issues/11931#issuecomment-2179847257.

There is also a branch for entirely refactoring the servlet api `ErrorHandler` (https://github.com/jetty/jetty.project/tree/jetty-12.1.x-refactor-servlet-error-handler) however that is orthogonal to this fix.