### PR TITLE
Issue #12023 - Remove WriteFlusher.Listener.

### DIFF
--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/WriteFlusher.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/WriteFlusher.java
@@ -426,13 +426,6 @@ public abstract class WriteFlusher
             if (LOG.isDebugEnabled())
                 LOG.debug("Flushed={} written={} remaining={} {}", flushed, written, after, this);
 
-            if (written > 0)
-            {
-                Connection connection = _endPoint.getConnection();
-                if (connection instanceof Listener listener)
-                    listener.onFlushed(written);
-            }
-
             if (flushed)
                 return null;
 
@@ -576,31 +569,5 @@ public abstract class WriteFlusher
     {
         State s = _state.get();
         return String.format("WriteFlusher@%x{%s}->%s", hashCode(), s, s instanceof PendingState ? ((PendingState)s)._callback : null);
-    }
-
-    /**
-     * <p>A listener of {@link WriteFlusher} events.
-     * If implemented by a Connection class, the {@link #onFlushed(long)} event will be delivered to it.</p>
-     *
-     * @deprecated functionality removed, no replacement
-     */
-    @Deprecated(since = "12.0.10", forRemoval = true)
-    public interface Listener
-    {
-        /**
-         * <p>Invoked when a {@link WriteFlusher} flushed bytes in a non-blocking way,
-         * as part of a - possibly larger - write.</p>
-         * <p>This method may be invoked multiple times, for example when writing a large
-         * buffer: a first flush of bytes, then the connection became TCP congested, and
-         * a subsequent flush of bytes when the connection became writable again.</p>
-         * <p>This method is never invoked concurrently, but may be invoked by different
-         * threads, so implementations may not rely on thread-local variables.</p>
-         * <p>Implementations may throw an {@link IOException} to signal that the write
-         * should fail, for example if the implementation enforces a minimum data rate.</p>
-         *
-         * @param bytes the number of bytes flushed
-         * @throws IOException if the write should fail
-         */
-        void onFlushed(long bytes) throws IOException;
     }
 }

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
@@ -24,7 +24,6 @@ import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
 import java.util.concurrent.CancellationException;
-import java.util.concurrent.TimeUnit;
 
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletOutputStream;
@@ -1242,30 +1241,6 @@ public class HttpOutput extends ServletOutputStream implements Runnable
     {
         _bufferSize = size;
         _commitSize = size;
-    }
-
-    /**
-     * <p>Invoked when bytes have been flushed to the network.</p>
-     *
-     * @param bytes the number of bytes flushed
-     * @throws IOException if the minimum data rate, when set, is not respected
-     * @see org.eclipse.jetty.io.WriteFlusher.Listener
-     */
-    public void onFlushed(long bytes) throws IOException
-    {
-        if (_firstByteNanoTime == -1 || _firstByteNanoTime == Long.MAX_VALUE)
-            return;
-        long minDataRate = _servletChannel.getConnectionMetaData().getHttpConfiguration().getMinResponseDataRate();
-        _flushed += bytes;
-        long minFlushed = minDataRate * NanoTime.millisSince(_firstByteNanoTime) / TimeUnit.SECONDS.toMillis(1);
-        if (LOG.isDebugEnabled())
-            LOG.debug("Flushed bytes min/actual {}/{}", minFlushed, _flushed);
-        if (_flushed < minFlushed)
-        {
-            IOException ioe = new IOException(String.format("Response content data rate < %d B/s", minDataRate));
-            _servletChannel.abort(ioe);
-            throw ioe;
-        }
     }
 
     public void recycle()

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/HttpOutput.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/HttpOutput.java
@@ -24,7 +24,6 @@ import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
 import java.util.concurrent.CancellationException;
-import java.util.concurrent.TimeUnit;
 
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletOutputStream;
@@ -1244,30 +1243,6 @@ public class HttpOutput extends ServletOutputStream implements Runnable
     {
         _bufferSize = size;
         _commitSize = size;
-    }
-
-    /**
-     * <p>Invoked when bytes have been flushed to the network.</p>
-     *
-     * @param bytes the number of bytes flushed
-     * @throws IOException if the minimum data rate, when set, is not respected
-     * @see org.eclipse.jetty.io.WriteFlusher.Listener
-     */
-    public void onFlushed(long bytes) throws IOException
-    {
-        if (_firstByteNanoTime == -1 || _firstByteNanoTime == Long.MAX_VALUE)
-            return;
-        long minDataRate = _servletChannel.getConnectionMetaData().getHttpConfiguration().getMinResponseDataRate();
-        _flushed += bytes;
-        long minFlushed = minDataRate * NanoTime.millisSince(_firstByteNanoTime) / TimeUnit.SECONDS.toMillis(1);
-        if (LOG.isDebugEnabled())
-            LOG.debug("Flushed bytes min/actual {}/{}", minFlushed, _flushed);
-        if (_flushed < minFlushed)
-        {
-            IOException ioe = new IOException(String.format("Response content data rate < %d B/s", minDataRate));
-            _servletChannel.abort(ioe);
-            throw ioe;
-        }
     }
 
     public void recycle()

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpOutput.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpOutput.java
@@ -24,7 +24,6 @@ import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
 import java.util.concurrent.CancellationException;
-import java.util.concurrent.TimeUnit;
 
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletOutputStream;
@@ -1416,35 +1415,6 @@ public class HttpOutput extends ServletOutputStream implements Runnable
     {
         _bufferSize = size;
         _commitSize = size;
-    }
-
-    /**
-     * <p>Invoked when bytes have been flushed to the network.</p>
-     * <p>The number of flushed bytes may be different from the bytes written
-     * by the application if an {@link Interceptor} changed them, for example
-     * by compressing them.</p>
-     *
-     * @param bytes the number of bytes flushed
-     * @throws IOException if the minimum data rate, when set, is not respected
-     * @see org.eclipse.jetty.io.WriteFlusher.Listener
-     */
-    public void onFlushed(long bytes) throws IOException
-    {
-        // TODO not called.... do we need this now?
-        if (_firstByteNanoTime == -1 || _firstByteNanoTime == Long.MAX_VALUE)
-            return;
-        long minDataRate = getHttpChannel().getHttpConfiguration().getMinResponseDataRate();
-        _flushed += bytes;
-        long elapsed = NanoTime.since(_firstByteNanoTime);
-        long minFlushed = minDataRate * TimeUnit.NANOSECONDS.toMillis(elapsed) / TimeUnit.SECONDS.toMillis(1);
-        if (LOG.isDebugEnabled())
-            LOG.debug("Flushed bytes min/actual {}/{}", minFlushed, _flushed);
-        if (_flushed < minFlushed)
-        {
-            IOException ioe = new IOException(String.format("Response content data rate < %d B/s", minDataRate));
-            _channel.abort(ioe);
-            throw ioe;
-        }
     }
 
     public void recycle()


### PR DESCRIPTION
WriteFlusher.Listener functionality was removed, and the class deprecated in 12.0.10 as part of the work for #9778 and #11839.