### PR TITLE
Issue #12070 fix session lastAccessedTime and isNew

### DIFF
--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-common/src/test/java/org/eclipse/jetty/ee10/session/CreationTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-common/src/test/java/org/eclipse/jetty/ee10/session/CreationTest.java
@@ -441,6 +441,70 @@ public class CreationTest
         }
     }
 
+    /**
+     * Test creating a session in a request and then invalidating it in another request
+     */
+    @Test
+    public void testSessionSimpleCreateInvalidate() throws Exception
+    {
+        String contextPath = "";
+        String servletMapping = "/server";
+        int inactivePeriod = -1; //immortal session
+        int scavengePeriod = 3;
+        DefaultSessionCacheFactory cacheFactory = new DefaultSessionCacheFactory();
+        cacheFactory.setEvictionPolicy(SessionCache.NEVER_EVICT);
+        cacheFactory.setSaveOnCreate(true);
+        cacheFactory.setFlushOnResponseCommit(true); //ensure session saved before response returned
+        SessionDataStoreFactory storeFactory = new TestSessionDataStoreFactory();
+        SessionTestSupport server1 = new SessionTestSupport(0, inactivePeriod, scavengePeriod, cacheFactory, storeFactory);
+        TestServlet servlet = new TestServlet();
+        ServletHolder holder = new ServletHolder(servlet);
+        ServletContextHandler contextHandler = server1.addContext(contextPath);
+        contextHandler.addServlet(holder, servletMapping);
+        servlet.setStore(contextHandler.getSessionHandler().getSessionCache().getSessionDataStore());
+        server1.start();
+        int port1 = server1.getPort();
+
+        try (StacklessLogging stackless = new StacklessLogging(CreationTest.class.getPackage()))
+        {
+            HttpClient client = new HttpClient();
+            client.start();
+            String url = "http://localhost:" + port1 + contextPath + servletMapping + "?action=create";
+
+            //make a request to set up a session on the server
+            ContentResponse response = client.GET(url);
+            assertEquals(HttpServletResponse.SC_OK, response.getStatus());
+            //Ensure session handling is finished
+            Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(() -> contextHandler.getSessionHandler().getSessionCache().getSessionDataStore().exists(servlet._id));
+
+            //make a request to re-obtain the session on the server
+            Request request = client.newRequest("http://localhost:" + port1 + contextPath + servletMapping + "?action=test");
+            response = request.send();
+            assertEquals(HttpServletResponse.SC_OK, response.getStatus());
+            Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(() -> contextHandler.getSessionHandler().getSessionCache().getSessionDataStore().exists(servlet._id));
+            //at this point the last accessed time should be the creation time
+            long lastAccessedTime = servlet._lastAccessedTime;
+            assertEquals(lastAccessedTime, servlet._creationTime);
+
+            //make another request to re-obtain the session on the server
+            request = client.newRequest("http://localhost:" + port1 + contextPath + servletMapping + "?action=test");
+            response = request.send();
+            assertEquals(HttpServletResponse.SC_OK, response.getStatus());
+            Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(() -> contextHandler.getSessionHandler().getSessionCache().getSessionDataStore().exists(servlet._id));
+            //check that the lastAccessedTime is being updated
+            assertTrue(lastAccessedTime < servlet._lastAccessedTime);
+
+            //make a request to invalidate it
+            request = client.newRequest("http://localhost:" + port1 + contextPath + servletMapping + "?action=invalidate");
+            response = request.send();
+            assertEquals(HttpServletResponse.SC_OK, response.getStatus());
+        }
+        finally
+        {
+            server1.stop();
+        }
+    }
+
     public static class MySessionListener implements HttpSessionListener
     {
         @Override
@@ -460,6 +524,8 @@ public class CreationTest
         private static final long serialVersionUID = 1L;
         public String _id = null;
         public SessionDataStore _store;
+        public long _lastAccessedTime;
+        public long _creationTime;
 
         public void setStore(SessionDataStore store)
         {
@@ -475,6 +541,7 @@ public class CreationTest
                 case "forward" ->
                 {
                     HttpSession session = createAndSaveSessionId(request);
+                    assertTrue(session.isNew());
                     ServletContext contextB = getServletContext().getContext("/contextB");
                     RequestDispatcher dispatcherB = contextB.getRequestDispatcher(request.getServletPath());
                     dispatcherB.forward(request, httpServletResponse);
@@ -488,7 +555,7 @@ public class CreationTest
                 case "forwardc" ->
                 {
                     HttpSession session = createAndSaveSessionId(request);
-
+                    assertTrue(session.isNew());
                     //forward to contextC
                     ServletContext contextC = getServletContext().getContext("/contextC");
                     RequestDispatcher dispatcherC = contextC.getRequestDispatcher(request.getServletPath());
@@ -498,7 +565,7 @@ public class CreationTest
                 {
                     HttpSession session = createAndSaveSessionId(request);
                     assertNotNull(session);
-
+                    assertTrue(session.isNew());
                     ServletContext contextB = getServletContext().getContext("/contextB");
                     RequestDispatcher dispatcherB = contextB.getRequestDispatcher(request.getServletPath());
                     dispatcherB.forward(request, httpServletResponse);
@@ -509,14 +576,27 @@ public class CreationTest
                     assertNotNull(_id);
                     HttpSession session = request.getSession(false);
                     assertNotNull(session);
+                    _lastAccessedTime = session.getLastAccessedTime();
+                    assertFalse(session.isNew());
                     assertNotNull(session.getAttribute("value")); //check we see our previous session
                     assertNull(session.getAttribute("B")); //check we don't see stuff from other contexts
                     assertNull(session.getAttribute("C"));
+                }
+                case "invalidate" ->
+                {
+                    HttpSession session = request.getSession(false);
+                    assertNotNull(session);
+                    _id = session.getId();
+                    assertFalse(session.isNew());
+                    session.invalidate();
+                    assertNull(request.getSession(false));
                 }
                 case "create", "createinv", "createinvcreate" ->
                 {
                     currentRequest.set(request);
                     HttpSession session = createAndSaveSessionId(request);
+                    assertTrue(session.isNew());
+                    _creationTime = session.getCreationTime();
                     String check = request.getParameter("check");
                     if (!StringUtil.isBlank(check) && _store != null)
                     {

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/SessionHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/SessionHandler.java
@@ -520,7 +520,10 @@ public class SessionHandler extends ScopedHandler implements SessionConfig.Mutab
                     coreRequest.setSessionManager(_sessionManager);
                     coreRequest.setRequestedSession(currentRequestedSession);
                     if (currentRequestedSession != null)
+                    {
                         coreRequest.setManagedSession(currentRequestedSession.session());
+                        currentSession = currentRequestedSession.session();
+                    }
                     break;
                 }
                 case ASYNC:


### PR DESCRIPTION
For ee8/9 the `HttpSession` was not being updated correctly upon receipt of a new request referencing an existing session. The `lastAccessedTime`, `isNew` and `expiryTime` fields were not being updated correctly after the introduction of cross-context dispatch in PR #11451.