### PR TITLE
Fixes #12227 - Improve HttpConnection buffer recycling.

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -482,7 +482,8 @@ public class HttpChannelState implements HttpChannel, Components
             }
         }
 
-        // Consume content as soon as possible to open any flow control window.
+        // Consume content as soon as possible to open any
+        // flow control window and release any request buffer.
         Throwable unconsumed = stream.consumeAvailable();
         if (unconsumed != null && LOG.isDebugEnabled())
             LOG.debug("consuming content during error {}", unconsumed.toString());

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -488,11 +488,12 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
             if (!_parser.inContentState())
             {
                 // The request is complete, and we are going to re-enter onFillable(),
-                // because either A) the request/response was completed synchronously
-                // so the onFillable() thread will loop, or B) the request/response
+                // because either A: the request/response was completed synchronously
+                // so the onFillable() thread will loop, or B: the request/response
                 // was completed asynchronously, and the HttpStreamOverHTTP1 dispatches
                 // a call to onFillable() to process the next request.
-                // Therefore, there is no need to release the request buffer here.
+                // Therefore, there is no need to release the request buffer here,
+                // also because the buffer may contain pipelined requests.
                 break;
             }
 
@@ -612,19 +613,6 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
             fillInterested();
         else
             getExecutor().execute(this);
-    }
-
-    @Override
-    public void onClose(Throwable cause)
-    {
-        // TODO: do we really need to do this?
-        //  This event is fired really late, sendCallback should already be failed at this point.
-        //  Revisit whether we still need IteratingCallback.close().
-        if (cause == null)
-            _sendCallback.close();
-        else
-            _sendCallback.abort(cause);
-        super.onClose(cause);
     }
 
     @Override

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -319,14 +319,10 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
     public ByteBuffer onUpgradeFrom()
     {
         if (isRequestBufferEmpty())
-        {
-            releaseRequestBuffer();
             return null;
-        }
         ByteBuffer unconsumed = ByteBuffer.allocateDirect(_requestBuffer.remaining());
         unconsumed.put(_requestBuffer.getByteBuffer());
         unconsumed.flip();
-        releaseRequestBuffer();
         return unconsumed;
     }
 
@@ -1584,7 +1580,7 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
                 if (LOG.isDebugEnabled())
                     LOG.debug("Resuming onFillable() {}", HttpConnection.this);
                 // Dispatch to handle pipelined requests.
-                getExecutor().execute(HttpConnection.this);
+                _httpChannel.getRequest().getComponents().getExecutor().execute(HttpConnection.this);
             }
             catch (RejectedExecutionException x)
             {

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -103,7 +103,7 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
     private final LongAdder bytesOut = new LongAdder();
     private final AtomicBoolean _handling = new AtomicBoolean(false);
     private final HttpFields.Mutable _headerBuilder = HttpFields.build();
-    private volatile RetainableByteBuffer _retainableByteBuffer;
+    private volatile RetainableByteBuffer _requestBuffer;
     private HttpFields.Mutable _trailers;
     private Runnable _onRequest;
     private long _requests;
@@ -323,8 +323,8 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
             releaseRequestBuffer();
             return null;
         }
-        ByteBuffer unconsumed = ByteBuffer.allocateDirect(_retainableByteBuffer.remaining());
-        unconsumed.put(_retainableByteBuffer.getByteBuffer());
+        ByteBuffer unconsumed = ByteBuffer.allocateDirect(_requestBuffer.remaining());
+        unconsumed.put(_requestBuffer.getByteBuffer());
         unconsumed.flip();
         releaseRequestBuffer();
         return unconsumed;
@@ -333,56 +333,51 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
     @Override
     public void onUpgradeTo(ByteBuffer buffer)
     {
-        BufferUtil.append(getRequestBuffer(), buffer);
+        ensureRequestBuffer();
+        BufferUtil.append(_requestBuffer.getByteBuffer(), buffer);
     }
 
-    void releaseRequestBuffer()
+    private void releaseRequestBuffer()
     {
-        if (_retainableByteBuffer != null && !_retainableByteBuffer.hasRemaining())
-        {
-            if (LOG.isDebugEnabled())
-                LOG.debug("releaseRequestBuffer {}", this);
-            RetainableByteBuffer buffer = _retainableByteBuffer;
-            _retainableByteBuffer = null;
-            if (!buffer.release())
-                throw new IllegalStateException("unreleased buffer " + buffer);
-        }
+        if (LOG.isDebugEnabled())
+            LOG.debug("releasing request buffer {} {}", this, _requestBuffer);
+        _requestBuffer.release();
+        _requestBuffer = null;
     }
 
-    private ByteBuffer getRequestBuffer()
+    private void ensureRequestBuffer()
     {
-        if (_retainableByteBuffer == null)
-            _retainableByteBuffer = _bufferPool.acquire(getInputBufferSize(), isUseInputDirectByteBuffers());
-        return _retainableByteBuffer.getByteBuffer();
+        if (_requestBuffer == null)
+            _requestBuffer = _bufferPool.acquire(getInputBufferSize(), isUseInputDirectByteBuffers());
     }
 
     public boolean isRequestBufferEmpty()
     {
-        return _retainableByteBuffer == null || !_retainableByteBuffer.hasRemaining();
+        return _requestBuffer == null || !_requestBuffer.hasRemaining();
     }
 
     @Override
     public void onFillable()
     {
         if (LOG.isDebugEnabled())
-            LOG.debug(">>onFillable enter {} {} {}", this, _httpChannel, _retainableByteBuffer);
+            LOG.debug("onFillable enter {} {} {}", this, _httpChannel, _requestBuffer);
 
         HttpConnection last = setCurrentConnection(this);
         try
         {
+            ensureRequestBuffer();
+
             // We must loop until we fill -1 or there is an async pause in handling.
             // Note that the endpoint might already be closed in some special circumstances.
             while (true)
             {
-                // Fill the request buffer (if needed).
                 int filled = fillRequestBuffer();
                 if (LOG.isDebugEnabled())
-                    LOG.debug("onFillable filled {} {} {} {}", filled, this, _httpChannel, _retainableByteBuffer);
+                    LOG.debug("onFillable filled {} {} {} {}", filled, this, _httpChannel, _requestBuffer);
 
                 if (filled < 0 && getEndPoint().isOutputShutdown())
                     close();
 
-                // Parse the request buffer.
                 boolean handle = parseRequestBuffer();
 
                 // There could be a connection upgrade before handling
@@ -390,52 +385,64 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
                 // If there was a connection upgrade, the other
                 // connection took over, nothing more to do here.
                 if (getEndPoint().getConnection() != this)
+                {
+                    releaseRequestBuffer();
                     break;
+                }
 
-                // Handle channel event. This will only be true when the headers of a request have been received.
+                // The headers of a request have been received.
                 if (handle)
                 {
                     Request request = _httpChannel.getRequest();
                     if (LOG.isDebugEnabled())
                         LOG.debug("HANDLE {} {}", request, this);
 
-                    // handle the request by running the task obtained from onRequest
+                    // Handle the request by running the task.
                     _handling.set(true);
                     Runnable onRequest = _onRequest;
                     _onRequest = null;
                     onRequest.run();
 
-                    // If the _handling boolean has already been CaS'd to false, then stream is completed and we are no longer
-                    // handling, so the caller can continue to fill and parse more connections.  If it is still true, then some
-                    // thread is still handling the request and they will need to organize more filling and parsing once complete.
+                    // If the CaS succeeds, then some thread is still handling the request.
+                    // If the CaS fails, then stream is completed, we are no longer handling,
+                    // so the caller can continue to fill and parse more connections.
                     if (_handling.compareAndSet(true, false))
                     {
                         if (LOG.isDebugEnabled())
                             LOG.debug("request !complete {} {}", request, this);
+                        // Cannot release the request buffer here, because the
+                        // application may read concurrently from another thread.
+                        // The request buffer will be released by the application
+                        // reading the request content, or by the implementation
+                        // trying to consume the request content.
                         break;
                     }
 
-                    // If the request is complete, but has been upgraded, then break
+                    // If there was an upgrade, release and return.
                     if (getEndPoint().getConnection() != this)
                     {
                         if (LOG.isDebugEnabled())
                             LOG.debug("upgraded {} -> {}", this, getEndPoint().getConnection());
+                        releaseRequestBuffer();
                         break;
                     }
                 }
+                else if (filled == 0)
+                {
+                    releaseRequestBuffer();
+                    fillInterested();
+                    break;
+                }
                 else if (filled < 0)
                 {
+                    releaseRequestBuffer();
                     getEndPoint().shutdownOutput();
                     break;
                 }
                 else if (_requestHandler._failure != null)
                 {
                     // There was an error, don't fill more.
-                    break;
-                }
-                else if (filled == 0)
-                {
-                    fillInterested();
+                    releaseRequestBuffer();
                     break;
                 }
             }
@@ -446,11 +453,8 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
             {
                 if (LOG.isDebugEnabled())
                     LOG.debug("caught exception {} {}", this, _httpChannel, x);
-                if (_retainableByteBuffer != null)
-                {
-                    _retainableByteBuffer.clear();
+                if (_requestBuffer != null)
                     releaseRequestBuffer();
-                }
             }
             finally
             {
@@ -461,7 +465,7 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
         {
             setCurrentConnection(last);
             if (LOG.isDebugEnabled())
-                LOG.debug("<<onFillable exit {} {} {}", this, _httpChannel, _retainableByteBuffer);
+                LOG.debug("onFillable exit {} {} {}", this, _httpChannel, _requestBuffer);
         }
     }
 
@@ -471,70 +475,62 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
      */
     void parseAndFillForContent()
     {
-        // Defensive check to avoid an infinite select/wakeup/fillAndParseForContent/wait loop
-        // in case the parser was mistakenly closed and the connection was not aborted.
-        if (_parser.isTerminated())
-        {
-            _requestHandler.messageComplete();
-            return;
-        }
+        ensureRequestBuffer();
 
-        // When fillRequestBuffer() is called, it must always be followed by a parseRequestBuffer() call otherwise this method
-        // doesn't trigger EOF/earlyEOF which breaks AsyncRequestReadTest.testPartialReadThenShutdown().
-
-        // This loop was designed by a committee and voted by a majority.
         while (_parser.inContentState())
         {
             if (parseRequestBuffer())
                 break;
-            // Re-check the parser state after parsing to avoid filling,
-            // otherwise fillRequestBuffer() would acquire a ByteBuffer
-            // that may be leaked.
-            if (_parser.inContentState() && fillRequestBuffer() <= 0)
+
+            if (!_parser.inContentState())
+            {
+                // The request is complete, and we are going to re-enter onFillable(),
+                // because either A) the request/response was completed synchronously
+                // so the onFillable() thread will loop, or B) the request/response
+                // was completed asynchronously, and the HttpStreamOverHTTP1 dispatches
+                // a call to onFillable() to process the next request.
+                // Therefore, there is no need to release the request buffer here.
                 break;
+            }
+
+            assert !_requestBuffer.hasRemaining();
+
+            if (_requestBuffer.isRetained())
+            {
+                // The application has retained the content chunks,
+                // reacquire the buffer to avoid overwriting the content.
+                releaseRequestBuffer();
+                ensureRequestBuffer();
+            }
+
+            int filled = fillRequestBuffer();
+            if (filled <= 0)
+            {
+                releaseRequestBuffer();
+                break;
+            }
         }
     }
 
     private int fillRequestBuffer()
     {
-        if (_retainableByteBuffer != null && _retainableByteBuffer.isRetained())
-        {
-            // TODO this is almost certainly wrong
-            RetainableByteBuffer newBuffer = _bufferPool.acquire(getInputBufferSize(), isUseInputDirectByteBuffers());
-            if (LOG.isDebugEnabled())
-                LOG.debug("replace buffer {} <- {} in {}", _retainableByteBuffer, newBuffer, this);
-            _retainableByteBuffer.release();
-            _retainableByteBuffer = newBuffer;
-        }
-
         if (!isRequestBufferEmpty())
-            return _retainableByteBuffer.remaining();
+            return _requestBuffer.remaining();
 
-        // Get a buffer
-        // We are not in a race here for the request buffer as we have not yet received a request,
-        // so there are not any possible legal threads calling #parseContent or #completed.
-        ByteBuffer requestBuffer = getRequestBuffer();
-
-        // fill
         try
         {
+            ByteBuffer requestBuffer = _requestBuffer.getByteBuffer();
             int filled = getEndPoint().fill(requestBuffer);
             if (filled == 0) // Do a retry on fill 0 (optimization for SSL connections)
                 filled = getEndPoint().fill(requestBuffer);
 
             if (LOG.isDebugEnabled())
-                LOG.debug("{} filled {} {}", this, filled, _retainableByteBuffer);
+                LOG.debug("{} filled {} {}", this, filled, _requestBuffer);
 
             if (filled > 0)
-            {
                 bytesIn.add(filled);
-            }
-            else
-            {
-                if (filled < 0)
-                    _parser.atEOF();
-                releaseRequestBuffer();
-            }
+            else if (filled < 0)
+                _parser.atEOF();
 
             return filled;
         }
@@ -543,11 +539,6 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
             if (LOG.isDebugEnabled())
                 LOG.debug("Unable to fill from endpoint {}", getEndPoint(), x);
             _parser.atEOF();
-            if (_retainableByteBuffer != null)
-            {
-                _retainableByteBuffer.clear();
-                releaseRequestBuffer();
-            }
             return -1;
         }
     }
@@ -555,19 +546,15 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
     private boolean parseRequestBuffer()
     {
         if (LOG.isDebugEnabled())
-            LOG.debug("{} parse {}", this, _retainableByteBuffer);
+            LOG.debug("{} parse {}", this, _requestBuffer);
 
         if (_parser.isTerminated())
             throw new RuntimeIOException("Parser is terminated");
 
-        boolean handle = _parser.parseNext(_retainableByteBuffer == null ? BufferUtil.EMPTY_BUFFER : _retainableByteBuffer.getByteBuffer());
+        boolean handle = _parser.parseNext(_requestBuffer.getByteBuffer());
 
         if (LOG.isDebugEnabled())
             LOG.debug("{} parsed {} {}", this, handle, _parser);
-
-        // recycle buffer ?
-        if (_retainableByteBuffer != null && !_retainableByteBuffer.isRetained())
-            releaseRequestBuffer();
 
         return handle;
     }
@@ -969,14 +956,14 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
         public boolean content(ByteBuffer buffer)
         {
             HttpStreamOverHTTP1 stream = _stream.get();
-            if (stream == null || stream._chunk != null || _retainableByteBuffer == null)
+            if (stream == null || stream._chunk != null || _requestBuffer == null)
                 throw new IllegalStateException();
 
             if (LOG.isDebugEnabled())
-                LOG.debug("content {}/{} for {}", BufferUtil.toDetailString(buffer), _retainableByteBuffer, HttpConnection.this);
+                LOG.debug("content {}/{} for {}", BufferUtil.toDetailString(buffer), _requestBuffer, HttpConnection.this);
 
-            _retainableByteBuffer.retain();
-            stream._chunk = Content.Chunk.asChunk(buffer, false, _retainableByteBuffer);
+            _requestBuffer.retain();
+            stream._chunk = Content.Chunk.asChunk(buffer, false, _requestBuffer);
             return true;
         }
 
@@ -1520,6 +1507,11 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
                 if (LOG.isDebugEnabled())
                     LOG.debug("abort due to pending read {} {} ", this, getEndPoint());
                 abort(new IOException("Pending read in onCompleted"));
+                _httpChannel.recycle();
+                _parser.reset();
+                _generator.reset();
+                if (!_handling.compareAndSet(true, false))
+                    resume();
                 return;
             }
 
@@ -1529,6 +1521,8 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
                 _httpChannel.recycle();
                 _parser.close();
                 _generator.reset();
+                if (!_handling.compareAndSet(true, false))
+                    releaseRequestBuffer();
                 return;
             }
 
@@ -1560,40 +1554,7 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
             if (LOG.isDebugEnabled())
                 LOG.debug("non-current completion {}", this);
 
-            // If we are looking for the next request
-            if (_parser.isStart())
-            {
-                // if the buffer is empty
-                if (isRequestBufferEmpty())
-                {
-                    // look for more data
-                    fillInterested();
-                }
-                // else if we are still running
-                else if (getConnector().isRunning())
-                {
-                    // Dispatched to handle a pipelined request
-                    try
-                    {
-                        getExecutor().execute(HttpConnection.this);
-                    }
-                    catch (RejectedExecutionException e)
-                    {
-                        if (getConnector().isRunning())
-                            LOG.warn("Failed dispatch of {}", this, e);
-                        else
-                            LOG.trace("IGNORED", e);
-                        getEndPoint().close();
-                    }
-                }
-                else
-                {
-                    getEndPoint().close();
-                }
-            }
-            // else the parser must be closed, so seek the EOF if we are still open
-            else if (getEndPoint().isOpen())
-                fillInterested();
+            resume();
         }
 
         @Override
@@ -1609,6 +1570,28 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
             if (LOG.isDebugEnabled())
                 LOG.debug("aborting", x);
             abort(x);
+            _httpChannel.recycle();
+            _parser.reset();
+            _generator.reset();
+            if (!_handling.compareAndSet(true, false))
+                resume();
+        }
+
+        private void resume()
+        {
+            try
+            {
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Resuming onFillable() {}", HttpConnection.this);
+                // Dispatch to handle pipelined requests.
+                getExecutor().execute(HttpConnection.this);
+            }
+            catch (RejectedExecutionException x)
+            {
+                getEndPoint().close(x);
+                // Resume by running, to release the request buffer.
+                run();
+            }
         }
 
         private void abort(Throwable failure)

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -1118,7 +1118,6 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
                     _chunk.release();
                 _chunk = Content.Chunk.from(result, true);
             }
-            releaseRequestBuffer();
             return result;
         }
 

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestListenersTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestListenersTest.java
@@ -191,7 +191,7 @@ public class RequestListenersTest
             Content-Length: 1
             Connection: close
                             
-            """, 2000 * idleTimeout, TimeUnit.MILLISECONDS));
+            """, 2 * idleTimeout, TimeUnit.MILLISECONDS));
 
         int expectedStatus = succeedCallback ? HttpStatus.OK_200 : HttpStatus.INTERNAL_SERVER_ERROR_500;
         assertEquals(expectedStatus, response.getStatus());

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestListenersTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestListenersTest.java
@@ -195,7 +195,9 @@ public class RequestListenersTest
 
         int expectedStatus = succeedCallback ? HttpStatus.OK_200 : HttpStatus.INTERNAL_SERVER_ERROR_500;
         assertEquals(expectedStatus, response.getStatus());
-        assertThat(failureLatch.await(idleTimeout + 500, TimeUnit.MILLISECONDS), is(failIdleTimeout && !succeedCallback));
+        // The failure listener is never invoked because completing the callback
+        // produces a response that completes the stream so the failure is ignored.
+        assertThat(failureLatch.await(idleTimeout + 500, TimeUnit.MILLISECONDS), is(false));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Alternative to #12228.

In this PR, the responsibility to release the buffers is in 2 methods: onFillable() (called when network data is available, and to process the next request) and parseAndFillForContent() (called from Request.read()).