### PR TITLE
Issue #12019 ensure cmd line properties files applied

### DIFF
--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
@@ -656,14 +656,14 @@ public class StartArgs
                 cmd.addArg(propPath.toAbsolutePath().toString());
             }
 
-            for (Path xml : jettyEnvironment.getXmlFiles())
-            {
-                cmd.addArg(xml.toAbsolutePath().toString());
-            }
-
             for (Path propertyFile : jettyEnvironment.getPropertyFiles())
             {
                 cmd.addArg(propertyFile.toAbsolutePath().toString());
+            }
+
+            for (Path xml : jettyEnvironment.getXmlFiles())
+            {
+                cmd.addArg(xml.toAbsolutePath().toString());
             }
         }
 


### PR DESCRIPTION
Closes #12019 

Extra properties files on the command line were being passed as args to `XmlConfiguration` _after_ the xml files. As `XmlConfiguration` has changed to be order-specific, this meant that the properties were not being applied.