### PR TITLE
Issue #12173 Ignore dependencies of type pom for the webapp classpath

### DIFF
--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/AbstractUnassembledWebAppMojo.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/AbstractUnassembledWebAppMojo.java
@@ -242,6 +242,10 @@ public abstract class AbstractUnassembledWebAppMojo extends AbstractWebAppMojo
         if ("war".equalsIgnoreCase(artifact.getType()))
             return false;
 
+        //The dependency cannot be a pom
+        if ("pom".equalsIgnoreCase(artifact.getType()))
+            return false;
+
         //The dependency cannot be scope provided (those should be added to the plugin classpath)
         if (Artifact.SCOPE_PROVIDED.equals(artifact.getScope()))
             return false;


### PR DESCRIPTION
Closes #12173 

In previous versions of jetty, we added all dependencies of the webapp to the webapp's classpath as a `File` or a `String`. In jetty-12 we are converting all dependencies into `jar:file` urls, which isn't appropriate for a `.pom` file.  I've fixed this by avoiding considering `.pom` files as being eligible for the classpath (in the same way we don't consider `.war` files as eligible).  