### PR TITLE
sendError(-1) is an abort

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -47,6 +47,7 @@ import org.eclipse.jetty.http.MultiPartCompliance;
 import org.eclipse.jetty.http.MultiPartConfig;
 import org.eclipse.jetty.http.Trailers;
 import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.server.internal.CompletionStreamWrapper;
 import org.eclipse.jetty.server.internal.HttpChannelState;
 import org.eclipse.jetty.util.Attributes;
@@ -716,6 +717,7 @@ public interface Request extends Attributes, Content.Source
          *         is returned, then this method must not generate a response, nor complete the callback.
          * @throws Exception if there is a failure during the handling. Catchers cannot assume that the callback will be
          *                   called and thus should attempt to complete the request as if a false had been returned.
+         * @see AbortException
          */
         boolean handle(Request request, Response response, Callback callback) throws Exception;
 
@@ -724,6 +726,34 @@ public interface Request extends Attributes, Content.Source
         default InvocationType getInvocationType()
         {
             return InvocationType.BLOCKING;
+        }
+
+        /**
+         * A marker {@link Exception} that can be passed the {@link Callback#failed(Throwable)} of the {@link Callback}
+         * passed in {@link #handle(Request, Response, Callback)}, to cause request handling to be aborted.  For HTTP/1
+         * an abort is handled with a {@link EndPoint#close()}, for later versions of HTTP, a reset message will be sent.
+         */
+        class AbortException extends Exception
+        {
+            public AbortException()
+            {
+                super();
+            }
+
+            public AbortException(String message)
+            {
+                super(message);
+            }
+
+            public AbortException(String message, Throwable cause)
+            {
+                super(message, cause);
+            }
+
+            public AbortException(Throwable cause)
+            {
+                super(cause);
+            }
         }
     }
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -1590,18 +1590,18 @@ public class HttpChannelState implements HttpChannel, Components
 
                     httpChannelState._callbackFailure = failure;
 
-                    // Consume any input.
-                    Throwable unconsumed = stream.consumeAvailable();
-                    ExceptionUtil.addSuppressedIfNotAssociated(failure, unconsumed);
+                    if (!stream.isCommitted() && !(failure instanceof Request.Handler.AbortException))
+                    {
+                        // Consume any input.
+                        Throwable unconsumed = stream.consumeAvailable();
+                        ExceptionUtil.addSuppressedIfNotAssociated(failure, unconsumed);
 
-                    ChannelResponse response = httpChannelState._response;
-                    if (LOG.isDebugEnabled())
-                        LOG.debug("failed stream.isCommitted={}, response.isCommitted={} {}", stream.isCommitted(), response.isCommitted(), this);
+                        ChannelResponse response = httpChannelState._response;
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("failed stream.isCommitted={}, response.isCommitted={} {}", stream.isCommitted(), response.isCommitted(), this);
 
-                    // There may have been an attempt to write an error response that failed.
-                    // Do not try to write again an error response if already committed.
-                    if (!stream.isCommitted())
                         errorResponse = new ErrorResponse(request);
+                    }
                 }
 
                 if (errorResponse != null)

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiResponse.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiResponse.java
@@ -138,7 +138,7 @@ public class ServletApiResponse implements HttpServletResponse
     {
         switch (sc)
         {
-            case -1 -> getServletChannel().abort(new IOException(msg));
+            case -1 -> getServletChannel().abort(new Request.Handler.AbortException(msg));
             case HttpStatus.PROCESSING_102, HttpStatus.EARLY_HINTS_103 ->
             {
                 if (!isCommitted())

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Response.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Response.java
@@ -488,7 +488,7 @@ public class Response implements HttpServletResponse
 
         switch (code)
         {
-            case -1 -> _channel.abort(new IOException(message));
+            case -1 -> _channel.abort(new org.eclipse.jetty.server.Request.Handler.AbortException(message));
             case HttpStatus.PROCESSING_102 -> sendProcessing();
             case HttpStatus.EARLY_HINTS_103 -> sendEarlyHint();
             default -> _channel.getState().sendError(code, message);


### PR DESCRIPTION
restore behaviour from jetty <= 11 where a sendError(-1) is a true abort, without an attempt to send an error response.