### PR TITLE
Issue #12104 - HTTP/1.0 should produce a valid `Connection` header, never blank/null.

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpGenerator.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpGenerator.java
@@ -639,11 +639,15 @@ public class HttpGenerator
                             }
                             if (keepAlive && _persistent == Boolean.FALSE)
                             {
-                                field = new HttpField(HttpHeader.CONNECTION,
-                                    Stream.of(field.getValues()).filter(s -> !HttpHeaderValue.KEEP_ALIVE.is(s))
-                                        .collect(Collectors.joining(", ")));
+                                String resultingValue = Stream.of(field.getValues()).filter(s -> !HttpHeaderValue.KEEP_ALIVE.is(s))
+                                    .collect(Collectors.joining(", "));
+                                if (StringUtil.isBlank(resultingValue))
+                                    field = null; // all values stripped, do not produce a Connection header with no values
+                                else
+                                    field = new HttpField(HttpHeader.CONNECTION, resultingValue);
                             }
-                            putTo(field, header);
+                            if (field != null)
+                                putTo(field, header);
                             break;
                         }
 

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpGeneratorServerTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpGeneratorServerTest.java
@@ -819,6 +819,7 @@ public class HttpGeneratorServerTest
     public void testKeepAliveWithClose() throws Exception
     {
         HttpGenerator generator = new HttpGenerator();
+        generator.setPersistent(false);
         HttpFields.Mutable fields = HttpFields.build();
         fields.put(HttpHeader.CONNECTION, HttpHeaderValue.KEEP_ALIVE.asString() + ", other, " + HttpHeaderValue.CLOSE.asString());
         MetaData.Response info = new MetaData.Response(200, "OK", HttpVersion.HTTP_1_0, fields);

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -1384,8 +1384,18 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
         @Override
         public void prepareResponse(HttpFields.Mutable headers)
         {
-            if (_connectionKeepAlive && _version == HttpVersion.HTTP_1_0 && !headers.contains(HttpHeader.CONNECTION, HttpHeaderValue.CLOSE.asString()))
-                headers.add(HttpFields.CONNECTION_KEEPALIVE);
+            // If the HTTP/1 generator is set to no longer be persistent then the
+            // logic for handling HTTP/1.0 shouldn't occur.  This typically happens
+            // in the case of errors with the request or response.
+//            if (_version == HttpVersion.HTTP_1_0 && _generator.isPersistent())
+            {
+                // attempt to cover HTTP/1.0 case where the Connection response header
+                // doesn't have a close value (set by the application) and it needs to
+                // be represented as a `Connection: keep-alive` response instead due
+                // to the existence of the `Connection: keep-alive` request header
+                if (_connectionKeepAlive && !headers.contains(HttpHeader.CONNECTION, HttpHeaderValue.CLOSE.asString()))
+                    headers.add(HttpFields.CONNECTION_KEEPALIVE);
+            }
         }
 
         @Override

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -1387,7 +1387,7 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
             // If the HTTP/1 generator is set to no longer be persistent then the
             // logic for handling HTTP/1.0 shouldn't occur.  This typically happens
             // in the case of errors with the request or response.
-//            if (_version == HttpVersion.HTTP_1_0 && _generator.isPersistent())
+            if (_version == HttpVersion.HTTP_1_0 && _generator.isPersistent())
             {
                 // attempt to cover HTTP/1.0 case where the Connection response header
                 // doesn't have a close value (set by the application) and it needs to

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
@@ -694,7 +694,6 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
                 if (!HttpField.contains(coalesced, HttpHeaderValue.CLOSE.asString()))
                     coalesced += ", close";
 
-                // Returns a single Cookie header with all cookies.
                 return new HttpField(HttpHeader.CONNECTION, coalesced);
 
             });

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/ErrorHandlerTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/ErrorHandlerTest.java
@@ -299,7 +299,7 @@ public class ErrorHandlerTest
         assertThat(response.getField(HttpHeader.CONTENT_LENGTH).getIntValue(), greaterThan(0));
         assertThat(response.get(HttpHeader.CONTENT_TYPE), containsString("text/html;charset=ISO-8859-1"));
         assertThat(response.getContent(), containsString("content=\"text/html;charset=ISO-8859-1\""));
-        assertThat(response.getField(HttpHeader.CONNECTION), nullValue());
+        assertThat(response.get(HttpHeader.CONNECTION), is("close"));
         assertContent(response);
     }
 


### PR DESCRIPTION
- Enable ee9 ErrorHandlerTest again 
- Fix empty `Connection:` response header issue seen on HTTP/1.0

Fixes #12104