### PR TITLE
Issue #11307 - Explicit demand control in WebSocket endpoints with only onWebSocketFrame

### DIFF
--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/Callback.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/Callback.java
@@ -58,6 +58,34 @@ public interface Callback
     }
 
     /**
+     * Creates a nested callback that runs completed after
+     * completing the nested callback.
+     *
+     * @param callback The nested callback
+     * @param completed The completion to run after the nested callback is completed
+     * @return a new callback.
+     */
+    static Callback from(Callback callback, Runnable completed)
+    {
+        return new Callback()
+        {
+            @Override
+            public void succeed()
+            {
+                callback.succeed();
+                completed.run();
+            }
+
+            @Override
+            public void fail(Throwable x)
+            {
+                callback.fail(x);
+                completed.run();
+            }
+        };
+    }
+
+    /**
      * <p>Method to invoke to succeed the callback.</p>
      *
      * @see #fail(Throwable)

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/Callback.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/Callback.java
@@ -72,15 +72,27 @@ public interface Callback
             @Override
             public void succeed()
             {
-                callback.succeed();
-                completed.run();
+                try
+                {
+                    callback.succeed();
+                }
+                finally
+                {
+                    completed.run();
+                }
             }
 
             @Override
             public void fail(Throwable x)
             {
-                callback.fail(x);
-                completed.run();
+                try
+                {
+                    callback.fail(x);
+                }
+                finally
+                {
+                    completed.run();
+                }
             }
         };
     }

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/Frame.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/Frame.java
@@ -102,6 +102,15 @@ public interface Frame
 
     boolean isRsv3();
 
+    default CloseStatus getCloseStatus()
+    {
+        return null;
+    }
+
+    record CloseStatus(int statusCode, String reason)
+    {
+    }
+
     /**
      * The effective opcode of the frame accounting for the CONTINUATION opcode.
      * If the frame is a CONTINUATION frame for a TEXT message, this will return TEXT.
@@ -110,122 +119,4 @@ public interface Frame
      * @return the effective opcode of the frame.
      */
     byte getEffectiveOpCode();
-
-    class Wrapper implements Frame
-    {
-        private final Frame _frame;
-
-        public Wrapper(Frame frame)
-        {
-            _frame = frame;
-        }
-
-        public Frame getWrapped()
-        {
-            return _frame;
-        }
-
-        @Override
-        public byte[] getMask()
-        {
-            return _frame.getMask();
-        }
-
-        @Override
-        public byte getOpCode()
-        {
-            return _frame.getOpCode();
-        }
-
-        @Override
-        public ByteBuffer getPayload()
-        {
-            return _frame.getPayload();
-        }
-
-        @Override
-        public int getPayloadLength()
-        {
-            return _frame.getPayloadLength();
-        }
-
-        @Override
-        public Type getType()
-        {
-            return _frame.getType();
-        }
-
-        @Override
-        public boolean hasPayload()
-        {
-            return _frame.hasPayload();
-        }
-
-        @Override
-        public boolean isFin()
-        {
-            return _frame.isFin();
-        }
-
-        @Override
-        public boolean isMasked()
-        {
-            return _frame.isMasked();
-        }
-
-        @Override
-        public boolean isRsv1()
-        {
-            return _frame.isRsv1();
-        }
-
-        @Override
-        public boolean isRsv2()
-        {
-            return _frame.isRsv2();
-        }
-
-        @Override
-        public boolean isRsv3()
-        {
-            return _frame.isRsv3();
-        }
-
-        @Override
-        public byte getEffectiveOpCode()
-        {
-            return _frame.getEffectiveOpCode();
-        }
-    }
-
-    static Frame copy(Frame frame)
-    {
-        ByteBuffer payloadCopy = copy(frame.getPayload());
-        return new Frame.Wrapper(frame)
-        {
-            @Override
-            public ByteBuffer getPayload()
-            {
-                return payloadCopy;
-            }
-
-            @Override
-            public int getPayloadLength()
-            {
-                return payloadCopy == null ? 0 : payloadCopy.remaining();
-            }
-        };
-    }
-
-    private static ByteBuffer copy(ByteBuffer buffer)
-    {
-        if (buffer == null)
-            return null;
-        int p = buffer.position();
-        ByteBuffer clone = buffer.isDirect() ? ByteBuffer.allocateDirect(buffer.remaining()) : ByteBuffer.allocate(buffer.remaining());
-        clone.put(buffer);
-        clone.flip();
-        buffer.position(p);
-        return clone;
-    }
 }

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/Frame.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/Frame.java
@@ -120,6 +120,11 @@ public interface Frame
             _frame = frame;
         }
 
+        public Frame getWrapped()
+        {
+            return _frame;
+        }
+
         @Override
         public byte[] getMask()
         {

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/Frame.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/Frame.java
@@ -101,4 +101,111 @@ public interface Frame
     boolean isRsv2();
 
     boolean isRsv3();
+
+    class Wrapper implements Frame
+    {
+        private final Frame _frame;
+
+        public Wrapper(Frame frame)
+        {
+            _frame = frame;
+        }
+
+        @Override
+        public byte[] getMask()
+        {
+            return _frame.getMask();
+        }
+
+        @Override
+        public byte getOpCode()
+        {
+            return _frame.getOpCode();
+        }
+
+        @Override
+        public ByteBuffer getPayload()
+        {
+            return _frame.getPayload();
+        }
+
+        @Override
+        public int getPayloadLength()
+        {
+            return _frame.getPayloadLength();
+        }
+
+        @Override
+        public Type getType()
+        {
+            return _frame.getType();
+        }
+
+        @Override
+        public boolean hasPayload()
+        {
+            return _frame.hasPayload();
+        }
+
+        @Override
+        public boolean isFin()
+        {
+            return _frame.isFin();
+        }
+
+        @Override
+        public boolean isMasked()
+        {
+            return _frame.isMasked();
+        }
+
+        @Override
+        public boolean isRsv1()
+        {
+            return _frame.isRsv1();
+        }
+
+        @Override
+        public boolean isRsv2()
+        {
+            return _frame.isRsv2();
+        }
+
+        @Override
+        public boolean isRsv3()
+        {
+            return _frame.isRsv3();
+        }
+    }
+
+    static Frame copy(Frame frame)
+    {
+        ByteBuffer payloadCopy = copy(frame.getPayload());
+        return new Frame.Wrapper(frame)
+        {
+            @Override
+            public ByteBuffer getPayload()
+            {
+                return payloadCopy;
+            }
+
+            @Override
+            public int getPayloadLength()
+            {
+                return payloadCopy == null ? 0 : payloadCopy.remaining();
+            }
+        };
+    }
+
+    private static ByteBuffer copy(ByteBuffer buffer)
+    {
+        if (buffer == null)
+            return null;
+        int p = buffer.position();
+        ByteBuffer clone = buffer.isDirect() ? ByteBuffer.allocateDirect(buffer.remaining()) : ByteBuffer.allocate(buffer.remaining());
+        clone.put(buffer);
+        clone.flip();
+        buffer.position(p);
+        return clone;
+    }
 }

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/Frame.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/Frame.java
@@ -102,6 +102,15 @@ public interface Frame
 
     boolean isRsv3();
 
+    /**
+     * The effective opcode of the frame accounting for the CONTINUATION opcode.
+     * If the frame is a CONTINUATION frame for a TEXT message, this will return TEXT.
+     * If the frame is a CONTINUATION frame for a BINARY message, this will return BINARY.
+     * Otherwise, this will return the same opcode as the frame.
+     * @return the effective opcode of the frame.
+     */
+    byte getEffectiveOpCode();
+
     class Wrapper implements Frame
     {
         private final Frame _frame;
@@ -175,6 +184,12 @@ public interface Frame
         public boolean isRsv3()
         {
             return _frame.isRsv3();
+        }
+
+        @Override
+        public byte getEffectiveOpCode()
+        {
+            return _frame.getEffectiveOpCode();
         }
     }
 

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/Session.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/Session.java
@@ -227,6 +227,7 @@ public interface Session extends Configurable, Closeable
          * or data frames either BINARY or TEXT.</p>
          *
          * @param frame the received frame
+         * @param callback the callback to complete once the frame has been processed.
          */
         default void onWebSocketFrame(Frame frame, Callback callback)
         {
@@ -284,6 +285,7 @@ public interface Session extends Configurable, Closeable
          * <p>A WebSocket BINARY message has been received.</p>
          *
          * @param payload the raw payload array received
+         * @param callback the callback to complete when the payload has been processed
          */
         default void onWebSocketBinary(ByteBuffer payload, Callback callback)
         {

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrame.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrame.java
@@ -20,10 +20,18 @@ import org.eclipse.jetty.websocket.core.Frame;
 public class JettyWebSocketFrame implements org.eclipse.jetty.websocket.api.Frame
 {
     private final Frame frame;
+    private final byte effectiveOpCode;
 
+    @Deprecated
     public JettyWebSocketFrame(Frame frame)
     {
+        this(frame, frame.getOpCode());
+    }
+
+    JettyWebSocketFrame(Frame frame, byte effectiveOpCode)
+    {
         this.frame = frame;
+        this.effectiveOpCode = effectiveOpCode;
     }
 
     @Override
@@ -90,6 +98,12 @@ public class JettyWebSocketFrame implements org.eclipse.jetty.websocket.api.Fram
     public boolean isRsv3()
     {
         return frame.isRsv3();
+    }
+
+    @Override
+    public byte getEffectiveOpCode()
+    {
+        return effectiveOpCode;
     }
 
     @Override

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrame.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrame.java
@@ -22,12 +22,21 @@ public class JettyWebSocketFrame implements org.eclipse.jetty.websocket.api.Fram
     private final Frame frame;
     private final byte effectiveOpCode;
 
+    /**
+     * @param frame the core websocket {@link Frame} to wrap as a {@link org.eclipse.jetty.websocket.api.Frame}.
+     * @deprecated there is no alternative intended to publicly construct a {@link JettyWebSocketFrame}.
+     */
     @Deprecated
     public JettyWebSocketFrame(Frame frame)
     {
         this(frame, frame.getOpCode());
     }
 
+    /**
+     * @param frame the core websocket {@link Frame} to wrap as a Jetty API {@link org.eclipse.jetty.websocket.api.Frame}.
+     * @param effectiveOpCode the effective OpCode of the Frame, where any CONTINUATION should be replaced with the
+     * initial opcode of that websocket message.
+     */
     JettyWebSocketFrame(Frame frame, byte effectiveOpCode)
     {
         this.frame = frame;

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrame.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrame.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.websocket.common;
 import java.nio.ByteBuffer;
 
 import org.eclipse.jetty.websocket.core.Frame;
+import org.eclipse.jetty.websocket.core.OpCode;
 
 public class JettyWebSocketFrame implements org.eclipse.jetty.websocket.api.Frame
 {
@@ -26,7 +27,7 @@ public class JettyWebSocketFrame implements org.eclipse.jetty.websocket.api.Fram
      * @param frame the core websocket {@link Frame} to wrap as a {@link org.eclipse.jetty.websocket.api.Frame}.
      * @deprecated there is no alternative intended to publicly construct a {@link JettyWebSocketFrame}.
      */
-    @Deprecated
+    @Deprecated(forRemoval = true, since = "12.1.0")
     public JettyWebSocketFrame(Frame frame)
     {
         this(frame, frame.getOpCode());
@@ -113,6 +114,15 @@ public class JettyWebSocketFrame implements org.eclipse.jetty.websocket.api.Fram
     public byte getEffectiveOpCode()
     {
         return effectiveOpCode;
+    }
+
+    @Override
+    public CloseStatus getCloseStatus()
+    {
+        if (getOpCode() != OpCode.CLOSE)
+            return null;
+        org.eclipse.jetty.websocket.core.CloseStatus closeStatus = org.eclipse.jetty.websocket.core.CloseStatus.getCloseStatus(frame);
+        return new CloseStatus(closeStatus.getCode(), closeStatus.getReason());
     }
 
     @Override

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandler.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandler.java
@@ -19,7 +19,6 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.jetty.util.BufferUtil;
@@ -197,49 +196,37 @@ public class JettyWebSocketFrameHandler implements FrameHandler
         if (frame.getOpCode() == OpCode.TEXT || frame.getOpCode() == OpCode.BINARY)
             messageType = frame.getOpCode();
 
-        CompletableFuture<Void> frameCallback = null;
         if (frameHandle != null)
         {
             try
             {
                 byte effectiveOpCode = frame.isDataFrame() ? messageType : frame.getOpCode();
-                frameCallback = new org.eclipse.jetty.websocket.api.Callback.Completable();
-                frameHandle.invoke(new JettyWebSocketFrame(frame, effectiveOpCode), frameCallback);
+                frameHandle.invoke(new JettyWebSocketFrame(frame, effectiveOpCode),
+                    org.eclipse.jetty.websocket.api.Callback.from(coreCallback::succeeded, coreCallback::failed));
             }
             catch (Throwable cause)
             {
                 coreCallback.failed(new WebSocketException(endpointInstance.getClass().getSimpleName() + " FRAME method error: " + cause.getMessage(), cause));
-                return;
             }
+
+            autoDemand();
+            return;
         }
 
-        Callback.Completable eventCallback = new Callback.Completable();
         switch (frame.getOpCode())
         {
-            case OpCode.TEXT -> onTextFrame(frame, eventCallback);
-            case OpCode.BINARY -> onBinaryFrame(frame, eventCallback);
-            case OpCode.CONTINUATION -> onContinuationFrame(frame, eventCallback);
-            case OpCode.PING -> onPingFrame(frame, eventCallback);
-            case OpCode.PONG -> onPongFrame(frame, eventCallback);
-            case OpCode.CLOSE -> onCloseFrame(frame, eventCallback);
+            case OpCode.TEXT -> onTextFrame(frame, coreCallback);
+            case OpCode.BINARY -> onBinaryFrame(frame, coreCallback);
+            case OpCode.CONTINUATION -> onContinuationFrame(frame, coreCallback);
+            case OpCode.PING -> onPingFrame(frame, coreCallback);
+            case OpCode.PONG -> onPongFrame(frame, coreCallback);
+            case OpCode.CLOSE -> onCloseFrame(frame, coreCallback);
             default ->
             {
                 coreCallback.failed(new IllegalStateException());
                 return;
             }
         };
-
-        // Combine the callback from the frame handler and the event handler.
-        CompletableFuture<Void> callback = eventCallback;
-        if (frameCallback != null)
-            callback = frameCallback.thenCompose(ignored -> eventCallback);
-        callback.whenComplete((r, x) ->
-        {
-            if (x == null)
-                coreCallback.succeeded();
-            else
-                coreCallback.failed(x);
-        });
     }
 
     @Override
@@ -324,14 +311,6 @@ public class JettyWebSocketFrameHandler implements FrameHandler
         }
         else
         {
-            // If we have a frameHandler it takes responsibility for handling the ping and demanding.
-            if (frameHandle != null)
-            {
-                callback.succeeded();
-                autoDemand();
-                return;
-            }
-
             // Automatically respond.
             getSession().sendPong(frame.getPayload(), new org.eclipse.jetty.websocket.api.Callback()
             {
@@ -375,12 +354,8 @@ public class JettyWebSocketFrameHandler implements FrameHandler
         }
         else
         {
-            // If we have a frameHandler it takes responsibility for handling the pong and demanding.
             callback.succeeded();
-            if (frameHandle == null)
-                internalDemand();
-            else
-                autoDemand();
+            internalDemand();
         }
     }
 
@@ -409,10 +384,7 @@ public class JettyWebSocketFrameHandler implements FrameHandler
         if (activeMessageSink == null)
         {
             callback.succeeded();
-            if (frameHandle == null)
-                internalDemand();
-            else
-                autoDemand();
+            internalDemand();
             return;
         }
 

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandler.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandler.java
@@ -221,12 +221,8 @@ public class JettyWebSocketFrameHandler implements FrameHandler
             case OpCode.PING -> onPingFrame(frame, coreCallback);
             case OpCode.PONG -> onPongFrame(frame, coreCallback);
             case OpCode.CLOSE -> onCloseFrame(frame, coreCallback);
-            default ->
-            {
-                coreCallback.failed(new IllegalStateException());
-                return;
-            }
-        };
+            default -> coreCallback.failed(new IllegalStateException());
+        }
     }
 
     @Override

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandler.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandler.java
@@ -206,44 +206,6 @@ public class JettyWebSocketFrameHandler implements FrameHandler
                 coreCallback.failed(new WebSocketException(endpointInstance.getClass().getSimpleName() + " FRAME method error: " + cause.getMessage(), cause));
                 return;
             }
-
-            switch (frame.getOpCode())
-            {
-                case OpCode.TEXT ->
-                {
-                    if (textHandle == null)
-                        autoDemand();
-                }
-                case OpCode.BINARY ->
-                {
-                    if (binaryHandle == null)
-                        autoDemand();
-                }
-                case OpCode.CONTINUATION ->
-                {
-                    if (activeMessageSink == null)
-                        autoDemand();
-                }
-                case OpCode.PING ->
-                {
-                    if (pingHandle == null)
-                        autoDemand();
-                }
-                case OpCode.PONG ->
-                {
-                    if (pongHandle == null)
-                        autoDemand();
-                }
-                case OpCode.CLOSE ->
-                {
-                    // Do nothing.
-                }
-                default ->
-                {
-                    coreCallback.failed(new IllegalStateException());
-                    return;
-                }
-            };
         }
 
         Callback.Completable eventCallback = new Callback.Completable();
@@ -361,6 +323,7 @@ public class JettyWebSocketFrameHandler implements FrameHandler
             if (frameHandle != null)
             {
                 callback.succeeded();
+                autoDemand();
                 return;
             }
 
@@ -411,6 +374,8 @@ public class JettyWebSocketFrameHandler implements FrameHandler
             callback.succeeded();
             if (frameHandle == null)
                 internalDemand();
+            else
+                autoDemand();
         }
     }
 
@@ -441,6 +406,8 @@ public class JettyWebSocketFrameHandler implements FrameHandler
             callback.succeeded();
             if (frameHandle == null)
                 internalDemand();
+            else
+                autoDemand();
             return;
         }
 

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandlerMetadata.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandlerMetadata.java
@@ -46,6 +46,7 @@ public class JettyWebSocketFrameHandlerMetadata extends Configuration.Configurat
     public void setBinaryHandle(Class<? extends MessageSink> sinkClass, MethodHandle binary, Object origin)
     {
         assertNotSet(this.binaryHandle, "BINARY Handler", origin);
+        assertNotSet(this.frameHandle, "FRAME Handler", origin);
         this.binaryHandle = binary;
         this.binarySink = sinkClass;
     }
@@ -85,6 +86,10 @@ public class JettyWebSocketFrameHandlerMetadata extends Configuration.Configurat
     public void setFrameHandle(MethodHandle frame, Object origin)
     {
         assertNotSet(this.frameHandle, "FRAME Handler", origin);
+        assertNotSet(this.textHandle, "TEXT Handler", origin);
+        assertNotSet(this.binaryHandle, "BINARY Handler", origin);
+        assertNotSet(this.pingHandle, "PING Handler", origin);
+        assertNotSet(this.pongHandle, "PONG Handler", origin);
         this.frameHandle = frame;
     }
 
@@ -107,6 +112,7 @@ public class JettyWebSocketFrameHandlerMetadata extends Configuration.Configurat
     public void setPingHandle(MethodHandle ping, Object origin)
     {
         assertNotSet(this.pingHandle, "PING Handler", origin);
+        assertNotSet(this.frameHandle, "FRAME Handler", origin);
         this.pingHandle = ping;
     }
 
@@ -118,6 +124,7 @@ public class JettyWebSocketFrameHandlerMetadata extends Configuration.Configurat
     public void setPongHandle(MethodHandle pong, Object origin)
     {
         assertNotSet(this.pongHandle, "PONG Handler", origin);
+        assertNotSet(this.frameHandle, "FRAME Handler", origin);
         this.pongHandle = pong;
     }
 
@@ -129,6 +136,7 @@ public class JettyWebSocketFrameHandlerMetadata extends Configuration.Configurat
     public void setTextHandle(Class<? extends MessageSink> sinkClass, MethodHandle text, Object origin)
     {
         assertNotSet(this.textHandle, "TEXT Handler", origin);
+        assertNotSet(this.frameHandle, "FRAME Handler", origin);
         this.textHandle = text;
         this.textSink = sinkClass;
     }

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/ExplicitDemandTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/ExplicitDemandTest.java
@@ -44,6 +44,7 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -72,6 +73,7 @@ public class ExplicitDemandTest
     public static class ListenerSocket implements Session.Listener
     {
         final List<Frame> frames = new CopyOnWriteArrayList<>();
+        final List<Callback> callbacks = new CopyOnWriteArrayList<>();
         Session session;
 
         @Override
@@ -84,16 +86,22 @@ public class ExplicitDemandTest
         @Override
         public void onWebSocketFrame(Frame frame, Callback callback)
         {
-            frames.add(Frame.copy(frame));
+            frames.add(frame);
+            callbacks.add(callback);
 
             // Because no pingListener is registered, the frameListener is responsible for handling pings.
             if (frame.getOpCode() == OpCode.PING)
             {
-                session.sendPong(frame.getPayload(), Callback.from(callback, session::demand));
+                session.sendPong(frame.getPayload(), Callback.from(session::demand, callback::fail));
+                return;
+            }
+            else if (frame.getOpCode() == OpCode.CLOSE)
+            {
+                Frame.CloseStatus closeStatus = frame.getCloseStatus();
+                session.close(closeStatus.statusCode(), closeStatus.reason(), Callback.NOOP);
                 return;
             }
 
-            callback.succeed();
             session.demand();
         }
     }
@@ -226,13 +234,23 @@ public class ExplicitDemandTest
         Frame frame0 = listenerSocket.frames.get(0);
         assertThat(frame0.getType(), is(Frame.Type.PONG));
         assertThat(StandardCharsets.UTF_8.decode(frame0.getPayload()).toString(), is("ping-0"));
+        Callback callback0 = listenerSocket.callbacks.get(0);
+        assertNotNull(callback0);
+        callback0.succeed();
+
         Frame frame1 = listenerSocket.frames.get(1);
         assertThat(frame1.getType(), is(Frame.Type.PONG));
         assertThat(StandardCharsets.UTF_8.decode(frame1.getPayload()).toString(), is("ping-1"));
+        Callback callback1 = listenerSocket.callbacks.get(1);
+        assertNotNull(callback1);
+        callback1.succeed();
 
         session.close();
         await().atMost(5, TimeUnit.SECONDS).until(listenerSocket.frames::size, is(3));
         assertThat(listenerSocket.frames.get(2).getType(), is(Frame.Type.CLOSE));
+        Callback closeCallback = listenerSocket.callbacks.get(2);
+        assertNotNull(closeCallback);
+        closeCallback.succeed();
     }
 
     @Test

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/proxy/WebSocketProxyTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/proxy/WebSocketProxyTest.java
@@ -347,10 +347,18 @@ public class WebSocketProxyTest
         {
             switch (frame.getOpCode())
             {
-                case OpCode.PING -> pingMessages.add(BufferUtil.copy(frame.getPayload()));
-                case OpCode.PONG -> pongMessages.add(BufferUtil.copy(frame.getPayload()));
+                case OpCode.PING ->
+                {
+                    pingMessages.add(BufferUtil.copy(frame.getPayload()));
+                    session.sendPong(frame.getPayload(), callback);
+                }
+                case OpCode.PONG ->
+                {
+                    pongMessages.add(BufferUtil.copy(frame.getPayload()));
+                    callback.succeed();
+                }
+                default -> callback.succeed();
             }
-            callback.succeed();
         }
     }
 

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/server/FrameListenerTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/server/FrameListenerTest.java
@@ -131,10 +131,12 @@ public class FrameListenerTest
     {
         public CountDownLatch closeLatch = new CountDownLatch(1);
         public LinkedBlockingQueue<String> frameEvents = new LinkedBlockingQueue<>();
+        public Session session;
 
         @Override
         public void onWebSocketOpen(Session session)
         {
+            this.session = session;
             session.demand();
         }
 
@@ -147,6 +149,7 @@ public class FrameListenerTest
                 BufferUtil.toUTF8String(frame.getPayload()),
                 frame.getPayloadLength()));
             callback.succeed();
+            session.demand();
         }
 
         @Override


### PR DESCRIPTION
## Issue #11307
Support endpoints in the Jetty WebSocket API to be use only a `onWebSocketFrame` method. They should demand in the `onWebSocketFrame` if they don't have another handler registered for this frame type.

There are some surprising changes of behavior needed to implement this which will likely surprise users if they are using `onWebSocketFrame`.

- For PING frames, if there is only `onWebSocketFrame` and no `onWebSocketPing` method defined, then we now expect the user to handle `PING` frames in their `onWebSocketFrame`, so we will no longer send an automatic frame in this case.
- If they had a `onWebSocketText` and no `onWebSocketBinary` and also a `onWebSocketFrame`, then they would now be expected to demand for `BINARY`/`CONTINUATION` opCodes in the `onWebSocketFrame` method.