### PR TITLE
Removed reliance on exception to shutdown non persistent connections

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -1523,15 +1523,15 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
                 return;
             }
 
-            // as this is not an upgrade, we can shutdown the output if we know we are not persistent
+            // As this is not an upgrade, we can shutdown the output if we know we are not persistent
             if (_sendCallback._shutdownOut)
                 getEndPoint().shutdownOutput();
 
             _httpChannel.recycle();
 
 
-            // If we are still expecting 100 Continue and no content was read, then
-            // close the parser so that below it seeks EOF, not the next request.
+            // If a 100 Continue is still expected to be sent, but no content was read, then
+            // close the parser so that seeks EOF below, not the next request.
             if (_expects100Continue)
             {
                 _expects100Continue = false;

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestBase.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestBase.java
@@ -200,7 +200,7 @@ public abstract class HttpServerTestBase extends HttpServerTestFixture
             }
         });
 
-        try (Socket client = newSocket(_serverURI.getHost(), _serverURI.getPort()))
+        try (StacklessLogging ignored = new StacklessLogging(Response.class); Socket client = newSocket(_serverURI.getHost(), _serverURI.getPort()))
         {
             OutputStream os = client.getOutputStream();
 
@@ -233,7 +233,7 @@ public abstract class HttpServerTestBase extends HttpServerTestFixture
             }
         });
 
-        try (Socket client = newSocket(_serverURI.getHost(), _serverURI.getPort()))
+        try (StacklessLogging ignored = new StacklessLogging(Response.class); Socket client = newSocket(_serverURI.getHost(), _serverURI.getPort()))
         {
             OutputStream os = client.getOutputStream();
 
@@ -1669,12 +1669,10 @@ public abstract class HttpServerTestBase extends HttpServerTestFixture
         BufferedReader in = new BufferedReader(new InputStreamReader(client.getInputStream()));
 
         String line = in.readLine();
-        System.err.println(line);
         assertThat(line, containsString(" 304 "));
         while (true)
         {
             line = in.readLine();
-            System.err.println(line);
             if (line == null)
                 throw new EOFException();
             if (line.length() == 0)
@@ -1685,7 +1683,6 @@ public abstract class HttpServerTestBase extends HttpServerTestFixture
             assertThat(line, not(containsString("Transfer-Encoding")));
         }
 
-        System.err.println("---");
         line = in.readLine();
         assertThat(line, containsString(" 304 "));
         while (true)


### PR DESCRIPTION
Moved the shutdownOutput in HttpStreamOverHttp1 to before the continuation of handling