### PR TITLE
Fix NPEs in `HttpSender.ContentSender`

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpSender.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpSender.java
@@ -426,11 +426,10 @@ public abstract class HttpSender
     @Override
     public String toString()
     {
-        return String.format("%s@%x(req=%s,channel=%s,cs=%s,failure=%s)",
+        return String.format("%s@%x(req=%s,cs=%s,failure=%s)",
             getClass().getSimpleName(),
             hashCode(),
             requestState,
-            channel,
             contentSender,
             failure);
     }


### PR DESCRIPTION
Remove contentSender.exchange variable, add null checks, improve toString(), add troubleshooting info

Trying to fix the following exception reported [here](https://github.com/jetty/jetty.project/pull/12199#issuecomment-2316265619):
```
Caused by: java.util.concurrent.ExecutionException: java.lang.NullPointerException: Cannot invoke "org.eclipse.jetty.client.transport.HttpExchange.getRequest()" because "exchange" is null
	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:396)
	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2073)
	at org.eclipse.jetty.client.transport.HttpRequest.send(HttpRequest.java:707)
	at <our code, redacted>
	... 18 more
Caused by: java.lang.NullPointerException: Cannot invoke "org.eclipse.jetty.client.transport.HttpExchange.getRequest()" because "exchange" is null
	at org.eclipse.jetty.client.transport.HttpSender$ContentSender.process(HttpSender.java:511)
	at org.eclipse.jetty.util.IteratingCallback.processing(IteratingCallback.java:262)
	at org.eclipse.jetty.util.IteratingCallback.iterate(IteratingCallback.java:243)
	at org.eclipse.jetty.client.transport.HttpSender.send(HttpSender.java:85)
	at org.eclipse.jetty.client.transport.internal.HttpChannelOverHTTP.send(HttpChannelOverHTTP.java:86)
	at org.eclipse.jetty.client.transport.HttpChannel.send(HttpChannel.java:142)
	at org.eclipse.jetty.client.transport.HttpConnection.send(HttpConnection.java:112)
	at org.eclipse.jetty.client.transport.internal.HttpConnectionOverHTTP$Delegate.send(HttpConnectionOverHTTP.java:379)
	at org.eclipse.jetty.client.transport.internal.HttpConnectionOverHTTP.send(HttpConnectionOverHTTP.java:168)
	at org.eclipse.jetty.client.transport.HttpDestination.send(HttpDestination.java:444)
	at org.eclipse.jetty.client.transport.HttpDestination.process(HttpDestination.java:420)
	at org.eclipse.jetty.client.transport.HttpDestination.process(HttpDestination.java:375)
	at org.eclipse.jetty.client.transport.HttpDestination.send(HttpDestination.java:358)
	at org.eclipse.jetty.client.transport.HttpDestination.send(HttpDestination.java:352)
	at org.eclipse.jetty.client.transport.HttpDestination.send(HttpDestination.java:329)
	at org.eclipse.jetty.client.transport.HttpDestination.send(HttpDestination.java:308)
	at org.eclipse.jetty.client.transport.HttpRequest.sendAsync(HttpRequest.java:751)
	at org.eclipse.jetty.client.transport.HttpDestination.send(HttpDestination.java:303)
	at org.eclipse.jetty.client.transport.HttpRequest.send(HttpRequest.java:744)
	at org.eclipse.jetty.client.CompletableResponseListener.send(CompletableResponseListener.java:79)
	... 20 more
```


Note: this is an experimental PR; trying to figure out what's going on, not meant to be merged in.

