### PR TITLE
Make sure the delegate callback has been failed before SendCallback's iteration returns

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -931,7 +931,7 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
         public void onFailure(final Throwable x)
         {
             Callback callback = resetCallback();
-            failedCallback(callback, x);
+            callback.failed(x);
         }
 
         @Override


### PR DESCRIPTION
Fix for #12330

`LargeHeaderTest.testLargeHeaderNewConnectionsConcurrent()` tests a write failure case, with the given callback being of invocable type BLOCKING. In this case, `SendCallback.onFailure()` gives the responsibility of failing the delegate callback to an executor, meaning that when `SendCallback.iterate()` returns the delegate callback may or may not have been failed.

This behavior is racy and may lead to all kinds of problems in the server, like the response data being written before the headers, NPEs, ISEs...