### PR TITLE
Jetty 12.1.x various updates to demos

### DIFF
--- a/jetty-demos/jetty-servlet4-demos/jetty-servlet4-demo-async-rest/jetty-servlet4-demo-async-rest-jar/pom.xml
+++ b/jetty-demos/jetty-servlet4-demos/jetty-servlet4-demo-async-rest/jetty-servlet4-demo-async-rest-jar/pom.xml
@@ -26,9 +26,9 @@
       <artifactId>jetty-util-ajax</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.toolchain</groupId>
-      <artifactId>jetty-servlet-api</artifactId>
-      <version>${ee8.jetty.servlet.api.version}</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${ee8.jakarta.servlet.api.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/jetty-demos/jetty-servlet4-demos/jetty-servlet4-demo-async-rest/jetty-servlet4-demo-async-rest-webapp/pom.xml
+++ b/jetty-demos/jetty-servlet4-demos/jetty-servlet4-demo-async-rest/jetty-servlet4-demo-async-rest-webapp/pom.xml
@@ -31,9 +31,9 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.toolchain</groupId>
-      <artifactId>jetty-servlet-api</artifactId>
-      <version>${ee8.jetty.servlet.api.version}</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${ee8.jakarta.servlet.api.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/jetty-demos/jetty-servlet4-demos/jetty-servlet4-demo-javax-websocket-webapp/pom.xml
+++ b/jetty-demos/jetty-servlet4-demos/jetty-servlet4-demo-javax-websocket-webapp/pom.xml
@@ -20,9 +20,9 @@
       <version>${ee8.jakarta.websocket.api.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.toolchain</groupId>
-      <artifactId>jetty-servlet-api</artifactId>
-      <version>${ee8.jetty.servlet.api.version}</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${ee8.jakarta.servlet.api.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/jetty-demos/jetty-servlet4-demos/jetty-servlet4-demo-jetty-webapp/pom.xml
+++ b/jetty-demos/jetty-servlet4-demos/jetty-servlet4-demo-jetty-webapp/pom.xml
@@ -21,6 +21,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${ee8.jakarta.servlet.api.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>jakarta.servlet.jsp</groupId>
       <artifactId>jakarta.servlet.jsp-api</artifactId>
       <version>${ee8.jakarta.servlet.jsp.api.version}</version>
@@ -35,12 +41,6 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty.toolchain</groupId>
-      <artifactId>jetty-servlet-api</artifactId>
-      <version>${ee8.jetty.servlet.api.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/jetty-demos/jetty-servlet4-demos/jetty-servlet4-demo-jndi-webapp/pom.xml
+++ b/jetty-demos/jetty-servlet4-demos/jetty-servlet4-demo-jndi-webapp/pom.xml
@@ -15,6 +15,12 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${ee8.jakarta.servlet.api.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>jakarta.transaction</groupId>
       <artifactId>jakarta.transaction-api</artifactId>
       <version>${ee8.jakarta.transaction-api.version}</version>
@@ -30,12 +36,6 @@
       <groupId>org.eclipse.jetty.orbit</groupId>
       <artifactId>javax.mail.glassfish</artifactId>
       <version>${ee8.javax.mail.glassfish.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty.toolchain</groupId>
-      <artifactId>jetty-servlet-api</artifactId>
-      <version>${ee8.jetty.servlet.api.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/jetty-demos/jetty-servlet4-demos/jetty-servlet4-demo-jsp-webapp/pom.xml
+++ b/jetty-demos/jetty-servlet4-demos/jetty-servlet4-demo-jsp-webapp/pom.xml
@@ -18,6 +18,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${ee8.jakarta.servlet.api.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>jakarta.servlet.jsp</groupId>
       <artifactId>jakarta.servlet.jsp-api</artifactId>
       <version>${ee8.jakarta.servlet.jsp.api.version}</version>
@@ -27,12 +33,6 @@
       <groupId>jakarta.servlet.jsp.jstl</groupId>
       <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
       <version>${ee8.jakarta.servlet.jsp.jstl.api.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty.toolchain</groupId>
-      <artifactId>jetty-servlet-api</artifactId>
-      <version>${ee8.jetty.servlet.api.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/jetty-demos/jetty-servlet4-demos/jetty-servlet4-demo-mock-resources/pom.xml
+++ b/jetty-demos/jetty-servlet4-demos/jetty-servlet4-demo-mock-resources/pom.xml
@@ -15,6 +15,12 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${ee8.jakarta.servlet.api.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>jakarta.transaction</groupId>
       <artifactId>jakarta.transaction-api</artifactId>
       <version>${ee8.jakarta.transaction-api.version}</version>
@@ -24,12 +30,6 @@
       <groupId>org.eclipse.jetty.orbit</groupId>
       <artifactId>javax.mail.glassfish</artifactId>
       <version>${ee8.javax.mail.glassfish.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty.toolchain</groupId>
-      <artifactId>jetty-servlet-api</artifactId>
-      <version>${ee8.jetty.servlet.api.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/jetty-demos/jetty-servlet4-demos/jetty-servlet4-demo-simple-webapp/pom.xml
+++ b/jetty-demos/jetty-servlet4-demos/jetty-servlet4-demo-simple-webapp/pom.xml
@@ -18,9 +18,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.eclipse.jetty.toolchain</groupId>
-      <artifactId>jetty-servlet-api</artifactId>
-      <version>${ee8.jetty.servlet.api.version}</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${ee8.jakarta.servlet.api.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/jetty-demos/jetty-servlet4-demos/jetty-servlet4-demo-spec/jetty-servlet4-demo-container-initializer/pom.xml
+++ b/jetty-demos/jetty-servlet4-demos/jetty-servlet4-demo-spec/jetty-servlet4-demo-container-initializer/pom.xml
@@ -15,9 +15,9 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>org.eclipse.jetty.toolchain</groupId>
-      <artifactId>jetty-servlet-api</artifactId>
-      <version>${ee8.jetty.servlet.api.version}</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${ee8.jakarta.servlet.api.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/jetty-demos/jetty-servlet4-demos/jetty-servlet4-demo-spec/jetty-servlet4-demo-spec-webapp/pom.xml
+++ b/jetty-demos/jetty-servlet4-demos/jetty-servlet4-demo-spec/jetty-servlet4-demo-spec-webapp/pom.xml
@@ -32,15 +32,15 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>jakarta.transaction</groupId>
-      <artifactId>jakarta.transaction-api</artifactId>
-      <version>${ee8.jakarta.transaction-api.version}</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${ee8.jakarta.servlet.api.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.toolchain</groupId>
-      <artifactId>jetty-servlet-api</artifactId>
-      <version>${ee8.jetty.servlet.api.version}</version>
+      <groupId>jakarta.transaction</groupId>
+      <artifactId>jakarta.transaction-api</artifactId>
+      <version>${ee8.jakarta.transaction-api.version}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/jetty-demos/jetty-servlet4-demos/jetty-servlet4-demo-spec/jetty-servlet4-demo-web-fragment/pom.xml
+++ b/jetty-demos/jetty-servlet4-demos/jetty-servlet4-demo-spec/jetty-servlet4-demo-web-fragment/pom.xml
@@ -18,9 +18,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.eclipse.jetty.toolchain</groupId>
-      <artifactId>jetty-servlet-api</artifactId>
-      <version>${ee8.jetty.servlet.api.version}</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${ee8.jakarta.servlet.api.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-async-rest/jetty-servlet5-demo-async-rest-jar/pom.xml
+++ b/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-async-rest/jetty-servlet5-demo-async-rest-jar/pom.xml
@@ -27,9 +27,9 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.toolchain</groupId>
-      <artifactId>jetty-jakarta-servlet-api</artifactId>
-      <version>${ee9.jetty.servlet.api.version}</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${ee9.jakarta.servlet.api.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-async-rest/jetty-servlet5-demo-async-rest-webapp/pom.xml
+++ b/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-async-rest/jetty-servlet5-demo-async-rest-webapp/pom.xml
@@ -27,9 +27,9 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.toolchain</groupId>
-      <artifactId>jetty-jakarta-servlet-api</artifactId>
-      <version>${ee9.jetty.servlet.api.version}</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${ee9.jakarta.servlet.api.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-jakarta-websocket-webapp/pom.xml
+++ b/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-jakarta-websocket-webapp/pom.xml
@@ -19,9 +19,9 @@
       <version>${ee9.jakarta.websocket.api.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.toolchain</groupId>
-      <artifactId>jetty-jakarta-servlet-api</artifactId>
-      <version>${ee9.jetty.servlet.api.version}</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${ee9.jakarta.servlet.api.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-jetty-webapp/pom.xml
+++ b/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-jetty-webapp/pom.xml
@@ -20,6 +20,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${ee9.jakarta.servlet.api.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>jakarta.servlet.jsp</groupId>
       <artifactId>jakarta.servlet.jsp-api</artifactId>
       <version>${ee9.jakarta.servlet.jsp.api.version}</version>
@@ -46,18 +52,6 @@
       <artifactId>jetty-util</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty.toolchain</groupId>
-      <artifactId>jetty-jakarta-servlet-api</artifactId>
-      <version>${ee9.jetty.servlet.api.version}</version>
-      <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>jakarta.servlet</groupId>
-          <artifactId>jakarta.servlet-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
   <build>

--- a/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-jetty-webapp/src/main/java/org/example/RegTest.java
+++ b/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-jetty-webapp/src/main/java/org/example/RegTest.java
@@ -22,7 +22,6 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.eclipse.jetty.util.StringUtil;
 
 /**
  * Rego Servlet - tests being accessed from servlet 3.0 programmatic
@@ -163,9 +162,9 @@ public class RegTest extends HttpServlet
     {
         if (s == null)
             return "null";
-        s = StringUtil.replace(s, "&", "&amp;");
-        s = StringUtil.replace(s, "<", "&lt;");
-        s = StringUtil.replace(s, ">", "&gt;");
+        s = s.replace("&", "&amp;");
+        s = s.replace("<", "&lt;");
+        s = s.replace(">", "&gt;");
         return s;
     }
 }

--- a/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-jetty-webapp/src/main/java/org/example/TestListener.java
+++ b/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-jetty-webapp/src/main/java/org/example/TestListener.java
@@ -54,8 +54,6 @@ public class TestListener implements HttpSessionListener, HttpSessionAttributeLi
     @Override
     public void attributeAdded(HttpSessionBindingEvent se)
     {
-        // System.err.println("attributedAdded "+se);
-
         _called.put("attributeAdded", new Throwable());
     }
 
@@ -63,20 +61,17 @@ public class TestListener implements HttpSessionListener, HttpSessionAttributeLi
     public void attributeAdded(ServletContextAttributeEvent scab)
     {
         _called.put("attributeAdded", new Throwable());
-        // System.err.println("attributeAdded "+scab);
     }
 
     @Override
     public void attributeAdded(ServletRequestAttributeEvent srae)
     {
         _called.put("attributeAdded", new Throwable());
-        // System.err.println("attributeAdded "+srae);
     }
 
     @Override
     public void attributeRemoved(HttpSessionBindingEvent se)
     {
-        // System.err.println("attributeRemoved "+se);
         _called.put("attributeRemoved", new Throwable());
     }
 
@@ -84,20 +79,17 @@ public class TestListener implements HttpSessionListener, HttpSessionAttributeLi
     public void attributeRemoved(ServletContextAttributeEvent scab)
     {
         _called.put("attributeRemoved", new Throwable());
-        // System.err.println("attributeRemoved "+scab);
     }
 
     @Override
     public void attributeRemoved(ServletRequestAttributeEvent srae)
     {
         _called.put("attributeRemoved", new Throwable());
-        // System.err.println("attributeRemoved "+srae);
     }
 
     @Override
     public void attributeReplaced(HttpSessionBindingEvent se)
     {
-        // System.err.println("attributeReplaced "+se);
         _called.put("attributeReplaced", new Throwable());
     }
 
@@ -105,28 +97,23 @@ public class TestListener implements HttpSessionListener, HttpSessionAttributeLi
     public void attributeReplaced(ServletContextAttributeEvent scab)
     {
         _called.put("attributeReplaced", new Throwable());
-        // System.err.println("attributeReplaced "+scab);
     }
 
     @Override
     public void attributeReplaced(ServletRequestAttributeEvent srae)
     {
         _called.put("attributeReplaced", new Throwable());
-        // System.err.println("attributeReplaced "+srae);
     }
 
     @Override
     public void contextDestroyed(ServletContextEvent sce)
     {
         _called.put("contextDestroyed", new Throwable());
-        // System.err.println("contextDestroyed "+sce);
     }
 
     @Override
     public void contextInitialized(ServletContextEvent sce)
     {
-
-        // System.err.println("contextInitialized "+sce);
         _called.put("contextInitialized", new Throwable());
 
         //configure programmatic security
@@ -136,14 +123,12 @@ public class TestListener implements HttpSessionListener, HttpSessionAttributeLi
             ServletSecurity.TransportGuarantee.NONE, new String[]{"admin"});
         ServletSecurityElement securityElement = new ServletSecurityElement(constraintElement, null);
         Set<String> unchanged = rego.setServletSecurity(securityElement);
-        //// System.err.println("Security constraints registered: "+unchanged.isEmpty());
 
         //Test that a security constraint from web.xml can't be overridden programmatically
         ServletRegistration.Dynamic rego2 = sce.getServletContext().addServlet("RegoTest2", RegTest.class.getName());
         rego2.addMapping("/rego2/*");
         securityElement = new ServletSecurityElement(constraintElement, null);
         unchanged = rego2.setServletSecurity(securityElement);
-        //// System.err.println("Overridding web.xml constraints not possible:" +!unchanged.isEmpty());
 
         /* For servlet 3.0 */
         FilterRegistration registration = sce.getServletContext().addFilter("TestFilter", TestFilter.class.getName());
@@ -191,7 +176,6 @@ public class TestListener implements HttpSessionListener, HttpSessionAttributeLi
         _called.put("requestDestroyed", new Throwable());
         ((HttpServletRequest)sre.getServletRequest()).getSession(false);
         sre.getServletRequest().setAttribute("requestInitialized", null);
-        // System.err.println("requestDestroyed "+sre);
     }
 
     @Override
@@ -199,34 +183,29 @@ public class TestListener implements HttpSessionListener, HttpSessionAttributeLi
     {
         _called.put("requestInitialized", new Throwable());
         sre.getServletRequest().setAttribute("requestInitialized", "'" + sre.getServletContext().getContextPath() + "'");
-        // System.err.println("requestInitialized "+sre);
     }
 
     @Override
     public void sessionCreated(HttpSessionEvent se)
     {
         _called.put("sessionCreated", new Throwable());
-        // System.err.println("sessionCreated "+se);
     }
 
     @Override
     public void sessionDestroyed(HttpSessionEvent se)
     {
         _called.put("sessionDestroyed", new Throwable());
-        // System.err.println("sessionDestroyed "+se);
     }
 
     @Override
     public void sessionDidActivate(HttpSessionEvent se)
     {
-        // System.err.println("sessionDidActivate "+se);
         _called.put("sessionDidActivate", new Throwable());
     }
 
     @Override
     public void sessionWillPassivate(HttpSessionEvent se)
     {
-        // System.err.println("sessionWillPassivate "+se);
         _called.put("sessionWillPassivate", new Throwable());
     }
 }

--- a/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-jndi-webapp/pom.xml
+++ b/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-jndi-webapp/pom.xml
@@ -14,6 +14,12 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${ee9.jakarta.servlet.api.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>jakarta.transaction</groupId>
       <artifactId>jakarta.transaction-api</artifactId>
       <version>${ee9.jakarta.transaction-api.version}</version>
@@ -29,12 +35,6 @@
       <groupId>org.eclipse.jetty.orbit</groupId>
       <artifactId>javax.mail.glassfish</artifactId>
       <version>${ee9.javax.mail.glassfish.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty.toolchain</groupId>
-      <artifactId>jetty-jakarta-servlet-api</artifactId>
-      <version>${ee9.jetty.servlet.api.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-jsp-webapp/pom.xml
+++ b/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-jsp-webapp/pom.xml
@@ -17,6 +17,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${ee9.jakarta.servlet.api.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>jakarta.servlet.jsp</groupId>
       <artifactId>jakarta.servlet.jsp-api</artifactId>
       <version>${ee9.jakarta.servlet.jsp.api.version}</version>
@@ -37,12 +43,6 @@
           <artifactId>jakarta.servlet-api</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty.toolchain</groupId>
-      <artifactId>jetty-jakarta-servlet-api</artifactId>
-      <version>${ee9.jetty.servlet.api.version}</version>
-      <scope>provided</scope>
     </dependency>
   </dependencies>
 

--- a/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-mock-resources/pom.xml
+++ b/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-mock-resources/pom.xml
@@ -20,15 +20,15 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>jakarta.transaction</groupId>
-      <artifactId>jakarta.transaction-api</artifactId>
-      <version>${ee9.jakarta.transaction-api.version}</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${ee9.jakarta.servlet.api.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.toolchain</groupId>
-      <artifactId>jetty-jakarta-servlet-api</artifactId>
-      <version>${ee9.jetty.servlet.api.version}</version>
+      <groupId>jakarta.transaction</groupId>
+      <artifactId>jakarta.transaction-api</artifactId>
+      <version>${ee9.jakarta.transaction-api.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-simple-webapp/pom.xml
+++ b/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-simple-webapp/pom.xml
@@ -17,9 +17,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.eclipse.jetty.toolchain</groupId>
-      <artifactId>jetty-jakarta-servlet-api</artifactId>
-      <version>${ee9.jetty.servlet.api.version}</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${ee9.jakarta.servlet.api.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-spec/jetty-servlet5-demo-container-initializer/pom.xml
+++ b/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-spec/jetty-servlet5-demo-container-initializer/pom.xml
@@ -15,9 +15,9 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>org.eclipse.jetty.toolchain</groupId>
-      <artifactId>jetty-jakarta-servlet-api</artifactId>
-      <version>${ee9.jetty.servlet.api.version}</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${ee9.jakarta.servlet.api.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-spec/jetty-servlet5-demo-spec-webapp/pom.xml
+++ b/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-spec/jetty-servlet5-demo-spec-webapp/pom.xml
@@ -32,18 +32,17 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${ee9.jakarta.servlet.api.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>jakarta.transaction</groupId>
       <artifactId>jakarta.transaction-api</artifactId>
       <version>${ee9.jakarta.transaction-api.version}</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty.toolchain</groupId>
-      <artifactId>jetty-jakarta-servlet-api</artifactId>
-      <version>${ee9.jetty.servlet.api.version}</version>
-      <scope>provided</scope>
-    </dependency>
-
   </dependencies>
   <build>
     <plugins>

--- a/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-spec/jetty-servlet5-demo-spec-webapp/src/main/webapp/index.html
+++ b/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-spec/jetty-servlet5-demo-spec-webapp/src/main/webapp/index.html
@@ -19,7 +19,7 @@
           <span style="color:red; font-style:italic; font-weight:bold">Demo Web Application Only - Do NOT Deploy in Production</span>
       </center>
 
-     <h1>Servlet 5.0 Demo WebApp</h1>
+     <h1>Servlet Demo WebApp</h1>
      <p>This example tests some aspects of the servlet specification:</p>
      <ul>
       <li>context defaults</li>

--- a/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-spec/jetty-servlet5-demo-web-fragment/pom.xml
+++ b/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-spec/jetty-servlet5-demo-web-fragment/pom.xml
@@ -18,9 +18,10 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.eclipse.jetty.toolchain</groupId>
-      <artifactId>jetty-jakarta-servlet-api</artifactId>
-      <version>${ee9.jetty.servlet.api.version}</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${ee9.jakarta.servlet.api.version}</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -242,6 +242,7 @@
 
     <ee8.jakarta.activation.api.version>1.2.2</ee8.jakarta.activation.api.version>
     <ee8.jakarta.annotation.api.version>1.3.5</ee8.jakarta.annotation.api.version>
+    <ee8.jakarta.servlet.api.version>4.0.4</ee8.jakarta.servlet.api.version>
     <ee8.jakarta.servlet.jsp.api.version>2.3.6</ee8.jakarta.servlet.jsp.api.version>
     <ee8.jakarta.servlet.jsp.jstl.api.version>1.2.7</ee8.jakarta.servlet.jsp.jstl.api.version>
     <ee8.jakarta.transaction-api.version>1.3.3</ee8.jakarta.transaction-api.version>


### PR DESCRIPTION
* Use standard spec api jars for jetty demos
* Remove some printlns from demos
* Remove use of jetty util class StringUtil