### PR TITLE
invoker:install should include test dependencies as well as they are used by the tests, this issue can happen only when not snapshots have been deployed of demos new versions

### DIFF
--- a/jetty-ee10/jetty-ee10-runner/pom.xml
+++ b/jetty-ee10/jetty-ee10-runner/pom.xml
@@ -131,15 +131,7 @@
         <configuration>
           <debug>${it.debug}</debug>
           <addTestClassPath>true</addTestClassPath>
-          <extraArtifacts>
-            <extraArtifact>org.eclipse.jetty:jetty-client:${project.version}</extraArtifact>
-          </extraArtifacts>
           <junitPackageName>org.eclipse.jetty.maven.its.ee10.runner</junitPackageName>
-          <scriptVariables>
-            <maven.dependency.plugin.version>${maven.dependency.plugin.version}</maven.dependency.plugin.version>
-            <maven.surefire.plugin.version>${maven.surefire.plugin.version}</maven.surefire.plugin.version>
-            <hamcrest.version>${hamcrest.version}</hamcrest.version>
-          </scriptVariables>
           <goals>
             <goal>clean</goal>
           </goals>

--- a/jetty-ee8/jetty-ee8-runner/pom.xml
+++ b/jetty-ee8/jetty-ee8-runner/pom.xml
@@ -135,15 +135,7 @@
         <configuration>
           <debug>${it.debug}</debug>
           <addTestClassPath>true</addTestClassPath>
-          <extraArtifacts>
-            <extraArtifact>org.eclipse.jetty:jetty-client:${project.version}</extraArtifact>
-          </extraArtifacts>
           <junitPackageName>org.eclipse.jetty.maven.its.ee8.runner</junitPackageName>
-          <scriptVariables>
-            <maven.dependency.plugin.version>${maven.dependency.plugin.version}</maven.dependency.plugin.version>
-            <maven.surefire.plugin.version>${maven.surefire.plugin.version}</maven.surefire.plugin.version>
-            <hamcrest.version>${hamcrest.version}</hamcrest.version>
-          </scriptVariables>
           <goals>
             <goal>clean</goal>
           </goals>

--- a/jetty-ee9/jetty-ee9-runner/pom.xml
+++ b/jetty-ee9/jetty-ee9-runner/pom.xml
@@ -133,15 +133,7 @@
         <configuration>
           <debug>${it.debug}</debug>
           <addTestClassPath>true</addTestClassPath>
-          <extraArtifacts>
-            <extraArtifact>org.eclipse.jetty:jetty-client:${project.version}</extraArtifact>
-          </extraArtifacts>
           <junitPackageName>org.eclipse.jetty.maven.its.ee9.runner</junitPackageName>
-          <scriptVariables>
-            <maven.dependency.plugin.version>${maven.dependency.plugin.version}</maven.dependency.plugin.version>
-            <maven.surefire.plugin.version>${maven.surefire.plugin.version}</maven.surefire.plugin.version>
-            <hamcrest.version>${hamcrest.version}</hamcrest.version>
-          </scriptVariables>
           <goals>
             <goal>clean</goal>
           </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -1440,6 +1440,7 @@
             <timeoutInSeconds>300</timeoutInSeconds>
             <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
             <localRepositoryPath>${localRepoPath}</localRepositoryPath>
+            <scope>test</scope>
             <settingsFile>${settingsPath}</settingsFile>
             <skipInvocation>${skipTests}</skipInvocation>
             <streamLogsOnFailures>true</streamLogsOnFailures>


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>
