### PR TITLE
Issue #12309 replaced transient keyword for SessionAuthentication.session

### DIFF
--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/SessionAuthentication.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/SessionAuthentication.java
@@ -43,7 +43,7 @@ public class SessionAuthentication extends LoginAuthenticator.UserAuthentication
 
     private final String _name;
     private final Object _credentials;
-    private Session _session;
+    private transient Session _session;
 
     public SessionAuthentication(String method, UserIdentity userIdentity, Object credentials)
     {


### PR DESCRIPTION
Closes #12309 


The `transient` keyword was removed from the `SessionAuthentication` class private data member `Session session`. This leads to problems because the `SessionAuthentication` itself is stored in the `session` during some forms of authentication, such as form or openid. Thus, if the `session` needs to be passivated, there is a backpointer to itself. 