### PR TITLE
Fixes #3553 - Support sslSession() in Jetty Client.

### DIFF
--- a/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/client/http/HTTPClientDocs.java
+++ b/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/client/http/HTTPClientDocs.java
@@ -17,6 +17,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.SocketAddress;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
@@ -26,6 +27,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLSession;
 
 import org.eclipse.jetty.client.AsyncRequestContent;
 import org.eclipse.jetty.client.Authentication;
@@ -34,6 +36,7 @@ import org.eclipse.jetty.client.BasicAuthentication;
 import org.eclipse.jetty.client.BufferingResponseListener;
 import org.eclipse.jetty.client.BytesRequestContent;
 import org.eclipse.jetty.client.CompletableResponseListener;
+import org.eclipse.jetty.client.Connection;
 import org.eclipse.jetty.client.ConnectionPool;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.Destination;
@@ -1179,5 +1182,30 @@ public class HTTPClientDocs
             .body(new BytesRequestContent(validatedResponse.getContent()))
             .send();
         // end::mixedTransports[]
+    }
+
+    public void connectionInformation() throws Exception
+    {
+        // tag::connectionInformation[]
+        HttpClient httpClient = new HttpClient();
+        httpClient.start();
+
+        ContentResponse response = httpClient.newRequest("http://domain.com/path")
+            // The connection information is only available starting from the request begin event.
+            .onRequestBegin(request ->
+            {
+                Connection connection = request.getConnection();
+
+                // Obtain the address of the server.
+                SocketAddress remoteAddress = connection.getRemoteSocketAddress();
+                System.getLogger("connection").log(INFO, "Server address: %s", remoteAddress);
+
+                // Obtain the SSLSession.
+                SSLSession sslSession = connection.getSSLSession();
+                if (sslSession != null)
+                    System.getLogger("connection").log(INFO, "SSLSession: %s", sslSession);
+            })
+            .send();
+        // end::connectionInformation[]
     }
 }

--- a/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/client/http/HTTPClientDocs.java
+++ b/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/client/http/HTTPClientDocs.java
@@ -1201,7 +1201,7 @@ public class HTTPClientDocs
                 System.getLogger("connection").log(INFO, "Server address: %s", remoteAddress);
 
                 // Obtain the SSLSession.
-                SSLSession sslSession = connection.getSSLSession();
+                SSLSession sslSession = connection.getSslSessionData().sslSession();
                 if (sslSession != null)
                     System.getLogger("connection").log(INFO, "SSLSession: %s", sslSession);
             })

--- a/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/client/http/HTTPClientDocs.java
+++ b/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/client/http/HTTPClientDocs.java
@@ -27,7 +27,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
-import javax.net.ssl.SSLSession;
 
 import org.eclipse.jetty.client.AsyncRequestContent;
 import org.eclipse.jetty.client.Authentication;
@@ -75,6 +74,7 @@ import org.eclipse.jetty.http3.client.transport.HttpClientTransportOverHTTP3;
 import org.eclipse.jetty.io.ClientConnectionFactory;
 import org.eclipse.jetty.io.ClientConnector;
 import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.io.Transport;
 import org.eclipse.jetty.io.ssl.SslHandshakeListener;
 import org.eclipse.jetty.quic.client.ClientQuicConfiguration;
@@ -1200,10 +1200,10 @@ public class HTTPClientDocs
                 SocketAddress remoteAddress = connection.getRemoteSocketAddress();
                 System.getLogger("connection").log(INFO, "Server address: %s", remoteAddress);
 
-                // Obtain the SSLSession.
-                SSLSession sslSession = connection.getSslSessionData().sslSession();
-                if (sslSession != null)
-                    System.getLogger("connection").log(INFO, "SSLSession: %s", sslSession);
+                // Obtain the SslSessionData.
+                EndPoint.SslSessionData sslSessionData = connection.getSslSessionData();
+                if (sslSessionData != null)
+                    System.getLogger("connection").log(INFO, "SslSessionData: %s", sslSessionData);
             })
             .send();
         // end::connectionInformation[]

--- a/documentation/jetty/modules/programming-guide/pages/client/http.adoc
+++ b/documentation/jetty/modules/programming-guide/pages/client/http.adoc
@@ -235,7 +235,12 @@ A second request with the same origin sent _after_ the first request/response cy
 A second request with the same origin sent _concurrently_ with the first request will likely cause the opening of a second connection, depending on the connection pool implementation.
 The configuration parameter `HttpClient.maxConnectionsPerDestination` (see also the <<configuration,configuration section>>) controls the max number of connections that can be opened for a destination.
 
-NOTE: If opening connections to a given origin takes a long time, then requests for that origin will queue up in the corresponding destination until the connections are established.
+[NOTE]
+====
+If opening connections to a given origin takes a long time, then requests for that origin will queue up in the corresponding destination until the connections are established.
+
+To save the time spent opening connections, you can xref:connection-pool-precreate-connections[pre-create connections].
+====
 
 Each connection can handle a limited number of concurrent requests.
 For HTTP/1.1, this number is always `1`: there can only be one outstanding request for each connection.
@@ -527,6 +532,28 @@ This is a fancy example of how to mix HTTP versions and low-level transports:
 ----
 include::code:example$src/main/java/org/eclipse/jetty/docs/programming/client/http/HTTPClientDocs.java[tag=mixedTransports]
 ----
+
+[[connection-information]]
+=== Request Connection Information
+
+In order to send a request, it is necessary to obtain a connection, as explained in the xref:request-processing[request processing section].
+
+The HTTP/1.1 protocol may send only one request at a time on a single connection, while multiplexed protocols such as HTTP/2 may send many requests at a time on a single connection.
+
+You can access the connection information, for example the local and remote `SocketAddress`, or the `SSLSession` if the connection is secured using TLS, in the following way:
+
+[,java,indent=0]
+----
+include::code:example$src/main/java/org/eclipse/jetty/docs/programming/client/http/HTTPClientDocs.java[tag=connectionInformation]
+----
+
+[NOTE]
+====
+The connection information is only available when the request is associated with a connection.
+
+This means that the connection is not available in the _request queued_ event, but only starting from the _request begin_ event.
+For more information about request events, see xref:non-blocking[this section].
+====
 
 [[configuration]]
 == HttpClient Configuration

--- a/documentation/jetty/modules/programming-guide/pages/client/http.adoc
+++ b/documentation/jetty/modules/programming-guide/pages/client/http.adoc
@@ -540,7 +540,7 @@ In order to send a request, it is necessary to obtain a connection, as explained
 
 The HTTP/1.1 protocol may send only one request at a time on a single connection, while multiplexed protocols such as HTTP/2 may send many requests at a time on a single connection.
 
-You can access the connection information, for example the local and remote `SocketAddress`, or the `SSLSession` if the connection is secured using TLS, in the following way:
+You can access the connection information, for example the local and remote `SocketAddress`, or the `SslSessionData` if the connection is secured, in the following way:
 
 [,java,indent=0]
 ----

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/Connection.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/Connection.java
@@ -15,7 +15,6 @@ package org.eclipse.jetty.client;
 
 import java.io.Closeable;
 import java.net.SocketAddress;
-import javax.net.ssl.SSLSession;
 
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.util.Promise;
@@ -67,8 +66,8 @@ public interface Connection extends Closeable
     }
 
     /**
-     * @return the {@link SSLSession} associated with the connection, or {@code null}
-     * if the connection is not secure or the {@link SSLSession} is not available.
+     * @return the {@link EndPoint.SslSessionData} associated with
+     * the connection, or {@code null} if the connection is not secure.
      */
     default EndPoint.SslSessionData getSslSessionData()
     {

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/Connection.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/Connection.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.client;
 
 import java.io.Closeable;
 import java.net.SocketAddress;
+import javax.net.ssl.SSLSession;
 
 import org.eclipse.jetty.util.Promise;
 
@@ -60,6 +61,15 @@ public interface Connection extends Closeable
      * @return the remote socket address associated with the connection
      */
     default SocketAddress getRemoteSocketAddress()
+    {
+        return null;
+    }
+
+    /**
+     * @return the {@link SSLSession} associated with the connection, or {@code null}
+     * if the connection is not secure or the {@link SSLSession} is not available.
+     */
+    default SSLSession getSSLSession()
     {
         return null;
     }

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/Connection.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/Connection.java
@@ -17,6 +17,7 @@ import java.io.Closeable;
 import java.net.SocketAddress;
 import javax.net.ssl.SSLSession;
 
+import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.util.Promise;
 
 /**
@@ -69,7 +70,7 @@ public interface Connection extends Closeable
      * @return the {@link SSLSession} associated with the connection, or {@code null}
      * if the connection is not secure or the {@link SSLSession} is not available.
      */
-    default SSLSession getSSLSession()
+    default EndPoint.SslSessionData getSslSessionData()
     {
         return null;
     }

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpProxy.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpProxy.java
@@ -20,6 +20,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLSession;
 
 import org.eclipse.jetty.client.internal.TunnelRequest;
 import org.eclipse.jetty.client.transport.HttpConversation;
@@ -344,6 +345,12 @@ public class HttpProxy extends ProxyConfiguration.Proxy
         public SocketAddress getRemoteSocketAddress()
         {
             return connection.getRemoteSocketAddress();
+        }
+
+        @Override
+        public SSLSession getSSLSession()
+        {
+            return connection.getSSLSession();
         }
 
         @Override

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpProxy.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpProxy.java
@@ -20,7 +20,6 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import javax.net.ssl.SSLSession;
 
 import org.eclipse.jetty.client.internal.TunnelRequest;
 import org.eclipse.jetty.client.transport.HttpConversation;
@@ -348,9 +347,9 @@ public class HttpProxy extends ProxyConfiguration.Proxy
         }
 
         @Override
-        public SSLSession getSSLSession()
+        public EndPoint.SslSessionData getSslSessionData()
         {
-            return connection.getSSLSession();
+            return connection.getSslSessionData();
         }
 
         @Override

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpConnectionOverHTTP.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpConnectionOverHTTP.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAdder;
+import javax.net.ssl.SSLSession;
 
 import org.eclipse.jetty.client.Connection;
 import org.eclipse.jetty.client.Destination;
@@ -114,6 +115,12 @@ public class HttpConnectionOverHTTP extends AbstractConnection implements IConne
     public SocketAddress getRemoteSocketAddress()
     {
         return delegate.getRemoteSocketAddress();
+    }
+
+    @Override
+    public SSLSession getSSLSession()
+    {
+        return delegate.getSSLSession();
     }
 
     @Override
@@ -348,6 +355,13 @@ public class HttpConnectionOverHTTP extends AbstractConnection implements IConne
         public SocketAddress getRemoteSocketAddress()
         {
             return getEndPoint().getRemoteSocketAddress();
+        }
+
+        @Override
+        public SSLSession getSSLSession()
+        {
+            EndPoint.SslSessionData sslSessionData = getEndPoint().getSslSessionData();
+            return sslSessionData == null ? null : sslSessionData.sslSession();
         }
 
         @Override

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpConnectionOverHTTP.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpConnectionOverHTTP.java
@@ -24,7 +24,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAdder;
-import javax.net.ssl.SSLSession;
 
 import org.eclipse.jetty.client.Connection;
 import org.eclipse.jetty.client.Destination;
@@ -118,9 +117,9 @@ public class HttpConnectionOverHTTP extends AbstractConnection implements IConne
     }
 
     @Override
-    public SSLSession getSSLSession()
+    public EndPoint.SslSessionData getSslSessionData()
     {
-        return delegate.getSSLSession();
+        return delegate.getSslSessionData();
     }
 
     @Override
@@ -358,10 +357,9 @@ public class HttpConnectionOverHTTP extends AbstractConnection implements IConne
         }
 
         @Override
-        public SSLSession getSSLSession()
+        public EndPoint.SslSessionData getSslSessionData()
         {
-            EndPoint.SslSessionData sslSessionData = getEndPoint().getSslSessionData();
-            return sslSessionData == null ? null : sslSessionData.sslSession();
+            return getEndPoint().getSslSessionData();
         }
 
         @Override

--- a/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpConnectionOverFCGI.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpConnectionOverFCGI.java
@@ -21,6 +21,7 @@ import java.util.Iterator;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.net.ssl.SSLSession;
 
 import org.eclipse.jetty.client.Connection;
 import org.eclipse.jetty.client.Destination;
@@ -99,6 +100,12 @@ public class HttpConnectionOverFCGI extends AbstractConnection implements IConne
     public SocketAddress getRemoteSocketAddress()
     {
         return delegate.getRemoteSocketAddress();
+    }
+
+    @Override
+    public SSLSession getSSLSession()
+    {
+        return delegate.getSSLSession();
     }
 
     protected Flusher getFlusher()
@@ -357,6 +364,13 @@ public class HttpConnectionOverFCGI extends AbstractConnection implements IConne
         public SocketAddress getRemoteSocketAddress()
         {
             return getEndPoint().getRemoteSocketAddress();
+        }
+
+        @Override
+        public SSLSession getSSLSession()
+        {
+            EndPoint.SslSessionData sslSessionData = getEndPoint().getSslSessionData();
+            return sslSessionData == null ? null : sslSessionData.sslSession();
         }
 
         @Override

--- a/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpConnectionOverFCGI.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpConnectionOverFCGI.java
@@ -21,7 +21,6 @@ import java.util.Iterator;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import javax.net.ssl.SSLSession;
 
 import org.eclipse.jetty.client.Connection;
 import org.eclipse.jetty.client.Destination;
@@ -103,9 +102,9 @@ public class HttpConnectionOverFCGI extends AbstractConnection implements IConne
     }
 
     @Override
-    public SSLSession getSSLSession()
+    public EndPoint.SslSessionData getSslSessionData()
     {
-        return delegate.getSSLSession();
+        return delegate.getSslSessionData();
     }
 
     protected Flusher getFlusher()
@@ -367,10 +366,9 @@ public class HttpConnectionOverFCGI extends AbstractConnection implements IConne
         }
 
         @Override
-        public SSLSession getSSLSession()
+        public EndPoint.SslSessionData getSslSessionData()
         {
-            EndPoint.SslSessionData sslSessionData = getEndPoint().getSslSessionData();
-            return sslSessionData == null ? null : sslSessionData.sslSession();
+            return getEndPoint().getSslSessionData();
         }
 
         @Override

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpConnectionOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpConnectionOverHTTP2.java
@@ -23,7 +23,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import javax.net.ssl.SSLSession;
 
 import org.eclipse.jetty.client.ConnectionPool;
 import org.eclipse.jetty.client.Destination;
@@ -88,10 +87,9 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
     }
 
     @Override
-    public SSLSession getSSLSession()
+    public EndPoint.SslSessionData getSslSessionData()
     {
-        EndPoint.SslSessionData sslSessionData = connection.getEndPoint().getSslSessionData();
-        return sslSessionData == null ? null : sslSessionData.sslSession();
+        return connection.getEndPoint().getSslSessionData();
     }
 
     public boolean isRecycleHttpChannels()

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpConnectionOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpConnectionOverHTTP2.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.net.ssl.SSLSession;
 
 import org.eclipse.jetty.client.ConnectionPool;
 import org.eclipse.jetty.client.Destination;
@@ -44,6 +45,7 @@ import org.eclipse.jetty.http2.HTTP2Session;
 import org.eclipse.jetty.http2.api.Session;
 import org.eclipse.jetty.http2.api.Stream;
 import org.eclipse.jetty.http2.frames.HeadersFrame;
+import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.thread.Sweeper;
 import org.slf4j.Logger;
@@ -83,6 +85,13 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
     public SocketAddress getRemoteSocketAddress()
     {
         return session.getRemoteSocketAddress();
+    }
+
+    @Override
+    public SSLSession getSSLSession()
+    {
+        EndPoint.SslSessionData sslSessionData = connection.getEndPoint().getSslSessionData();
+        return sslSessionData == null ? null : sslSessionData.sslSession();
     }
 
     public boolean isRecycleHttpChannels()

--- a/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpConnectionOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpConnectionOverHTTP3.java
@@ -19,7 +19,6 @@ import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
-import javax.net.ssl.SSLSession;
 
 import org.eclipse.jetty.client.ConnectionPool;
 import org.eclipse.jetty.client.Destination;
@@ -31,6 +30,8 @@ import org.eclipse.jetty.client.transport.HttpRequest;
 import org.eclipse.jetty.client.transport.SendFailure;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http3.client.HTTP3SessionClient;
+import org.eclipse.jetty.io.EndPoint;
+import org.eclipse.jetty.quic.common.QuicSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,11 +67,10 @@ public class HttpConnectionOverHTTP3 extends HttpConnection implements Connectio
     }
 
     @Override
-    public SSLSession getSSLSession()
+    public EndPoint.SslSessionData getSslSessionData()
     {
-        // No SSLSession in QUIC as SSLSession is TLS specific,
-        // and QUIC does not use TLS to secure the communication.
-        return null;
+        QuicSession quicSession = getSession().getProtocolSession().getQuicSession();
+        return EndPoint.SslSessionData.from(null, null, null, quicSession.getPeerCertificates());
     }
 
     @Override

--- a/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpConnectionOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpConnectionOverHTTP3.java
@@ -19,6 +19,7 @@ import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import javax.net.ssl.SSLSession;
 
 import org.eclipse.jetty.client.ConnectionPool;
 import org.eclipse.jetty.client.Destination;
@@ -62,6 +63,14 @@ public class HttpConnectionOverHTTP3 extends HttpConnection implements Connectio
     public SocketAddress getRemoteSocketAddress()
     {
         return session.getRemoteSocketAddress();
+    }
+
+    @Override
+    public SSLSession getSSLSession()
+    {
+        // No SSLSession in QUIC as SSLSession is TLS specific,
+        // and QUIC does not use TLS to secure the communication.
+        return null;
     }
 
     @Override

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
@@ -30,7 +30,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
-import javax.net.ssl.SSLSession;
 
 import org.eclipse.jetty.client.BytesRequestContent;
 import org.eclipse.jetty.client.CompletableResponseListener;
@@ -47,6 +46,7 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http2.FlowControlStrategy;
 import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Request;
@@ -1032,10 +1032,10 @@ public class HttpClientTest extends AbstractTest
             })
             .onRequestHeaders(r ->
             {
-                if (transport.isSecure() && transport != Transport.H3)
+                if (transport.isSecure())
                 {
-                    SSLSession sslSession = r.getConnection().getSSLSession();
-                    if (sslSession == null)
+                    EndPoint.SslSessionData sslSessionData = r.getConnection().getSslSessionData();
+                    if (sslSessionData == null)
                         r.abort(new IllegalStateException());
                 }
             })


### PR DESCRIPTION
Implemented Connection.getSSLSession(), where the Connection can be obtained from the Request: request.getConnection().getSSLSession().

Updated documentation.