### PR TITLE
Issue #9980 - add additional codes for CustomRequestLog

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/CustomRequestLog.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/CustomRequestLog.java
@@ -309,13 +309,17 @@ import static java.lang.invoke.MethodType.methodType;
  * <dd>The path of the request URI.</dd>
  * <dt>%{query}uri</dt>
  * <dd>The query of the request URI.</dd>
+ * <dt>%{host}uri</dt>
+ * <dd>The host of the request URI.</dd>
+ * <dt>%{port}uri</dt>
+ * <dd>The port of the request URI.</dd>
  * </dl>
  * </td>
  * </tr>
  * <tr>
  * <td>%{attributeName}attr</td>
  * <td>
- * <p>A request attribute.</p>
+ * <p>The value of the request attribute with the given name.</p>
  * </td>
  * </tr>
  * </table>
@@ -1246,15 +1250,13 @@ public class CustomRequestLog extends ContainerLifeCycle implements RequestLog
     @SuppressWarnings("unused")
     private static void logRequestHttpUriHost(StringBuilder b, Request request, Response response)
     {
-        HttpURI.Mutable uri = HttpURI.build(request.getHttpURI()).query(null);
-        append(b, uri.toString());
+        append(b, request.getHttpURI().getHost());
     }
 
     @SuppressWarnings("unused")
     private static void logRequestHttpUriPort(StringBuilder b, Request request, Response response)
     {
-        HttpURI.Mutable uri = HttpURI.build(request.getHttpURI()).query(null);
-        append(b, uri.toString());
+        b.append(request.getHttpURI().getPort());
     }
 
     @SuppressWarnings("unused")

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/CustomRequestLog.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/CustomRequestLog.java
@@ -309,6 +309,7 @@ import static java.lang.invoke.MethodType.methodType;
  * <dd>The path of the request URI.</dd>
  * <dt>%{query}uri</dt>
  * <dd>The query of the request URI.</dd>
+ * </dl>
  * </td>
  * </tr>
  * <tr>

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/CustomRequestLogTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/CustomRequestLogTest.java
@@ -819,46 +819,6 @@ public class CustomRequestLogTest
     }
 
     @Test
-    public void testLogRequestAuthority() throws Exception
-    {
-        start("%A", new SimpleHandler()
-        {
-            @Override
-            public boolean handle(Request request, Response response, Callback callback)
-            {
-                Content.Sink.write(response, false, "hello", Callback.NOOP);
-                callback.succeeded();
-                return true;
-            }
-        });
-
-        HttpTester.Response response = getResponse("GET / HTTP/1.0\n\n");
-        assertEquals(HttpStatus.OK_200, response.getStatus());
-        String log = _logs.poll(5, TimeUnit.SECONDS);
-        assertThat(log, is("127.0.0.1:" + _serverConnector.getLocalPort()));
-    }
-
-    @Test
-    public void testLogRequestScheme() throws Exception
-    {
-        start("%h", new SimpleHandler()
-        {
-            @Override
-            public boolean handle(Request request, Response response, Callback callback)
-            {
-                Content.Sink.write(response, false, "hello", Callback.NOOP);
-                callback.succeeded();
-                return true;
-            }
-        });
-
-        HttpTester.Response response = getResponse("GET / HTTP/1.0\n\n");
-        assertEquals(HttpStatus.OK_200, response.getStatus());
-        String log = _logs.poll(5, TimeUnit.SECONDS);
-        assertThat(log, is("http"));
-    }
-
-    @Test
     public void testLogRequestHttpUri() throws Exception
     {
         start("%uri", new SimpleHandler()

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/CustomRequestLogTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/CustomRequestLogTest.java
@@ -818,6 +818,107 @@ public class CustomRequestLogTest
         assertThat(log, is("42"));
     }
 
+    @Test
+    public void testLogRequestAuthority() throws Exception
+    {
+        start("%A", new SimpleHandler()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                Content.Sink.write(response, false, "hello", Callback.NOOP);
+                callback.succeeded();
+                return true;
+            }
+        });
+
+        HttpTester.Response response = getResponse("GET / HTTP/1.0\n\n");
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+        String log = _logs.poll(5, TimeUnit.SECONDS);
+        assertThat(log, is("127.0.0.1:" + _serverConnector.getLocalPort()));
+    }
+
+    @Test
+    public void testLogRequestScheme() throws Exception
+    {
+        start("%h", new SimpleHandler()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                Content.Sink.write(response, false, "hello", Callback.NOOP);
+                callback.succeeded();
+                return true;
+            }
+        });
+
+        HttpTester.Response response = getResponse("GET / HTTP/1.0\n\n");
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+        String log = _logs.poll(5, TimeUnit.SECONDS);
+        assertThat(log, is("http"));
+    }
+
+    @Test
+    public void testLogRequestHttpUri() throws Exception
+    {
+        start("%uri", new SimpleHandler()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                Content.Sink.write(response, false, "hello", Callback.NOOP);
+                callback.succeeded();
+                return true;
+            }
+        });
+
+        HttpTester.Response response = getResponse("GET /?hello=world HTTP/1.0\n\n");
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+        String log = _logs.poll(5, TimeUnit.SECONDS);
+        assertThat(log, is("http://127.0.0.1:" + _serverConnector.getLocalPort() + "/"));
+    }
+
+    @Test
+    public void testLogRequestHttpUriWithQuery() throws Exception
+    {
+        start("%{q}uri", new SimpleHandler()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                Content.Sink.write(response, false, "hello", Callback.NOOP);
+                callback.succeeded();
+                return true;
+            }
+        });
+
+        HttpTester.Response response = getResponse("GET /?hello=world HTTP/1.0\n\n");
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+        String log = _logs.poll(5, TimeUnit.SECONDS);
+        assertThat(log, is("http://127.0.0.1:" + _serverConnector.getLocalPort() + "/?hello=world"));
+    }
+
+    @Test
+    public void testLogRequestAttribute() throws Exception
+    {
+        start("%{myAttribute}attr", new SimpleHandler()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                request.setAttribute("myAttribute", "value1234");
+                Content.Sink.write(response, false, "hello", Callback.NOOP);
+                callback.succeeded();
+                return true;
+            }
+        });
+
+        HttpTester.Response response = getResponse("GET /?hello=world HTTP/1.0\n\n");
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+        String log = _logs.poll(5, TimeUnit.SECONDS);
+        assertThat(log, is("value1234"));
+    }
+
     class TestRequestLogWriter implements RequestLog.Writer
     {
         @Override

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/CustomRequestLogTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/CustomRequestLogTest.java
@@ -872,16 +872,16 @@ public class CustomRequestLogTest
             }
         });
 
-        HttpTester.Response response = getResponse("GET /?hello=world HTTP/1.0\n\n");
+        HttpTester.Response response = getResponse("GET /path?hello=world#fragment HTTP/1.0\n\n");
         assertEquals(HttpStatus.OK_200, response.getStatus());
         String log = _logs.poll(5, TimeUnit.SECONDS);
-        assertThat(log, is("http://127.0.0.1:" + _serverConnector.getLocalPort() + "/"));
+        assertThat(log, is("http://127.0.0.1:" + _serverConnector.getLocalPort() + "/path?hello=world#fragment"));
     }
 
     @Test
-    public void testLogRequestHttpUriWithQuery() throws Exception
+    public void testLogRequestHttpUriWithoutQuery() throws Exception
     {
-        start("%{q}uri", new SimpleHandler()
+        start("%{-query}uri", new SimpleHandler()
         {
             @Override
             public boolean handle(Request request, Response response, Callback callback)
@@ -892,10 +892,110 @@ public class CustomRequestLogTest
             }
         });
 
-        HttpTester.Response response = getResponse("GET /?hello=world HTTP/1.0\n\n");
+        HttpTester.Response response = getResponse("GET /path?hello=world#fragment HTTP/1.0\n\n");
         assertEquals(HttpStatus.OK_200, response.getStatus());
         String log = _logs.poll(5, TimeUnit.SECONDS);
-        assertThat(log, is("http://127.0.0.1:" + _serverConnector.getLocalPort() + "/?hello=world"));
+        assertThat(log, is("http://127.0.0.1:" + _serverConnector.getLocalPort() + "/path"));
+    }
+
+    @Test
+    public void testLogRequestHttpUriWithoutQueryAndPath() throws Exception
+    {
+        start("%{-path,-query}uri", new SimpleHandler()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                Content.Sink.write(response, false, "hello", Callback.NOOP);
+                callback.succeeded();
+                return true;
+            }
+        });
+
+        HttpTester.Response response = getResponse("GET /path?hello=world#fragment HTTP/1.0\n\n");
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+        String log = _logs.poll(5, TimeUnit.SECONDS);
+        assertThat(log, is("http://127.0.0.1:" + _serverConnector.getLocalPort()));
+    }
+
+    @Test
+    public void testLogRequestHttpUriScheme() throws Exception
+    {
+        start("%{scheme}uri", new SimpleHandler()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                Content.Sink.write(response, false, "hello", Callback.NOOP);
+                callback.succeeded();
+                return true;
+            }
+        });
+
+        HttpTester.Response response = getResponse("GET /path?hello=world#fragment HTTP/1.0\n\n");
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+        String log = _logs.poll(5, TimeUnit.SECONDS);
+        assertThat(log, is("http"));
+    }
+
+    @Test
+    public void testLogRequestHttpUriAuthority() throws Exception
+    {
+        start("%{authority}uri", new SimpleHandler()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                Content.Sink.write(response, false, "hello", Callback.NOOP);
+                callback.succeeded();
+                return true;
+            }
+        });
+
+        HttpTester.Response response = getResponse("GET /path?hello=world#fragment HTTP/1.0\n\n");
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+        String log = _logs.poll(5, TimeUnit.SECONDS);
+        assertThat(log, is("127.0.0.1:" + _serverConnector.getLocalPort()));
+    }
+
+    @Test
+    public void testLogRequestHttpUriPath() throws Exception
+    {
+        start("%{path}uri", new SimpleHandler()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                Content.Sink.write(response, false, "hello", Callback.NOOP);
+                callback.succeeded();
+                return true;
+            }
+        });
+
+        HttpTester.Response response = getResponse("GET /path?hello=world#fragment HTTP/1.0\n\n");
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+        String log = _logs.poll(5, TimeUnit.SECONDS);
+        assertThat(log, is("/path"));
+    }
+
+    @Test
+    public void testLogRequestHttpUriQuery() throws Exception
+    {
+        start("%{query}uri", new SimpleHandler()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                Content.Sink.write(response, false, "hello", Callback.NOOP);
+                callback.succeeded();
+                return true;
+            }
+        });
+
+        HttpTester.Response response = getResponse("GET /path?hello=world#fragment HTTP/1.0\n\n");
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+        String log = _logs.poll(5, TimeUnit.SECONDS);
+        assertThat(log, is("?hello=world"));
     }
 
     @Test

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/CustomRequestLogTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/CustomRequestLogTest.java
@@ -879,6 +879,46 @@ public class CustomRequestLogTest
     }
 
     @Test
+    public void testLogRequestHttpUriHost() throws Exception
+    {
+        start("%{host}uri", new SimpleHandler()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                Content.Sink.write(response, false, "hello", Callback.NOOP);
+                callback.succeeded();
+                return true;
+            }
+        });
+
+        HttpTester.Response response = getResponse("GET /path?hello=world#fragment HTTP/1.0\n\n");
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+        String log = _logs.poll(5, TimeUnit.SECONDS);
+        assertThat(log, is("127.0.0.1"));
+    }
+
+    @Test
+    public void testLogRequestHttpUriPort() throws Exception
+    {
+        start("%{port}uri", new SimpleHandler()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                Content.Sink.write(response, false, "hello", Callback.NOOP);
+                callback.succeeded();
+                return true;
+            }
+        });
+
+        HttpTester.Response response = getResponse("GET /path?hello=world#fragment HTTP/1.0\n\n");
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+        String log = _logs.poll(5, TimeUnit.SECONDS);
+        assertThat(log, is("8080"));
+    }
+
+    @Test
     public void testLogRequestHttpUriScheme() throws Exception
     {
         start("%{scheme}uri", new SimpleHandler()

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/CustomRequestLogTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/CustomRequestLogTest.java
@@ -915,7 +915,7 @@ public class CustomRequestLogTest
         HttpTester.Response response = getResponse("GET /path?hello=world#fragment HTTP/1.0\n\n");
         assertEquals(HttpStatus.OK_200, response.getStatus());
         String log = _logs.poll(5, TimeUnit.SECONDS);
-        assertThat(log, is("8080"));
+        assertThat(log, is(Integer.toString(_serverConnector.getLocalPort())));
     }
 
     @Test


### PR DESCRIPTION
Adds the following options to the CustomRequestLog

```
%A                    - the Request authority (which might differ from the Host header).
%h                    - the Request scheme
%uri                  - the entire Request HttpURI (including query)
%{q}uri               - the entire Request HttpURI (excluding query)
%{attributeName}attr  - a request attribute
```

Let me know if you can think of better codes for these.

closes #9980