### PR TITLE
Fix NPE when GzipHandler is writing and an exception is thrown by the wrapping's Response.write()

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipResponseAndCallback.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipResponseAndCallback.java
@@ -326,6 +326,7 @@ public class GzipResponseAndCallback extends Response.Wrapper implements Callbac
         {
             if (_deflaterEntry != null)
             {
+                _state.set(GZState.FINISHED);
                 _deflaterEntry.release();
                 _deflaterEntry = null;
             }
@@ -381,6 +382,7 @@ public class GzipResponseAndCallback extends Response.Wrapper implements Callbac
         {
             if (_deflaterEntry != null)
             {
+                _state.set(GZState.FINISHED);
                 _deflaterEntry.release();
                 _deflaterEntry = null;
             }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipResponseAndCallback.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipResponseAndCallback.java
@@ -72,6 +72,7 @@ public class GzipResponseAndCallback extends Response.Wrapper implements Callbac
     private final int _bufferSize;
     private final boolean _syncFlush;
     private DeflaterPool.Entry _deflaterEntry;
+    private RetainableByteBuffer _buffer;
     private boolean _last;
 
     public GzipResponseAndCallback(GzipHandler handler, Request request, Response response, Callback callback)
@@ -302,7 +303,6 @@ public class GzipResponseAndCallback extends Response.Wrapper implements Callbac
     {
         private final ByteBuffer _content;
         private final boolean _last;
-        private RetainableByteBuffer _buffer;
 
         public GzipBufferCB(boolean complete, Callback callback, ByteBuffer content)
         {
@@ -319,13 +319,6 @@ public class GzipResponseAndCallback extends Response.Wrapper implements Callbac
 
             if (LOG.isDebugEnabled())
                 LOG.debug("GzipBufferCB(complete={}, callback={}, content={})", complete, callback, BufferUtil.toDetailString(content));
-        }
-
-        @Override
-        protected void onCompleteSuccess()
-        {
-            cleanup();
-            super.onCompleteSuccess();
         }
 
         @Override
@@ -349,6 +342,7 @@ public class GzipResponseAndCallback extends Response.Wrapper implements Callbac
                 // then the trailer has been generated and written below.
                 // We have finished compressing the entire content, so
                 // cleanup and succeed.
+                cleanup();
                 return Action.SUCCEEDED;
             }
 

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/gzip/GzipHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/gzip/GzipHandlerTest.java
@@ -59,6 +59,7 @@ import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.eclipse.jetty.server.handler.ResourceHandler;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
@@ -192,6 +193,61 @@ public class GzipHandlerTest
 
         _contextHandler = new ContextHandler("/ctx");
         _gzipHandler.setHandler(_contextHandler);
+    }
+
+    @Test
+    public void testFailureDuringGzipWrite() throws Exception
+    {
+        Handler leafHandler = new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            {
+                try (var out = Content.Sink.asOutputStream(response))
+                {
+                    out.write("Hello, Jetty".getBytes(StandardCharsets.UTF_8));
+                }
+                return true;
+            }
+        };
+        Handler rootHandler = new Handler.Wrapper(new GzipHandler(leafHandler))
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            {
+                return super.handle(request, new Response.Wrapper(request, response)
+                {
+                    @Override
+                    public void write(boolean last, ByteBuffer byteBuffer, Callback callback)
+                    {
+                        throw new StacklessException("expected");
+                    }
+                }, callback);
+            }
+        };
+        _server.setHandler(rootHandler);
+        ErrorHandler errorHandler = new ErrorHandler();
+        errorHandler.setShowStacks(true);
+        errorHandler.setShowCauses(true);
+        _server.setErrorHandler(errorHandler);
+        _server.start();
+
+        // generated and parsed test
+        HttpTester.Request request = HttpTester.newRequest();
+        HttpTester.Response response;
+
+        request.setMethod("GET");
+        request.setURI("/");
+        request.setVersion("HTTP/1.0");
+        request.setHeader("Host", "tester");
+        request.setHeader("accept-encoding", "gzip");
+
+        response = HttpTester.parseResponse(_connector.getResponse(request.generate()));
+
+        assertThat(response.getStatus(), is(500));
+        String content = response.getContent();
+        assertThat(content, containsString("StacklessException: expected"));
+        assertThat(content, not(containsString("Suppressed: ")));
     }
 
     @Test
@@ -2051,6 +2107,20 @@ public class GzipHandlerTest
             else if (request.getLength() >= 0)
                 MatcherAssert.assertThat(request.getHeaders().get("X-Content-Encoding"), nullValue());
             return super.handle(request, response, callback);
+        }
+    }
+
+    public static class StacklessException extends RuntimeException
+    {
+        public StacklessException(String message)
+        {
+            super(message);
+        }
+
+        @Override
+        public synchronized Throwable fillInStackTrace()
+        {
+            return this;
         }
     }
 }


### PR DESCRIPTION
`GzipBufferCB` does not set the `GZState` to `FINISHED` when it fails, which leaves the code trying to finish up gzipping while everything has already been cleaned up.

Fixes #12022