### PR TITLE
Issue #12207 reinstate DefaultHandler for jetty maven plugin

### DIFF
--- a/jetty-core/jetty-maven/src/main/java/org/eclipse/jetty/maven/ServerSupport.java
+++ b/jetty-core/jetty-maven/src/main/java/org/eclipse/jetty/maven/ServerSupport.java
@@ -23,10 +23,12 @@ import org.eclipse.jetty.maven.MavenServerConnector;
 import org.eclipse.jetty.maven.PluginLog;
 import org.eclipse.jetty.security.LoginService;
 import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
+import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.xml.XmlConfiguration;
 
@@ -55,6 +57,9 @@ public class ServerSupport
 
         if (requestLog != null)
             server.setRequestLog(requestLog);
+
+        if (server.getDefaultHandler() == null)
+            server.setDefaultHandler(new DefaultHandler());
 
         ContextHandlerCollection contexts = findContextHandlerCollection(server);
         if (contexts == null)


### PR DESCRIPTION
Closes #12207 

The `DefaultHandler` seems to have been removed from the jetty maven plugin in #9305, this PR reinstates it.