### PR TITLE
Expose File integration point for ee9 / ee8 MultiPart.Part parsing

### DIFF
--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/MultiPart.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/MultiPart.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.List;
 
 import jakarta.servlet.MultipartConfigElement;
-import jakarta.servlet.http.Part;
 import org.eclipse.jetty.http.ComplianceViolation;
 import org.eclipse.jetty.http.MultiPartCompliance;
 
@@ -62,5 +61,28 @@ class MultiPart
         Collection<Part> getParts() throws IOException;
 
         List<ComplianceViolation.Event> getNonComplianceWarnings();
+    }
+
+    /**
+     * Expose File of MultiPart section.
+     *
+     * @deprecated this interface is not available in ee10 or newer.
+     */
+    @Deprecated(since = "12.0.12", forRemoval = true)
+    public interface Part extends jakarta.servlet.http.Part
+    {
+        /**
+         * Get the file
+         *
+         * @return the file, if any, the data has been written to.
+         */
+        File getFile();
+
+        /**
+         * Get the filename from the content-disposition.
+         *
+         * @return null or the filename
+         */
+        String getContentDispositionFilename();
     }
 }

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/MultiPart.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/MultiPart.java
@@ -56,9 +56,9 @@ class MultiPart
     {
         void deleteParts();
 
-        Part getPart(String name) throws IOException;
+        jakarta.servlet.http.Part getPart(String name) throws IOException;
 
-        Collection<Part> getParts() throws IOException;
+        Collection<jakarta.servlet.http.Part> getParts() throws IOException;
 
         List<ComplianceViolation.Event> getNonComplianceWarnings();
     }

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/MultiPartFormInputStream.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/MultiPartFormInputStream.java
@@ -121,7 +121,7 @@ public class MultiPartFormInputStream implements MultiPart.Parser
         return _nonComplianceWarnings;
     }
 
-    public class MultiPart implements Part
+    public class MultiPart implements org.eclipse.jetty.ee9.nested.MultiPart.Part
     {
         protected String _name;
         protected String _filename;
@@ -352,6 +352,7 @@ public class MultiPartFormInputStream implements MultiPart.Parser
          *
          * @return the file, if any, the data has been written to.
          */
+        @Override
         public File getFile()
         {
             return _file;
@@ -362,6 +363,7 @@ public class MultiPartFormInputStream implements MultiPart.Parser
          *
          * @return null or the filename
          */
+        @Override
         public String getContentDispositionFilename()
         {
             return _filename;

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/MultiPartInputStreamLegacyParser.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/MultiPartInputStreamLegacyParser.java
@@ -97,7 +97,7 @@ class MultiPartInputStreamLegacyParser implements MultiPart.Parser
         return nonComplianceWarnings;
     }
 
-    public class MultiPart implements Part
+    public class MultiPart implements org.eclipse.jetty.ee9.nested.MultiPart.Part
     {
         protected String _name;
         protected String _filename;
@@ -361,6 +361,7 @@ class MultiPartInputStreamLegacyParser implements MultiPart.Parser
          *
          * @return the file, if any, the data has been written to.
          */
+        @Override
         public File getFile()
         {
             return _file;
@@ -371,6 +372,7 @@ class MultiPartInputStreamLegacyParser implements MultiPart.Parser
          *
          * @return null or the filename
          */
+        @Override
         public String getContentDispositionFilename()
         {
             return _filename;

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/MultiPartInputStreamLegacyParser.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/MultiPartInputStreamLegacyParser.java
@@ -464,7 +464,7 @@ class MultiPartInputStreamLegacyParser implements MultiPart.Parser
      * @throws IOException if unable to get the parts
      */
     @Override
-    public Collection<Part> getParts()
+    public Collection<jakarta.servlet.http.Part> getParts()
         throws IOException
     {
         if (!_parsed)


### PR DESCRIPTION
The legacy `multipart/form-data` parser in ee9/ee8 called `MultiPartInputStreamLegacyParser` has an internal `File` representation that is not accessible for deep integration.

Introduce a new `org.eclipse.jetty.ee9.nested.MultiPart.Part` (based on `jakarta.servlet.http.Part`) to expose this information in both the legacy and normal parsers for those that have deep integration with Jetty.
