### PR TITLE
Issue #11408 - Environment property values are not expanded

### DIFF
--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
@@ -687,8 +687,9 @@ public class StartArgs
 
                 // TODO module path
 
-                for (Prop property : environment.getProperties())
-                    cmd.addArg(property.key, property.value);
+                Props props = environment.getProperties();
+                for (Prop property : props)
+                    cmd.addArg(property.key, props.expand(property.value));
 
                 for (Path xmlFile : environment.getXmlFiles())
                     cmd.addArg(xmlFile.toAbsolutePath().toString());

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/MainTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/MainTest.java
@@ -14,7 +14,6 @@
 package org.eclipse.jetty.start;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -67,7 +66,7 @@ public class MainTest
     public void testListConfig() throws Exception
     {
         List<String> cmdLineArgs = new ArrayList<>();
-        File testJettyHome = MavenTestingUtils.getTestResourceDir("dist-home");
+        Path testJettyHome = MavenPaths.findTestResourceDir("dist-home");
         cmdLineArgs.add("user.dir=" + testJettyHome);
         cmdLineArgs.add("-Duser.dir=foo"); // used to test "source" display on "Java Environment"
         cmdLineArgs.add("jetty.home=" + testJettyHome);
@@ -99,8 +98,8 @@ public class MainTest
     public void testUnknownDistroCommand() throws Exception
     {
         List<String> cmdLineArgs = new ArrayList<>();
-        File testJettyHome = MavenTestingUtils.getTestResourceDir("dist-home");
-        Path testJettyBase = MavenTestingUtils.getTargetTestingPath("base-example-unknown");
+        Path testJettyHome = MavenPaths.targetTestDir("dist-home");
+        Path testJettyBase = MavenPaths.targetTestDir("base-example-unknown");
         FS.ensureDirectoryExists(testJettyBase);
         Path zedIni = testJettyBase.resolve("start.d/zed.ini");
         FS.ensureDirectoryExists(zedIni.getParent());

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/MainTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/MainTest.java
@@ -23,7 +23,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.eclipse.jetty.toolchain.test.MavenPaths;
-import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -98,7 +97,7 @@ public class MainTest
     public void testUnknownDistroCommand() throws Exception
     {
         List<String> cmdLineArgs = new ArrayList<>();
-        Path testJettyHome = MavenPaths.targetTestDir("dist-home");
+        Path testJettyHome = MavenPaths.findTestResourceDir("dist-home");
         Path testJettyBase = MavenPaths.targetTestDir("base-example-unknown");
         FS.ensureDirectoryExists(testJettyBase);
         Path zedIni = testJettyBase.resolve("start.d/zed.ini");
@@ -158,7 +157,7 @@ public class MainTest
     {
         List<String> cmdLineArgs = new ArrayList<>();
 
-        Path homePath = MavenTestingUtils.getTestResourcePathDir("dist-home").toRealPath();
+        Path homePath = MavenPaths.findTestResourceDir("dist-home");
         cmdLineArgs.add("jetty.home=" + homePath);
         cmdLineArgs.add("user.dir=" + homePath);
 

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/PropertyDump.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/PropertyDump.java
@@ -16,30 +16,35 @@ package org.eclipse.jetty.start;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.util.Enumeration;
+import java.util.Collections;
+import java.util.Objects;
 import java.util.Properties;
+import java.util.function.Predicate;
 
 public class PropertyDump
 {
     public static void main(String[] args)
     {
         System.out.printf("PropertyDump%n");
+
+        Predicate<String> nameSelectionPredicate =
+            (name) ->
+                name.startsWith("test.") ||
+                    name.startsWith("jetty.");
+
         // As System Properties
         Properties props = System.getProperties();
-        Enumeration<?> names = props.propertyNames();
-        while (names.hasMoreElements())
-        {
-            String name = (String)names.nextElement();
-            // only interested in "test." prefixed properties
-            if (name.startsWith("test."))
-            {
-                System.out.printf("System %s=%s%n", name, props.getProperty(name));
-            }
-        }
+        props.stringPropertyNames()
+            .stream()
+            .filter(nameSelectionPredicate)
+            .sorted()
+            .forEach((name) ->
+                System.out.printf("System %s=%s%n", name, props.getProperty(name)));
 
         // As File Argument
         for (String arg : args)
         {
+            System.out.printf("Arg [%s]%n", arg);
             if (arg.endsWith(".properties"))
             {
                 Properties aprops = new Properties();
@@ -47,15 +52,13 @@ public class PropertyDump
                 try (FileReader reader = new FileReader(propFile))
                 {
                     aprops.load(reader);
-                    Enumeration<?> anames = aprops.propertyNames();
-                    while (anames.hasMoreElements())
-                    {
-                        String name = (String)anames.nextElement();
-                        if (name.startsWith("test."))
-                        {
-                            System.out.printf("%s %s=%s%n", propFile.getName(), name, aprops.getProperty(name));
-                        }
-                    }
+                    Collections.list(aprops.propertyNames())
+                        .stream()
+                        .map(Objects::toString)
+                        .filter(nameSelectionPredicate)
+                        .sorted()
+                        .forEach((name) ->
+                            System.out.printf("%s %s=%s%n", propFile.getName(), name, aprops.getProperty(name)));
                 }
                 catch (IOException e)
                 {


### PR DESCRIPTION
If a property belonged to an Environment, then that property value was not expanded.

Fixes: #11408