### PR TITLE
Issue #12163 - Adding missing HttpConfiguration fields to JMX and dump()

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java
@@ -163,6 +163,7 @@ public class HttpConfiguration implements Dumpable
         _redirectUriCompliance = config._redirectUriCompliance;
         _serverAuthority = config._serverAuthority;
         _localAddress = config._localAddress;
+        _maxUnconsumedRequestContentReads = config._maxUnconsumedRequestContentReads;
     }
 
     /**
@@ -499,8 +500,9 @@ public class HttpConfiguration implements Dumpable
 
     /**
      * @return the set of HTTP methods of requests that can be decoded as
-     * {@code x-www-form-urlencoded} content.
+     * {@code application/x-www-form-urlencoded} content.
      */
+    @ManagedAttribute("The methods that support application/x-www-form-urlencoded content")
     public Set<String> getFormEncodedMethods()
     {
         return _formEncodedMethods.keySet();
@@ -585,6 +587,7 @@ public class HttpConfiguration implements Dumpable
         _minResponseDataRate = bytesPerSecond;
     }
 
+    @ManagedAttribute("The HTTP compliance mode")
     public HttpCompliance getHttpCompliance()
     {
         return _httpCompliance;
@@ -595,6 +598,7 @@ public class HttpConfiguration implements Dumpable
         _httpCompliance = httpCompliance;
     }
 
+    @ManagedAttribute("The URI compliance mode")
     public UriCompliance getUriCompliance()
     {
         return _uriCompliance;
@@ -622,6 +626,7 @@ public class HttpConfiguration implements Dumpable
      * @return The CookieCompliance used for parsing request {@code Cookie} headers.
      * @see #getResponseCookieCompliance()
      */
+    @ManagedAttribute("The HTTP request cookie compliance mode")
     public CookieCompliance getRequestCookieCompliance()
     {
         return _requestCookieCompliance;
@@ -639,6 +644,7 @@ public class HttpConfiguration implements Dumpable
      * @return The CookieCompliance used for generating response {@code Set-Cookie} headers
      * @see #getRequestCookieCompliance()
      */
+    @ManagedAttribute("The HTTP response cookie compliance mode")
     public CookieCompliance getResponseCookieCompliance()
     {
         return _responseCookieCompliance;
@@ -655,6 +661,7 @@ public class HttpConfiguration implements Dumpable
     /**
      * @return the {@link MultiPartCompliance} used for validating multipart form syntax.
      */
+    @ManagedAttribute("The multipart/form-data compliance mode")
     public MultiPartCompliance getMultiPartCompliance()
     {
         return _multiPartCompliance;
@@ -765,7 +772,7 @@ public class HttpConfiguration implements Dumpable
      *
      * @return Returns the connection server authority (name/port) or null
      */
-    @ManagedAttribute("The server authority if none provided by requests")
+    @ManagedAttribute("The server authority override")
     public HostPort getServerAuthority()
     {
         return _serverAuthority;
@@ -833,6 +840,7 @@ public class HttpConfiguration implements Dumpable
             "requestHeaderSize=" + _requestHeaderSize,
             "responseHeaderSize=" + _responseHeaderSize,
             "headerCacheSize=" + _headerCacheSize,
+            "headerCacheCaseSensitive=" + _headerCacheCaseSensitive,
             "secureScheme=" + _secureScheme,
             "securePort=" + _securePort,
             "idleTimeout=" + _idleTimeout,
@@ -842,12 +850,21 @@ public class HttpConfiguration implements Dumpable
             "delayDispatchUntilContent=" + _delayDispatchUntilContent,
             "persistentConnectionsEnabled=" + _persistentConnectionsEnabled,
             "maxErrorDispatches=" + _maxErrorDispatches,
+            "useInputDirectByteBuffers=" + _useInputDirectByteBuffers,
+            "useOutputDirectByteBuffers=" + _useOutputDirectByteBuffers,
             "minRequestDataRate=" + _minRequestDataRate,
             "minResponseDataRate=" + _minResponseDataRate,
+            "httpCompliance=" + _httpCompliance,
+            "uriCompliance=" + _uriCompliance,
+            "redirectUriCompliance=" + _redirectUriCompliance,
             "requestCookieCompliance=" + _requestCookieCompliance,
             "responseCookieCompliance=" + _responseCookieCompliance,
+            "multiPartCompliance=" + _multiPartCompliance,
             "notifyRemoteAsyncErrors=" + _notifyRemoteAsyncErrors,
-            "relativeRedirectAllowed=" + _relativeRedirectAllowed
+            "relativeRedirectAllowed=" + _relativeRedirectAllowed,
+            "serverAuthority=" + _serverAuthority,
+            "localAddress=" + _localAddress,
+            "maxUnconsumedRequestContentReads=" + _maxUnconsumedRequestContentReads
         );
     }
 


### PR DESCRIPTION
Adding missing `HttpConfiguration` attributes/fields to both `dump()` and JMX outputs.

Fixes: #12163