### PR TITLE
Fixes #12265 - Jetty 12.0.13 fails to start when the threadpool-all-virtual module is enabled.

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/VirtualThreadPool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/VirtualThreadPool.java
@@ -40,7 +40,7 @@ public class VirtualThreadPool extends ContainerLifeCycle implements ThreadPool,
 
     private final AutoLock.WithCondition _joinLock = new AutoLock.WithCondition();
     private String _name;
-    private int _maxThreads = 200;
+    private int _maxThreads;
     private boolean _tracking;
     private boolean _detailedDump;
     private Thread _keepAlive;
@@ -50,8 +50,14 @@ public class VirtualThreadPool extends ContainerLifeCycle implements ThreadPool,
 
     public VirtualThreadPool()
     {
+        this(200);
+    }
+
+    public VirtualThreadPool(int maxThreads)
+    {
         if (!VirtualThreads.areSupported())
             throw new IllegalStateException("Virtual Threads not supported");
+        _maxThreads = maxThreads;
     }
 
     /**

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -1540,9 +1540,10 @@ public class DistributionTests extends AbstractJettyHomeTest
         }
     }
 
-    @Test
     @DisabledForJreRange(max = JRE.JAVA_20)
-    public void testVirtualThreadPool() throws Exception
+    @ParameterizedTest
+    @ValueSource(strings = {"threadpool-virtual", "threadpool-all-virtual"})
+    public void testVirtualThreadPool(String threadPoolModule) throws Exception
     {
         Path jettyBase = newTestJettyBaseDirectory();
         String jettyVersion = System.getProperty("jettyVersion");
@@ -1551,7 +1552,7 @@ public class DistributionTests extends AbstractJettyHomeTest
             .jettyBase(jettyBase)
             .build();
 
-        try (JettyHomeTester.Run run1 = distribution.start("--add-modules=threadpool-virtual,http"))
+        try (JettyHomeTester.Run run1 = distribution.start("--add-modules=http," + threadPoolModule))
         {
             assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
             assertEquals(0, run1.getExitValue());


### PR DESCRIPTION
Added missing constructor and test case.