### PR TITLE
Fixes #3184 - Make LifeCycle implement AutoCloseable.

### DIFF
--- a/jetty-core/jetty-alpn/jetty-alpn-conscrypt-client/src/test/java/org/eclipse/jetty/alpn/java/client/ConscryptHTTP2ClientTest.java
+++ b/jetty-core/jetty-alpn/jetty-alpn-conscrypt-client/src/test/java/org/eclipse/jetty/alpn/java/client/ConscryptHTTP2ClientTest.java
@@ -57,8 +57,7 @@ public class ConscryptHTTP2ClientTest
         sslContextFactory.setProvider("Conscrypt");
         Conscrypt.setDefaultHostnameVerifier((certs, hostname, session) -> true);
 
-        HTTP2Client client = new HTTP2Client();
-        try
+        try (HTTP2Client client = new HTTP2Client())
         {
             client.addBean(sslContextFactory);
             client.start();
@@ -96,10 +95,6 @@ public class ConscryptHTTP2ClientTest
             });
 
             assertTrue(latch.await(15, TimeUnit.SECONDS));
-        }
-        finally
-        {
-            client.stop();
         }
     }
 

--- a/jetty-core/jetty-alpn/jetty-alpn-conscrypt-server/src/test/java/org/eclipse/jetty/alpn/conscrypt/server/ConscryptHTTP2ServerTest.java
+++ b/jetty-core/jetty-alpn/jetty-alpn-conscrypt-server/src/test/java/org/eclipse/jetty/alpn/conscrypt/server/ConscryptHTTP2ServerTest.java
@@ -132,17 +132,12 @@ public class ConscryptHTTP2ServerTest
         ClientConnector clientConnector = new ClientConnector();
         clientConnector.setSslContextFactory(newClientSslContextFactory());
         HTTP2Client h2Client = new HTTP2Client(clientConnector);
-        HttpClient client = new HttpClient(new HttpClientTransportOverHTTP2(h2Client));
-        client.start();
-        try
+        try (HttpClient client = new HttpClient(new HttpClientTransportOverHTTP2(h2Client)))
         {
+            client.start();
             int port = ((ServerConnector)server.getConnectors()[0]).getLocalPort();
             ContentResponse contentResponse = client.GET("https://localhost:" + port);
             assertEquals(200, contentResponse.getStatus());
-        }
-        finally
-        {
-            client.stop();
         }
     }
 }

--- a/jetty-core/jetty-alpn/jetty-alpn-java-client/src/test/java/org/eclipse/jetty/alpn/java/client/JDK9HTTP2ClientTest.java
+++ b/jetty-core/jetty-alpn/jetty-alpn-java-client/src/test/java/org/eclipse/jetty/alpn/java/client/JDK9HTTP2ClientTest.java
@@ -45,8 +45,7 @@ public class JDK9HTTP2ClientTest
 
         Assumptions.assumeTrue(canConnectTo(host, port));
 
-        HTTP2Client client = new HTTP2Client();
-        try
+        try (HTTP2Client client = new HTTP2Client())
         {
             SslContextFactory.Client sslContextFactory = new SslContextFactory.Client();
             client.addBean(sslContextFactory);
@@ -86,10 +85,6 @@ public class JDK9HTTP2ClientTest
             });
 
             latch.await(15, TimeUnit.SECONDS);
-        }
-        finally
-        {
-            client.stop();
         }
     }
 

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -104,7 +104,7 @@ import org.slf4j.LoggerFactory;
  * }</pre>
  */
 @ManagedObject("The HTTP client")
-public class HttpClient extends ContainerLifeCycle
+public class HttpClient extends ContainerLifeCycle implements AutoCloseable
 {
     public static final String USER_AGENT = "Jetty/" + Jetty.VERSION;
     private static final Logger LOG = LoggerFactory.getLogger(HttpClient.class);
@@ -1140,5 +1140,11 @@ public class HttpClient extends ContainerLifeCycle
         if (sslContextFactory == null)
             sslContextFactory = getSslContextFactory();
         return new SslClientConnectionFactory(sslContextFactory, getByteBufferPool(), getExecutor(), connectionFactory);
+    }
+
+    @Override
+    public void close() throws Exception
+    {
+        stop();
     }
 }

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/jmx/HttpClientJMXTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/jmx/HttpClientJMXTest.java
@@ -31,12 +31,11 @@ public class HttpClientJMXTest
     @Test
     public void testHttpClientName() throws Exception
     {
-        String name = "foo";
-        HttpClient httpClient = new HttpClient();
-        httpClient.setName(name);
-
-        try
+        try (HttpClient httpClient = new HttpClient())
         {
+            String name = "foo";
+            httpClient.setName(name);
+
             MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
             MBeanContainer mbeanContainer = new MBeanContainer(mbeanServer);
             // Adding MBeanContainer as a bean will trigger the registration of MBeans.
@@ -58,10 +57,6 @@ public class HttpClientJMXTest
             {
                 assertEquals(name, oName.getKeyProperty("context"));
             }
-        }
-        finally
-        {
-            httpClient.stop();
         }
     }
 }

--- a/jetty-core/jetty-http2/jetty-http2-client/src/main/java/org/eclipse/jetty/http2/client/HTTP2Client.java
+++ b/jetty-core/jetty-http2/jetty-http2-client/src/main/java/org/eclipse/jetty/http2/client/HTTP2Client.java
@@ -99,7 +99,7 @@ import org.eclipse.jetty.util.thread.Scheduler;
  *} </pre>
  */
 @ManagedObject
-public class HTTP2Client extends ContainerLifeCycle
+public class HTTP2Client extends ContainerLifeCycle implements AutoCloseable
 {
     private final ClientConnector connector;
     private int inputBufferSize = 8192;
@@ -491,5 +491,11 @@ public class HTTP2Client extends ContainerLifeCycle
             factory = new SslClientConnectionFactory(sslContextFactory, getByteBufferPool(), getExecutor(), factory);
         }
         return factory;
+    }
+
+    @Override
+    public void close() throws Exception
+    {
+        stop();
     }
 }

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
@@ -106,27 +106,26 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
     public void testPropertiesAreForwarded() throws Exception
     {
         HTTP2Client http2Client = new HTTP2Client();
-        HttpClient httpClient = new HttpClient(new HttpClientTransportOverHTTP2(http2Client));
-        Executor executor = new QueuedThreadPool();
-        httpClient.setExecutor(executor);
-        httpClient.setConnectTimeout(13);
-        httpClient.setIdleTimeout(17);
-        httpClient.setUseInputDirectByteBuffers(false);
-        httpClient.setUseOutputDirectByteBuffers(false);
+        try (HttpClient httpClient = new HttpClient(new HttpClientTransportOverHTTP2(http2Client)))
+        {
+            Executor executor = new QueuedThreadPool();
+            httpClient.setExecutor(executor);
+            httpClient.setConnectTimeout(13);
+            httpClient.setIdleTimeout(17);
+            httpClient.setUseInputDirectByteBuffers(false);
+            httpClient.setUseOutputDirectByteBuffers(false);
 
-        httpClient.start();
+            httpClient.start();
 
-        assertTrue(http2Client.isStarted());
-        assertSame(httpClient.getExecutor(), http2Client.getExecutor());
-        assertSame(httpClient.getScheduler(), http2Client.getScheduler());
-        assertSame(httpClient.getByteBufferPool(), http2Client.getByteBufferPool());
-        assertEquals(httpClient.getConnectTimeout(), http2Client.getConnectTimeout());
-        assertEquals(httpClient.getIdleTimeout(), http2Client.getIdleTimeout());
-        assertEquals(httpClient.isUseInputDirectByteBuffers(), http2Client.isUseInputDirectByteBuffers());
-        assertEquals(httpClient.isUseOutputDirectByteBuffers(), http2Client.isUseOutputDirectByteBuffers());
-
-        httpClient.stop();
-
+            assertTrue(http2Client.isStarted());
+            assertSame(httpClient.getExecutor(), http2Client.getExecutor());
+            assertSame(httpClient.getScheduler(), http2Client.getScheduler());
+            assertSame(httpClient.getByteBufferPool(), http2Client.getByteBufferPool());
+            assertEquals(httpClient.getConnectTimeout(), http2Client.getConnectTimeout());
+            assertEquals(httpClient.getIdleTimeout(), http2Client.getIdleTimeout());
+            assertEquals(httpClient.isUseInputDirectByteBuffers(), http2Client.isUseInputDirectByteBuffers());
+            assertEquals(httpClient.isUseOutputDirectByteBuffers(), http2Client.isUseOutputDirectByteBuffers());
+        }
         assertTrue(http2Client.isStopped());
     }
 
@@ -833,16 +832,16 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
     {
         ClientConnector clientConnector = new ClientConnector();
         HTTP2Client http2Client = new HTTP2Client(clientConnector);
-        SslContextFactory.Client sslContextFactory = new SslContextFactory.Client();
-        clientConnector.setSslContextFactory(sslContextFactory);
-        HttpClient httpClient = new HttpClient(new HttpClientTransportOverHTTP2(http2Client));
-        Executor executor = new QueuedThreadPool();
-        clientConnector.setExecutor(executor);
-        httpClient.start();
+        try (HttpClient httpClient = new HttpClient(new HttpClientTransportOverHTTP2(http2Client)))
+        {
+            Executor executor = new QueuedThreadPool();
+            clientConnector.setExecutor(executor);
+            SslContextFactory.Client sslContextFactory = new SslContextFactory.Client();
+            clientConnector.setSslContextFactory(sslContextFactory);
+            httpClient.start();
 
-        ContentResponse response = httpClient.GET("https://webtide.com/");
-        assertEquals(HttpStatus.OK_200, response.getStatus());
-
-        httpClient.stop();
+            ContentResponse response = httpClient.GET("https://webtide.com/");
+            assertEquals(HttpStatus.OK_200, response.getStatus());
+        }
     }
 }

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/ResponseTrailerTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/ResponseTrailerTest.java
@@ -73,10 +73,9 @@ public class ResponseTrailerTest extends AbstractTest
             }
         });
 
-        HTTP2Client http2Client = new HTTP2Client();
-        http2Client.start();
-        try
+        try (HTTP2Client http2Client = new HTTP2Client())
         {
+            http2Client.start();
             String host = "localhost";
             int port = connector.getLocalPort();
             InetSocketAddress address = new InetSocketAddress(host, port);
@@ -115,10 +114,6 @@ public class ResponseTrailerTest extends AbstractTest
             frame = headers.poll();
             assertNotNull(frame);
             assertTrue(frame.getMetaData().isResponse());
-        }
-        finally
-        {
-            http2Client.stop();
         }
     }
 }

--- a/jetty-core/jetty-http3/jetty-http3-client/src/main/java/org/eclipse/jetty/http3/client/HTTP3Client.java
+++ b/jetty-core/jetty-http3/jetty-http3-client/src/main/java/org/eclipse/jetty/http3/client/HTTP3Client.java
@@ -125,7 +125,7 @@ import org.slf4j.LoggerFactory;
  * <p>HTTP/3+QUIC support is experimental and not suited for production use.
  * APIs may change incompatibly between releases.</p>
  */
-public class HTTP3Client extends ContainerLifeCycle
+public class HTTP3Client extends ContainerLifeCycle implements AutoCloseable
 {
     public static final String CLIENT_CONTEXT_KEY = HTTP3Client.class.getName();
     public static final String SESSION_LISTENER_CONTEXT_KEY = CLIENT_CONTEXT_KEY + ".listener";
@@ -216,5 +216,11 @@ public class HTTP3Client extends ContainerLifeCycle
     public CompletableFuture<Void> shutdown()
     {
         return container.shutdown();
+    }
+
+    @Override
+    public void close() throws Exception
+    {
+        stop();
     }
 }

--- a/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/ExternalServerTest.java
+++ b/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/ExternalServerTest.java
@@ -54,18 +54,12 @@ public class ExternalServerTest
         SslContextFactory.Client sslClient = new SslContextFactory.Client();
         ClientQuicConfiguration quicConfig = new ClientQuicConfiguration(sslClient, null);
         HTTP3Client client = new HTTP3Client(quicConfig);
-        HttpClientTransportOverHTTP3 transport = new HttpClientTransportOverHTTP3(client);
-        HttpClient httpClient = new HttpClient(transport);
-        httpClient.start();
-        try
+        try (HttpClient httpClient = new HttpClient(new HttpClientTransportOverHTTP3(client)))
         {
+            httpClient.start();
             URI uri = URI.create("https://maven-central-eu.storage-download.googleapis.com/maven2/org/apache/maven/maven-parent/38/maven-parent-38.pom");
             ContentResponse response = httpClient.newRequest(uri).send();
             assertThat(response.getContentAsString(), containsString("<artifactId>maven-parent</artifactId>"));
-        }
-        finally
-        {
-            httpClient.stop();
         }
     }
 
@@ -75,10 +69,9 @@ public class ExternalServerTest
     {
         SslContextFactory.Client sslClient = new SslContextFactory.Client();
         ClientQuicConfiguration quicConfig = new ClientQuicConfiguration(sslClient, null);
-        HTTP3Client client = new HTTP3Client(quicConfig);
-        client.start();
-        try
+        try (HTTP3Client client = new HTTP3Client(quicConfig))
         {
+            client.start();
             // Well-known HTTP/3 servers to try.
 //            HostPort hostPort = new HostPort("maven-central-eu.storage-download.googleapis.com:443");
             HostPort hostPort = new HostPort("google.com:443");
@@ -136,10 +129,6 @@ public class ExternalServerTest
             });
 
             assertTrue(requestLatch.await(5, TimeUnit.SECONDS));
-        }
-        finally
-        {
-            client.stop();
         }
     }
 }

--- a/jetty-core/jetty-unixdomain-server/src/test/java/org/eclipse/jetty/unixdomain/server/UnixDomainTest.java
+++ b/jetty-core/jetty-unixdomain-server/src/test/java/org/eclipse/jetty/unixdomain/server/UnixDomainTest.java
@@ -118,19 +118,14 @@ public class UnixDomainTest
 
         // Use the deprecated APIs for backwards compatibility testing.
         ClientConnector clientConnector = ClientConnector.forUnixDomain(unixDomainPath);
-        HttpClient httpClient = new HttpClient(new HttpClientTransportDynamic(clientConnector));
-        httpClient.start();
-        try
+        try (HttpClient httpClient = new HttpClient(new HttpClientTransportDynamic(clientConnector)))
         {
+            httpClient.start();
             ContentResponse response = httpClient.newRequest(uri)
                 .timeout(5, TimeUnit.SECONDS)
                 .send();
 
             assertEquals(HttpStatus.OK_200, response.getStatus());
-        }
-        finally
-        {
-            httpClient.stop();
         }
     }
 
@@ -153,28 +148,23 @@ public class UnixDomainTest
             }
         });
 
-        HttpClient httpClient = new HttpClient(new HttpClientTransportDynamic());
-        Origin proxyOrigin = new Origin(
-            "http",
-            new Origin.Address("localhost", fakeProxyPort),
-            null,
-            new Origin.Protocol(List.of("http/1.1"), false),
-            new Transport.TCPUnix(unixDomainPath)
-        );
-        httpClient.getProxyConfiguration().addProxy(new HttpProxy(proxyOrigin, null));
-        httpClient.start();
-        try
+        try (HttpClient httpClient = new HttpClient(new HttpClientTransportDynamic()))
         {
+            Origin proxyOrigin = new Origin(
+                "http",
+                new Origin.Address("localhost", fakeProxyPort),
+                null,
+                new Origin.Protocol(List.of("http/1.1"), false),
+                new Transport.TCPUnix(unixDomainPath)
+            );
+            httpClient.getProxyConfiguration().addProxy(new HttpProxy(proxyOrigin, null));
+            httpClient.start();
             ContentResponse response = httpClient.newRequest("localhost", fakeServerPort)
                 .transport(new Transport.TCPUnix(unixDomainPath))
                 .timeout(5, TimeUnit.SECONDS)
                 .send();
 
             assertEquals(HttpStatus.OK_200, response.getStatus());
-        }
-        finally
-        {
-            httpClient.stop();
         }
     }
 
@@ -215,10 +205,9 @@ public class UnixDomainTest
             }
         });
 
-        HttpClient httpClient = new HttpClient(new HttpClientTransportDynamic());
-        httpClient.start();
-        try
+        try (HttpClient httpClient = new HttpClient(new HttpClientTransportDynamic()))
         {
+            httpClient.start();
             // Try PROXYv1 with the PROXY information retrieved from the EndPoint.
             // PROXYv1 does not support the UNIX family.
             ContentResponse response1 = httpClient.newRequest("localhost", 0)
@@ -240,10 +229,6 @@ public class UnixDomainTest
                 .send();
 
             assertEquals(HttpStatus.OK_200, response2.getStatus());
-        }
-        finally
-        {
-            httpClient.stop();
         }
     }
 

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
@@ -50,7 +50,7 @@ import org.eclipse.jetty.websocket.core.client.WebSocketCoreClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class WebSocketClient extends ContainerLifeCycle implements Configurable, WebSocketContainer
+public class WebSocketClient extends ContainerLifeCycle implements Configurable, WebSocketContainer, AutoCloseable
 {
     private static final Logger LOG = LoggerFactory.getLogger(WebSocketClient.class);
     private final WebSocketCoreClient coreClient;
@@ -401,6 +401,12 @@ public class WebSocketClient extends ContainerLifeCycle implements Configurable,
         if (getStopTimeout() > 0)
             Graceful.shutdown(this).get(getStopTimeout(), TimeUnit.MILLISECONDS);
         super.doStop();
+    }
+
+    @Override
+    public void close() throws Exception
+    {
+        stop();
     }
 
     @Override

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/test/java/org/eclipse/jetty/websocket/client/HttpClientInitTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/test/java/org/eclipse/jetty/websocket/client/HttpClientInitTest.java
@@ -30,8 +30,7 @@ public class HttpClientInitTest
     @Test
     public void testDefaultInit() throws Exception
     {
-        WebSocketClient client = new WebSocketClient();
-        try
+        try (WebSocketClient client = new WebSocketClient())
         {
             client.start();
             HttpClient httpClient = client.getHttpClient();
@@ -43,27 +42,20 @@ public class HttpClientInitTest
             QueuedThreadPool threadPool = (QueuedThreadPool)executor;
             assertThat("QueuedThreadPool.name", threadPool.getName(), startsWith("WebSocket@"));
         }
-        finally
-        {
-            client.stop();
-        }
     }
 
     @Test
     public void testManualInit() throws Exception
     {
         HttpClient http = new HttpClient();
-        {
-            QueuedThreadPool threadPool = new QueuedThreadPool();
-            threadPool.setName("ManualWSClient@" + http.hashCode());
-            http.setExecutor(threadPool);
-            http.setConnectTimeout(7777);
-        }
+        QueuedThreadPool httpThreadPool = new QueuedThreadPool();
+        httpThreadPool.setName("ManualWSClient@" + http.hashCode());
+        http.setExecutor(httpThreadPool);
+        http.setConnectTimeout(7777);
 
-        WebSocketClient client = new WebSocketClient(http);
-        client.addBean(http);
-        try
+        try (WebSocketClient client = new WebSocketClient(http))
         {
+            client.addBean(http);
             client.start();
             HttpClient httpClient = client.getHttpClient();
             assertThat("HttpClient exists", httpClient, notNullValue());
@@ -74,10 +66,6 @@ public class HttpClientInitTest
             assertThat("Executor instanceof", executor, instanceOf(QueuedThreadPool.class));
             QueuedThreadPool threadPool = (QueuedThreadPool)executor;
             assertThat("QueuedThreadPool.name", threadPool.getName(), startsWith("ManualWSClient@"));
-        }
-        finally
-        {
-            client.stop();
         }
     }
 }

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientSessionsTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientSessionsTest.java
@@ -83,22 +83,18 @@ public class ClientSessionsTest
     @Test
     public void testBasicEchoFromClient() throws Exception
     {
-        WebSocketClient client = new WebSocketClient();
-
-        CountDownLatch onSessionCloseLatch = new CountDownLatch(1);
-
-        client.addSessionListener(new WebSocketSessionListener()
+        try (WebSocketClient client = new WebSocketClient())
         {
-            @Override
-            public void onWebSocketSessionClosed(Session session)
+            CountDownLatch onSessionCloseLatch = new CountDownLatch(1);
+            client.addSessionListener(new WebSocketSessionListener()
             {
-                onSessionCloseLatch.countDown();
-            }
-        });
-
-        client.start();
-        try
-        {
+                @Override
+                public void onWebSocketSessionClosed(Session session)
+                {
+                    onSessionCloseLatch.countDown();
+                }
+            });
+            client.start();
             CloseTrackingEndpoint cliSock = new CloseTrackingEndpoint();
             client.setIdleTimeout(Duration.ofSeconds(10));
 
@@ -135,10 +131,6 @@ public class ClientSessionsTest
 
             Collection<Session> open = client.getOpenSessions();
             assertThat("(After Close) Open Sessions.size", open.size(), is(0));
-        }
-        finally
-        {
-            client.stop();
         }
     }
 }

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/WebSocketClientTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/WebSocketClientTest.java
@@ -125,28 +125,19 @@ public class WebSocketClientTest
     @ValueSource(booleans = {false, true})
     public void testCustomizeExecutorDirectly(boolean startHttpClient) throws Exception
     {
-        Executor executor = Executors.newFixedThreadPool(50);
-        HttpClient httpClient = new HttpClient();
-        httpClient.setExecutor(executor);
-        try
+        try (HttpClient httpClient = new HttpClient())
         {
+            Executor executor = Executors.newFixedThreadPool(50);
+            httpClient.setExecutor(executor);
             if (startHttpClient)
                 httpClient.start();
-            WebSocketClient webSocketClient = new WebSocketClient(httpClient);
-            try
+
+            try (WebSocketClient webSocketClient = new WebSocketClient(httpClient))
             {
                 webSocketClient.start();
                 Executor wsExecutor = webSocketClient.getExecutor();
                 assertSame(executor, wsExecutor);
             }
-            finally
-            {
-                webSocketClient.stop();
-            }
-        }
-        finally
-        {
-            httpClient.stop();
         }
     }
 
@@ -158,25 +149,15 @@ public class WebSocketClientTest
         Executor executor = Executors.newFixedThreadPool(50);
         clientConnector.setExecutor(executor);
         HttpClientTransport transport = new HttpClientTransportOverHTTP(clientConnector);
-        HttpClient httpClient = new HttpClient(transport);
-        try
+        try (HttpClient httpClient = new HttpClient(transport))
         {
             httpClient.start();
-            WebSocketClient webSocketClient = new WebSocketClient(httpClient);
-            try
+            try (WebSocketClient webSocketClient = new WebSocketClient(httpClient))
             {
                 webSocketClient.start();
                 Executor inuseExecutor = webSocketClient.getExecutor();
                 assertSame(executor, inuseExecutor);
             }
-            finally
-            {
-                webSocketClient.stop();
-            }
-        }
-        finally
-        {
-            httpClient.stop();
         }
     }
 


### PR DESCRIPTION
Rather than making LifeCycle AutoCloseable, just implement AutoCloseable in the client components.

Update tests to use try-with-resources accordingly.