### PR TITLE
9.4.x: ` IteratingCallback` reset `_iterate` flag when another processing is scheduled

### DIFF
--- a/jetty-util/src/main/java/org/eclipse/jetty/util/IteratingCallback.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/IteratingCallback.java
@@ -280,6 +280,7 @@ public abstract class IteratingCallback implements Callback
                                 }
                                 case SCHEDULED:
                                 {
+                                    _iterate = false;
                                     // we won the race against the callback, so the callback has to process and we can break processing
                                     _state = State.PENDING;
                                     break processing;
@@ -305,6 +306,7 @@ public abstract class IteratingCallback implements Callback
                     {
                         if (action != Action.SCHEDULED)
                             throw new IllegalStateException(String.format("%s[action=%s]", this, action));
+                        _iterate = false;
                         // we lost the race, so we have to keep processing
                         _state = State.PROCESSING;
                         continue;
@@ -462,6 +464,14 @@ public abstract class IteratingCallback implements Callback
 
         if (failure != null)
             onCompleteFailure(new IOException(failure));
+    }
+
+    boolean isPending()
+    {
+        try (Locker.Lock lock = _locker.lock())
+        {
+            return _state == State.PENDING;
+        }
     }
 
     /**

--- a/jetty-util/src/test/java/org/eclipse/jetty/util/IteratingCallbackTest.java
+++ b/jetty-util/src/test/java/org/eclipse/jetty/util/IteratingCallbackTest.java
@@ -27,7 +27,11 @@ import org.eclipse.jetty.util.thread.Scheduler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -47,6 +51,45 @@ public class IteratingCallbackTest
     public void dispose() throws Exception
     {
         scheduler.stop();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testIterateWhileProcessingLoopCount(boolean succeededWinsRace)
+    {
+        AtomicInteger count = new AtomicInteger();
+        IteratingCallback icb = new IteratingCallback()
+        {
+
+            @Override
+            protected Action process()
+            {
+                int counter = count.getAndIncrement();
+                if (counter == 0)
+                {
+                    iterate();
+                    if (succeededWinsRace)
+                    {
+                        succeeded();
+                    }
+                    else
+                    {
+                        new Thread(() ->
+                        {
+                            await().atMost(5, TimeUnit.SECONDS).until(this::isPending, is(true));
+                            succeeded();
+                        }).start();
+                    }
+                    return Action.SCHEDULED;
+                }
+                return Action.IDLE;
+            }
+        };
+
+        icb.iterate();
+
+        await().atMost(10, TimeUnit.SECONDS).until(icb::isIdle, is(true));
+        assertEquals(2, count.get());
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/jetty/jetty.project/issues/12268