### PR TITLE
Fix Regression on ee9 / ee8 MultiPart parsing

### DIFF
--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/MultiPartFormInputStream.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/MultiPartFormInputStream.java
@@ -38,6 +38,7 @@ import java.util.stream.Collectors;
 import jakarta.servlet.MultipartConfigElement;
 import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.Part;
+import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.ComplianceViolation;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.MultiPartCompliance;
@@ -617,6 +618,14 @@ public class MultiPartFormInputStream implements MultiPart.Parser
                 }
                 else if (len == -1)
                 {
+                    if (total == 0)
+                    {
+                        throw new BadMessageException(
+                            "No progress made on multipart/form-data",
+                            new IOException("Missing content for multipart request")
+                        );
+                    }
+
                     parser.parse(BufferUtil.EMPTY_BUFFER, true);
                     break;
                 }

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/MultiPartFormInputStream.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/MultiPartFormInputStream.java
@@ -38,7 +38,6 @@ import java.util.stream.Collectors;
 import jakarta.servlet.MultipartConfigElement;
 import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.Part;
-import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.ComplianceViolation;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.MultiPartCompliance;
@@ -618,14 +617,6 @@ public class MultiPartFormInputStream implements MultiPart.Parser
                 }
                 else if (len == -1)
                 {
-                    if (total == 0)
-                    {
-                        throw new BadMessageException(
-                            "No progress made on multipart/form-data",
-                            new IOException("Missing content for multipart request")
-                        );
-                    }
-
                     parser.parse(BufferUtil.EMPTY_BUFFER, true);
                     break;
                 }
@@ -641,7 +632,7 @@ public class MultiPartFormInputStream implements MultiPart.Parser
             if (parser.getState() != MultiPartParser.State.END)
             {
                 if (parser.getState() == MultiPartParser.State.PREAMBLE)
-                    _err = new IOException("Missing initial multi part boundary");
+                    _err = new IOException("Missing content for multipart request");
                 else
                     _err = new IOException("Incomplete Multipart");
             }

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/MultiPartInputStreamLegacyParser.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/MultiPartInputStreamLegacyParser.java
@@ -41,6 +41,7 @@ import java.util.Locale;
 import jakarta.servlet.MultipartConfigElement;
 import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.Part;
+import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.ComplianceViolation;
 import org.eclipse.jetty.http.MultiPartCompliance;
 import org.eclipse.jetty.util.ByteArrayOutputStream2;
@@ -578,7 +579,12 @@ class MultiPartInputStreamLegacyParser implements MultiPart.Parser
             }
 
             if (line == null)
-                throw new IOException("Missing content for multipart request");
+            {
+                throw new BadMessageException(
+                    "No progress made on multipart/form-data",
+                    new IOException("Missing content for multipart request")
+                );
+            }
 
             boolean badFormatLogged = false;
 

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/MultiPartInputStreamLegacyParser.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/MultiPartInputStreamLegacyParser.java
@@ -705,7 +705,7 @@ class MultiPartInputStreamLegacyParser implements MultiPart.Parser
                 // Check if we can create a new part.
                 _numParts++;
                 if (_maxParts >= 0 && _numParts > _maxParts)
-                    throw new IllegalStateException(String.format("Form with too many parts [%d > %d]", _numParts, _maxParts));
+                    throw new IllegalStateException(String.format("Form with too many keys [%d > %d]", _numParts, _maxParts));
 
                 //Have a new Part
                 MultiPart part = new MultiPart(name, filename);

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/MultiPartInputStreamLegacyParser.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/MultiPartInputStreamLegacyParser.java
@@ -869,7 +869,7 @@ class MultiPartInputStreamLegacyParser implements MultiPart.Parser
                         MultiPartCompliance.Violation.LF_LINE_TERMINATION, "0x10"));
             }
             else
-                throw new IOException("Incomplete parts");
+                throw new IOException("Incomplete Multipart");
         }
         catch (Exception e)
         {

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/MultiPartInputStreamLegacyParser.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/MultiPartInputStreamLegacyParser.java
@@ -41,7 +41,6 @@ import java.util.Locale;
 import jakarta.servlet.MultipartConfigElement;
 import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.Part;
-import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.ComplianceViolation;
 import org.eclipse.jetty.http.MultiPartCompliance;
 import org.eclipse.jetty.util.ByteArrayOutputStream2;
@@ -579,12 +578,7 @@ class MultiPartInputStreamLegacyParser implements MultiPart.Parser
             }
 
             if (line == null)
-            {
-                throw new BadMessageException(
-                    "No progress made on multipart/form-data",
-                    new IOException("Missing content for multipart request")
-                );
-            }
+                throw new IOException("Missing content for multipart request");
 
             boolean badFormatLogged = false;
 
@@ -604,7 +598,7 @@ class MultiPartInputStreamLegacyParser implements MultiPart.Parser
             }
 
             if (line == null || line.length() == 0)
-                throw new IOException("Missing initial multi part boundary");
+                throw new IOException("Missing content for multipart request");
 
             // Empty multipart.
             if (line.equals(lastBoundary))

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
@@ -2044,7 +2044,16 @@ public class Request implements HttpServletRequest
             MultiPartCompliance multiPartCompliance = getHttpChannel().getHttpConfiguration().getMultiPartCompliance();
 
             _multiParts = newMultiParts(multiPartCompliance, config, maxFormKeys);
-            Collection<Part> parts = _multiParts.getParts();
+
+            Collection<Part> parts;
+            try
+            {
+                parts = _multiParts.getParts();
+            }
+            catch (IOException e)
+            {
+                throw new BadMessageException("Unable to parse form content", e);
+            }
             reportComplianceViolations();
 
             String formCharset = null;

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
@@ -515,7 +515,7 @@ public class Request implements HttpServletRequest
                         String msg = "Unable to extract content parameters";
                         if (LOG.isDebugEnabled())
                             LOG.debug(msg, e);
-                        throw new RuntimeIOException(msg, e);
+                        throw new BadMessageException(msg, e);
                     }
                 }
             }

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/MultiPartServletTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/MultiPartServletTest.java
@@ -333,7 +333,7 @@ public class MultiPartServletTest
             else if (multiPartCompliance == MultiPartCompliance.LEGACY)
             {
                 assertThat(responseContent, containsString("Unable to extract content parameters"));
-                assertThat(responseContent, containsString("Incomplete parts"));
+                assertThat(responseContent, containsString("Incomplete Multipart"));
             }
         });
     }

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/MultiPartServletTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/MultiPartServletTest.java
@@ -526,7 +526,7 @@ public class MultiPartServletTest
             assertThat(headers.get(HttpHeader.CONTENT_TYPE), startsWith("multipart/form-data"));
             assertThat(headers.get(HttpHeader.CONTENT_ENCODING), is("gzip"));
 
-            try(InputStream inputStream = new GZIPInputStream(responseStream.getInputStream()))
+            try (InputStream inputStream = new GZIPInputStream(responseStream.getInputStream()))
             {
                 String contentType = headers.get(HttpHeader.CONTENT_TYPE);
                 MultiPartFormInputStream mpis = new MultiPartFormInputStream(inputStream, contentType, null, null);


### PR DESCRIPTION
In Jetty 10 / Jetty 11 when a `multipart/form-data` is sent with an empty request body, it would result in an error status 400 (Bad Request).

The implementation in ee9 / ee8 in Jetty 12 returns an error status 500.

Introduce test cases and fix to restore this behavior.