### PR TITLE
Fixes #12266 - InvocationType improvements and cleanups.

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClientTransport.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClientTransport.java
@@ -18,6 +18,7 @@ import java.util.Map;
 
 import org.eclipse.jetty.client.transport.HttpDestination;
 import org.eclipse.jetty.io.ClientConnectionFactory;
+import org.eclipse.jetty.util.thread.Invocable;
 
 /**
  * {@link HttpClientTransport} represents what transport implementations should provide
@@ -83,4 +84,9 @@ public interface HttpClientTransport extends ClientConnectionFactory
      * @param factory the factory for ConnectionPool instances
      */
     public void setConnectionPoolFactory(ConnectionPool.Factory factory);
+
+    public default Invocable.InvocationType getInvocationType(Connection connection)
+    {
+        return Invocable.InvocationType.BLOCKING;
+    }
 }

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/ProxyProtocolClientConnectionFactory.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/ProxyProtocolClientConnectionFactory.java
@@ -509,12 +509,6 @@ public abstract class ProxyProtocolClientConnectionFactory implements ClientConn
         }
 
         @Override
-        public InvocationType getInvocationType()
-        {
-            return InvocationType.NON_BLOCKING;
-        }
-
-        @Override
         public void onFillable()
         {
         }

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpReceiverOverHTTP.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpReceiverOverHTTP.java
@@ -386,7 +386,7 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
     {
         if (LOG.isDebugEnabled())
             LOG.debug("Registering as fill interested in {}", this);
-        getHttpConnection().fillInterested();
+        getHttpConnection().setFillInterest();
     }
 
     private void shutdown()

--- a/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpReceiverOverFCGI.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpReceiverOverFCGI.java
@@ -36,7 +36,7 @@ public class HttpReceiverOverFCGI extends HttpReceiver
             HttpConnectionOverFCGI httpConnection = getHttpChannel().getHttpConnection();
             boolean setFillInterest = httpConnection.parseAndFill(true);
             if (!hasContent() && setFillInterest)
-                httpConnection.fillInterested();
+                fillInterested(httpConnection);
         }
         else
         {
@@ -86,7 +86,7 @@ public class HttpReceiverOverFCGI extends HttpReceiver
         if (chunk != null)
             return chunk;
         if (needFillInterest && fillInterestIfNeeded)
-            httpConnection.fillInterested();
+            fillInterested(httpConnection);
         return null;
     }
 
@@ -138,7 +138,12 @@ public class HttpReceiverOverFCGI extends HttpReceiver
         HttpConnectionOverFCGI httpConnection = getHttpChannel().getHttpConnection();
         boolean setFillInterest = httpConnection.parseAndFill(true);
         if (!hasContent() && setFillInterest)
-            httpConnection.fillInterested();
+            fillInterested(httpConnection);
+    }
+
+    private void fillInterested(HttpConnectionOverFCGI httpConnection)
+    {
+        httpConnection.setFillInterest();
     }
 
     @Override

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpChannelOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpChannelOverHTTP2.java
@@ -31,6 +31,7 @@ import org.eclipse.jetty.http2.frames.PushPromiseFrame;
 import org.eclipse.jetty.http2.frames.ResetFrame;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.Promise;
+import org.eclipse.jetty.util.thread.Invocable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -173,7 +174,7 @@ public class HttpChannelOverHTTP2 extends HttpChannel
         }
     }
 
-    private class Listener implements Stream.Listener
+    private class Listener implements Stream.Listener, Invocable
     {
         @Override
         public void onNewStream(Stream stream)
@@ -197,28 +198,38 @@ public class HttpChannelOverHTTP2 extends HttpChannel
         public void onDataAvailable(Stream stream)
         {
             HTTP2Channel.Client channel = (HTTP2Channel.Client)((HTTP2Stream)stream).getAttachment();
-            connection.offerTask(channel.onDataAvailable(), false);
+            channel.onDataAvailable();
         }
 
         @Override
         public void onReset(Stream stream, ResetFrame frame, Callback callback)
         {
             HTTP2Channel.Client channel = (HTTP2Channel.Client)((HTTP2Stream)stream).getAttachment();
-            connection.offerTask(channel.onReset(frame, callback), false);
+            channel.onReset(frame, callback);
         }
 
         @Override
         public void onIdleTimeout(Stream stream, TimeoutException x, Promise<Boolean> promise)
         {
             HTTP2Channel.Client channel = (HTTP2Channel.Client)((HTTP2Stream)stream).getAttachment();
-            connection.offerTask(channel.onTimeout(x, promise), false);
+            channel.onTimeout(x, promise);
         }
 
         @Override
         public void onFailure(Stream stream, int error, String reason, Throwable failure, Callback callback)
         {
             HTTP2Channel.Client channel = (HTTP2Channel.Client)((HTTP2Stream)stream).getAttachment();
-            connection.offerTask(channel.onFailure(failure, callback), false);
+            channel.onFailure(failure, callback);
+        }
+
+        @Override
+        public InvocationType getInvocationType()
+        {
+            Stream stream = getStream();
+            if (stream == null)
+                return connection.getInvocationType();
+            HTTP2Channel.Client channel = (HTTP2Channel.Client)((HTTP2Stream)stream).getAttachment();
+            return Invocable.getInvocationType(channel);
         }
     }
 }

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpConnectionOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpConnectionOverHTTP2.java
@@ -46,6 +46,7 @@ import org.eclipse.jetty.http2.api.Stream;
 import org.eclipse.jetty.http2.frames.HeadersFrame;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.thread.Invocable;
 import org.eclipse.jetty.util.thread.Sweeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -287,10 +288,9 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
         return sweeps.incrementAndGet() >= 4;
     }
 
-    void offerTask(Runnable task, boolean dispatch)
+    Invocable.InvocationType getInvocationType()
     {
-        if (task != null)
-            connection.offerTask(task, dispatch);
+        return getHttpClient().getTransport().getInvocationType(this);
     }
 
     @Override

--- a/jetty-core/jetty-http2/jetty-http2-client/src/main/java/org/eclipse/jetty/http2/client/HTTP2ClientConnectionFactory.java
+++ b/jetty-core/jetty-http2/jetty-http2-client/src/main/java/org/eclipse/jetty/http2/client/HTTP2ClientConnectionFactory.java
@@ -173,12 +173,6 @@ public class HTTP2ClientConnectionFactory implements ClientConnectionFactory
             close();
             promise.failed(x);
         }
-
-        @Override
-        public InvocationType getInvocationType()
-        {
-            return InvocationType.NON_BLOCKING;
-        }
     }
 
     private static class ConnectionListener implements Connection.Listener

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Channel.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Channel.java
@@ -34,13 +34,13 @@ public interface HTTP2Channel
      */
     public interface Client
     {
-        public Runnable onDataAvailable();
+        public void onDataAvailable();
 
-        public Runnable onReset(ResetFrame frame, Callback callback);
+        public void onReset(ResetFrame frame, Callback callback);
 
-        public Runnable onTimeout(TimeoutException failure, Promise<Boolean> promise);
+        public void onTimeout(TimeoutException failure, Promise<Boolean> promise);
 
-        public Runnable onFailure(Throwable failure, Callback callback);
+        public void onFailure(Throwable failure, Callback callback);
     }
 
     /**

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -1216,6 +1216,12 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
         return (streamId & 1) == 1;
     }
 
+    void offerTask(Runnable task)
+    {
+        HTTP2Connection connection = (HTTP2Connection)getEndPoint().getConnection();
+        connection.offerTask(task, false);
+    }
+
     @Override
     public void dump(Appendable out, String indent) throws IOException
     {

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2StreamEndPoint.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2StreamEndPoint.java
@@ -34,7 +34,7 @@ import org.eclipse.jetty.util.thread.Invocable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public abstract class HTTP2StreamEndPoint implements EndPoint
+public abstract class HTTP2StreamEndPoint implements EndPoint, Invocable
 {
     private static final Logger LOG = LoggerFactory.getLogger(HTTP2StreamEndPoint.class);
 
@@ -478,7 +478,8 @@ public abstract class HTTP2StreamEndPoint implements EndPoint
             callback.succeeded();
     }
 
-    protected Invocable.InvocationType getInvocationType()
+    @Override
+    public Invocable.InvocationType getInvocationType()
     {
         Callback callback = readCallback.get();
         return callback == null ? Invocable.InvocationType.NON_BLOCKING : callback.getInvocationType();

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/api/Stream.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/api/Stream.java
@@ -24,6 +24,7 @@ import org.eclipse.jetty.io.Retainable;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.Promise;
+import org.eclipse.jetty.util.thread.Invocable;
 
 /**
  * <p>A {@link Stream} represents a bidirectional exchange of data on top of a {@link Session}.</p>
@@ -432,6 +433,15 @@ public interface Stream
          */
         public default void onClosed(Stream stream)
         {
+        }
+
+        interface NonBlocking extends Listener, Invocable
+        {
+            @Override
+            default InvocationType getInvocationType()
+            {
+                return InvocationType.NON_BLOCKING;
+            }
         }
     }
 

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/GoAwayTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/GoAwayTest.java
@@ -165,7 +165,7 @@ public class GoAwayTest extends AbstractTest
 
         MetaData.Request request1 = newRequest(HttpMethod.GET.asString(), HttpFields.EMPTY);
         CountDownLatch streamFailureLatch = new CountDownLatch(1);
-        clientSession.newStream(new HeadersFrame(request1, null, true), new Promise.Adapter<>(), new Stream.Listener()
+        clientSession.newStream(new HeadersFrame(request1, null, true), new Promise.Adapter<>(), new Stream.Listener.NonBlocking()
         {
             @Override
             public void onHeaders(Stream stream, HeadersFrame frame)
@@ -176,7 +176,7 @@ public class GoAwayTest extends AbstractTest
                 // The client sends the second request and should eventually fail it
                 // locally since it has a larger streamId, and the server discarded it.
                 MetaData.Request request2 = newRequest(HttpMethod.GET.asString(), HttpFields.EMPTY);
-                clientSession.newStream(new HeadersFrame(request2, null, true), new Promise.Adapter<>(), new Stream.Listener()
+                clientSession.newStream(new HeadersFrame(request2, null, true), new Promise.Adapter<>(), new Stream.Listener.NonBlocking()
                 {
                     @Override
                     public void onFailure(Stream stream, int error, String reason, Throwable failure, Callback callback)
@@ -471,7 +471,7 @@ public class GoAwayTest extends AbstractTest
         MetaData.Request request1 = newRequest("GET", HttpFields.EMPTY);
         HeadersFrame headersFrame1 = new HeadersFrame(request1, null, false);
         DataFrame dataFrame1 = new DataFrame(ByteBuffer.allocate(flowControlWindow / 2), false);
-        ((HTTP2Session)clientSession).newStream(new HTTP2Stream.FrameList(headersFrame1, dataFrame1, null), new Promise.Adapter<>(), new Stream.Listener()
+        ((HTTP2Session)clientSession).newStream(new HTTP2Stream.FrameList(headersFrame1, dataFrame1, null), new Promise.Adapter<>(), new Stream.Listener.NonBlocking()
         {
             @Override
             public void onHeaders(Stream clientStream1, HeadersFrame frame)

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
@@ -846,19 +846,23 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
 
         AtomicReference<Content.Source> contentSourceRef = new AtomicReference<>();
         AtomicReference<Content.Chunk> chunkRef = new AtomicReference<>();
+        CountDownLatch requestFailureLatch = new CountDownLatch(1);
         CountDownLatch responseFailureLatch = new CountDownLatch(1);
         AtomicReference<Result> resultRef = new AtomicReference<>();
         httpClient.newRequest("localhost", connector.getLocalPort())
             .method(HttpMethod.POST)
             .body(new AsyncRequestContent(ByteBuffer.allocate(1024)))
             .onResponseContentSource((response, contentSource) -> contentSourceRef.set(contentSource))
-            // The request is failed before the response, verify that
-            // reading at the request failure event yields a failure chunk.
-            .onRequestFailure((request, failure) -> chunkRef.set(contentSourceRef.get().read()))
-            .onResponseFailure((response, failure) -> responseFailureLatch.countDown())
+            .onRequestFailure((request, failure) -> requestFailureLatch.countDown())
+            .onResponseFailure((response, failure) ->
+            {
+                chunkRef.set(contentSourceRef.get().read());
+                responseFailureLatch.countDown();
+            })
             .send(resultRef::set);
 
         // Wait for the RST_STREAM to arrive and drain the response content.
+        assertTrue(requestFailureLatch.await(5, TimeUnit.SECONDS));
         assertTrue(responseFailureLatch.await(5, TimeUnit.SECONDS));
 
         // Verify that the chunk read at the request failure event is a failure chunk.

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/IdleTimeoutTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/IdleTimeoutTest.java
@@ -323,7 +323,7 @@ public class IdleTimeoutTest extends AbstractTest
             {
                 stream.setIdleTimeout(10 * idleTimeout);
             }
-        }, new Stream.Listener()
+        }, new Stream.Listener.NonBlocking()
         {
             @Override
             public void onHeaders(Stream stream, HeadersFrame frame)

--- a/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpConnectionOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpConnectionOverHTTP3.java
@@ -32,6 +32,7 @@ import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http3.client.HTTP3SessionClient;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.quic.common.QuicSession;
+import org.eclipse.jetty.util.thread.Invocable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -162,5 +163,10 @@ public class HttpConnectionOverHTTP3 extends HttpConnection implements Connectio
         if (super.onIdleTimeout(idleTimeout, failure))
             close(failure);
         return false;
+    }
+
+    Invocable.InvocationType getInvocationType()
+    {
+        return getHttpClient().getTransport().getInvocationType(this);
     }
 }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractConnection.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractConnection.java
@@ -52,15 +52,6 @@ public abstract class AbstractConnection implements Connection, Invocable
         _readCallback = new ReadCallback();
     }
 
-    @Deprecated
-    @Override
-    public InvocationType getInvocationType()
-    {
-        // TODO consider removing the #fillInterested method from the connection and only use #fillInterestedCallback
-        //      so a connection need not be Invocable
-        return Invocable.super.getInvocationType();
-    }
-
     @Override
     public void addEventListener(EventListener listener)
     {
@@ -140,17 +131,14 @@ public abstract class AbstractConnection implements Connection, Invocable
      */
     public void fillInterested()
     {
-        if (LOG.isDebugEnabled())
-            LOG.debug("fillInterested {}", this);
-        getEndPoint().fillInterested(_readCallback);
+        fillInterested(_readCallback);
     }
 
     /**
-     * <p>Utility method to be called to register read interest.</p>
-     * <p>After a call to this method, {@link #onFillable()} or {@link #onFillInterestedFailed(Throwable)}
-     * will be called back as appropriate.</p>
+     * <p>Registers read interest with the given callback.</p>
+     * <p>When read readiness is signaled, the callback will be completed.</p>
      *
-     * @see #onFillable()
+     * @param callback the callback to complete when read readiness is signaled
      */
     public void fillInterested(Callback callback)
     {
@@ -181,10 +169,10 @@ public abstract class AbstractConnection implements Connection, Invocable
      *
      * @param cause the exception that caused the failure
      */
-    protected void onFillInterestedFailed(Throwable cause)
+    public void onFillInterestedFailed(Throwable cause)
     {
         if (LOG.isDebugEnabled())
-            LOG.debug("{} onFillInterestedFailed {}", this, cause);
+            LOG.debug("{} onFillInterestedFailed", this, cause);
         if (_endPoint.isOpen())
         {
             boolean close = true;
@@ -346,12 +334,6 @@ public abstract class AbstractConnection implements Connection, Invocable
         public String toString()
         {
             return String.format("%s@%x{%s}", getClass().getSimpleName(), hashCode(), AbstractConnection.this);
-        }
-
-        @Override
-        public InvocationType getInvocationType()
-        {
-            return AbstractConnection.this.getInvocationType();
         }
     }
 }

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/VirtualThreadsTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/VirtualThreadsTest.java
@@ -13,24 +13,33 @@
 
 package org.eclipse.jetty.test.client.transport;
 
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import org.eclipse.jetty.client.ContentResponse;
+import org.eclipse.jetty.client.Result;
 import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.VirtualThreads;
 import org.eclipse.jetty.util.thread.ThreadPool;
+import org.eclipse.jetty.util.thread.VirtualThreadPool;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.condition.DisabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisabledForJreRange(max = JRE.JAVA_18)
 public class VirtualThreadsTest extends AbstractTest
@@ -70,5 +79,56 @@ public class VirtualThreadsTest extends AbstractTest
             .send();
 
         assertEquals(HttpStatus.OK_200, response.getStatus(), " for transport " + transport);
+    }
+
+    @ParameterizedTest
+    @MethodSource("transports")
+    public void testClientListenersInvokedOnVirtualThread(Transport transport) throws Exception
+    {
+        startServer(transport, new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            {
+                // Send only the headers.
+                response.write(false, null, Callback.NOOP);
+                // Wait to force the client to invoke the content
+                // callback separately from the headers callback.
+                Thread.sleep(500);
+                // Send the content.
+                Content.Sink.write(response, true, "hello", callback);
+                return true;
+            }
+        });
+
+        prepareClient(transport);
+        VirtualThreads.Configurable executor = (VirtualThreads.Configurable)client.getExecutor();
+        VirtualThreadPool vtp = new VirtualThreadPool();
+        vtp.setName("green-");
+        executor.setVirtualThreadsExecutor(vtp);
+        client.start();
+
+        for (int i = 0; i < 2; ++i)
+        {
+            AtomicReference<Result> resultRef = new AtomicReference<>();
+            ConcurrentLinkedQueue<String> queue = new ConcurrentLinkedQueue<>();
+            Consumer<String> verify = name -> queue.offer((VirtualThreads.isVirtualThread() ? "virtual" : "platform") + "-" + name);
+            client.newRequest(newURI(transport))
+                .onResponseBegin(r -> verify.accept("begin"))
+                .onResponseHeaders(r -> verify.accept("headers"))
+                .onResponseContent((r, b) -> verify.accept("content"))
+                .onResponseSuccess(r -> verify.accept("success"))
+                .onComplete(r -> verify.accept("complete"))
+                .send(r ->
+                {
+                    verify.accept("send");
+                    resultRef.set(r);
+                });
+
+            Result result = await().atMost(5, TimeUnit.SECONDS).until(resultRef::get, notNullValue());
+            assertTrue(result.isSucceeded());
+            assertEquals(HttpStatus.OK_200, result.getResponse().getStatus());
+            queue.forEach(event -> assertTrue(event.startsWith("virtual"), event));
+        }
     }
 }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/Invocable.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/Invocable.java
@@ -44,29 +44,38 @@ public interface Invocable
     enum InvocationType
     {
         /**
-         * <p>Invoking the {@link Invocable} may block the invoker thread,
+         * <p>Invoking the task may block the invoker thread,
          * and the invocation may be performed immediately (possibly blocking
          * the invoker thread) or deferred to a later time, for example
-         * by submitting the {@code Invocable} to a thread pool.</p>
-         * <p>This invocation type is suitable for {@code Invocable}s that
+         * by submitting the task to a thread pool.</p>
+         * <p>This invocation type is suitable for tasks that
          * call application code, for example to process an HTTP request.</p>
          */
         BLOCKING,
         /**
-         * <p>Invoking the {@link Invocable} does not block the invoker thread,
+         * <p>Invoking the task does not block the invoker thread,
          * and the invocation may be performed immediately in the invoker thread.</p>
-         * <p>This invocation type is suitable for {@code Invocable}s that
+         * <p>This invocation type is suitable for tasks that
          * call implementation code that is guaranteed to never block the
          * invoker thread.</p>
          */
         NON_BLOCKING,
         /**
-         * <p>Invoking the {@link Invocable} may block the invoker thread,
-         * but the invocation cannot be deferred to a later time, differently
+         * <p>Invoking the task does not block the invoker thread,
+         * and the invocation may be performed immediately in the invoker thread.</p>
+         * <p>The thread that produced the task may dispatch another
+         * thread to resume production, and then invoke the task, differently
+         * from {@link #NON_BLOCKING} which does not dispatch production to
+         * another thread.</p>
+         * <p>The invocation cannot be deferred to a later time, differently
          * from {@link #BLOCKING}.</p>
-         * <p>This invocation type is suitable for {@code Invocable}s that
-         * themselves perform the non-deferrable action in a non-blocking way,
-         * thus advancing a possibly stalled system.</p>
+         * <p>A series of {@code NON_BLOCKING} tasks is run sequentially,
+         * while a series of {@code EITHER} tasks may be run in parallel,
+         * if there are threads available to resume task production.</p>
+         * <p>This invocation type is suitable for tasks that
+         * perform the non-deferrable action in a non-blocking way,
+         * hinting that may be run in parallel, for example when each task
+         * processes a different connection or a different stream.</p>
          */
         EITHER
     }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/SerializedInvoker.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/SerializedInvoker.java
@@ -212,7 +212,7 @@ public class SerializedInvoker
         @Override
         public InvocationType getInvocationType()
         {
-            return InvocationType.BLOCKING;
+            return Invocable.getInvocationType(_task);
         }
 
         Link next()


### PR DESCRIPTION
* Removed usages of `AbstractConnection.getInvocationType()`.
* Changed HTTP server-side Connection implementations to use `AbstractConnection.fillInterested(Callback)` with a callback that specifies the `InvocationType`, derived from the `Server`, which derives it from the `Handler` chain.
* Changed client-side receivers to use `AbstractConnection.fillInterested(Callback)` with a callback that specifies the `InvocationType`, derived from the `HttpClientTransport`.
* Introduced `HttpClientTransport.getInvocationType(Connection)`, so that client applications can specify whether they block or not.
* Made sure client-side HTTP/2 and HTTP/3 return tasks with the proper `InvocationType` to be run by the `ExecutionStrategy` when calling application code.
* HTTP3StreamConnection now uses an `EITHER` fillable callback to possibly process streams in parallel.
* `QuicStreamEndPoint` now uses a task to invoke `FillInterest.fillable()`, rather than invoking it directly, therefore honoring the `InvocationType` of callback set by the `Connection` associated with the `QuicStreamEndPoint`.