### PR TITLE
Avoid list copy on reverse iteration

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -653,11 +653,11 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
      */
     protected void notifyExitScope(Request request)
     {
-        for (ContextScopeListener listener : TypeUtil.reverse(_contextListeners))
+        for (ListIterator<ContextScopeListener> i = TypeUtil.listIteratorAtEnd(_contextListeners); i.hasPrevious();)
         {
             try
             {
-                listener.exitScope(_context, request);
+                i.previous().exitScope(_context, request);
             }
             catch (Throwable e)
             {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
@@ -175,12 +175,10 @@ public class TypeUtil
     }
 
     /**
-     * <p>Returns a {@link ListIterator} positioned at the last item in a list</p>
-     * <p>The method is safe for concurrent modifications iff the list iterator itself is safe.</p>
+     * <p>Returns a {@link ListIterator} positioned at the last item in a list.</p>
      * @param list the list
      * @param <T> the element type
-     * @return A {@link ListIterator} with {@link ListIterator#hasNext()} that would have return {@code false}
-     * at the snapshot of the list represented by this call.
+     * @return A {@link ListIterator} positioned at the last item of the list.
      */
     public static <T> ListIterator<T> listIteratorAtEnd(List<T> list)
     {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
@@ -65,7 +65,6 @@ public class TypeUtil
     public static final int CR = '\r';
     public static final int LF = '\n';
     private static final  Pattern TRAILING_DIGITS = Pattern.compile("^\\D*(\\d+)$");
-    private static final ListIterator<?> EMPTY_LIST_ITERATOR = Collections.EMPTY_LIST.listIterator();
 
     private static final HashMap<String, Class<?>> name2Class = new HashMap<>();
 
@@ -189,11 +188,7 @@ public class TypeUtil
         {
             int size = list.size();
             if (size == 0)
-            {
-                @SuppressWarnings("unchecked")
-                ListIterator<T> emptyListIterator = (ListIterator<T>)EMPTY_LIST_ITERATOR;
-                return emptyListIterator;
-            }
+                return Collections.emptyListIterator();
             return list.listIterator(size);
         }
         catch (IndexOutOfBoundsException e)

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
@@ -31,6 +31,7 @@ import java.util.EventListener;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -519,11 +520,11 @@ public class ServletContextHandler extends ContextHandler
                     //Call context listeners
                     Throwable multiException = null;
                     ServletContextEvent event = new ServletContextEvent(getServletContext());
-                    for (ServletContextListener listener : TypeUtil.reverse(_destroyServletContextListeners))
+                    for (ListIterator<ServletContextListener> i = TypeUtil.listIteratorAtEnd(_destroyServletContextListeners); i.hasPrevious();)
                     {
                         try
                         {
-                            callContextDestroyed(listener, event);
+                            callContextDestroyed(i.previous(), event);
                         }
                         catch (Exception x)
                         {
@@ -574,17 +575,17 @@ public class ServletContextHandler extends ContextHandler
         if (!_servletRequestListeners.isEmpty())
         {
             final ServletRequestEvent sre = new ServletRequestEvent(getServletContext(), request);
-            for (ServletRequestListener listener : TypeUtil.reverse(_servletRequestListeners))
+            for (ListIterator<ServletRequestListener> i = TypeUtil.listIteratorAtEnd(_servletRequestListeners); i.hasPrevious();)
             {
-                listener.requestDestroyed(sre);
+                i.previous().requestDestroyed(sre);
             }
         }
 
         if (!_servletRequestAttributeListeners.isEmpty())
         {
-            for (ServletRequestAttributeListener listener : TypeUtil.reverse(_servletRequestAttributeListeners))
+            for (ListIterator<ServletRequestAttributeListener> i = TypeUtil.listIteratorAtEnd(_servletRequestAttributeListeners); i.hasPrevious();)
             {
-                scopedRequest.removeEventListener(listener);
+                scopedRequest.removeEventListener(i.previous());
             }
         }
     }
@@ -1223,11 +1224,11 @@ public class ServletContextHandler extends ContextHandler
         ServletContextRequest scopedRequest = Request.as(request, ServletContextRequest.class);
         if (!_contextListeners.isEmpty())
         {
-            for (ServletContextScopeListener listener : TypeUtil.reverse(_contextListeners))
+            for (ListIterator<ServletContextScopeListener> i = TypeUtil.listIteratorAtEnd(_contextListeners); i.hasPrevious(); )
             {
                 try
                 {
-                    listener.exitScope(getContext(), scopedRequest);
+                    i.previous().exitScope(getContext(), scopedRequest);
                 }
                 catch (Throwable e)
                 {

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/SessionHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/SessionHandler.java
@@ -19,6 +19,7 @@ import java.util.Enumeration;
 import java.util.EventListener;
 import java.util.Iterator;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -570,9 +571,9 @@ public class SessionHandler extends AbstractSessionManager implements Handler.Si
         getSessionContext().run(() ->
         {
             HttpSessionEvent event = new HttpSessionEvent(session.getApi());
-            for (HttpSessionListener  listener : TypeUtil.reverse(_sessionListeners))
+            for (ListIterator<HttpSessionListener> i = TypeUtil.listIteratorAtEnd(_sessionListeners); i.hasPrevious();)
             {
-                listener.sessionDestroyed(event);
+                i.previous().sessionDestroyed(event);
             }
         });
     }

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
@@ -29,6 +29,7 @@ import java.util.EventListener;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -1000,17 +1001,17 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
         if (!_servletRequestListeners.isEmpty())
         {
             final ServletRequestEvent sre = new ServletRequestEvent(_apiContext, request);
-            for (ServletRequestListener listener : TypeUtil.reverse(_servletRequestListeners))
+            for (ListIterator<ServletRequestListener> i = TypeUtil.listIteratorAtEnd(_servletRequestListeners); i.hasPrevious();)
             {
-                listener.requestDestroyed(sre);
+                i.previous().requestDestroyed(sre);
             }
         }
 
         if (!_servletRequestAttributeListeners.isEmpty())
         {
-            for (ServletRequestAttributeListener listener : TypeUtil.reverse(_servletRequestAttributeListeners))
+            for (ListIterator<ServletRequestAttributeListener> i = TypeUtil.listIteratorAtEnd(_servletRequestAttributeListeners); i.hasPrevious();)
             {
-                baseRequest.removeEventListener(listener);
+                baseRequest.removeEventListener(i.previous());
             }
         }
     }
@@ -1070,11 +1071,11 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
     {
         if (!_contextListeners.isEmpty())
         {
-            for (ContextScopeListener listener : TypeUtil.reverse(_contextListeners))
+            for (ListIterator<ContextScopeListener> i = TypeUtil.listIteratorAtEnd(_contextListeners); i.hasPrevious();)
             {
                 try
                 {
-                    listener.exitScope(_apiContext, request);
+                    i.previous().exitScope(_apiContext, request);
                 }
                 catch (Throwable e)
                 {

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/SessionHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/SessionHandler.java
@@ -20,6 +20,7 @@ import java.util.EnumSet;
 import java.util.Enumeration;
 import java.util.EventListener;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
@@ -835,9 +836,9 @@ public class SessionHandler extends ScopedHandler implements SessionConfig.Mutab
             Runnable r = () ->
             {
                 HttpSessionEvent event = new HttpSessionEvent(session.getApi());
-                for (HttpSessionListener listener : TypeUtil.reverse(_sessionListeners))
+                for (ListIterator<HttpSessionListener> i = TypeUtil.listIteratorAtEnd(_sessionListeners); i.hasPrevious();)
                 {
-                    listener.sessionDestroyed(event);
+                    i.previous().sessionDestroyed(event);
                 }
             };
             _contextHandler.getCoreContextHandler().getContext().run(r);


### PR DESCRIPTION
The changes in #12289 introduced several list copy and reverses operations on every request.
This PR replaces that reversed list with a `ListIterator` used with `previous`