### PR TITLE
Fixes #11822 - HTTP/2 responses exceeding SETTINGS_MAX_HEADER_LIST_SIZE do not result in RST_STREAM or GOAWAY.

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-client/src/main/java/org/eclipse/jetty/http2/client/HTTP2ClientConnectionFactory.java
+++ b/jetty-core/jetty-http2/jetty-http2-client/src/main/java/org/eclipse/jetty/http2/client/HTTP2ClientConnectionFactory.java
@@ -95,8 +95,7 @@ public class HTTP2ClientConnectionFactory implements ClientConnectionFactory
         public void onOpen()
         {
             Map<Integer, Integer> settings = listener.onPreface(getSession());
-            if (settings == null)
-                settings = new HashMap<>();
+            settings = settings == null ? new HashMap<>() : new HashMap<>(settings);
 
             // Below we want to populate any settings to send to the server
             // that have a different default than what prescribed by the RFC.

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -1248,6 +1248,11 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
             this.stream = stream;
         }
 
+        public Frame frame()
+        {
+            return frame;
+        }
+
         public abstract int getFrameBytesGenerated();
 
         public int getDataBytesRemaining()

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HTTP2ServerTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HTTP2ServerTest.java
@@ -428,11 +428,20 @@ public class HTTP2ServerTest extends AbstractServerTest
                 }
                 output.flush();
 
+                AtomicBoolean goAway = new AtomicBoolean();
                 Parser parser = new Parser(bufferPool, 8192);
-                parser.init(new Parser.Listener() {});
+                parser.init(new Parser.Listener()
+                {
+                    @Override
+                    public void onGoAway(GoAwayFrame frame)
+                    {
+                        goAway.set(true);
+                    }
+                });
                 boolean closed = parseResponse(client, parser);
 
-                assertTrue(closed);
+                assertFalse(closed);
+                assertTrue(goAway.get());
             }
         }
     }


### PR DESCRIPTION
Now HpackException.SessionException is treated specially in HTTP2Flusher. 

It is caught, it fails all the entries, and then tries to send a GOAWAY, which will be the only frame allowed into the HTTP2FLusher at that point.