### PR TITLE
Issue #12326 Jetty 12.1.x Infinispan flaky tests

### DIFF
--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-infinispan/src/test/resources/config.yaml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-infinispan/src/test/resources/config.yaml
@@ -1,4 +1,0 @@
-jgroups:
-  transport: tcp
-  dnsPing:
-    query: infinispan-dns-ping.myproject.svc.cluster.local

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-sessions/jetty-ee11-test-sessions-infinispan/src/test/resources/config.yaml
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-sessions/jetty-ee11-test-sessions-infinispan/src/test/resources/config.yaml
@@ -1,4 +1,0 @@
-jgroups:
-  transport: tcp
-  dnsPing:
-    query: infinispan-dns-ping.myproject.svc.cluster.local

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-infinispan/src/test/java/org/eclipse/jetty/ee9/session/infinispan/remote/RemoteClusteredInvalidationSessionTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-infinispan/src/test/java/org/eclipse/jetty/ee9/session/infinispan/remote/RemoteClusteredInvalidationSessionTest.java
@@ -20,6 +20,8 @@ import org.eclipse.jetty.session.test.tools.LoggingUtil;
 import org.eclipse.jetty.session.test.tools.RemoteInfinispanTestSupport;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import java.util.UUID;
+
 /**
  * InvalidationSessionTest
  */

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-infinispan/src/test/java/org/eclipse/jetty/ee9/session/infinispan/remote/RemoteClusteredInvalidationSessionTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-infinispan/src/test/java/org/eclipse/jetty/ee9/session/infinispan/remote/RemoteClusteredInvalidationSessionTest.java
@@ -20,8 +20,6 @@ import org.eclipse.jetty.session.test.tools.LoggingUtil;
 import org.eclipse.jetty.session.test.tools.RemoteInfinispanTestSupport;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import java.util.UUID;
-
 /**
  * InvalidationSessionTest
  */

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-infinispan/src/test/resources/config.yaml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-infinispan/src/test/resources/config.yaml
@@ -1,4 +1,0 @@
-jgroups:
-  transport: tcp
-  dnsPing:
-    query: infinispan-dns-ping.myproject.svc.cluster.local

--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,7 @@
     <hazelcast.version>5.5.0</hazelcast.version>
     <hibernate.search.version>7.1.1.Final</hibernate.search.version>
     <infinispan.docker.image.name>infinispan/server</infinispan.docker.image.name>
-    <infinispan.docker.image.version>15.0.5.Final</infinispan.docker.image.version>
+    <infinispan.docker.image.version>15.0.9.Final</infinispan.docker.image.version>
     <infinispan.protostream.version>5.0.5.Final</infinispan.protostream.version>
     <infinispan.version>15.0.5.Final</infinispan.version>
     <injection.bundle.version>1.2</injection.bundle.version>

--- a/tests/jetty-test-session-common/src/main/java/org/eclipse/jetty/session/test/tools/InfinispanTestSupport.java
+++ b/tests/jetty-test-session-common/src/main/java/org/eclipse/jetty/session/test/tools/InfinispanTestSupport.java
@@ -13,10 +13,8 @@
 
 package org.eclipse.jetty.session.test.tools;
 
-import java.lang.annotation.ElementType;
 import java.nio.file.Path;
 import java.util.Objects;
-import java.util.Properties;
 
 import org.eclipse.jetty.session.SessionData;
 import org.eclipse.jetty.session.infinispan.InfinispanSerializationContextInitializer;

--- a/tests/jetty-test-session-common/src/main/java/org/eclipse/jetty/session/test/tools/RemoteInfinispanTestSupport.java
+++ b/tests/jetty-test-session-common/src/main/java/org/eclipse/jetty/session/test/tools/RemoteInfinispanTestSupport.java
@@ -71,6 +71,7 @@ public class RemoteInfinispanTestSupport
                     .withEnv("MGMT_USER", "admin")
                     .withEnv("MGMT_PASS", "admin")
                     .withEnv("CONFIG_PATH", "/user-config/config.yaml")
+                    .withEnv("JAVA_OPTIONS", "-Xms64m -Xmx256m")
                     .waitingFor(Wait.forListeningPorts(11222))
                     .withExposedPorts(4712, 4713, 8088, 8089, 8443, 9990, 9993, 11211, 11222, 11223, 11224)
                     .withLogConsumer(new Slf4jLogConsumer(INFINISPAN_LOG))

--- a/tests/jetty-test-session-common/src/main/java/org/eclipse/jetty/session/test/tools/RemoteInfinispanTestSupport.java
+++ b/tests/jetty-test-session-common/src/main/java/org/eclipse/jetty/session/test/tools/RemoteInfinispanTestSupport.java
@@ -49,7 +49,6 @@ public class RemoteInfinispanTestSupport
     private static final Logger LOG = LoggerFactory.getLogger(RemoteInfinispanTestSupport.class);
     public RemoteCache<String, InfinispanSessionData> _cache;
     private final String _name;
-    public static RemoteCacheManager _manager;
     private static final Logger INFINISPAN_LOG =
             LoggerFactory.getLogger("org.eclipse.jetty.server.session.remote.infinispanLogs");
 
@@ -57,27 +56,31 @@ public class RemoteInfinispanTestSupport
     private static final String IMAGE_NAME = System.getProperty("infinispan.docker.image.name", "infinispan/server") +
             ":" + INFINISPAN_VERSION;
 
-    private static final GenericContainer<?> infinispan = new GenericContainer<>(IMAGE_NAME);
-
-    static
+    private static final class Holder
     {
-        infinispan.withEnv("USER", "theuser")
-                .withEnv("PASS", "foobar")
-                .withEnv("MGMT_USER", "admin")
-                .withEnv("MGMT_PASS", "admin")
-                .withEnv("CONFIG_PATH", "/user-config/config.yaml")
-                .waitingFor(Wait.forListeningPorts(11222))
-                .withExposedPorts(4712, 4713, 8088, 8089, 8443, 9990, 9993, 11211, 11222, 11223, 11224)
-                .withLogConsumer(new Slf4jLogConsumer(INFINISPAN_LOG))
-                .withClasspathResourceMapping("/config.yaml", "/user-config/config.yaml", BindMode.READ_ONLY)
-                .start();
+        private static final Holder INSTANCE = new Holder();
 
-        // setup instance
+        private final RemoteCacheManager manager;
+
+        private Holder()
         {
+            GenericContainer<?> container = new GenericContainer<>(IMAGE_NAME);
+
+            container.withEnv("USER", "theuser")
+                    .withEnv("PASS", "foobar")
+                    .withEnv("MGMT_USER", "admin")
+                    .withEnv("MGMT_PASS", "admin")
+                    .withEnv("CONFIG_PATH", "/user-config/config.yaml")
+                    .waitingFor(Wait.forListeningPorts(11222))
+                    .withExposedPorts(4712, 4713, 8088, 8089, 8443, 9990, 9993, 11211, 11222, 11223, 11224)
+                    .withLogConsumer(new Slf4jLogConsumer(INFINISPAN_LOG))
+                    .withClasspathResourceMapping("/config.yaml", "/user-config/config.yaml", BindMode.READ_ONLY)
+                    .start();
+
             ConfigurationBuilder configurationBuilder = new ConfigurationBuilder()
                     .addServer()
-                    .host(infinispan.getHost())
-                    .port(infinispan.getMappedPort(11222))
+                    .host(container.getHost())
+                    .port(container.getMappedPort(11222))
                     // we just want to limit connectivity to list of host:port we knows at start
                     // as infinispan create new host:port dynamically but due to how docker expose host/port we cannot do that
                     .clientIntelligence(ClientIntelligence.BASIC)
@@ -93,7 +96,7 @@ public class RemoteInfinispanTestSupport
             configurationBuilder.addContextInitializer(new InfinispanSerializationContextInitializer());
             Configuration configuration = configurationBuilder.build();
 
-            _manager = new RemoteCacheManager(configuration);
+            manager = new RemoteCacheManager(configuration);
 
             //upload the session.proto file to the remote cache
             ByteArrayOutputStream baos;
@@ -111,10 +114,8 @@ public class RemoteInfinispanTestSupport
             }
 
             String content = baos.toString(StandardCharsets.UTF_8);
-            _manager.administration().getOrCreateCache("___protobuf_metadata", (String)null).put("session.proto", content);
-
+            manager.administration().getOrCreateCache("___protobuf_metadata", (String)null).put("session.proto", content);
         }
-
     }
 
     public RemoteInfinispanTestSupport(String cacheName)
@@ -129,7 +130,7 @@ public class RemoteInfinispanTestSupport
                 "</infinispan>", _name);
 
         StringConfiguration xmlConfig = new StringConfiguration(xml);
-        _cache = _manager.administration().getOrCreateCache(_name, xmlConfig);
+        _cache = Holder.INSTANCE.manager.administration().getOrCreateCache(_name, xmlConfig);
     }
 
     public RemoteCache<String, InfinispanSessionData> getCache()

--- a/tests/jetty-test-session-common/src/main/java/org/eclipse/jetty/session/test/tools/RemoteInfinispanTestSupport.java
+++ b/tests/jetty-test-session-common/src/main/java/org/eclipse/jetty/session/test/tools/RemoteInfinispanTestSupport.java
@@ -116,6 +116,23 @@ public class RemoteInfinispanTestSupport
 
             String content = baos.toString(StandardCharsets.UTF_8);
             manager.administration().getOrCreateCache("___protobuf_metadata", (String)null).put("session.proto", content);
+
+            Runtime.getRuntime().addShutdownHook(new Thread(() ->
+            {
+                try
+                {
+                    if(container.isRunning())
+                    {
+                        LOG.info("Stopping Infinispan");
+                        container.stop();
+                    }
+                }
+                catch (Throwable x)
+                {
+                    // ignore any error here
+                    LOG.warn(x.getMessage(), x);
+                }
+            }));
         }
     }
 

--- a/tests/jetty-test-session-common/src/main/java/org/eclipse/jetty/session/test/tools/RemoteInfinispanTestSupport.java
+++ b/tests/jetty-test-session-common/src/main/java/org/eclipse/jetty/session/test/tools/RemoteInfinispanTestSupport.java
@@ -70,12 +70,12 @@ public class RemoteInfinispanTestSupport
                     .withEnv("PASS", "foobar")
                     .withEnv("MGMT_USER", "admin")
                     .withEnv("MGMT_PASS", "admin")
-                    .withEnv("CONFIG_PATH", "/user-config/config.yaml")
-                    .withEnv("JAVA_OPTIONS", "-Xms64m -Xmx256m")
+                    //.withEnv("CONFIG_PATH", "/user-config/config.yaml")
+                    .withEnv("JAVA_OPTIONS", "-Xms64m -Xmx256m -Djgroups.dns.query=infinispan-dns-ping.myproject.svc.cluster.local")
                     .waitingFor(Wait.forListeningPorts(11222))
                     .withExposedPorts(4712, 4713, 8088, 8089, 8443, 9990, 9993, 11211, 11222, 11223, 11224)
                     .withLogConsumer(new Slf4jLogConsumer(INFINISPAN_LOG))
-                    .withClasspathResourceMapping("/config.yaml", "/user-config/config.yaml", BindMode.READ_ONLY)
+                    //.withClasspathResourceMapping("/config.yaml", "/user-config/config.yaml", BindMode.READ_ONLY)
                     .start();
 
             ConfigurationBuilder configurationBuilder = new ConfigurationBuilder()

--- a/tests/jetty-test-session-common/src/main/java/org/eclipse/jetty/session/test/tools/RemoteInfinispanTestSupport.java
+++ b/tests/jetty-test-session-common/src/main/java/org/eclipse/jetty/session/test/tools/RemoteInfinispanTestSupport.java
@@ -121,7 +121,7 @@ public class RemoteInfinispanTestSupport
             {
                 try
                 {
-                    if(container.isRunning())
+                    if (container.isRunning())
                     {
                         LOG.info("Stopping Infinispan");
                         container.stop();

--- a/tests/jetty-test-session-common/src/main/java/org/eclipse/jetty/session/test/tools/RemoteInfinispanTestSupport.java
+++ b/tests/jetty-test-session-common/src/main/java/org/eclipse/jetty/session/test/tools/RemoteInfinispanTestSupport.java
@@ -20,6 +20,7 @@ import java.lang.annotation.ElementType;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.UUID;
 
 import org.eclipse.jetty.session.SessionData;
 import org.eclipse.jetty.session.infinispan.InfinispanSerializationContextInitializer;
@@ -54,7 +55,7 @@ public class RemoteInfinispanTestSupport
     private static final Logger INFINISPAN_LOG =
             LoggerFactory.getLogger("org.eclipse.jetty.server.session.remote.infinispanLogs");
 
-    private static final String INFINISPAN_VERSION = System.getProperty("infinispan.docker.image.version", "14.0.25.Final");
+    private static final String INFINISPAN_VERSION = System.getProperty("infinispan.docker.image.version", "15.0.9.Final");
     private static final String IMAGE_NAME = System.getProperty("infinispan.docker.image.name", "infinispan/server") +
             ":" + INFINISPAN_VERSION;
 
@@ -121,7 +122,7 @@ public class RemoteInfinispanTestSupport
     public RemoteInfinispanTestSupport(String cacheName)
     {
         Objects.requireNonNull(cacheName, "cacheName cannot be null");
-        _name = cacheName;
+        _name = UUID.randomUUID().toString();
         String xml = String.format("<infinispan>"  +
                 "<cache-container>" + "<distributed-cache name=\"%s\" mode=\"SYNC\">" +
                 "<encoding media-type=\"application/x-protostream\"/>" +

--- a/tests/jetty-test-session-common/src/main/java/org/eclipse/jetty/session/test/tools/RemoteInfinispanTestSupport.java
+++ b/tests/jetty-test-session-common/src/main/java/org/eclipse/jetty/session/test/tools/RemoteInfinispanTestSupport.java
@@ -16,10 +16,8 @@ package org.eclipse.jetty.session.test.tools;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.annotation.ElementType;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
-import java.util.Properties;
 import java.util.UUID;
 
 import org.eclipse.jetty.session.SessionData;

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/session/InfinispanSessionDistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/session/InfinispanSessionDistributionTests.java
@@ -65,11 +65,12 @@ public class InfinispanSessionDistributionTests extends AbstractSessionDistribut
                         .withEnv("PASS", "foobar")
                         .withEnv("MGMT_USER", "admin")
                         .withEnv("MGMT_PASS", "admin")
-                        .withEnv("CONFIG_PATH", "/user-config/config.yaml")
+                        .withEnv("JAVA_OPTIONS", "-Xms64m -Xmx256m -Djgroups.dns.query=infinispan-dns-ping.myproject.svc.cluster.local")
+                        //.withEnv("CONFIG_PATH", "/user-config/config.yaml")
                         .waitingFor(Wait.forListeningPorts(11222))
                         .withExposedPorts(4712, 4713, 8088, 8089, 8443, 9990, 9993, 11211, 11222, 11223, 11224)
-                        .withLogConsumer(new Slf4jLogConsumer(INFINISPAN_LOG))
-                        .withClasspathResourceMapping("/config.yaml", "/user-config/config.yaml", BindMode.READ_ONLY);
+                        .withLogConsumer(new Slf4jLogConsumer(INFINISPAN_LOG));
+                        //.withClasspathResourceMapping("/config.yaml", "/user-config/config.yaml", BindMode.READ_ONLY);
         infinispan.start();
         host = infinispan.getHost();
         port = infinispan.getMappedPort(11222);

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/session/InfinispanSessionDistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/session/InfinispanSessionDistributionTests.java
@@ -66,11 +66,9 @@ public class InfinispanSessionDistributionTests extends AbstractSessionDistribut
                         .withEnv("MGMT_USER", "admin")
                         .withEnv("MGMT_PASS", "admin")
                         .withEnv("JAVA_OPTIONS", "-Xms64m -Xmx256m -Djgroups.dns.query=infinispan-dns-ping.myproject.svc.cluster.local")
-                        //.withEnv("CONFIG_PATH", "/user-config/config.yaml")
                         .waitingFor(Wait.forListeningPorts(11222))
                         .withExposedPorts(4712, 4713, 8088, 8089, 8443, 9990, 9993, 11211, 11222, 11223, 11224)
                         .withLogConsumer(new Slf4jLogConsumer(INFINISPAN_LOG));
-                        //.withClasspathResourceMapping("/config.yaml", "/user-config/config.yaml", BindMode.READ_ONLY);
         infinispan.start();
         host = infinispan.getHost();
         port = infinispan.getMappedPort(11222);

--- a/tests/test-distribution/test-distribution-common/src/test/resources/config.yaml
+++ b/tests/test-distribution/test-distribution-common/src/test/resources/config.yaml
@@ -1,4 +1,0 @@
-jgroups:
-  transport: tcp
-  dnsPing:
-    query: infinispan-dns-ping.myproject.svc.cluster.local


### PR DESCRIPTION
- **use Infinispan image 15.0.9, use UUID for cache name**
- **checkstyle**
- **use a single instance via singleton holder**
- **reduce memory usage of Infinispan**
