### PR TITLE
Fixed #12284 - Excessive heap consumption by SSLSessionImpl by Jetty Server with TLS 1.3 and long-lived client.

### DIFF
--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/EndPoint.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/EndPoint.java
@@ -386,8 +386,8 @@ public interface EndPoint extends Closeable
     interface SslSessionData
     {
         /**
-         * The name at which an {@code SslSessionData} instance may be found as a request
-         * {@link org.eclipse.jetty.util.Attributes Attribute} or from {@link SSLSession#getValue(String)}.
+         * The name at which an {@code SslSessionData} instance may be found
+         * as a request {@link org.eclipse.jetty.util.Attributes attribute}.
          */
         String ATTRIBUTE = "org.eclipse.jetty.io.Endpoint.SslSessionData";
 


### PR DESCRIPTION
Now `SslSessionData` is stored as a field, rather than in the `SSLSession` as an attribute. This implies a little more cost to create the `SslSessionData` per connection rather than per `SSLSession`, but it should be negligible.

Now `SslSessionData` cannot be retrieved as a `SSLSession` attribute, but we have explicit APIs to retrieve it, so it should not be a problem.