### PR TITLE
Issue #12094 restore classloader association during comp/env creation

### DIFF
--- a/jetty-ee10/jetty-ee10-plus/src/main/java/module-info.java
+++ b/jetty-ee10/jetty-ee10-plus/src/main/java/module-info.java
@@ -23,6 +23,7 @@ module org.eclipse.jetty.ee10.plus
 
     // Only required if using Transaction.
     requires static transitive jakarta.transaction;
+    requires org.eclipse.jetty.jndi;
 
     exports org.eclipse.jetty.ee10.plus.jndi;
     exports org.eclipse.jetty.ee10.plus.webapp;

--- a/jetty-ee10/jetty-ee10-plus/src/main/java/org/eclipse/jetty/ee10/plus/webapp/EnvConfiguration.java
+++ b/jetty-ee10/jetty-ee10-plus/src/main/java/org/eclipse/jetty/ee10/plus/webapp/EnvConfiguration.java
@@ -226,9 +226,17 @@ public class EnvConfiguration extends AbstractConfiguration
         ContextFactory.associateClassLoader(wac.getClassLoader());
         try
         {
-            Context context = new InitialContext();
-            Context compCtx = (Context)context.lookup("java:comp");
-            compCtx.createSubcontext("env");
+            WebAppClassLoader.runWithServerClassAccess(() ->
+            {
+                Context context = new InitialContext();
+                Context compCtx = (Context)context.lookup("java:comp");
+                compCtx.createSubcontext("env");
+                return null;
+            });
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException(e);
         }
         finally
         {

--- a/jetty-ee10/jetty-ee10-plus/src/main/java/org/eclipse/jetty/ee10/plus/webapp/EnvConfiguration.java
+++ b/jetty-ee10/jetty-ee10-plus/src/main/java/org/eclipse/jetty/ee10/plus/webapp/EnvConfiguration.java
@@ -28,6 +28,7 @@ import org.eclipse.jetty.ee10.webapp.MetaInfConfiguration;
 import org.eclipse.jetty.ee10.webapp.WebAppClassLoader;
 import org.eclipse.jetty.ee10.webapp.WebAppContext;
 import org.eclipse.jetty.ee10.webapp.WebXmlConfiguration;
+import org.eclipse.jetty.jndi.ContextFactory;
 import org.eclipse.jetty.plus.jndi.EnvEntry;
 import org.eclipse.jetty.plus.jndi.NamingEntryUtil;
 import org.eclipse.jetty.util.jndi.NamingDump;
@@ -123,6 +124,7 @@ public class EnvConfiguration extends AbstractConfiguration
         //get rid of any bindings for comp/env for webapp
         ClassLoader oldLoader = Thread.currentThread().getContextClassLoader();
         Thread.currentThread().setContextClassLoader(context.getClassLoader());
+        ContextFactory.associateClassLoader(context.getClassLoader());
         try
         {
             Context ic = new InitialContext();
@@ -147,6 +149,7 @@ public class EnvConfiguration extends AbstractConfiguration
         }
         finally
         {
+            ContextFactory.disassociateClassLoader();
             Thread.currentThread().setContextClassLoader(oldLoader);
         }
     }
@@ -218,6 +221,9 @@ public class EnvConfiguration extends AbstractConfiguration
     {
         ClassLoader oldLoader = Thread.currentThread().getContextClassLoader();
         Thread.currentThread().setContextClassLoader(wac.getClassLoader());
+        //ensure that we create a unique comp/env context for this webapp based off
+        //its classloader
+        ContextFactory.associateClassLoader(wac.getClassLoader());
         try
         {
             Context context = new InitialContext();
@@ -226,6 +232,7 @@ public class EnvConfiguration extends AbstractConfiguration
         }
         finally
         {
+            ContextFactory.disassociateClassLoader();
             Thread.currentThread().setContextClassLoader(oldLoader);
         }
     }

--- a/jetty-ee10/jetty-ee10-plus/src/test/java/org/eclipse/jetty/ee10/plus/webapp/EnvConfigurationTest.java
+++ b/jetty-ee10/jetty-ee10-plus/src/test/java/org/eclipse/jetty/ee10/plus/webapp/EnvConfigurationTest.java
@@ -44,13 +44,6 @@ public class EnvConfigurationTest
 {
     Server _server;
 
-    @BeforeAll
-    public static void exposeJNDIClasses()
-    {
-        //we need to expose the org.eclipse.jetty.jndi classes so the InitialContextFactory can be found
-        WebAppClassLoading.addHiddenClasses("-org.eclipse.jetty.jndi.");
-    }
-
     @BeforeEach
     public void setUp()
     {
@@ -119,6 +112,10 @@ public class EnvConfigurationTest
             Context namingContextB = getCompEnvFor(webappB);
 
             assertThat(namingContextA, is(not(namingContextB)));
+        }
+        catch (Throwable t)
+        {
+            t.printStackTrace();
         }
         finally
         {

--- a/jetty-ee10/jetty-ee10-plus/src/test/java/org/eclipse/jetty/ee10/plus/webapp/EnvConfigurationTest.java
+++ b/jetty-ee10/jetty-ee10-plus/src/test/java/org/eclipse/jetty/ee10/plus/webapp/EnvConfigurationTest.java
@@ -15,22 +15,41 @@ package org.eclipse.jetty.ee10.plus.webapp;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
 
+import org.eclipse.jetty.ee.WebAppClassLoading;
+import org.eclipse.jetty.ee10.webapp.Configuration;
+import org.eclipse.jetty.ee10.webapp.WebAppClassLoader;
 import org.eclipse.jetty.ee10.webapp.WebAppContext;
 import org.eclipse.jetty.plus.jndi.NamingEntryUtil;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Isolated("jndi entries")
 public class EnvConfigurationTest
 {
     Server _server;
+
+    @BeforeAll
+    public static void exposeJNDIClasses()
+    {
+        //we need to expose the org.eclipse.jetty.jndi classes so the InitialContextFactory can be found
+        WebAppClassLoading.addHiddenClasses("-org.eclipse.jetty.jndi.");
+    }
 
     @BeforeEach
     public void setUp()
@@ -73,4 +92,75 @@ public class EnvConfigurationTest
         assertNotNull(NamingEntryUtil.lookupNamingEntry(context, "peach"));
         assertNull(NamingEntryUtil.lookupNamingEntry(context, "cabbage"));
     }
+
+    @Test
+    public void testCompEnvCreation() throws Exception
+    {
+        EnvConfiguration envConfigurationA = new EnvConfiguration();
+        EnvConfiguration envConfigurationB = new EnvConfiguration();
+        WebAppContext webappA = null;
+        WebAppContext webappB = null;
+        try
+        {
+            webappA = new WebAppContext();
+            webappA.setConfigurations(new Configuration[]{new PlusConfiguration(), new EnvConfiguration()});
+            webappA.setClassLoader(new WebAppClassLoader(Thread.currentThread().getContextClassLoader(), webappA));
+
+            //ensure that a java:comp/env Context was created for webappA
+            envConfigurationA.preConfigure(webappA);
+            Context namingContextA = getCompEnvFor(webappA);
+
+            webappB = new WebAppContext();
+            webappB.setConfigurations(new Configuration[]{new PlusConfiguration(), new EnvConfiguration()});
+            webappB.setClassLoader(new WebAppClassLoader(Thread.currentThread().getContextClassLoader(), webappB));
+
+            //ensure that a different java:comp/env Context was created for webappB
+            envConfigurationB.preConfigure(webappB);
+            Context namingContextB = getCompEnvFor(webappB);
+
+            assertThat(namingContextA, is(not(namingContextB)));
+        }
+        finally
+        {
+            envConfigurationA.deconfigure(webappA);
+            envConfigurationB.deconfigure(webappB);
+        }
+    }
+
+    @Test
+    public void testPriorCompCreation() throws Exception
+    {
+        //pre-create java:comp on the app classloader
+        new InitialContext().lookup("java:comp");
+        //test that each webapp still gets its own naming Context
+        testCompEnvCreation();
+    }
+
+    /**
+     * Find the java:comp/env naming Context for the given webapp
+     * @param webapp the WebAppContext whose naming comp/env Context to find
+     * @return the comp/env naming Context specific to the given WebAppContext
+     * @throws NamingException
+     */
+    private Context getCompEnvFor(WebAppContext webapp)
+        throws NamingException
+    {
+        if (webapp == null)
+            return null;
+
+        ClassLoader oldLoader = Thread.currentThread().getContextClassLoader();
+        Context namingContext = null;
+        try
+        {
+            Thread.currentThread().setContextClassLoader(webapp.getClassLoader());
+            InitialContext ic = new InitialContext();
+            namingContext = (Context)ic.lookup("java:comp/env");
+            return namingContext;
+        }
+        finally
+        {
+            Thread.currentThread().setContextClassLoader(oldLoader);
+        }
+    }
+
 }

--- a/jetty-ee9/jetty-ee9-plus/src/main/java/module-info.java
+++ b/jetty-ee9/jetty-ee9-plus/src/main/java/module-info.java
@@ -24,6 +24,7 @@ module org.eclipse.jetty.ee9.plus
 
     // Only required if using Transaction.
     requires static transitive jakarta.transaction;
+    requires org.eclipse.jetty.jndi;
 
     exports org.eclipse.jetty.ee9.plus.jndi;
     exports org.eclipse.jetty.ee9.plus.webapp;

--- a/jetty-ee9/jetty-ee9-plus/src/main/java/org/eclipse/jetty/ee9/plus/webapp/EnvConfiguration.java
+++ b/jetty-ee9/jetty-ee9-plus/src/main/java/org/eclipse/jetty/ee9/plus/webapp/EnvConfiguration.java
@@ -245,9 +245,17 @@ public class EnvConfiguration extends AbstractConfiguration
 
         try
         {
-            Context context = new InitialContext();
-            Context compCtx = (Context)context.lookup("java:comp");
-            compCtx.createSubcontext("env");
+            WebAppClassLoader.runWithServerClassAccess(() ->
+            {
+                Context context = new InitialContext();
+                Context compCtx = (Context)context.lookup("java:comp");
+                compCtx.createSubcontext("env");
+                return null;
+            });
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException(e);
         }
         finally
         {

--- a/jetty-ee9/jetty-ee9-plus/src/main/java/org/eclipse/jetty/ee9/plus/webapp/EnvConfiguration.java
+++ b/jetty-ee9/jetty-ee9-plus/src/main/java/org/eclipse/jetty/ee9/plus/webapp/EnvConfiguration.java
@@ -29,6 +29,7 @@ import org.eclipse.jetty.ee9.webapp.MetaInfConfiguration;
 import org.eclipse.jetty.ee9.webapp.WebAppClassLoader;
 import org.eclipse.jetty.ee9.webapp.WebAppContext;
 import org.eclipse.jetty.ee9.webapp.WebXmlConfiguration;
+import org.eclipse.jetty.jndi.ContextFactory;
 import org.eclipse.jetty.plus.jndi.EnvEntry;
 import org.eclipse.jetty.plus.jndi.NamingEntryUtil;
 import org.eclipse.jetty.util.IO;
@@ -139,6 +140,7 @@ public class EnvConfiguration extends AbstractConfiguration
         //get rid of any bindings for comp/env for webapp
         ClassLoader oldLoader = Thread.currentThread().getContextClassLoader();
         Thread.currentThread().setContextClassLoader(context.getClassLoader());
+        ContextFactory.associateClassLoader(context.getClassLoader());
         try
         {
             Context ic = new InitialContext();
@@ -163,6 +165,7 @@ public class EnvConfiguration extends AbstractConfiguration
         }
         finally
         {
+            ContextFactory.disassociateClassLoader();
             Thread.currentThread().setContextClassLoader(oldLoader);
             IO.close(_resourceFactory);
             _resourceFactory = null;
@@ -236,6 +239,10 @@ public class EnvConfiguration extends AbstractConfiguration
     {
         ClassLoader oldLoader = Thread.currentThread().getContextClassLoader();
         Thread.currentThread().setContextClassLoader(wac.getClassLoader());
+        //ensure that we create a unique comp/env context for this webapp based off
+        //its classloader
+        ContextFactory.associateClassLoader(wac.getClassLoader());
+
         try
         {
             Context context = new InitialContext();
@@ -244,6 +251,7 @@ public class EnvConfiguration extends AbstractConfiguration
         }
         finally
         {
+            ContextFactory.disassociateClassLoader();
             Thread.currentThread().setContextClassLoader(oldLoader);
         }
     }

--- a/jetty-ee9/jetty-ee9-plus/src/test/java/org/eclipse/jetty/ee9/plus/webapp/EnvConfigurationTest.java
+++ b/jetty-ee9/jetty-ee9-plus/src/test/java/org/eclipse/jetty/ee9/plus/webapp/EnvConfigurationTest.java
@@ -94,7 +94,6 @@ public class EnvConfigurationTest
         try
         {
             webappA = new WebAppContext();
-            webappA.getServerClassMatcher().exclude("org.eclipse.jetty.jndi.");
             webappA.setConfigurations(new Configuration[]{new PlusConfiguration(), new EnvConfiguration()});
             webappA.setClassLoader(new WebAppClassLoader(Thread.currentThread().getContextClassLoader(), webappA));
 
@@ -103,7 +102,6 @@ public class EnvConfigurationTest
             Context namingContextA = getCompEnvFor(webappA);
 
             webappB = new WebAppContext();
-            webappB.getServerClassMatcher().exclude("org.eclipse.jetty.jndi.");
             webappB.setConfigurations(new Configuration[]{new PlusConfiguration(), new EnvConfiguration()});
             webappB.setClassLoader(new WebAppClassLoader(Thread.currentThread().getContextClassLoader(), webappB));
 

--- a/jetty-ee9/jetty-ee9-plus/src/test/java/org/eclipse/jetty/ee9/plus/webapp/EnvConfigurationTest.java
+++ b/jetty-ee9/jetty-ee9-plus/src/test/java/org/eclipse/jetty/ee9/plus/webapp/EnvConfigurationTest.java
@@ -15,20 +15,29 @@ package org.eclipse.jetty.ee9.plus.webapp;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
 
+import org.eclipse.jetty.ee9.webapp.Configuration;
+import org.eclipse.jetty.ee9.webapp.WebAppClassLoader;
 import org.eclipse.jetty.ee9.webapp.WebAppContext;
 import org.eclipse.jetty.plus.jndi.NamingEntryUtil;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
-import org.eclipse.jetty.util.jndi.NamingUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Isolated("jndi entries")
 public class EnvConfigurationTest
 {
     Server _server;
@@ -73,5 +82,77 @@ public class EnvConfigurationTest
         _server.start();
         assertNotNull(NamingEntryUtil.lookupNamingEntry(context, "peach"));
         assertNull(NamingEntryUtil.lookupNamingEntry(context, "cabbage"));
+    }
+
+    @Test
+    public void testCompEnvCreation() throws Exception
+    {
+        EnvConfiguration envConfigurationA = new EnvConfiguration();
+        EnvConfiguration envConfigurationB = new EnvConfiguration();
+        WebAppContext webappA = null;
+        WebAppContext webappB = null;
+        try
+        {
+            webappA = new WebAppContext();
+            webappA.getServerClassMatcher().exclude("org.eclipse.jetty.jndi.");
+            webappA.setConfigurations(new Configuration[]{new PlusConfiguration(), new EnvConfiguration()});
+            webappA.setClassLoader(new WebAppClassLoader(Thread.currentThread().getContextClassLoader(), webappA));
+
+            //ensure that a java:comp/env Context was created for webappA
+            envConfigurationA.preConfigure(webappA);
+            Context namingContextA = getCompEnvFor(webappA);
+
+            webappB = new WebAppContext();
+            webappB.getServerClassMatcher().exclude("org.eclipse.jetty.jndi.");
+            webappB.setConfigurations(new Configuration[]{new PlusConfiguration(), new EnvConfiguration()});
+            webappB.setClassLoader(new WebAppClassLoader(Thread.currentThread().getContextClassLoader(), webappB));
+
+            //ensure that a different java:comp/env Context was created for webappB
+            envConfigurationB.preConfigure(webappB);
+            Context namingContextB = getCompEnvFor(webappB);
+
+            assertThat(namingContextA, is(not(namingContextB)));
+        }
+        finally
+        {
+            envConfigurationA.deconfigure(webappA);
+            envConfigurationB.deconfigure(webappB);
+        }
+    }
+
+    @Test
+    public void testPriorCompCreation() throws Exception
+    {
+        //pre-create java:comp on the app classloader
+        new InitialContext().lookup("java:comp");
+        //test that each webapp still gets its own naming Context
+        testCompEnvCreation();
+    }
+
+    /**
+     * Find the java:comp/env naming Context for the given webapp
+     * @param webapp the WebAppContext whose naming comp/env Context to find
+     * @return the comp/env naming Context specific to the given WebAppContext
+     * @throws NamingException
+     */
+    private Context getCompEnvFor(WebAppContext webapp)
+        throws NamingException
+    {
+        if (webapp == null)
+            return null;
+
+        ClassLoader oldLoader = Thread.currentThread().getContextClassLoader();
+        Context namingContext = null;
+        try
+        {
+            Thread.currentThread().setContextClassLoader(webapp.getClassLoader());
+            InitialContext ic = new InitialContext();
+            namingContext = (Context)ic.lookup("java:comp/env");
+            return namingContext;
+        }
+        finally
+        {
+            Thread.currentThread().setContextClassLoader(oldLoader);
+        }
     }
 }


### PR DESCRIPTION
Closes #12094 

We removed explicit association/disassociation of the webapp classloader to use to create or find the appropriate `java:comp/env` naming context from `EnvConfiguration`. This is not a problem for code running in the distribution. However, if embedded code:

+ fails to create an EE level classloader as the parent loader for all webapps
+  pre-creates the `java:comp` naming `Context` using the common application classloader 
+ starts multiple `WebAppContexts`

 then those webapps all wind up trying to share the same  `java:comp/env` environment. The relevant example code, paraphrased from  #12094, is as follows:

Main.java:

``` java
void run() throws Exception
{
        new InitialContext().lookup("java:comp");

       WebAppContext webappA = new WebAppContext();
       WebAppContext webbappB = new WebAppContext();
}
```

So we could require that embedded users create an empty classloader that emulates the EE classloader, but does nothing (because as all classes are on the application classloader instead):
``` java
void run() throws Exception
{
      //create useless "EE" parent classloader for webapps before creating java:comp
       Thread.currentThread().setContextClassLoader(new URLClassLoader(new URL[]{}, Thread.currentThread().getContextClassLoader());
        new InitialContext().lookup("java:comp");

       WebAppContext webappA = new WebAppContext();
       WebAppContext webbappB = new WebAppContext();
}
```

However, I think it's reasonable that "naive" code (ie that doesn't know about the new EE classloader level) should be able to work. So this PR re-introduces the associate/disassociate idiom that was used before. This allows embedded code to work, as well as apps using the distribution.
