### PR TITLE
Issue #11092 - Allow MetaInfConfiguration parsing of `java.class.path` to support globs

### DIFF
--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceFactoryTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceFactoryTest.java
@@ -418,9 +418,13 @@ public class ResourceFactoryTest
             FS.ensureDirExists(bar);
             Files.copy(MavenPaths.findTestResourceFile("jar-file-resource.jar"), bar.resolve("lib-foo.jar"));
             Files.copy(MavenPaths.findTestResourceFile("jar-file-resource.jar"), bar.resolve("lib-zed.zip"));
+            Path exampleJar = base.resolve("example.jar");
+            Files.copy(MavenPaths.findTestResourceFile("example.jar"), exampleJar);
 
-            // This represents the user-space raw configuration with a glob
-            String config = String.format("%s%s%s%s%s%s*", dir, File.pathSeparator, foo, File.pathSeparator, bar, File.separator);
+            // This represents a classpath with a glob
+            String config = String.join(File.pathSeparator, List.of(
+                dir.toString(), foo.toString(), bar + File.separator + "*", exampleJar.toString()
+            ));
 
             // Split using commas
             List<URI> uris = resourceFactory.split(config, File.pathSeparator).stream().map(Resource::getURI).toList();
@@ -430,19 +434,23 @@ public class ResourceFactoryTest
                 foo.toUri(),
                 // Should see the two archives as `jar:file:` URI entries
                 URIUtil.toJarFileUri(bar.resolve("lib-foo.jar").toUri()),
-                URIUtil.toJarFileUri(bar.resolve("lib-zed.zip").toUri())
+                URIUtil.toJarFileUri(bar.resolve("lib-zed.zip").toUri()),
+                URIUtil.toJarFileUri(exampleJar.toUri())
             };
 
             assertThat(uris, contains(expected));
         }
     }
 
-    @Test
-    public void testSplitOnPipeWithGlob() throws IOException
+    @ParameterizedTest
+    @ValueSource(strings = {";", "|", ","})
+    public void testSplitOnDelimWithGlob(String delimChar) throws IOException
     {
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {
-            Path base = workDir.getEmptyPathDir();
+            // TIP: don't allow raw delim to show up in base dir, otherwise the string split later will be wrong.
+            Path base = MavenPaths.targetTestDir("testSplitOnPipeWithGlob_%02x".formatted((byte)delimChar.charAt(0)));
+            FS.ensureEmpty(base);
             Path dir = base.resolve("dir");
             FS.ensureDirExists(dir);
             Path foo = dir.resolve("foo");
@@ -451,9 +459,13 @@ public class ResourceFactoryTest
             FS.ensureDirExists(bar);
             Files.copy(MavenPaths.findTestResourceFile("jar-file-resource.jar"), bar.resolve("lib-foo.jar"));
             Files.copy(MavenPaths.findTestResourceFile("jar-file-resource.jar"), bar.resolve("lib-zed.zip"));
+            Path exampleJar = base.resolve("example.jar");
+            Files.copy(MavenPaths.findTestResourceFile("example.jar"), exampleJar);
 
             // This represents the user-space raw configuration with a glob
-            String config = String.format("%s;%s;%s%s*", dir, foo, bar, File.separator);
+            String config = String.join(delimChar, List.of(
+                dir.toString(), foo.toString(), bar + File.separator + "*", exampleJar.toString()
+            ));
 
             // Split using commas
             List<URI> uris = resourceFactory.split(config).stream().map(Resource::getURI).toList();
@@ -463,7 +475,8 @@ public class ResourceFactoryTest
                 foo.toUri(),
                 // Should see the two archives as `jar:file:` URI entries
                 URIUtil.toJarFileUri(bar.resolve("lib-foo.jar").toUri()),
-                URIUtil.toJarFileUri(bar.resolve("lib-zed.zip").toUri())
+                URIUtil.toJarFileUri(bar.resolve("lib-zed.zip").toUri()),
+                URIUtil.toJarFileUri(exampleJar.toUri())
             };
 
             assertThat(uris, contains(expected));

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
@@ -166,8 +166,8 @@ public class MetaInfConfiguration extends AbstractConfiguration
         String classPath = System.getProperty("java.class.path");
         if (classPath != null)
         {
-            Stream.of(classPath.split(File.pathSeparator))
-                .map(resourceFactory::newResource)
+            resourceFactory.split(classPath, File.pathSeparator)
+                .stream()
                 .filter(Objects::nonNull)
                 .filter(r -> uriPatternPredicate.test(r.getURI()))
                 .forEach(addContainerResource);

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
@@ -169,7 +169,7 @@ public class MetaInfConfiguration extends AbstractConfiguration
             resourceFactory.split(classPath, File.pathSeparator)
                 .stream()
                 .filter(Objects::nonNull)
-                .filter(r -> uriPatternPredicate.test(r.getURI()))
+                .filter(r -> uriPatternPredicate.test(URIUtil.unwrapContainer(r.getURI())))
                 .forEach(addContainerResource);
         }
 

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/MetaInfConfigurationTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/MetaInfConfigurationTest.java
@@ -557,6 +557,7 @@ public class MetaInfConfigurationTest
                 .stream()
                 .sorted(ResourceCollators.byName(true))
                 .map(Resource::getURI)
+                .map(URIUtil::unwrapContainer)
                 .map(URI::toASCIIString)
                 .toList();
             // we "correct" the bad file URLs that come from the ClassLoader

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
@@ -169,8 +169,9 @@ public class MetaInfConfiguration extends AbstractConfiguration
         String classPath = System.getProperty("java.class.path");
         if (classPath != null)
         {
-            Stream.of(classPath.split(File.pathSeparator))
-                .map(resourceFactory::newResource)
+            resourceFactory.split(classPath, File.pathSeparator)
+                .stream()
+                .filter(Objects::nonNull)
                 .filter(r -> uriPatternPredicate.test(r.getURI()))
                 .forEach(addContainerResource);
         }

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
@@ -172,7 +172,7 @@ public class MetaInfConfiguration extends AbstractConfiguration
             resourceFactory.split(classPath, File.pathSeparator)
                 .stream()
                 .filter(Objects::nonNull)
-                .filter(r -> uriPatternPredicate.test(r.getURI()))
+                .filter(r -> uriPatternPredicate.test(URIUtil.unwrapContainer(r.getURI())))
                 .forEach(addContainerResource);
         }
 

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/MetaInfConfigurationTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/MetaInfConfigurationTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.util.URIUtil;
+import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.resource.Resource;
 import org.junit.jupiter.api.Test;
 
@@ -156,6 +157,7 @@ public class MetaInfConfigurationTest
         finally
         {
             config.postConfigure(context);
+            LifeCycle.stop(context.getResourceFactory());
         }
     }
 }

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/MetaInfConfigurationTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/MetaInfConfigurationTest.java
@@ -20,14 +20,10 @@ import java.util.List;
 
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
-import org.eclipse.jetty.util.resource.FileSystemPool;
+import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.resource.Resource;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -153,7 +149,7 @@ public class MetaInfConfigurationTest
             assertEquals(2, containerResources.size());
             for (Resource r : containerResources)
             {
-                String s = r.toString();
+                String s = URIUtil.unwrapContainer(r.getURI()).toASCIIString();
                 assertTrue(s.endsWith("foo-bar-janb.jar") || s.contains("servlet-api"));
             }
         }


### PR DESCRIPTION
Use ResourceFactory.split(String) to properly parse the `java.class.path` so that globs can be supported in MetaInfConfiguration as well.

Fixes #11092 
Fixes #12283