### PR TITLE
Issue #12241 Restore SameSite config as session cookie comment.

### DIFF
--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Response.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Response.java
@@ -76,20 +76,20 @@ public class Response implements HttpServletResponse
      * String used in the {@code Comment} attribute of {@link Cookie}
      * to support the {@code HttpOnly} attribute.
      **/
-    private static final String HTTP_ONLY_COMMENT = "__HTTP_ONLY__";
+    protected static final String HTTP_ONLY_COMMENT = "__HTTP_ONLY__";
     /**
      * String used in the {@code Comment} attribute of {@link Cookie}
      * to support the {@code Partitioned} attribute.
      **/
-    private static final String PARTITIONED_COMMENT = "__PARTITIONED__";
+    protected static final String PARTITIONED_COMMENT = "__PARTITIONED__";
     /**
      * The strings used in the {@code Comment} attribute of {@link Cookie}
      * to support the {@code SameSite} attribute.
      **/
-    private static final String SAME_SITE_COMMENT = "__SAME_SITE_";
-    private static final String SAME_SITE_NONE_COMMENT = SAME_SITE_COMMENT + "NONE__";
-    private static final String SAME_SITE_LAX_COMMENT = SAME_SITE_COMMENT + "LAX__";
-    private static final String SAME_SITE_STRICT_COMMENT = SAME_SITE_COMMENT + "STRICT__";
+    protected static final String SAME_SITE_COMMENT = "__SAME_SITE_";
+    protected static final String SAME_SITE_NONE_COMMENT = SAME_SITE_COMMENT + "NONE__";
+    protected static final String SAME_SITE_LAX_COMMENT = SAME_SITE_COMMENT + "LAX__";
+    protected static final String SAME_SITE_STRICT_COMMENT = SAME_SITE_COMMENT + "STRICT__";
 
     public enum OutputType
     {

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Response.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Response.java
@@ -1494,7 +1494,7 @@ public class Response implements HttpServletResponse
         }
     }
 
-    private static class HttpCookieFacade implements HttpCookie
+    protected static class HttpCookieFacade implements HttpCookie
     {
         private final Cookie _cookie;
         private final String _comment;
@@ -1622,12 +1622,12 @@ public class Response implements HttpServletResponse
             return comment != null && comment.contains(HTTP_ONLY_COMMENT);
         }
 
-        private static boolean isPartitionedInComment(String comment)
+        protected static boolean isPartitionedInComment(String comment)
         {
             return comment != null && comment.contains(PARTITIONED_COMMENT);
         }
 
-        private static SameSite getSameSiteFromComment(String comment)
+        protected static SameSite getSameSiteFromComment(String comment)
         {
             if (comment == null)
                 return null;
@@ -1640,7 +1640,7 @@ public class Response implements HttpServletResponse
             return null;
         }
 
-        private static String getCommentWithoutAttributes(String comment)
+        protected static String getCommentWithoutAttributes(String comment)
         {
             if (comment == null)
                 return null;

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/SessionHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/SessionHandler.java
@@ -679,17 +679,18 @@ public class SessionHandler extends ScopedHandler implements SessionConfig.Mutab
         public void setComment(String comment)
         {
             checkAvailable();
-            _sessionManager.setSessionComment(comment);
+
             if (!StringUtil.isEmpty(comment))
             {
-                if (comment.contains(SAME_SITE_STRICT_COMMENT))
-                    _sessionManager.setSameSite(HttpCookie.SameSite.STRICT);
-                if (comment.contains(SAME_SITE_LAX_COMMENT))
-                     _sessionManager.setSameSite(HttpCookie.SameSite.LAX);
-                if (comment.contains(SAME_SITE_NONE_COMMENT))
-                    _sessionManager.setSameSite(HttpCookie.SameSite.NONE);
-                if (comment.contains(PARTITIONED_COMMENT))
-                    _sessionManager.setPartitioned(true);
+                HttpCookie.SameSite sameSite = Response.HttpCookieFacade.getSameSiteFromComment(comment);
+                if (sameSite != null)
+                    _sessionManager.setSameSite(sameSite);
+
+                boolean partitioned = Response.HttpCookieFacade.isPartitionedInComment(comment);
+                if (partitioned)
+                    _sessionManager.setPartitioned(partitioned);
+
+                _sessionManager.setSessionComment(Response.HttpCookieFacade.getCommentWithoutAttributes(comment));
             }
         }
 

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/SessionHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/SessionHandler.java
@@ -53,6 +53,7 @@ import org.eclipse.jetty.session.SessionConfig;
 import org.eclipse.jetty.session.SessionIdManager;
 import org.eclipse.jetty.session.SessionManager;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -613,12 +614,19 @@ public class SessionHandler extends ScopedHandler implements SessionConfig.Mutab
      * CookieConfig
      *
      * Implementation of the jakarta.servlet.SessionCookieConfig.
-     * SameSite configuration can be achieved by using setComment
+     * SameSite configuration can be achieved by using setComment.
+     * Partitioned configuration can be achieved by using setComment.
      *
      * @see HttpCookie
      */
     public final class CookieConfig implements SessionCookieConfig
     {
+        protected static final String SAME_SITE_COMMENT = "__SAME_SITE_";
+        protected static final String SAME_SITE_NONE_COMMENT = SAME_SITE_COMMENT + "NONE__";
+        protected static final String SAME_SITE_LAX_COMMENT = SAME_SITE_COMMENT + "LAX__";
+        protected static final String SAME_SITE_STRICT_COMMENT = SAME_SITE_COMMENT + "STRICT__";
+        protected static final String PARTITIONED_COMMENT = "__PARTITIONED__";
+
         @Override
         public String getComment()
         {
@@ -672,6 +680,17 @@ public class SessionHandler extends ScopedHandler implements SessionConfig.Mutab
         {
             checkAvailable();
             _sessionManager.setSessionComment(comment);
+            if (!StringUtil.isEmpty(comment))
+            {
+                if (comment.contains(SAME_SITE_STRICT_COMMENT))
+                    _sessionManager.setSameSite(HttpCookie.SameSite.STRICT);
+                if (comment.contains(SAME_SITE_LAX_COMMENT))
+                     _sessionManager.setSameSite(HttpCookie.SameSite.LAX);
+                if (comment.contains(SAME_SITE_NONE_COMMENT))
+                    _sessionManager.setSameSite(HttpCookie.SameSite.NONE);
+                if (comment.contains(PARTITIONED_COMMENT))
+                    _sessionManager.setPartitioned(true);
+            }
         }
 
         @Override

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/SessionHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/SessionHandler.java
@@ -621,12 +621,6 @@ public class SessionHandler extends ScopedHandler implements SessionConfig.Mutab
      */
     public final class CookieConfig implements SessionCookieConfig
     {
-        protected static final String SAME_SITE_COMMENT = "__SAME_SITE_";
-        protected static final String SAME_SITE_NONE_COMMENT = SAME_SITE_COMMENT + "NONE__";
-        protected static final String SAME_SITE_LAX_COMMENT = SAME_SITE_COMMENT + "LAX__";
-        protected static final String SAME_SITE_STRICT_COMMENT = SAME_SITE_COMMENT + "STRICT__";
-        protected static final String PARTITIONED_COMMENT = "__PARTITIONED__";
-
         @Override
         public String getComment()
         {

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/SessionHandlerTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/SessionHandlerTest.java
@@ -168,7 +168,7 @@ public class SessionHandlerTest
     }
     
     @Test
-    public void testSessionCookie() throws Exception
+    public void testSessionCookieConfig() throws Exception
     {
         Server server = new Server();
         MockSessionIdManager idMgr = new MockSessionIdManager(server);
@@ -193,9 +193,51 @@ public class SessionHandlerTest
         
         //for < ee10, SameSite cannot be set on the SessionCookieConfig, only on the SessionManager, or 
         //a default value on the context attribute org.eclipse.jetty.cookie.sameSiteDefault
+        //mgr.setSameSite(HttpCookie.SameSite.STRICT);
+        //mgr.setPartitioned(true);
+        //test setting SameSite and Partitioned the old way in the comment
+        sessionCookieConfig.setComment(SessionHandler.CookieConfig.PARTITIONED_COMMENT + " " + SessionHandler.CookieConfig.SAME_SITE_STRICT_COMMENT);
+        
+        HttpCookie cookie = mgr.getSessionManager().getSessionCookie(session, false);
+        assertEquals("SPECIAL", cookie.getName());
+        assertEquals("universe", cookie.getDomain());
+        assertEquals("/foo", cookie.getPath());
+        assertFalse(cookie.isHttpOnly());
+        assertFalse(cookie.isSecure());
+        assertTrue(cookie.isPartitioned());
+        assertEquals(99, cookie.getMaxAge());
+        assertEquals(HttpCookie.SameSite.STRICT, cookie.getSameSite());
+
+        String cookieStr = HttpCookieUtils.getRFC6265SetCookie(cookie);
+        assertThat(cookieStr, containsString("; Partitioned; SameSite=Strict"));
+    }
+
+    @Test
+    public void testSessionCookieViaSetters() throws Exception
+    {
+        Server server = new Server();
+        MockSessionIdManager idMgr = new MockSessionIdManager(server);
+        idMgr.setWorkerName("node1");
+        SessionHandler mgr = new SessionHandler();
+        MockSessionCache cache = new MockSessionCache(mgr.getSessionManager());
+        cache.setSessionDataStore(new NullSessionDataStore());
+        mgr.setSessionCache(cache);
+        mgr.setSessionIdManager(idMgr);
+
+        long now = System.currentTimeMillis();
+
+        ManagedSession session = new ManagedSession(mgr.getSessionManager(), new SessionData("123", "_foo", "0.0.0.0", now, now, now, 30));
+        session.setExtendedId("123.node1");
+
+        mgr.setSessionCookie("SPECIAL");
+        mgr.setSessionDomain("universe");
+        mgr.setHttpOnly(false);
+        mgr.setSecureCookies(false);
+        mgr.setSessionPath("/foo");
+        mgr.setMaxCookieAge(99);
         mgr.setSameSite(HttpCookie.SameSite.STRICT);
         mgr.setPartitioned(true);
-        
+
         HttpCookie cookie = mgr.getSessionManager().getSessionCookie(session, false);
         assertEquals("SPECIAL", cookie.getName());
         assertEquals("universe", cookie.getDomain());

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/SessionHandlerTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/SessionHandlerTest.java
@@ -192,7 +192,7 @@ public class SessionHandlerTest
         sessionCookieConfig.setMaxAge(99);
 
         //test setting SameSite and Partitioned the old way in the comment
-        sessionCookieConfig.setComment(SessionHandler.CookieConfig.PARTITIONED_COMMENT + " " + SessionHandler.CookieConfig.SAME_SITE_STRICT_COMMENT);
+        sessionCookieConfig.setComment(Response.PARTITIONED_COMMENT + " " + Response.SAME_SITE_STRICT_COMMENT);
         
         HttpCookie cookie = mgr.getSessionManager().getSessionCookie(session, false);
         assertEquals("SPECIAL", cookie.getName());

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/SessionHandlerTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/SessionHandlerTest.java
@@ -190,11 +190,7 @@ public class SessionHandlerTest
         sessionCookieConfig.setSecure(false);
         sessionCookieConfig.setPath("/foo");
         sessionCookieConfig.setMaxAge(99);
-        
-        //for < ee10, SameSite cannot be set on the SessionCookieConfig, only on the SessionManager, or 
-        //a default value on the context attribute org.eclipse.jetty.cookie.sameSiteDefault
-        //mgr.setSameSite(HttpCookie.SameSite.STRICT);
-        //mgr.setPartitioned(true);
+
         //test setting SameSite and Partitioned the old way in the comment
         sessionCookieConfig.setComment(SessionHandler.CookieConfig.PARTITIONED_COMMENT + " " + SessionHandler.CookieConfig.SAME_SITE_STRICT_COMMENT);
         
@@ -229,6 +225,7 @@ public class SessionHandlerTest
         ManagedSession session = new ManagedSession(mgr.getSessionManager(), new SessionData("123", "_foo", "0.0.0.0", now, now, now, 30));
         session.setExtendedId("123.node1");
 
+        //test setting up session cookie via setters on SessionHandler
         mgr.setSessionCookie("SPECIAL");
         mgr.setSessionDomain("universe");
         mgr.setHttpOnly(false);


### PR DESCRIPTION
User reported not being able set `SameSite` via old jetty session cookie comment mechanism. This PR restores that, but only for ee8 and ee9.