### PR TITLE
Fixes #11581 - Flaky WebSocketOverHTTP2Test.testWebSocketOverDynamicHTTP2()

### DIFF
--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee10/websocket/tests/WebSocketOverHTTP2Test.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee10/websocket/tests/WebSocketOverHTTP2Test.java
@@ -69,6 +69,7 @@ import org.eclipse.jetty.websocket.api.exceptions.UpgradeException;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -169,6 +170,7 @@ public class WebSocketOverHTTP2Test
     }
 
     @Test
+    @Tag("flaky") // See analysis in #12235.
     public void testWebSocketOverDynamicHTTP2() throws Exception
     {
         testWebSocketOverDynamicTransport(clientConnector -> new ClientConnectionFactoryOverHTTP2.HTTP2(new HTTP2Client(clientConnector)));


### PR DESCRIPTION
Marked the test as flaky, actual resolution needs resolving #12235.