### PR TITLE
Make `Fields` interpret null values as empty strings

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Fields.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Fields.java
@@ -190,8 +190,9 @@ public class Fields implements Iterable<Fields.Field>
      */
     public void put(String name, String value)
     {
+        String v = value == null ? "" : value;
         // Preserve the case for the field name
-        Field field = new Field(name, value);
+        Field field = new Field(name, v);
         fields.put(name, field);
     }
 
@@ -218,13 +219,14 @@ public class Fields implements Iterable<Fields.Field>
      */
     public void add(String name, String value)
     {
+        String v = value == null ? "" : value;
         fields.compute(name, (k, f) ->
         {
             if (f == null)
                 // Preserve the case for the field name
-                return new Field(name, value);
+                return new Field(name, v);
             else
-                return new Field(f.getName(), f.getValues(), value);
+                return new Field(f.getName(), f.getValues(), v);
         });
     }
 
@@ -246,10 +248,27 @@ public class Fields implements Iterable<Fields.Field>
             fields.compute(name, (k, f) ->
             {
                 if (f == null)
-                    return new Field(name, List.of(values));
+                    return new Field(name, toList(values));
                 else
-                    return new Field(f.getName(), f.getValues(), List.of(values));
+                    return new Field(f.getName(), f.getValues(), toList(values));
             });
+        }
+    }
+
+    static List<String> toList(String... strings)
+    {
+        try
+        {
+            return List.of(strings);
+        }
+        catch (NullPointerException e)
+        {
+            List<String> result = new ArrayList<>(strings.length);
+            for (String s : strings)
+            {
+                result.add(s == null ? "" : s);
+            }
+            return Collections.unmodifiableList(result);
         }
     }
 

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Fields.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Fields.java
@@ -248,27 +248,10 @@ public class Fields implements Iterable<Fields.Field>
             fields.compute(name, (k, f) ->
             {
                 if (f == null)
-                    return new Field(name, toList(values));
+                    return new Field(name, StringUtil.toListNonNull(values));
                 else
-                    return new Field(f.getName(), f.getValues(), toList(values));
+                    return new Field(f.getName(), f.getValues(), StringUtil.toListNonNull(values));
             });
-        }
-    }
-
-    static List<String> toList(String... strings)
-    {
-        try
-        {
-            return List.of(strings);
-        }
-        catch (NullPointerException e)
-        {
-            List<String> result = new ArrayList<>(strings.length);
-            for (String s : strings)
-            {
-                result.add(s == null ? "" : s);
-            }
-            return Collections.unmodifiableList(result);
         }
     }
 

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Fields.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Fields.java
@@ -190,9 +190,8 @@ public class Fields implements Iterable<Fields.Field>
      */
     public void put(String name, String value)
     {
-        String v = value == null ? "" : value;
         // Preserve the case for the field name
-        Field field = new Field(name, v);
+        Field field = new Field(name, StringUtil.nonNull(value));
         fields.put(name, field);
     }
 
@@ -219,14 +218,13 @@ public class Fields implements Iterable<Fields.Field>
      */
     public void add(String name, String value)
     {
-        String v = value == null ? "" : value;
         fields.compute(name, (k, f) ->
         {
             if (f == null)
                 // Preserve the case for the field name
-                return new Field(name, v);
+                return new Field(name, StringUtil.nonNull(value));
             else
-                return new Field(f.getName(), f.getValues(), v);
+                return new Field(f.getName(), f.getValues(), StringUtil.nonNull(value));
         });
     }
 

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/StringUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/StringUtil.java
@@ -540,6 +540,23 @@ public class StringUtil
         return s;
     }
 
+    /**
+     * Convert an array of strings to a list of non-null strings.
+     *
+     * @param strings the array
+     * @return The list of non-null strings.
+     * @see #nonNull(String)
+     */
+    public static List<String> toListNonNull(String... strings)
+    {
+        List<String> result = new ArrayList<>(strings.length);
+        for (String s : strings)
+        {
+            result.add(nonNull(s));
+        }
+        return result;
+    }
+
     public static boolean equals(String s, char[] buf, int offset, int length)
     {
         if (s.length() != length)

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/FieldsTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/FieldsTest.java
@@ -82,4 +82,18 @@ public class FieldsTest
 
         assertThat(set, containsInAnyOrder("x", "y", "z"));
     }
+
+    @Test
+    public void testNullValues()
+    {
+        Fields fields = new Fields();
+        fields.add("x", (String)null);
+        fields.add("y", "1", null, "2");
+        fields.put("z", null);
+
+        assertThat(fields.getSize(), equalTo(3));
+        assertThat(fields.getValues("x"), contains(""));
+        assertThat(fields.getValues("y"), contains("1", "", "2"));
+        assertThat(fields.getValues("z"), contains(""));
+    }
 }


### PR DESCRIPTION
`HttpRequest` on the client used to interpret null parameter values as empty strings in Jetty 11, and some of the 12 code still contains such checks, e.g.:

```java
    private String urlEncode(String value)
    {
        if (value == null)
            return "";

        return URLEncoder.encode(value, StandardCharsets.UTF_8);
    }
```

but the `Fields` class throws NPE when a null value is given.

This PR makes `Fields` consider a null value as empty strings.

Fixes #12018