### PR TITLE
Fixes #12266 - InvocationType improvements and cleanups.

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClientTransport.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClientTransport.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import org.eclipse.jetty.client.transport.HttpDestination;
 import org.eclipse.jetty.io.ClientConnectionFactory;
+import org.eclipse.jetty.util.thread.Invocable;
 
 /**
  * {@link HttpClientTransport} represents what transport implementations should provide
@@ -100,4 +101,9 @@ public interface HttpClientTransport extends ClientConnectionFactory
      * @param factory the factory for ConnectionPool instances
      */
     public void setConnectionPoolFactory(ConnectionPool.Factory factory);
+
+    public default Invocable.InvocationType getInvocationType(Connection connection)
+    {
+        return Invocable.InvocationType.BLOCKING;
+    }
 }

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/ProxyProtocolClientConnectionFactory.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/ProxyProtocolClientConnectionFactory.java
@@ -509,12 +509,6 @@ public abstract class ProxyProtocolClientConnectionFactory implements ClientConn
         }
 
         @Override
-        public InvocationType getInvocationType()
-        {
-            return InvocationType.NON_BLOCKING;
-        }
-
-        @Override
         public void onFillable()
         {
         }

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpReceiverOverHTTP.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpReceiverOverHTTP.java
@@ -386,7 +386,7 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
     {
         if (LOG.isDebugEnabled())
             LOG.debug("Registering as fill interested in {}", this);
-        getHttpConnection().fillInterested();
+        getHttpConnection().setFillInterest();
     }
 
     private void shutdown()

--- a/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpReceiverOverFCGI.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpReceiverOverFCGI.java
@@ -36,7 +36,7 @@ public class HttpReceiverOverFCGI extends HttpReceiver
             HttpConnectionOverFCGI httpConnection = getHttpChannel().getHttpConnection();
             boolean setFillInterest = httpConnection.parseAndFill(true);
             if (!hasContent() && setFillInterest)
-                httpConnection.fillInterested();
+                fillInterested(httpConnection);
         }
         else
         {
@@ -86,7 +86,7 @@ public class HttpReceiverOverFCGI extends HttpReceiver
         if (chunk != null)
             return chunk;
         if (needFillInterest && fillInterestIfNeeded)
-            httpConnection.fillInterested();
+            fillInterested(httpConnection);
         return null;
     }
 
@@ -138,7 +138,12 @@ public class HttpReceiverOverFCGI extends HttpReceiver
         HttpConnectionOverFCGI httpConnection = getHttpChannel().getHttpConnection();
         boolean setFillInterest = httpConnection.parseAndFill(true);
         if (!hasContent() && setFillInterest)
-            httpConnection.fillInterested();
+            fillInterested(httpConnection);
+    }
+
+    private void fillInterested(HttpConnectionOverFCGI httpConnection)
+    {
+        httpConnection.setFillInterest();
     }
 
     @Override

--- a/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/ServerFCGIConnection.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/ServerFCGIConnection.java
@@ -34,6 +34,7 @@ import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.HttpChannel;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.util.Attributes;
+import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,6 +43,7 @@ public class ServerFCGIConnection extends AbstractMetaDataConnection implements 
 {
     private static final Logger LOG = LoggerFactory.getLogger(ServerFCGIConnection.class);
 
+    private final Callback fillableCallback = new FillableCallback();
     private final HttpChannel.Factory httpChannelFactory = new HttpChannel.DefaultFactory();
     private final Attributes attributes = new Lazy();
     private final Connector connector;
@@ -160,7 +162,7 @@ public class ServerFCGIConnection extends AbstractMetaDataConnection implements 
     public void onOpen()
     {
         super.onOpen();
-        fillInterested();
+        setFillInterest();
     }
 
     @Override
@@ -188,7 +190,7 @@ public class ServerFCGIConnection extends AbstractMetaDataConnection implements 
                 else if (read == 0)
                 {
                     releaseInputBuffer();
-                    fillInterested();
+                    setFillInterest();
                     return;
                 }
                 else
@@ -305,9 +307,14 @@ public class ServerFCGIConnection extends AbstractMetaDataConnection implements 
     {
         releaseInputBuffer();
         if (failure == null)
-            fillInterested();
+            setFillInterest();
         else
             getFlusher().shutdown();
+    }
+
+    private void setFillInterest()
+    {
+        fillInterested(fillableCallback);
     }
 
     @Override
@@ -418,5 +425,26 @@ public class ServerFCGIConnection extends AbstractMetaDataConnection implements 
                 task.run();
         }
         super.close();
+    }
+
+    private class FillableCallback implements Callback
+    {
+        @Override
+        public void succeeded()
+        {
+            onFillable();
+        }
+
+        @Override
+        public void failed(Throwable x)
+        {
+            onFillInterestedFailed(x);
+        }
+
+        @Override
+        public InvocationType getInvocationType()
+        {
+            return getConnector().getServer().getInvocationType();
+        }
     }
 }

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/ClientHTTP2StreamEndPoint.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/ClientHTTP2StreamEndPoint.java
@@ -63,7 +63,7 @@ public class ClientHTTP2StreamEndPoint extends HTTP2StreamEndPoint implements HT
             promise.succeeded(true);
             return null;
         }
-        return new Invocable.ReadyTask(Invocable.InvocationType.NON_BLOCKING, () ->
+        return new Invocable.ReadyTask(getInvocationType(), () ->
         {
             boolean expire = connection.onIdleExpired(timeout);
             if (expire)
@@ -78,7 +78,7 @@ public class ClientHTTP2StreamEndPoint extends HTTP2StreamEndPoint implements HT
     @Override
     public Runnable onFailure(Throwable failure, Callback callback)
     {
-        return new Invocable.ReadyTask(Invocable.InvocationType.NON_BLOCKING, () ->
+        return new Invocable.ReadyTask(getInvocationType(), () ->
         {
             processFailure(failure);
             close(failure);

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpChannelOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpChannelOverHTTP2.java
@@ -184,7 +184,7 @@ public class HttpChannelOverHTTP2 extends HttpChannel
         @Override
         public void onHeaders(Stream stream, HeadersFrame frame)
         {
-            receiver.onHeaders(stream, frame);
+            offerTask(receiver.onHeaders(stream, frame));
         }
 
         @Override
@@ -197,28 +197,33 @@ public class HttpChannelOverHTTP2 extends HttpChannel
         public void onDataAvailable(Stream stream)
         {
             HTTP2Channel.Client channel = (HTTP2Channel.Client)((HTTP2Stream)stream).getAttachment();
-            connection.offerTask(channel.onDataAvailable(), false);
+            offerTask(channel.onDataAvailable());
         }
 
         @Override
         public void onReset(Stream stream, ResetFrame frame, Callback callback)
         {
             HTTP2Channel.Client channel = (HTTP2Channel.Client)((HTTP2Stream)stream).getAttachment();
-            connection.offerTask(channel.onReset(frame, callback), false);
+            offerTask(channel.onReset(frame, callback));
         }
 
         @Override
         public void onIdleTimeout(Stream stream, TimeoutException x, Promise<Boolean> promise)
         {
             HTTP2Channel.Client channel = (HTTP2Channel.Client)((HTTP2Stream)stream).getAttachment();
-            connection.offerTask(channel.onTimeout(x, promise), false);
+            offerTask(channel.onTimeout(x, promise));
         }
 
         @Override
         public void onFailure(Stream stream, int error, String reason, Throwable failure, Callback callback)
         {
             HTTP2Channel.Client channel = (HTTP2Channel.Client)((HTTP2Stream)stream).getAttachment();
-            connection.offerTask(channel.onFailure(failure, callback), false);
+            offerTask(channel.onFailure(failure, callback));
+        }
+
+        private void offerTask(Runnable task)
+        {
+            connection.offerTask(task, false);
         }
     }
 }

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpConnectionOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpConnectionOverHTTP2.java
@@ -46,6 +46,7 @@ import org.eclipse.jetty.http2.api.Stream;
 import org.eclipse.jetty.http2.frames.HeadersFrame;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.thread.Invocable;
 import org.eclipse.jetty.util.thread.Sweeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -291,6 +292,11 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
     {
         if (task != null)
             connection.offerTask(task, dispatch);
+    }
+
+    Invocable.InvocationType getInvocationType()
+    {
+        return getHttpClient().getTransport().getInvocationType(this);
     }
 
     @Override

--- a/jetty-core/jetty-http2/jetty-http2-client/src/main/java/org/eclipse/jetty/http2/client/HTTP2ClientConnectionFactory.java
+++ b/jetty-core/jetty-http2/jetty-http2-client/src/main/java/org/eclipse/jetty/http2/client/HTTP2ClientConnectionFactory.java
@@ -173,12 +173,6 @@ public class HTTP2ClientConnectionFactory implements ClientConnectionFactory
             close();
             promise.failed(x);
         }
-
-        @Override
-        public InvocationType getInvocationType()
-        {
-            return InvocationType.NON_BLOCKING;
-        }
     }
 
     private static class ConnectionListener implements Connection.Listener

--- a/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpConnectionOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpConnectionOverHTTP3.java
@@ -32,6 +32,7 @@ import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http3.client.HTTP3SessionClient;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.quic.common.QuicSession;
+import org.eclipse.jetty.util.thread.Invocable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -162,5 +163,10 @@ public class HttpConnectionOverHTTP3 extends HttpConnection implements Connectio
         if (super.onIdleTimeout(idleTimeout, failure))
             close(failure);
         return false;
+    }
+
+    Invocable.InvocationType getInvocationType()
+    {
+        return getHttpClient().getTransport().getInvocationType(this);
     }
 }

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/HTTP3StreamConnection.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/HTTP3StreamConnection.java
@@ -30,6 +30,7 @@ import org.eclipse.jetty.io.AbstractConnection;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.RetainableByteBuffer;
 import org.eclipse.jetty.quic.common.QuicStreamEndPoint;
+import org.eclipse.jetty.util.Callback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +40,7 @@ public abstract class HTTP3StreamConnection extends AbstractConnection
     // An empty DATA frame is the sequence of bytes [0x0, 0x0].
     private static final ByteBuffer EMPTY_DATA_FRAME = ByteBuffer.allocate(2);
 
+    private final Callback fillableCallback = new FillableCallback();
     private final AtomicReference<Runnable> action = new AtomicReference<>();
     private final ByteBufferPool bufferPool;
     private final MessageParser parser;
@@ -87,7 +89,7 @@ public abstract class HTTP3StreamConnection extends AbstractConnection
     public void onOpen()
     {
         super.onOpen();
-        fillInterested();
+        setFillInterest();
     }
 
     @Override
@@ -219,7 +221,7 @@ public abstract class HTTP3StreamConnection extends AbstractConnection
                                 // No bytes left in the buffer, but there is demand.
                                 // Set fill interest to call the application when bytes arrive.
                                 tryReleaseInputBuffer(false);
-                                fillInterested();
+                                setFillInterest();
                             }
                         }
 
@@ -321,7 +323,7 @@ public abstract class HTTP3StreamConnection extends AbstractConnection
                     }
 
                     if (setFillInterest)
-                        fillInterested();
+                        setFillInterest();
                 }
 
                 return MessageParser.Result.NO_FRAME;
@@ -333,6 +335,11 @@ public abstract class HTTP3StreamConnection extends AbstractConnection
                 LOG.debug("parse+fill failure on {}", this, x);
             throw x;
         }
+    }
+
+    private void setFillInterest()
+    {
+        fillInterested(fillableCallback);
     }
 
     private int fill(ByteBuffer byteBuffer) throws IOException
@@ -479,6 +486,27 @@ public abstract class HTTP3StreamConnection extends AbstractConnection
             Runnable action = () -> processData(frame, delegate);
             if (!HTTP3StreamConnection.this.action.compareAndSet(null, action))
                 throw new IllegalStateException();
+        }
+    }
+
+    private class FillableCallback implements Callback
+    {
+        @Override
+        public void succeeded()
+        {
+            onFillable();
+        }
+
+        @Override
+        public void failed(Throwable x)
+        {
+            onFillInterestedFailed(x);
+        }
+
+        @Override
+        public InvocationType getInvocationType()
+        {
+            return InvocationType.EITHER;
         }
     }
 }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractConnection.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractConnection.java
@@ -52,12 +52,10 @@ public abstract class AbstractConnection implements Connection, Invocable
         _readCallback = new ReadCallback();
     }
 
-    @Deprecated
     @Override
-    public InvocationType getInvocationType()
+    @Deprecated(since = "12.0.0", forRemoval = true)
+    public Invocable.InvocationType getInvocationType()
     {
-        // TODO consider removing the #fillInterested method from the connection and only use #fillInterestedCallback
-        //      so a connection need not be Invocable
         return Invocable.super.getInvocationType();
     }
 
@@ -140,9 +138,20 @@ public abstract class AbstractConnection implements Connection, Invocable
      */
     public void fillInterested()
     {
+        fillInterested(_readCallback);
+    }
+
+    /**
+     * <p>Registers read interest with the given callback.</p>
+     * <p>When read readiness is signaled, the callback will be completed.</p>
+     *
+     * @param callback the callback to complete when read readiness is signaled
+     */
+    public void fillInterested(Callback callback)
+    {
         if (LOG.isDebugEnabled())
-            LOG.debug("fillInterested {}", this);
-        getEndPoint().fillInterested(_readCallback);
+            LOG.debug("fillInterested {} {}", callback, this);
+        getEndPoint().fillInterested(callback);
     }
 
     public void tryFillInterested(Callback callback)
@@ -167,10 +176,10 @@ public abstract class AbstractConnection implements Connection, Invocable
      *
      * @param cause the exception that caused the failure
      */
-    protected void onFillInterestedFailed(Throwable cause)
+    public void onFillInterestedFailed(Throwable cause)
     {
         if (LOG.isDebugEnabled())
-            LOG.debug("{} onFillInterestedFailed {}", this, cause);
+            LOG.debug("{} onFillInterestedFailed", this, cause);
         if (_endPoint.isOpen())
         {
             boolean close = true;
@@ -332,12 +341,6 @@ public abstract class AbstractConnection implements Connection, Invocable
         public String toString()
         {
             return String.format("%s@%x{%s}", getClass().getSimpleName(), hashCode(), AbstractConnection.this);
-        }
-
-        @Override
-        public InvocationType getInvocationType()
-        {
-            return AbstractConnection.this.getInvocationType();
         }
     }
 }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -88,6 +88,7 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
     private static final ThreadLocal<HttpConnection> __currentConnection = new ThreadLocal<>();
     private static final AtomicLong __connectionIdGenerator = new AtomicLong();
 
+    private final Callback fillableCallback = new FillableCallback();
     private final TunnelSupport _tunnelSupport = new TunnelSupportOverHTTP1();
     private final AtomicLong _streamIdGenerator = new AtomicLong();
     private final long _id;
@@ -152,12 +153,6 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
         _parser = newHttpParser(configuration.getHttpCompliance());
         if (LOG.isDebugEnabled())
             LOG.debug("New HTTP Connection {}", this);
-    }
-
-    @Override
-    public InvocationType getInvocationType()
-    {
-        return getServer().getInvocationType();
     }
 
     /**
@@ -432,7 +427,7 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
                 {
                     assert isRequestBufferEmpty();
                     releaseRequestBuffer();
-                    fillInterested();
+                    setFillInterest();
                     break;
                 }
                 else if (filled < 0)
@@ -579,7 +574,7 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
     }
 
     @Override
-    protected void onFillInterestedFailed(Throwable cause)
+    public void onFillInterestedFailed(Throwable cause)
     {
         _parser.close();
         super.onFillInterestedFailed(cause);
@@ -610,20 +605,20 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
     {
         super.onOpen();
         if (isRequestBufferEmpty())
-            fillInterested();
+            setFillInterest();
         else
             getExecutor().execute(this);
+    }
+
+    private void setFillInterest()
+    {
+        fillInterested(fillableCallback);
     }
 
     @Override
     public void run()
     {
         onFillable();
-    }
-
-    public void asyncReadFillInterested()
-    {
-        getEndPoint().tryFillInterested(_demandContentCallback);
     }
 
     @Override
@@ -1629,6 +1624,27 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
         public String getReason()
         {
             return getMessage();
+        }
+    }
+
+    private class FillableCallback implements Callback
+    {
+        @Override
+        public void succeeded()
+        {
+            onFillable();
+        }
+
+        @Override
+        public void failed(Throwable x)
+        {
+            onFillInterestedFailed(x);
+        }
+
+        @Override
+        public InvocationType getInvocationType()
+        {
+            return getServer().getInvocationType();
         }
     }
 }

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/VirtualThreadsTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/VirtualThreadsTest.java
@@ -13,24 +13,33 @@
 
 package org.eclipse.jetty.test.client.transport;
 
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import org.eclipse.jetty.client.ContentResponse;
+import org.eclipse.jetty.client.Result;
 import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.VirtualThreads;
 import org.eclipse.jetty.util.thread.ThreadPool;
+import org.eclipse.jetty.util.thread.VirtualThreadPool;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.condition.DisabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisabledForJreRange(max = JRE.JAVA_18)
 public class VirtualThreadsTest extends AbstractTest
@@ -70,5 +79,56 @@ public class VirtualThreadsTest extends AbstractTest
             .send();
 
         assertEquals(HttpStatus.OK_200, response.getStatus(), " for transport " + transport);
+    }
+
+    @ParameterizedTest
+    @MethodSource("transports")
+    public void testClientListenersInvokedOnVirtualThread(Transport transport) throws Exception
+    {
+        startServer(transport, new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            {
+                // Send only the headers.
+                response.write(false, null, Callback.NOOP);
+                // Wait to force the client to invoke the content
+                // callback separately from the headers callback.
+                Thread.sleep(500);
+                // Send the content.
+                Content.Sink.write(response, true, "hello", callback);
+                return true;
+            }
+        });
+
+        prepareClient(transport);
+        VirtualThreads.Configurable executor = (VirtualThreads.Configurable)client.getExecutor();
+        VirtualThreadPool vtp = new VirtualThreadPool();
+        vtp.setName("green-");
+        executor.setVirtualThreadsExecutor(vtp);
+        client.start();
+
+        for (int i = 0; i < 2; ++i)
+        {
+            AtomicReference<Result> resultRef = new AtomicReference<>();
+            ConcurrentLinkedQueue<String> queue = new ConcurrentLinkedQueue<>();
+            Consumer<String> verify = name -> queue.offer((VirtualThreads.isVirtualThread() ? "virtual" : "platform") + "-" + name);
+            client.newRequest(newURI(transport))
+                .onResponseBegin(r -> verify.accept("begin"))
+                .onResponseHeaders(r -> verify.accept("headers"))
+                .onResponseContent((r, b) -> verify.accept("content"))
+                .onResponseSuccess(r -> verify.accept("success"))
+                .onComplete(r -> verify.accept("complete"))
+                .send(r ->
+                {
+                    verify.accept("send");
+                    resultRef.set(r);
+                });
+
+            Result result = await().atMost(5, TimeUnit.SECONDS).until(resultRef::get, notNullValue());
+            assertTrue(result.isSucceeded());
+            assertEquals(HttpStatus.OK_200, result.getResponse().getStatus());
+            queue.forEach(event -> assertTrue(event.startsWith("virtual"), event));
+        }
     }
 }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/Invocable.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/Invocable.java
@@ -44,29 +44,38 @@ public interface Invocable
     enum InvocationType
     {
         /**
-         * <p>Invoking the {@link Invocable} may block the invoker thread,
+         * <p>Invoking the task may block the invoker thread,
          * and the invocation may be performed immediately (possibly blocking
          * the invoker thread) or deferred to a later time, for example
-         * by submitting the {@code Invocable} to a thread pool.</p>
-         * <p>This invocation type is suitable for {@code Invocable}s that
+         * by submitting the task to a thread pool.</p>
+         * <p>This invocation type is suitable for tasks that
          * call application code, for example to process an HTTP request.</p>
          */
         BLOCKING,
         /**
-         * <p>Invoking the {@link Invocable} does not block the invoker thread,
+         * <p>Invoking the task does not block the invoker thread,
          * and the invocation may be performed immediately in the invoker thread.</p>
-         * <p>This invocation type is suitable for {@code Invocable}s that
+         * <p>This invocation type is suitable for tasks that
          * call implementation code that is guaranteed to never block the
          * invoker thread.</p>
          */
         NON_BLOCKING,
         /**
-         * <p>Invoking the {@link Invocable} may block the invoker thread,
-         * but the invocation cannot be deferred to a later time, differently
+         * <p>Invoking the task does not block the invoker thread,
+         * and the invocation may be performed immediately in the invoker thread.</p>
+         * <p>The thread that produced the task may dispatch another
+         * thread to resume production, and then invoke the task, differently
+         * from {@link #NON_BLOCKING} which does not dispatch production to
+         * another thread.</p>
+         * <p>The invocation cannot be deferred to a later time, differently
          * from {@link #BLOCKING}.</p>
-         * <p>This invocation type is suitable for {@code Invocable}s that
-         * themselves perform the non-deferrable action in a non-blocking way,
-         * thus advancing a possibly stalled system.</p>
+         * <p>A series of {@code NON_BLOCKING} tasks is run sequentially,
+         * while a series of {@code EITHER} tasks may be run in parallel,
+         * if there are threads available to resume task production.</p>
+         * <p>This invocation type is suitable for tasks that
+         * perform the non-deferrable action in a non-blocking way,
+         * hinting that may be run in parallel, for example when each task
+         * processes a different connection or a different stream.</p>
          */
         EITHER
     }


### PR DESCRIPTION
* Removed usages of `AbstractConnection.getInvocationType()`.
* Changed HTTP server-side Connection implementations to use `AbstractConnection.fillInterested(Callback)` with a callback that specifies the `InvocationType`, derived from the `Server`, which derives it from the `Handler` chain.
* Changed client-side receivers to use `AbstractConnection.fillInterested(Callback)` with a callback that specifies the `InvocationType`, derived from the `HttpClientTransport`.
* Introduced `HttpClientTransport.getInvocationType(Connection)`, so that client applications can specify whether they block or not.
* Made sure client-side HTTP/2 and HTTP/3 return tasks with the proper `InvocationType` to be run by the `ExecutionStrategy` when calling application code.
* HTTP3StreamConnection now uses an `EITHER` fillable callback to possibly process streams in parallel.
* `QuicStreamEndPoint` now uses a task to invoke `FillInterest.fillable()`, rather than invoking it directly, therefore honoring the `InvocationType` of callback set by the `Connection` associated with the `QuicStreamEndPoint`.