### PR TITLE
Issue #12044 ensure temp dir cleaned up

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -804,6 +804,12 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
         }
     }
 
+    /** Generate a reasonable name for the temp directory because one has not be
+     * explicitly configured by the user. The directory may also be created, if
+     * it is not persistent. If it is persistent it will be created as necessary by
+     * {@link #createTempDirectory()} later during the startup of the context.
+     * @throws Exception
+     */
     protected void makeTempDirectory()
         throws Exception
     {
@@ -836,6 +842,19 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
         _createdTempDirectoryName = true;
     }
 
+    /**
+     * Create a canonical name for a context temp directory.
+     * <p>
+     * The form of the name is:
+     *
+     * <pre>"jetty-"+host+"-"+port+"-"+resourceBase+"-_"+context+"-"+virtualhost+"-"+randomdigits+".dir"</pre>
+     *
+     * host and port uniquely identify the server
+     * context and virtual host uniquely identify the context
+     * randomdigits ensure every tmp directory is unique
+     *
+     * @return the canonical name for the context temp directory
+     */
     protected String getCanonicalNameForTmpDir()
     {
         StringBuilder canonicalName = new StringBuilder();
@@ -911,11 +930,18 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
         return StringUtil.sanitizeFileSystemName(canonicalName.toString());
     }
 
+    /**
+     * @return the baseResource for the context to use in the temp dir name
+     */
     protected Resource getResourceForTempDirName()
     {
         return getBaseResource();
     }
 
+    /**
+     * @param resource the resource whose filename minus suffix to extract
+     * @return the filename of the resource without suffix
+     */
     protected static String getBaseName(Resource resource)
     {
         // Use File System and File interface if present

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -258,7 +258,8 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
         {
             try
             {
-                if (tempDirectory == null || (!Files.isSameFile(oldTempDirectory.toPath(), tempDirectory.toPath())))
+                //if we had made up the name of the tmp directory previously, delete it if the new name is different
+                if (_createdTempDirectoryName && (tempDirectory == null || (!Files.isSameFile(oldTempDirectory.toPath(), tempDirectory.toPath()))))
                     IO.delete(oldTempDirectory);
             }
             catch (Exception e)

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -252,6 +252,7 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
             }
         }
         _tempDirectory = tempDirectory;
+         _createdTempDirectoryName = false;
     }
 
     /**

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -788,7 +788,13 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
 
         // if we're not persisting the temp dir contents delete it
         if (tempDirectory != null && tempDirectory.exists() && !isTempDirectoryPersistent())
+        {
             IO.delete(tempDirectory);
+        }
+
+        //if it was jetty that created the tmp dir, it can be reset, otherwise we need to retain the name
+        if ((getAttribute("org.eclipse.jetty.tmpdirCreated") instanceof Boolean tmpdirCreated && tmpdirCreated))
+            setTempDirectory(null);
     }
 
     public boolean checkVirtualHost(Request request)

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
@@ -1503,6 +1503,12 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
         return super.getCanonicalNameForTmpDir();
     }
 
+    /**
+     * If the webapp has no baseresource yet, use
+     * the war to make the temp directory name.
+     *
+     * @return the baseresource if non null, or the war
+     */
     @Override
     protected Resource getResourceForTempDirName()
     {

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
@@ -1491,6 +1491,34 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
         return _metadata;
     }
 
+    @Override
+    protected void makeTempDirectory() throws Exception
+    {
+        super.makeTempDirectory();
+    }
+
+    @Override
+    protected String getCanonicalNameForTmpDir()
+    {
+        return super.getCanonicalNameForTmpDir();
+    }
+
+    @Override
+    protected Resource getResourceForTempDirName()
+    {
+        Resource resource = super.getResourceForTempDirName();
+
+        if (resource == null)
+        {
+            if (getWar() == null || getWar().length() == 0)
+                throw new IllegalStateException("No resourceBase or war set for context");
+
+            // Use name of given resource in the temporary dirname
+            resource = newResource(getWar());
+        }
+        return resource;
+    }
+
     /**
      * Add a Server Class pattern to use for all WebAppContexts.
      * @param server The {@link Server} instance to add classes to

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebInfConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebInfConfiguration.java
@@ -366,7 +366,9 @@ public class WebInfConfiguration extends AbstractConfiguration
      *
      * @param context the context to get the canonical name from
      * @return the canonical name for the webapp temp directory
+     * @deprecated this method is no longer used
      */
+    @Deprecated(forRemoval = true, since = "12.0.12")
     public static String getCanonicalNameForWebAppTmpDir(WebAppContext context)
     {
        return context.getCanonicalNameForTmpDir();

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebInfConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebInfConfiguration.java
@@ -39,7 +39,7 @@ public class WebInfConfiguration extends AbstractConfiguration
 {
     private static final Logger LOG = LoggerFactory.getLogger(WebInfConfiguration.class);
 
-    public static final String TEMPDIR_CONFIGURED = "org.eclipse.jetty.tmpdirConfigured";
+    public static final String TEMPDIR_CREATED = "org.eclipse.jetty.tmpdirCreated";
     public static final String TEMPORARY_RESOURCE_BASE = "org.eclipse.jetty.webapp.tmpResourceBase";
     public static final String ORIGINAL_RESOURCE_BASE = "org.eclipse.jetty.webapp.originalResourceBase";
 
@@ -89,10 +89,6 @@ public class WebInfConfiguration extends AbstractConfiguration
     @Override
     public void deconfigure(WebAppContext context) throws Exception
     {
-        //if it wasn't explicitly configured by the user, then unset it
-        if (!(context.getAttribute(TEMPDIR_CONFIGURED) instanceof Boolean tmpdirConfigured && tmpdirConfigured))
-            context.setTempDirectory(null);
-
         //reset the base resource back to what it was before we did any unpacking of resources
         Resource originalBaseResource = (Resource)context.removeAttribute(ORIGINAL_RESOURCE_BASE);
         context.setBaseResource(originalBaseResource);
@@ -133,7 +129,6 @@ public class WebInfConfiguration extends AbstractConfiguration
         File tempDirectory = context.getTempDirectory();
         if (tempDirectory != null)
         {
-            context.setAttribute(TEMPDIR_CONFIGURED, Boolean.TRUE); //the tmp dir was set explicitly
             return;
         }
 
@@ -179,6 +174,7 @@ public class WebInfConfiguration extends AbstractConfiguration
             LOG.debug("Set temp dir {}", tmpDir);
         context.setTempDirectory(tmpDir);
         context.setTempDirectoryPersistent(persistent);
+        context.setAttribute(TEMPDIR_CREATED, Boolean.TRUE);
     }
 
     public void unpack(WebAppContext context) throws IOException

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebInfConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebInfConfiguration.java
@@ -39,7 +39,6 @@ public class WebInfConfiguration extends AbstractConfiguration
 {
     private static final Logger LOG = LoggerFactory.getLogger(WebInfConfiguration.class);
 
-    public static final String TEMPDIR_CREATED = "org.eclipse.jetty.tmpdirCreated";
     public static final String TEMPORARY_RESOURCE_BASE = "org.eclipse.jetty.webapp.tmpResourceBase";
     public static final String ORIGINAL_RESOURCE_BASE = "org.eclipse.jetty.webapp.originalResourceBase";
 
@@ -143,38 +142,14 @@ public class WebInfConfiguration extends AbstractConfiguration
             return;
         }
 
-        makeTempDirectory(context.getServer().getContext().getTempDirectory(), context);
+        context.makeTempDirectory();
     }
 
+    @Deprecated (forRemoval = true, since = "12.0.12")
     public void makeTempDirectory(File parent, WebAppContext context)
         throws Exception
     {
-        if (parent == null || !parent.exists() || !parent.canWrite() || !parent.isDirectory())
-            throw new IllegalStateException("Parent for temp dir not configured correctly: " + (parent == null ? "null" : "writeable=" + parent.canWrite()));
-
-        boolean persistent = context.isTempDirectoryPersistent() || "work".equals(parent.toPath().getFileName().toString());
-
-        //Create a name for the webapp
-        String temp = getCanonicalNameForWebAppTmpDir(context);
-        File tmpDir;
-        if (persistent)
-        {
-            //if it is to be persisted, make sure it will be the same name
-            //by not using File.createTempFile, which appends random digits
-            tmpDir = new File(parent, temp);
-        }
-        else
-        {
-            // ensure dir will always be unique by having classlib generate random path name
-            tmpDir = Files.createTempDirectory(parent.toPath(), temp).toFile();
-            tmpDir.deleteOnExit();
-        }
-
-        if (LOG.isDebugEnabled())
-            LOG.debug("Set temp dir {}", tmpDir);
-        context.setTempDirectory(tmpDir);
-        context.setTempDirectoryPersistent(persistent);
-        context.setAttribute(TEMPDIR_CREATED, Boolean.TRUE);
+        context.makeTempDirectory();
     }
 
     public void unpack(WebAppContext context) throws IOException
@@ -394,88 +369,15 @@ public class WebInfConfiguration extends AbstractConfiguration
      */
     public static String getCanonicalNameForWebAppTmpDir(WebAppContext context)
     {
-        StringBuilder canonicalName = new StringBuilder();
-        canonicalName.append("jetty-");
-
-        //get the host and the port from the first connector
-        Server server = context.getServer();
-        if (server != null)
-        {
-            Connector[] connectors = server.getConnectors();
-
-            if (connectors.length > 0)
-            {
-                //Get the host
-                String host = null;
-                int port = 0;
-                if (connectors[0] instanceof NetworkConnector connector)
-                {
-                    host = connector.getHost();
-                    port = connector.getLocalPort();
-                    if (port < 0)
-                        port = connector.getPort();
-                }
-                if (host == null)
-                    host = "0.0.0.0";
-                canonicalName.append(host);
-                canonicalName.append("-");
-                canonicalName.append(port);
-                canonicalName.append("-");
-            }
-        }
-
-        // Resource base
-        try
-        {
-            Resource resource = context.getBaseResource();
-            if (resource == null)
-            {
-                if (context.getWar() == null || context.getWar().length() == 0)
-                    throw new IllegalStateException("No resourceBase or war set for context");
-
-                // Set dir or WAR to resource
-                resource = context.newResource(context.getWar());
-            }
-
-            String resourceBaseName = getResourceBaseName(resource);
-            canonicalName.append(resourceBaseName);
-            canonicalName.append("-");
-        }
-        catch (Exception e)
-        {
-            if (LOG.isDebugEnabled())
-                LOG.debug("Can't get resource base name", e);
-
-            canonicalName.append("-"); // empty resourceBaseName segment
-        }
-
-        //Context name
-        String contextPath = context.getContextPath();
-        contextPath = contextPath.replace('/', '_');
-        contextPath = contextPath.replace('\\', '_');
-        canonicalName.append(contextPath);
-
-        //Virtual host (if there is one)
-        canonicalName.append("-");
-        List<String> vhosts = context.getVirtualHosts();
-        if (vhosts == null || vhosts.size() <= 0)
-            canonicalName.append("any");
-        else
-            canonicalName.append(vhosts.get(0));
-
-        // sanitize
-        for (int i = 0; i < canonicalName.length(); i++)
-        {
-            char c = canonicalName.charAt(i);
-            if (!Character.isJavaIdentifierPart(c) && "-.".indexOf(c) < 0)
-                canonicalName.setCharAt(i, '.');
-        }
-
-        canonicalName.append("-");
-
-        return StringUtil.sanitizeFileSystemName(canonicalName.toString());
+       return context.getCanonicalNameForTmpDir();
     }
 
+    /**
+     * @param resource the Resource for which to extract a short name
+     * @return extract a short name for the resource
+     * @deprecated this method is no longer needed
+     */
+    @Deprecated(forRemoval = true, since = "12.0.12")
     protected static String getResourceBaseName(Resource resource)
     {
         // Use File System and File interface if present

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/TempDirTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/TempDirTest.java
@@ -31,7 +31,6 @@ import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.IO;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -40,6 +39,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @ExtendWith(WorkDirExtension.class)
 public class TempDirTest
@@ -174,6 +175,7 @@ public class TempDirTest
         _server.start();
         File tempDirectory = webAppContext.getTempDirectory();
         webAppContext.stop();
+        assertNull(webAppContext.getTempDirectory());
         webAppContext.start();
         assertThat(tempDirectory.toPath(), not(PathMatchers.isSame(webAppContext.getTempDirectory().toPath())));
     }
@@ -208,6 +210,7 @@ public class TempDirTest
         File tempDirectory = webAppContext.getTempDirectory();
         assertThat(tempDirectory.toPath(), PathMatchers.isSame(configuredTmpDir));
         webAppContext.stop();
+        assertNotNull(webAppContext.getTempDirectory());
         webAppContext.start();
         assertThat(tempDirectory.toPath(), PathMatchers.isSame(webAppContext.getTempDirectory().toPath()));
     }
@@ -239,5 +242,6 @@ public class TempDirTest
         File tempDirectory = webAppContext.getTempDirectory();
         _server.stop();
         assertThat("Temp dir exists", !Files.exists(tempDirectory.toPath()));
+        assertNull(webAppContext.getTempDirectory());
     }
  }

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/TempDirTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/TempDirTest.java
@@ -178,7 +178,6 @@ public class TempDirTest
         assertThat(tempDirectory.toPath(), not(PathMatchers.isSame(webAppContext.getTempDirectory().toPath())));
     }
 
-    @Disabled ("Enable after issue 11548 fixed")
     @Test
     public void testSameTempDir(WorkDir workDir) throws Exception
     {
@@ -212,4 +211,33 @@ public class TempDirTest
         webAppContext.start();
         assertThat(tempDirectory.toPath(), PathMatchers.isSame(webAppContext.getTempDirectory().toPath()));
     }
-}
+
+    @Test
+    public void testTempDirDeleted(WorkDir workDir) throws Exception
+    {
+        // Create war on the fly
+        Path testWebappDir = MavenTestingUtils.getProjectDirPath("src/test/webapp");
+        Path warFile = workDir.getEmptyPathDir().resolve("test.war");
+
+        Map<String, String> env = new HashMap<>();
+        env.put("create", "true");
+
+        URI uri = URI.create("jar:" + warFile.toUri().toASCIIString());
+        // Use ZipFS so that we can create paths that are just "/"
+        try (FileSystem zipfs = FileSystems.newFileSystem(uri, env))
+        {
+            Path root = zipfs.getPath("/");
+            IO.copyDir(testWebappDir, root);
+        }
+
+         _server = new Server();
+        WebAppContext webAppContext = new WebAppContext();
+        webAppContext.setContextPath("/");
+        webAppContext.setWarResource(webAppContext.getResourceFactory().newResource(warFile));
+        _server.setHandler(webAppContext);
+        _server.start();
+        File tempDirectory = webAppContext.getTempDirectory();
+        _server.stop();
+        assertThat("Temp dir exists", !Files.exists(tempDirectory.toPath()));
+    }
+ }

--- a/jetty-ee8/jetty-ee8-webapp/src/test/webapp/WEB-INF/web.xml
+++ b/jetty-ee8/jetty-ee8-webapp/src/test/webapp/WEB-INF/web.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- // -->
+<!-- // ======================================================================== -->
+<!-- // Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others. -->
+<!-- // -->
+<!-- // This program and the accompanying materials are made available under the -->
+<!-- // terms of the Eclipse Public License v. 2.0 which is available at -->
+<!-- // https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0 -->
+<!-- // which is available at https://www.apache.org/licenses/LICENSE-2.0. -->
+<!-- // -->
+<!-- // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 -->
+<!-- // ======================================================================== -->
+<!-- // -->
+
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+         http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+  version="3.1">
+
+
+</web-app>

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
@@ -2674,6 +2674,24 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
         }
 
         @Override
+        public void makeTempDirectory() throws Exception
+        {
+            super.makeTempDirectory();
+        }
+
+        @Override
+        public String getCanonicalNameForTmpDir()
+        {
+            return super.getCanonicalNameForTmpDir();
+        }
+
+        @Override
+        public Resource getResourceForTempDirName()
+        {
+           return super.getResourceForTempDirName();
+        }
+
+        @Override
         public void setContextPath(String contextPath)
         {
             super.setContextPath(contextPath);

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
@@ -1171,6 +1171,31 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
         return getCoreContextHandler().getTempDirectory();
     }
 
+    protected void makeTempDirectory() throws Exception
+    {
+        getCoreContextHandler().makeTempDirectory();
+    }
+
+    protected String getCanonicalNameForTmpDir()
+    {
+        return getCoreContextHandler().getCanonicalNameForTmpDir();
+    }
+
+    protected Resource getResourceForTempDirName()
+    {
+        Resource resource = getCoreContextHandler().getResourceForTempDirName();
+
+        if (resource == null)
+        {
+            if (getWar() == null || getWar().length() == 0)
+                throw new IllegalStateException("No resourceBase or war set for context");
+
+            // Use name of given resource in the temporary dirname
+            resource = getResourceFactory().newResource(getWar());
+        }
+        return resource;
+    }
+
     /**
      * If true the temp directory for this
      * webapp will be kept when the webapp stops. Otherwise,

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebInfConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebInfConfiguration.java
@@ -38,7 +38,7 @@ public class WebInfConfiguration extends AbstractConfiguration
 {
     private static final Logger LOG = LoggerFactory.getLogger(WebInfConfiguration.class);
 
-    public static final String TEMPDIR_CONFIGURED = "org.eclipse.jetty.tmpdirConfigured";
+    public static final String TEMPDIR_CREATED = "org.eclipse.jetty.tmpdirCreated";
     public static final String TEMPORARY_RESOURCE_BASE = "org.eclipse.jetty.webapp.tmpResourceBase";
 
     protected Resource _preUnpackBaseResource;
@@ -83,10 +83,6 @@ public class WebInfConfiguration extends AbstractConfiguration
     @Override
     public void deconfigure(WebAppContext context) throws Exception
     {
-        //if it wasn't explicitly configured by the user, then unset it
-        if (!(context.getAttribute(TEMPDIR_CONFIGURED) instanceof Boolean tmpdirConfigured && tmpdirConfigured))
-            context.setTempDirectory(null);
-
         //reset the base resource back to what it was before we did any unpacking of resources
         context.setBaseResource(_preUnpackBaseResource);
     }
@@ -135,7 +131,6 @@ public class WebInfConfiguration extends AbstractConfiguration
         File tempDirectory = context.getTempDirectory();
         if (tempDirectory != null)
         {
-            context.setAttribute(TEMPDIR_CONFIGURED, Boolean.TRUE); //the tmp dir was set explicitly
             return;
         }
 
@@ -181,6 +176,7 @@ public class WebInfConfiguration extends AbstractConfiguration
             LOG.debug("Set temp dir {}", tmpDir);
         context.setTempDirectory(tmpDir);
         context.setPersistTempDirectory(persistent);
+        context.setAttribute(TEMPDIR_CREATED, Boolean.TRUE);
     }
 
     public void unpack(WebAppContext context) throws IOException

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebInfConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebInfConfiguration.java
@@ -38,7 +38,6 @@ public class WebInfConfiguration extends AbstractConfiguration
 {
     private static final Logger LOG = LoggerFactory.getLogger(WebInfConfiguration.class);
 
-    public static final String TEMPDIR_CREATED = "org.eclipse.jetty.tmpdirCreated";
     public static final String TEMPORARY_RESOURCE_BASE = "org.eclipse.jetty.webapp.tmpResourceBase";
 
     protected Resource _preUnpackBaseResource;
@@ -145,38 +144,14 @@ public class WebInfConfiguration extends AbstractConfiguration
             return;
         }
 
-        makeTempDirectory(context.getServer().getContext().getTempDirectory(), context);
+        context.makeTempDirectory();
     }
 
+    @Deprecated(forRemoval = true, since = "12.0.12")
     public void makeTempDirectory(File parent, WebAppContext context)
         throws Exception
     {
-        if (parent == null || !parent.exists() || !parent.canWrite() || !parent.isDirectory())
-            throw new IllegalStateException("Parent for temp dir not configured correctly: " + (parent == null ? "null" : "writeable=" + parent.canWrite()));
-
-        boolean persistent = context.isPersistTempDirectory() || "work".equals(parent.toPath().getFileName().toString());
-
-        //Create a name for the webapp
-        String temp = getCanonicalNameForWebAppTmpDir(context);
-        File tmpDir;
-        if (persistent)
-        {
-            //if it is to be persisted, make sure it will be the same name
-            //by not using File.createTempFile, which appends random digits
-            tmpDir = new File(parent, temp);
-        }
-        else
-        {
-            // ensure dir will always be unique by having classlib generate random path name
-            tmpDir = Files.createTempDirectory(parent.toPath(), temp).toFile();
-            tmpDir.deleteOnExit();
-        }
-
-        if (LOG.isDebugEnabled())
-            LOG.debug("Set temp dir {}", tmpDir);
-        context.setTempDirectory(tmpDir);
-        context.setPersistTempDirectory(persistent);
-        context.setAttribute(TEMPDIR_CREATED, Boolean.TRUE);
+        context.makeTempDirectory();
     }
 
     public void unpack(WebAppContext context) throws IOException
@@ -393,94 +368,10 @@ public class WebInfConfiguration extends AbstractConfiguration
      */
     public static String getCanonicalNameForWebAppTmpDir(WebAppContext context)
     {
-        StringBuffer canonicalName = new StringBuffer();
-        canonicalName.append("jetty-");
-
-        //get the host and the port from the first connector
-        Server server = context.getServer();
-        if (server != null)
-        {
-            Connector[] connectors = context.getServer().getConnectors();
-
-            if (connectors.length > 0)
-            {
-                //Get the host
-                String host = null;
-                int port = 0;
-                if (connectors != null && (connectors[0] instanceof NetworkConnector))
-                {
-                    NetworkConnector connector = (NetworkConnector)connectors[0];
-                    host = connector.getHost();
-                    port = connector.getLocalPort();
-                    if (port < 0)
-                        port = connector.getPort();
-                }
-                if (host == null)
-                    host = "0.0.0.0";
-                canonicalName.append(host);
-
-                //Get the port
-                canonicalName.append("-");
-
-                //if not available (eg no connectors or connector not started),
-                //try getting one that was configured.
-                canonicalName.append(port);
-                canonicalName.append("-");
-            }
-        }
-
-        // Resource base
-        try
-        {
-            Resource resource = context.getBaseResource();
-            if (resource == null)
-            {
-                if (context.getWar() == null || context.getWar().length() == 0)
-                    throw new IllegalStateException("No resourceBase or war set for context");
-
-                // Set dir or WAR to resource
-                resource = context.newResource(context.getWar());
-            }
-
-            String resourceBaseName = getResourceBaseName(resource);
-            canonicalName.append(resourceBaseName);
-            canonicalName.append("-");
-        }
-        catch (Exception e)
-        {
-            if (LOG.isDebugEnabled())
-                LOG.debug("Can't get resource base name", e);
-
-            canonicalName.append("-"); // empty resourceBaseName segment
-        }
-
-        //Context name
-        String contextPath = context.getContextPath();
-        contextPath = contextPath.replace('/', '_');
-        contextPath = contextPath.replace('\\', '_');
-        canonicalName.append(contextPath);
-
-        //Virtual host (if there is one)
-        canonicalName.append("-");
-        String[] vhosts = context.getVirtualHosts();
-        if (vhosts == null || vhosts.length <= 0)
-            canonicalName.append("any");
-        else
-            canonicalName.append(vhosts[0]);
-
-        // sanitize
-        for (int i = 0; i < canonicalName.length(); i++)
-        {
-            char c = canonicalName.charAt(i);
-            if (!Character.isJavaIdentifierPart(c) && "-.".indexOf(c) < 0)
-                canonicalName.setCharAt(i, '.');
-        }
-
-        canonicalName.append("-");
-
-        return StringUtil.sanitizeFileSystemName(canonicalName.toString());
+        return context.getCanonicalNameForTmpDir();
     }
 
+    @Deprecated(forRemoval = true, since = "12.0.12")
     protected static String getResourceBaseName(Resource resource)
     {
         // Use File System and File interface if present

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/TempDirTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/TempDirTest.java
@@ -41,6 +41,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(WorkDirExtension.class)
@@ -165,6 +166,7 @@ public class TempDirTest
             IO.copyDir(testWebappDir, root);
         }
 
+        //Let jetty create the tmp dir on the fly
         Server server = new Server();
         WebAppContext webAppContext = new WebAppContext();
         webAppContext.setContextPath("/");
@@ -173,6 +175,7 @@ public class TempDirTest
         server.start();
         File tempDirectory = webAppContext.getTempDirectory();
         server.stop();
+        assertNull(webAppContext.getTempDirectory());
         assertThat("Temp dir exists", !Files.exists(tempDirectory.toPath()));
     }
 }

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/TempDirTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/TempDirTest.java
@@ -14,15 +14,22 @@
 package org.eclipse.jetty.ee9.webapp;
 
 import java.io.File;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
 
 import jakarta.servlet.ServletContext;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.toolchain.test.FS;
+import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.toolchain.test.PathMatchers;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
+import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.resource.FileSystemPool;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -138,5 +145,34 @@ public class TempDirTest
         server.setHandler(webAppContext);
         webInfConfiguration.resolveTempDirectory(webAppContext);
         assertThat(webAppContext.getTempDirectory().getParentFile().toPath(), PathMatchers.isSame(workDir));
+    }
+
+    @Test
+    public void testTempDirDeleted(WorkDir workDir) throws Exception
+    {
+        // Create war on the fly
+        Path testWebappDir = MavenTestingUtils.getProjectDirPath("src/test/webapp");
+        Path warFile = workDir.getEmptyPathDir().resolve("test.war");
+
+        Map<String, String> env = new HashMap<>();
+        env.put("create", "true");
+
+        URI uri = URI.create("jar:" + warFile.toUri().toASCIIString());
+        // Use ZipFS so that we can create paths that are just "/"
+        try (FileSystem zipfs = FileSystems.newFileSystem(uri, env))
+        {
+            Path root = zipfs.getPath("/");
+            IO.copyDir(testWebappDir, root);
+        }
+
+        Server server = new Server();
+        WebAppContext webAppContext = new WebAppContext();
+        webAppContext.setContextPath("/");
+        webAppContext.setWarResource(webAppContext.getResourceFactory().newResource(warFile));
+        server.setHandler(webAppContext);
+        server.start();
+        File tempDirectory = webAppContext.getTempDirectory();
+        server.stop();
+        assertThat("Temp dir exists", !Files.exists(tempDirectory.toPath()));
     }
 }


### PR DESCRIPTION
Ensure that a temporary directory that has been created by jetty and is not persistent is cleared up. Also ensure that if the user sets a temporary directory, but does not want it persisted that the same directory can be reused between restarts.