### PR TITLE
Cleanup and javadoc `HttpContent` API

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/HttpContent.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/HttpContent.java
@@ -19,77 +19,144 @@ import java.util.Set;
 
 import org.eclipse.jetty.http.CompressedContentFormat;
 import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.MimeTypes.Type;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.resource.Resource;
 
 /**
- * HttpContent interface.
- * <p>This information represents all the information about a
- * static resource that is needed to evaluate conditional headers
- * and to serve the content if need be.     It can be implemented
- * either transiently (values and fields generated on demand) or
- * persistently (values and fields pre-generated in anticipation of
- * reuse in from a cache).
+ * <p>The {@code HttpContent} interface represents all the information about a
+ * static {@link Resource} that is needed to evaluate conditional headers
+ * and to eventually serve the actual content.
+ * It can be implemented either transiently (values and fields generated on
+ * demand) or persistently (values and fields pre-generated in anticipation
+ * of reuse in from a cache).
  * </p>
  */
 public interface HttpContent
 {
+    /**
+     * Get the {@link HttpHeader#CONTENT_TYPE} of this HTTP content.
+     *
+     * @return the content type field, or null if the type of this content is not known.
+     */
     HttpField getContentType();
 
-    String getContentTypeValue();
-
-    String getCharacterEncoding();
-
-    Type getMimeType();
-
+    /**
+     * Get the {@link HttpHeader#CONTENT_ENCODING} of this HTTP content.
+     *
+     * @return the content encoding field, or null if the encoding of this content is not known.
+     */
     HttpField getContentEncoding();
 
-    String getContentEncodingValue();
-
+    /**
+     * Get the {@link HttpHeader#CONTENT_LENGTH} of this HTTP content. The value of the returned field
+     * must always match the value returned by {@link #getContentLengthValue()}.
+     *
+     * @return the content length field, or null if the length of this content is not known.
+     */
     HttpField getContentLength();
 
-    long getContentLengthValue();
-
-    Instant getLastModifiedInstant();
-
+    /**
+     * Get the {@link HttpHeader#LAST_MODIFIED} of this HTTP content. The value of the returned field
+     * must always match the value returned by {@link #getLastModifiedInstant()}.
+     *
+     * @return the last modified field, or null if the last modification time of this content is not known.
+     */
     HttpField getLastModified();
 
-    String getLastModifiedValue();
-
+    /**
+     * Get the {@link HttpHeader#ETAG} of this HTTP content.
+     *
+     * @return the ETag, or null if this content has no ETag.
+     */
     HttpField getETag();
 
-    String getETagValue();
+    /**
+     * Get the character encoding of this HTTP content.
+     *
+     * @return the character encoding, or null if the character encoding of this content is not known.
+     */
+    String getCharacterEncoding();
+
+    /**
+     * Get the Mime type of this HTTP content.
+     *
+     * @return the mime type, or null if the mime type of this content is not known.
+     */
+    Type getMimeType();
+
+    /**
+     * Get the last modified instant of this resource.
+     *
+     * @return the last modified instant, or null if that instant of this content is not known.
+     * @see #getLastModified()
+     */
+    Instant getLastModifiedInstant();
+
+    /**
+     * Get the content length of this resource.
+     *
+     * @return the content length of this resource, or -1 if it is not known.
+     * @see #getContentLength()
+     */
+    long getContentLengthValue();
 
     /**
      * Get the {@link Resource} backing this HTTP content.
+     *
      * @return the backing resource.
      */
     Resource getResource();
 
     /**
-     * <p>Write a subset of this HTTP content, to a {@link Content.Sink}.</p>
+     * Asynchronously write a subset of this HTTP content to a {@link Content.Sink}.
+     * Calling this method does not consume the content, so it can be used repeatedly.
+     *
+     * @param sink the sink to write to.
+     * @param offset the offset byte of the resource to start from.
+     * @param length the length of the resource's contents to copy, -1 for the full length.
+     * @param callback the callback to notify when writing is done.
      */
     void writeTo(Content.Sink sink, long offset, long length, Callback callback);
 
-    default long getBytesOccupied()
-    {
-        return getContentLengthValue();
-    }
-
     /**
+     * Get available pre-compressed formats for this content.
+     *
      * @return Set of available pre-compressed formats for this content, or null if this has not been checked.
      */
     Set<CompressedContentFormat> getPreCompressedContentFormats();
 
-    void release();
+    // TODO get rid of these?
+    default String getContentTypeValue()
+    {
+        HttpField contentType = getContentType();
+        return contentType == null ? null : contentType.getValue();
+    }
 
+    default String getContentEncodingValue()
+    {
+        HttpField contentEncoding = getContentEncoding();
+        return contentEncoding == null ? null : contentEncoding.getValue();
+    }
+
+    default String getETagValue()
+    {
+        HttpField eTag = getETag();
+        return eTag == null ? null : eTag.getValue();
+    }
+
+    /**
+     * Factory of {@link HttpContent}.
+     */
     interface Factory
     {
         /**
-         * @param path The path within the context to the resource
-         * @return A {@link HttpContent}
+         * Get the {@link HttpContent} instance of a path.
+         *
+         * @param path The path.
+         * @return A {@link HttpContent} instance.
          * @throws IOException if unable to get content
          */
         HttpContent getContent(String path) throws IOException;
@@ -121,12 +188,6 @@ public interface HttpContent
         }
 
         @Override
-        public String getContentTypeValue()
-        {
-            return _delegate.getContentTypeValue();
-        }
-
-        @Override
         public String getCharacterEncoding()
         {
             return _delegate.getCharacterEncoding();
@@ -142,12 +203,6 @@ public interface HttpContent
         public HttpField getContentEncoding()
         {
             return _delegate.getContentEncoding();
-        }
-
-        @Override
-        public String getContentEncodingValue()
-        {
-            return _delegate.getContentEncodingValue();
         }
 
         @Override
@@ -175,21 +230,9 @@ public interface HttpContent
         }
 
         @Override
-        public String getLastModifiedValue()
-        {
-            return _delegate.getLastModifiedValue();
-        }
-
-        @Override
         public HttpField getETag()
         {
             return _delegate.getETag();
-        }
-
-        @Override
-        public String getETagValue()
-        {
-            return _delegate.getETagValue();
         }
 
         @Override
@@ -205,21 +248,9 @@ public interface HttpContent
         }
 
         @Override
-        public long getBytesOccupied()
-        {
-            return _delegate.getBytesOccupied();
-        }
-
-        @Override
         public Set<CompressedContentFormat> getPreCompressedContentFormats()
         {
             return _delegate.getPreCompressedContentFormats();
-        }
-
-        @Override
-        public void release()
-        {
-            _delegate.release();
         }
 
         @Override

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/PreCompressedHttpContent.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/PreCompressedHttpContent.java
@@ -60,12 +60,6 @@ public class PreCompressedHttpContent implements HttpContent
     }
 
     @Override
-    public String getETagValue()
-    {
-        return getETag().getValue();
-    }
-
-    @Override
     public Instant getLastModifiedInstant()
     {
         return _precompressedContent.getLastModifiedInstant();
@@ -78,33 +72,15 @@ public class PreCompressedHttpContent implements HttpContent
     }
 
     @Override
-    public String getLastModifiedValue()
-    {
-        return _precompressedContent.getLastModifiedValue();
-    }
-
-    @Override
     public HttpField getContentType()
     {
         return _content.getContentType();
     }
 
     @Override
-    public String getContentTypeValue()
-    {
-        return _content.getContentTypeValue();
-    }
-
-    @Override
     public HttpField getContentEncoding()
     {
         return _format.getContentEncoding();
-    }
-
-    @Override
-    public String getContentEncodingValue()
-    {
-        return _format.getContentEncoding().getValue();
     }
 
     @Override
@@ -152,11 +128,5 @@ public class PreCompressedHttpContent implements HttpContent
     public Set<CompressedContentFormat> getPreCompressedContentFormats()
     {
         return _content.getPreCompressedContentFormats();
-    }
-
-    @Override
-    public void release()
-    {
-        _precompressedContent.release();
     }
 }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceService.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceService.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.jetty.http.ByteRange;
 import org.eclipse.jetty.http.CompressedContentFormat;
+import org.eclipse.jetty.http.DateGenerator;
 import org.eclipse.jetty.http.EtagUtils;
 import org.eclipse.jetty.http.HttpDateTime;
 import org.eclipse.jetty.http.HttpField;
@@ -364,7 +365,7 @@ public class ResourceService
             if (ifms != null && ifnm == null)
             {
                 //Get jetty's Response impl
-                String mdlm = content.getLastModifiedValue();
+                String mdlm = DateGenerator.formatDate(content.getLastModifiedInstant());
                 if (ifms.equals(mdlm))
                 {
                     writeHttpError(request, response, callback, HttpStatus.NOT_MODIFIED_304);
@@ -637,7 +638,7 @@ public class ResourceService
         response.write(true, ByteBuffer.wrap(data), callback);
     }
 
-    private void sendData(Request request, Response response, Callback callback, HttpContent content, List<String> reqRanges) throws IOException
+    private void sendData(Request request, Response response, Callback callback, HttpContent content, List<String> reqRanges)
     {
         if (LOG.isDebugEnabled())
         {
@@ -646,7 +647,6 @@ public class ResourceService
         }
 
         long contentLength = content.getContentLengthValue();
-        callback = Callback.from(callback, content::release);
 
         if (LOG.isDebugEnabled())
             LOG.debug(String.format("sendData content=%s", content));

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ResourceServlet.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ResourceServlet.java
@@ -839,7 +839,7 @@ public class ResourceServlet extends HttpServlet
     private static class ForcedCharacterEncodingHttpContent extends HttpContent.Wrapper
     {
         private final String characterEncoding;
-        private final String contentType;
+        private final HttpField contentType;
 
         public ForcedCharacterEncodingHttpContent(HttpContent content, String characterEncoding)
         {
@@ -855,20 +855,14 @@ public class ResourceServlet extends HttpServlet
                 int idx = mimeType.indexOf(";charset");
                 if (idx >= 0)
                     mimeType = mimeType.substring(0, idx);
-                this.contentType = mimeType + ";charset=" + characterEncoding;
+                this.contentType = new HttpField(HttpHeader.CONTENT_TYPE, mimeType + ";charset=" + characterEncoding);
             }
         }
 
         @Override
         public HttpField getContentType()
         {
-            return new HttpField(HttpHeader.CONTENT_TYPE, this.contentType);
-        }
-
-        @Override
-        public String getContentTypeValue()
-        {
-            return this.contentType;
+            return contentType;
         }
 
         @Override

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ResourceServlet.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ResourceServlet.java
@@ -839,7 +839,7 @@ public class ResourceServlet extends HttpServlet
     private static class ForcedCharacterEncodingHttpContent extends HttpContent.Wrapper
     {
         private final String characterEncoding;
-        private final String contentType;
+        private final HttpField contentType;
 
         public ForcedCharacterEncodingHttpContent(HttpContent content, String characterEncoding)
         {
@@ -855,20 +855,14 @@ public class ResourceServlet extends HttpServlet
                 int idx = mimeType.indexOf(";charset");
                 if (idx >= 0)
                     mimeType = mimeType.substring(0, idx);
-                this.contentType = mimeType + ";charset=" + characterEncoding;
+                this.contentType = new HttpField(HttpHeader.CONTENT_TYPE, mimeType + ";charset=" + characterEncoding);
             }
         }
 
         @Override
         public HttpField getContentType()
         {
-            return new HttpField(HttpHeader.CONTENT_TYPE, this.contentType);
-        }
-
-        @Override
-        public String getContentTypeValue()
-        {
-            return this.contentType;
+            return contentType;
         }
 
         @Override


### PR DESCRIPTION
Followup work to https://github.com/jetty/jetty.project/pull/12020.

 - Remove `release()` from the API
 - Remove redundant methods from the API 
 - Javadoc HttpContent

Fixes #9080 