### PR TITLE
Issue #12315 fix flakey session AsyncTest

### DIFF
--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-common/src/test/java/org/eclipse/jetty/ee10/session/AsyncTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-common/src/test/java/org/eclipse/jetty/ee10/session/AsyncTest.java
@@ -60,6 +60,7 @@ public class AsyncTest
 
         DefaultSessionCacheFactory cacheFactory = new DefaultSessionCacheFactory();
         cacheFactory.setEvictionPolicy(SessionCache.EVICT_ON_SESSION_EXIT);
+        cacheFactory.setFlushOnResponseCommit(true);
         SessionDataStoreFactory storeFactory = new TestSessionDataStoreFactory();
         SessionTestSupport server = new SessionTestSupport(0, -1, -1, cacheFactory, storeFactory);
 
@@ -106,6 +107,7 @@ public class AsyncTest
 
         DefaultSessionCacheFactory cacheFactory = new DefaultSessionCacheFactory();
         cacheFactory.setEvictionPolicy(SessionCache.EVICT_ON_SESSION_EXIT);
+        cacheFactory.setFlushOnResponseCommit(true);
         SessionDataStoreFactory storeFactory = new TestSessionDataStoreFactory();
         SessionTestSupport server = new SessionTestSupport(0, -1, -1, cacheFactory, storeFactory);
 
@@ -156,6 +158,7 @@ public class AsyncTest
 
         DefaultSessionCacheFactory cacheFactory = new DefaultSessionCacheFactory();
         cacheFactory.setEvictionPolicy(SessionCache.EVICT_ON_SESSION_EXIT);
+        cacheFactory.setFlushOnResponseCommit(true);
         SessionDataStoreFactory storeFactory = new TestSessionDataStoreFactory();
         SessionTestSupport server = new SessionTestSupport(0, -1, -1, cacheFactory, storeFactory);
 
@@ -202,9 +205,9 @@ public class AsyncTest
     @Test
     public void testSessionCreatedBeforeDispatch() throws Exception
     {
-
         DefaultSessionCacheFactory cacheFactory = new DefaultSessionCacheFactory();
         cacheFactory.setEvictionPolicy(SessionCache.EVICT_ON_SESSION_EXIT);
+        cacheFactory.setFlushOnResponseCommit(true);
         SessionDataStoreFactory storeFactory = new TestSessionDataStoreFactory();
         SessionTestSupport server = new SessionTestSupport(0, -1, -1, cacheFactory, storeFactory);
 
@@ -257,6 +260,7 @@ public class AsyncTest
 
         DefaultSessionCacheFactory cacheFactory = new DefaultSessionCacheFactory();
         cacheFactory.setEvictionPolicy(SessionCache.EVICT_ON_SESSION_EXIT);
+        cacheFactory.setFlushOnResponseCommit(true);
         SessionDataStoreFactory storeFactory = new TestSessionDataStoreFactory();
         SessionTestSupport server = new SessionTestSupport(0, -1, -1, cacheFactory, storeFactory);
 

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-common/src/test/java/org/eclipse/jetty/ee9/session/AsyncTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-common/src/test/java/org/eclipse/jetty/ee9/session/AsyncTest.java
@@ -60,6 +60,7 @@ public class AsyncTest
 
         DefaultSessionCacheFactory cacheFactory = new DefaultSessionCacheFactory();
         cacheFactory.setEvictionPolicy(SessionCache.EVICT_ON_SESSION_EXIT);
+        cacheFactory.setFlushOnResponseCommit(true);
         SessionDataStoreFactory storeFactory = new TestSessionDataStoreFactory();
         SessionTestSupport server = new SessionTestSupport(0, -1, -1, cacheFactory, storeFactory);
 
@@ -102,9 +103,9 @@ public class AsyncTest
     public void testSessionWithAsyncComplete() throws Exception
     {
         // Test async write, which creates a session and completes outside of a dispatch
-
         DefaultSessionCacheFactory cacheFactory = new DefaultSessionCacheFactory();
         cacheFactory.setEvictionPolicy(SessionCache.EVICT_ON_SESSION_EXIT);
+        cacheFactory.setFlushOnResponseCommit(true);
         SessionDataStoreFactory storeFactory = new TestSessionDataStoreFactory();
         SessionTestSupport server = new SessionTestSupport(0, -1, -1, cacheFactory, storeFactory);
 
@@ -153,6 +154,7 @@ public class AsyncTest
 
         DefaultSessionCacheFactory cacheFactory = new DefaultSessionCacheFactory();
         cacheFactory.setEvictionPolicy(SessionCache.EVICT_ON_SESSION_EXIT);
+        cacheFactory.setFlushOnResponseCommit(true);
         SessionDataStoreFactory storeFactory = new TestSessionDataStoreFactory();
         SessionTestSupport server = new SessionTestSupport(0, -1, -1, cacheFactory, storeFactory);
 
@@ -198,9 +200,9 @@ public class AsyncTest
     @Test
     public void testSessionCreatedBeforeDispatch() throws Exception
     {
-
         DefaultSessionCacheFactory cacheFactory = new DefaultSessionCacheFactory();
         cacheFactory.setEvictionPolicy(SessionCache.EVICT_ON_SESSION_EXIT);
+        cacheFactory.setFlushOnResponseCommit(true);
         SessionDataStoreFactory storeFactory = new TestSessionDataStoreFactory();
         SessionTestSupport server = new SessionTestSupport(0, -1, -1, cacheFactory, storeFactory);
 
@@ -252,6 +254,7 @@ public class AsyncTest
 
         DefaultSessionCacheFactory cacheFactory = new DefaultSessionCacheFactory();
         cacheFactory.setEvictionPolicy(SessionCache.EVICT_ON_SESSION_EXIT);
+        cacheFactory.setFlushOnResponseCommit(true);
         SessionDataStoreFactory storeFactory = new TestSessionDataStoreFactory();
         SessionTestSupport server = new SessionTestSupport(0, -1, -1, cacheFactory, storeFactory);
 


### PR DESCRIPTION
Closes #12315 

Session `AsyncTest` needs to call `SessionCache.setFlushOnResponseCommit(true)` before it can test results of session operations after a response returns.