### PR TITLE
Jetty 10 Upgrade quiche to version 0.22.0

### DIFF
--- a/jetty-quic/quic-quiche/quic-quiche-foreign-incubator/src/main/java/org/eclipse/jetty/quic/quiche/foreign/incubator/quiche_h.java
+++ b/jetty-quic/quic-quiche/quic-quiche-foreign-incubator/src/main/java/org/eclipse/jetty/quic/quiche/foreign/incubator/quiche_h.java
@@ -33,7 +33,7 @@ public class quiche_h
 {
     // This interface is a translation of the quiche.h header of a specific version.
     // It needs to be reviewed each time the native lib version changes.
-    private static final String EXPECTED_QUICHE_VERSION = "0.21.0";
+    private static final String EXPECTED_QUICHE_VERSION = "0.22.0";
 
     public static final byte C_FALSE = 0;
     public static final byte C_TRUE = 1;
@@ -312,8 +312,8 @@ public class quiche_h
 
     private static final MethodHandle quiche_conn_stream_send$MH = downcallHandle(
         "quiche_conn_stream_send",
-        "(Ljdk/incubator/foreign/MemoryAddress;JLjdk/incubator/foreign/MemoryAddress;JB)J",
-        FunctionDescriptor.of(C_LONG, C_POINTER, C_LONG, C_POINTER, C_LONG, C_CHAR)
+        "(Ljdk/incubator/foreign/MemoryAddress;JLjdk/incubator/foreign/MemoryAddress;JBLjdk/incubator/foreign/MemoryAddress;)J",
+        FunctionDescriptor.of(C_LONG, C_POINTER, C_LONG, C_POINTER, C_LONG, C_CHAR, C_POINTER)
     );
 
     private static final MethodHandle quiche_conn_stream_writable$MH = downcallHandle(
@@ -324,8 +324,8 @@ public class quiche_h
 
     private static final MethodHandle quiche_conn_stream_recv$MH = downcallHandle(
         "quiche_conn_stream_recv",
-        "(Ljdk/incubator/foreign/MemoryAddress;JLjdk/incubator/foreign/MemoryAddress;JLjdk/incubator/foreign/MemoryAddress;)J",
-        FunctionDescriptor.of(C_LONG, C_POINTER, C_LONG, C_POINTER, C_LONG, C_POINTER)
+        "(Ljdk/incubator/foreign/MemoryAddress;JLjdk/incubator/foreign/MemoryAddress;JLjdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)J",
+        FunctionDescriptor.of(C_LONG, C_POINTER, C_LONG, C_POINTER, C_LONG, C_POINTER, C_POINTER)
     );
 
     private static final MethodHandle quiche_stream_iter_next$MH = downcallHandle(
@@ -658,11 +658,11 @@ public class quiche_h
         }
     }
 
-    public static long quiche_conn_stream_recv(MemoryAddress conn, long stream_id, MemoryAddress buf, long buf_len, MemoryAddress fin)
+    public static long quiche_conn_stream_recv(MemoryAddress conn, long stream_id, MemoryAddress buf, long buf_len, MemoryAddress fin, MemoryAddress outErrorCode)
     {
         try
         {
-            return (long) quiche_conn_stream_recv$MH.invokeExact(conn, stream_id, buf, buf_len, fin);
+            return (long) quiche_conn_stream_recv$MH.invokeExact(conn, stream_id, buf, buf_len, fin, outErrorCode);
         }
         catch (Throwable ex)
         {
@@ -670,11 +670,11 @@ public class quiche_h
         }
     }
 
-    public static long quiche_conn_stream_send(MemoryAddress conn, long stream_id, MemoryAddress buf, long buf_len, byte fin)
+    public static long quiche_conn_stream_send(MemoryAddress conn, long stream_id, MemoryAddress buf, long buf_len, byte fin, MemoryAddress outErrorCode)
     {
         try
         {
-            return (long) quiche_conn_stream_send$MH.invokeExact(conn, stream_id, buf, buf_len, fin);
+            return (long) quiche_conn_stream_send$MH.invokeExact(conn, stream_id, buf, buf_len, fin, outErrorCode);
         }
         catch (Throwable ex)
         {

--- a/jetty-quic/quic-quiche/quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/JnaQuicheConnection.java
+++ b/jetty-quic/quic-quiche/quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/JnaQuicheConnection.java
@@ -690,7 +690,8 @@ public class JnaQuicheConnection extends QuicheConnection
         {
             if (quicheConn == null)
                 throw new IOException("connection was released");
-            int written = LibQuiche.INSTANCE.quiche_conn_stream_send(quicheConn, new uint64_t(streamId), jnaBuffer(buffer), new size_t(buffer.remaining()), last).intValue();
+            uint64_t_pointer outErrorCode = new uint64_t_pointer();
+            int written = LibQuiche.INSTANCE.quiche_conn_stream_send(quicheConn, new uint64_t(streamId), jnaBuffer(buffer), new size_t(buffer.remaining()), last, outErrorCode).intValue();
             if (written == quiche_error.QUICHE_ERR_DONE)
             {
                 int rc = LibQuiche.INSTANCE.quiche_conn_stream_writable(quicheConn, new uint64_t(streamId), new size_t(buffer.remaining()));
@@ -742,7 +743,8 @@ public class JnaQuicheConnection extends QuicheConnection
             if (quicheConn == null)
                 throw new IOException("connection was released");
             bool_pointer fin = new bool_pointer();
-            int read = LibQuiche.INSTANCE.quiche_conn_stream_recv(quicheConn, new uint64_t(streamId), buffer, new size_t(buffer.remaining()), fin).intValue();
+            uint64_t_pointer outErrorCode = new uint64_t_pointer();
+            int read = LibQuiche.INSTANCE.quiche_conn_stream_recv(quicheConn, new uint64_t(streamId), buffer, new size_t(buffer.remaining()), fin, outErrorCode).intValue();
             if (read == quiche_error.QUICHE_ERR_DONE)
                 return isStreamFinished(streamId) ? -1 : 0;
             if (read < 0L)

--- a/jetty-quic/quic-quiche/quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/LibQuiche.java
+++ b/jetty-quic/quic-quiche/quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/LibQuiche.java
@@ -31,7 +31,7 @@ public interface LibQuiche extends Library
 {
     // This interface is a translation of the quiche.h header of a specific version.
     // It needs to be reviewed each time the native lib version changes.
-    String EXPECTED_QUICHE_VERSION = "0.21.0";
+    String EXPECTED_QUICHE_VERSION = "0.22.0";
 
     // The charset used to convert java.lang.String to char * and vice versa.
     Charset CHARSET = StandardCharsets.UTF_8;
@@ -540,10 +540,18 @@ public interface LibQuiche extends Library
     void quiche_stream_iter_free(quiche_stream_iter iter);
 
     // Reads contiguous data from a stream.
-    ssize_t quiche_conn_stream_recv(quiche_conn conn, uint64_t stream_id, ByteBuffer out, size_t buf_len, bool_pointer fin);
+    // out_error_code is only set when STREAM_STOPPED or STREAM_RESET are returned.
+    // Set to the reported error code associated with STOP_SENDING or STREAM_RESET.
+    ssize_t quiche_conn_stream_recv(quiche_conn conn, uint64_t stream_id,
+                                    ByteBuffer out, size_t buf_len, bool_pointer fin,
+                                    uint64_t_pointer out_error_code);
 
     // Writes data to a stream.
-    ssize_t quiche_conn_stream_send(quiche_conn conn, uint64_t stream_id, ByteBuffer buf, size_t buf_len, boolean fin);
+    // out_error_code is only set when STREAM_STOPPED or STREAM_RESET are returned.
+    // Set to the reported error code associated with STOP_SENDING or STREAM_RESET.
+    ssize_t quiche_conn_stream_send(quiche_conn conn, uint64_t stream_id,
+                                    ByteBuffer buf, size_t buf_len, boolean fin,
+                                    uint64_t_pointer out_error_code);
 
     // Frees the connection object.
     void quiche_conn_free(quiche_conn conn);

--- a/pom.xml
+++ b/pom.xml
@@ -265,7 +265,7 @@
     <jboss.logging.processor.version>2.2.1.Final</jboss.logging.processor.version>
     <jboss.logging.version>3.6.0.Final</jboss.logging.version>
     <jetty-assembly-descriptors.version>1.1</jetty-assembly-descriptors.version>
-    <jetty-quiche-native.version>0.21.0</jetty-quiche-native.version>
+    <jetty-quiche-native.version>0.22.0</jetty-quiche-native.version>
     <jetty-test-policy.version>1.2</jetty-test-policy.version>
     <jetty-version.maven.plugin.version>2.7</jetty-version.maven.plugin.version>
     <jetty.perf-helper.version>1.0.7</jetty.perf-helper.version>


### PR DESCRIPTION
This is already done in 12 (https://github.com/jetty/jetty.project/pull/11995) but needs to be backported to 10.