### PR TITLE
Fixes #7951 - OutputStreamContentProvider blocks forever during an HTTP2 upload after idle timeout is reached.

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/OutputStreamRequestContent.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/OutputStreamRequestContent.java
@@ -26,7 +26,7 @@ import org.eclipse.jetty.io.content.OutputStreamContentSource;
  * <p>Content must be provided by writing to the {@link #getOutputStream() output stream}
  * that must be {@link OutputStream#close() closed} when all content has been provided.</p>
  * <p>Example usage:</p>
- * <pre>
+ * <pre>{@code
  * HttpClient httpClient = ...;
  *
  * // Use try-with-resources to autoclose the output stream.
@@ -37,7 +37,7 @@ import org.eclipse.jetty.io.content.OutputStreamContentSource;
  *             .body(content)
  *             .send(new Response.CompleteListener()
  *             {
- *                 &#64;Override
+ *                 @Override
  *                 public void onComplete(Result result)
  *                 {
  *                     // Your logic here
@@ -50,7 +50,7 @@ import org.eclipse.jetty.io.content.OutputStreamContentSource;
  *     // Even later...
  *     output.write("more content".getBytes());
  * } // Implicit call to output.close().
- * </pre>
+ * }</pre>
  */
 public class OutputStreamRequestContent extends OutputStreamContentSource implements Request.Content
 {

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/OutputStreamContentSource.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/OutputStreamContentSource.java
@@ -23,12 +23,11 @@ import org.eclipse.jetty.util.FutureCallback;
 import org.eclipse.jetty.util.IO;
 
 /**
- * <p>
- * A {@link Content.Source} backed by an {@link OutputStream}.
- * Any bytes written to the {@link OutputStream} returned by {@link #getOutputStream()}
- * is converted to a {@link Content.Chunk} and returned from {@link #read()}. If
- * necessary, any {@link Runnable} passed to {@link #demand(Runnable)} is invoked.
- * </p>
+ * <p>A {@link Content.Source} that provides content asynchronously through an {@link OutputStream}.</p>
+ * <p>Bytes written to the {@link OutputStream} returned by {@link #getOutputStream()}
+ * are converted to a {@link Content.Chunk} and returned from {@link #read()}.</p>
+ * <p>The {@code OutputStream} must be closed to signal that all the content has been written.</p>
+ *
  * @see AsyncContent
  */
 public class OutputStreamContentSource implements Content.Source, Closeable


### PR DESCRIPTION
Improved javadocs.