### PR TITLE
Fixes #12289 - Improve ConcurrentPool concurrency.

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -653,7 +653,7 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
      */
     protected void notifyExitScope(Request request)
     {
-        for (ContextScopeListener listener : reverse(_contextListeners))
+        for (ContextScopeListener listener : TypeUtil.reverse(_contextListeners))
         {
             try
             {
@@ -664,13 +664,6 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
                 LOG.warn("Unable to exit scope", e);
             }
         }
-    }
-
-    private static <T> List<T> reverse(List<T> list)
-    {
-        List<T> result = new ArrayList<>(list);
-        Collections.reverse(result);
-        return result;
     }
 
     /**

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -653,17 +653,24 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
      */
     protected void notifyExitScope(Request request)
     {
-        for (int i = _contextListeners.size(); i-- > 0; )
+        for (ContextScopeListener listener : reverse(_contextListeners))
         {
             try
             {
-                _contextListeners.get(i).exitScope(_context, request);
+                listener.exitScope(_context, request);
             }
             catch (Throwable e)
             {
                 LOG.warn("Unable to exit scope", e);
             }
         }
+    }
+
+    private static <T> List<T> reverse(List<T> list)
+    {
+        List<T> result = new ArrayList<>(list);
+        Collections.reverse(result);
+        return result;
     }
 
     /**

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
@@ -174,6 +174,21 @@ public class TypeUtil
     }
 
     /**
+     * <p>Returns a new list with the elements of the specified list in reverse order.</p>
+     * <p>The specified list is not modified, differently from {@link Collections#reverse(List)}.</p>
+     *
+     * @param list the list whose elements are to be reversed
+     * @return a new list with the elements in reverse order
+     * @param <T> the element type
+     */
+    public static <T> List<T> reverse(List<T> list)
+    {
+        List<T> result = new ArrayList<>(list);
+        Collections.reverse(result);
+        return result;
+    }
+
+    /**
      * Class from a canonical name for a type.
      *
      * @param name A class or type name.

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
@@ -518,8 +518,7 @@ public class ServletContextHandler extends ContextHandler
                     //Call context listeners
                     Throwable multiException = null;
                     ServletContextEvent event = new ServletContextEvent(getServletContext());
-                    Collections.reverse(_destroyServletContextListeners);
-                    for (ServletContextListener listener : _destroyServletContextListeners)
+                    for (ServletContextListener listener : reverse(_destroyServletContextListeners))
                     {
                         try
                         {
@@ -574,17 +573,17 @@ public class ServletContextHandler extends ContextHandler
         if (!_servletRequestListeners.isEmpty())
         {
             final ServletRequestEvent sre = new ServletRequestEvent(getServletContext(), request);
-            for (int i = _servletRequestListeners.size(); i-- > 0; )
+            for (ServletRequestListener listener : reverse(_servletRequestListeners))
             {
-                _servletRequestListeners.get(i).requestDestroyed(sre);
+                listener.requestDestroyed(sre);
             }
         }
 
         if (!_servletRequestAttributeListeners.isEmpty())
         {
-            for (int i = _servletRequestAttributeListeners.size(); i-- > 0; )
+            for (ServletRequestAttributeListener listener : reverse(_servletRequestAttributeListeners))
             {
-                scopedRequest.removeEventListener(_servletRequestAttributeListeners.get(i));
+                scopedRequest.removeEventListener(listener);
             }
         }
     }
@@ -1223,11 +1222,11 @@ public class ServletContextHandler extends ContextHandler
         ServletContextRequest scopedRequest = Request.as(request, ServletContextRequest.class);
         if (!_contextListeners.isEmpty())
         {
-            for (int i = _contextListeners.size(); i-- > 0; )
+            for (ServletContextScopeListener listener : reverse(_contextListeners))
             {
                 try
                 {
-                    _contextListeners.get(i).exitScope(getContext(), scopedRequest);
+                    listener.exitScope(getContext(), scopedRequest);
                 }
                 catch (Throwable e)
                 {
@@ -1237,6 +1236,13 @@ public class ServletContextHandler extends ContextHandler
         }
 
         super.notifyExitScope(request);
+    }
+
+    private static <T> List<T> reverse(List<T> list)
+    {
+        List<T> result = new ArrayList<>(list);
+        Collections.reverse(result);
+        return result;
     }
 
     /**

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
@@ -95,6 +95,7 @@ import org.eclipse.jetty.util.DeprecationWarning;
 import org.eclipse.jetty.util.ExceptionUtil;
 import org.eclipse.jetty.util.Loader;
 import org.eclipse.jetty.util.StringUtil;
+import org.eclipse.jetty.util.TypeUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.annotation.ManagedObject;
@@ -518,7 +519,7 @@ public class ServletContextHandler extends ContextHandler
                     //Call context listeners
                     Throwable multiException = null;
                     ServletContextEvent event = new ServletContextEvent(getServletContext());
-                    for (ServletContextListener listener : reverse(_destroyServletContextListeners))
+                    for (ServletContextListener listener : TypeUtil.reverse(_destroyServletContextListeners))
                     {
                         try
                         {
@@ -573,7 +574,7 @@ public class ServletContextHandler extends ContextHandler
         if (!_servletRequestListeners.isEmpty())
         {
             final ServletRequestEvent sre = new ServletRequestEvent(getServletContext(), request);
-            for (ServletRequestListener listener : reverse(_servletRequestListeners))
+            for (ServletRequestListener listener : TypeUtil.reverse(_servletRequestListeners))
             {
                 listener.requestDestroyed(sre);
             }
@@ -581,7 +582,7 @@ public class ServletContextHandler extends ContextHandler
 
         if (!_servletRequestAttributeListeners.isEmpty())
         {
-            for (ServletRequestAttributeListener listener : reverse(_servletRequestAttributeListeners))
+            for (ServletRequestAttributeListener listener : TypeUtil.reverse(_servletRequestAttributeListeners))
             {
                 scopedRequest.removeEventListener(listener);
             }
@@ -1222,7 +1223,7 @@ public class ServletContextHandler extends ContextHandler
         ServletContextRequest scopedRequest = Request.as(request, ServletContextRequest.class);
         if (!_contextListeners.isEmpty())
         {
-            for (ServletContextScopeListener listener : reverse(_contextListeners))
+            for (ServletContextScopeListener listener : TypeUtil.reverse(_contextListeners))
             {
                 try
                 {
@@ -1236,13 +1237,6 @@ public class ServletContextHandler extends ContextHandler
         }
 
         super.notifyExitScope(request);
-    }
-
-    private static <T> List<T> reverse(List<T> list)
-    {
-        List<T> result = new ArrayList<>(list);
-        Collections.reverse(result);
-        return result;
     }
 
     /**

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/SessionHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/SessionHandler.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.ee10.servlet;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Enumeration;
@@ -48,6 +47,7 @@ import org.eclipse.jetty.session.AbstractSessionManager;
 import org.eclipse.jetty.session.ManagedSession;
 import org.eclipse.jetty.session.SessionConfig;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.TypeUtil;
 
 public class SessionHandler extends AbstractSessionManager implements Handler.Singleton
 {
@@ -570,18 +570,11 @@ public class SessionHandler extends AbstractSessionManager implements Handler.Si
         getSessionContext().run(() ->
         {
             HttpSessionEvent event = new HttpSessionEvent(session.getApi());
-            for (HttpSessionListener  listener : reverse(_sessionListeners))
+            for (HttpSessionListener  listener : TypeUtil.reverse(_sessionListeners))
             {
                 listener.sessionDestroyed(event);
             }
         });
-    }
-
-    private static <T> List<T> reverse(List<T> list)
-    {
-        List<T> result = new ArrayList<>(list);
-        Collections.reverse(result);
-        return result;
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/SessionHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/SessionHandler.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.ee10.servlet;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Enumeration;
@@ -569,11 +570,18 @@ public class SessionHandler extends AbstractSessionManager implements Handler.Si
         getSessionContext().run(() ->
         {
             HttpSessionEvent event = new HttpSessionEvent(session.getApi());
-            for (int i = _sessionListeners.size() - 1; i >= 0; i--)
+            for (HttpSessionListener  listener : reverse(_sessionListeners))
             {
-                _sessionListeners.get(i).sessionDestroyed(event);
+                listener.sessionDestroyed(event);
             }
         });
+    }
+
+    private static <T> List<T> reverse(List<T> list)
+    {
+        List<T> result = new ArrayList<>(list);
+        Collections.reverse(result);
+        return result;
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
@@ -1000,7 +1000,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
         if (!_servletRequestListeners.isEmpty())
         {
             final ServletRequestEvent sre = new ServletRequestEvent(_apiContext, request);
-            for (ServletRequestListener listener : reverse(_servletRequestListeners))
+            for (ServletRequestListener listener : TypeUtil.reverse(_servletRequestListeners))
             {
                 listener.requestDestroyed(sre);
             }
@@ -1008,7 +1008,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
 
         if (!_servletRequestAttributeListeners.isEmpty())
         {
-            for (ServletRequestAttributeListener listener : reverse(_servletRequestAttributeListeners))
+            for (ServletRequestAttributeListener listener : TypeUtil.reverse(_servletRequestAttributeListeners))
             {
                 baseRequest.removeEventListener(listener);
             }
@@ -1070,7 +1070,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
     {
         if (!_contextListeners.isEmpty())
         {
-            for (ContextScopeListener listener : reverse(_contextListeners))
+            for (ContextScopeListener listener : TypeUtil.reverse(_contextListeners))
             {
                 try
                 {
@@ -1082,13 +1082,6 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
                 }
             }
         }
-    }
-
-    private static <T> List<T> reverse(List<T> list)
-    {
-        List<T> result = new ArrayList<>(list);
-        Collections.reverse(result);
-        return result;
     }
 
     /**

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
@@ -1000,17 +1000,17 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
         if (!_servletRequestListeners.isEmpty())
         {
             final ServletRequestEvent sre = new ServletRequestEvent(_apiContext, request);
-            for (int i = _servletRequestListeners.size(); i-- > 0; )
+            for (ServletRequestListener listener : reverse(_servletRequestListeners))
             {
-                _servletRequestListeners.get(i).requestDestroyed(sre);
+                listener.requestDestroyed(sre);
             }
         }
 
         if (!_servletRequestAttributeListeners.isEmpty())
         {
-            for (int i = _servletRequestAttributeListeners.size(); i-- > 0; )
+            for (ServletRequestAttributeListener listener : reverse(_servletRequestAttributeListeners))
             {
-                baseRequest.removeEventListener(_servletRequestAttributeListeners.get(i));
+                baseRequest.removeEventListener(listener);
             }
         }
     }
@@ -1070,11 +1070,11 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
     {
         if (!_contextListeners.isEmpty())
         {
-            for (int i = _contextListeners.size(); i-- > 0; )
+            for (ContextScopeListener listener : reverse(_contextListeners))
             {
                 try
                 {
-                    _contextListeners.get(i).exitScope(_apiContext, request);
+                    listener.exitScope(_apiContext, request);
                 }
                 catch (Throwable e)
                 {
@@ -1082,6 +1082,13 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
                 }
             }
         }
+    }
+
+    private static <T> List<T> reverse(List<T> list)
+    {
+        List<T> result = new ArrayList<>(list);
+        Collections.reverse(result);
+        return result;
     }
 
     /**

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/SessionHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/SessionHandler.java
@@ -15,7 +15,6 @@ package org.eclipse.jetty.ee9.nested;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Enumeration;
@@ -55,6 +54,7 @@ import org.eclipse.jetty.session.SessionIdManager;
 import org.eclipse.jetty.session.SessionManager;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.StringUtil;
+import org.eclipse.jetty.util.TypeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -835,19 +835,12 @@ public class SessionHandler extends ScopedHandler implements SessionConfig.Mutab
             Runnable r = () ->
             {
                 HttpSessionEvent event = new HttpSessionEvent(session.getApi());
-                for (HttpSessionListener listener : reverse(_sessionListeners))
+                for (HttpSessionListener listener : TypeUtil.reverse(_sessionListeners))
                 {
                     listener.sessionDestroyed(event);
                 }
             };
             _contextHandler.getCoreContextHandler().getContext().run(r);
-        }
-
-        private static <T> List<T> reverse(List<T> list)
-        {
-            List<T> result = new ArrayList<>(list);
-            Collections.reverse(result);
-            return result;
         }
 
         @Override

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/SessionHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/SessionHandler.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.ee9.nested;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Enumeration;
@@ -834,12 +835,19 @@ public class SessionHandler extends ScopedHandler implements SessionConfig.Mutab
             Runnable r = () ->
             {
                 HttpSessionEvent event = new HttpSessionEvent(session.getApi());
-                for (int i = _sessionListeners.size() - 1; i >= 0; i--)
+                for (HttpSessionListener listener : reverse(_sessionListeners))
                 {
-                    _sessionListeners.get(i).sessionDestroyed(event);
+                    listener.sessionDestroyed(event);
                 }
             };
             _contextHandler.getCoreContextHandler().getContext().run(r);
+        }
+
+        private static <T> List<T> reverse(List<T> list)
+        {
+            List<T> result = new ArrayList<>(list);
+            Collections.reverse(result);
+            return result;
         }
 
         @Override


### PR DESCRIPTION
A call to `sweep()`, although protected by the lock for concurrent calls to `reserve()`, may be concurrent with `remove(Entry)`.

`remove(Entry)` in turn calls `entries.remove(Object)`, so that the concurrent iteration in `sweep()` over `entries` fails with an `ArrayIndexOutOfBoundsException`.

Now using the bulk `entries.removeIf(Predicate)` method in `sweep()`, so that sweeping is atomic with respect to `entries.remove(Object)`.