### PR TITLE
Fixes #12348 - HttpClientTransportDynamic does not initialize low-level clients.

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -218,7 +218,7 @@ public class HttpClient extends ContainerLifeCycle implements AutoCloseable
         if (cookieStore == null)
             cookieStore = new HttpCookieStore.Default();
 
-        transport.setHttpClient(this);
+        getContainedBeans(Aware.class).forEach(bean -> bean.setHttpClient(this));
 
         super.doStart();
 
@@ -1149,8 +1149,8 @@ public class HttpClient extends ContainerLifeCycle implements AutoCloseable
     }
 
     /**
-     * <p>Implementations of this interface are made aware of
-     * the {@code HttpClient} instance while it is starting.</p>
+     * <p>Descendant beans of {@code HttpClient} that implement this interface
+     * are made aware of the {@code HttpClient} instance while it is starting.</p>
      */
     public interface Aware
     {

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -1147,4 +1147,13 @@ public class HttpClient extends ContainerLifeCycle implements AutoCloseable
     {
         stop();
     }
+
+    /**
+     * <p>Implementations of this interface are made aware of
+     * the {@code HttpClient} instance while it is starting.</p>
+     */
+    public interface Aware
+    {
+        void setHttpClient(HttpClient httpClient);
+    }
 }

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClientTransport.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClientTransport.java
@@ -31,7 +31,7 @@ import org.eclipse.jetty.io.ClientConnectionFactory;
  * but the HTTP exchange may also be carried using the FCGI protocol, the HTTP/2 protocol or,
  * in future, other protocols.
  */
-public interface HttpClientTransport extends ClientConnectionFactory
+public interface HttpClientTransport extends ClientConnectionFactory, HttpClient.Aware
 {
     public static final String HTTP_DESTINATION_CONTEXT_KEY = "org.eclipse.jetty.client.destination";
     public static final String HTTP_CONNECTION_PROMISE_CONTEXT_KEY = "org.eclipse.jetty.client.connection.promise";
@@ -45,6 +45,7 @@ public interface HttpClientTransport extends ClientConnectionFactory
      *
      * @param client the {@link HttpClient} that uses this transport.
      */
+    @Override
     public void setHttpClient(HttpClient client);
 
     /**

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpClientTransportDynamic.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpClientTransportDynamic.java
@@ -25,6 +25,7 @@ import org.eclipse.jetty.alpn.client.ALPNClientConnection;
 import org.eclipse.jetty.alpn.client.ALPNClientConnectionFactory;
 import org.eclipse.jetty.client.AbstractConnectorHttpClientTransport;
 import org.eclipse.jetty.client.Destination;
+import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.HttpClientTransport;
 import org.eclipse.jetty.client.MultiplexConnectionPool;
 import org.eclipse.jetty.client.Origin;
@@ -127,6 +128,16 @@ public class HttpClientTransportDynamic extends AbstractConnectorHttpClientTrans
             .flatMap(info -> info.getContainedBeans(ClientConnector.class).stream())
             .findFirst()
             .orElseGet(ClientConnector::new);
+    }
+
+    @Override
+    public void setHttpClient(HttpClient client)
+    {
+        super.setHttpClient(client);
+        infos.stream()
+            .filter(info -> info instanceof HttpClient.Aware)
+            .map(HttpClient.Aware.class::cast)
+            .forEach(info -> info.setHttpClient(getHttpClient()));
     }
 
     @Override

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/ClientConnectionFactoryOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/ClientConnectionFactoryOverHTTP2.java
@@ -68,7 +68,7 @@ public class ClientConnectionFactoryOverHTTP2 extends ContainerLifeCycle impleme
      *
      * @see HttpClientConnectionFactory#HTTP11
      */
-    public static class HTTP2 extends Info implements HttpClient.Aware
+    public static class HTTP2 extends Info
     {
         private static final List<String> protocols = List.of("h2", "h2c");
         private static final List<String> h2c = List.of("h2c");
@@ -76,13 +76,6 @@ public class ClientConnectionFactoryOverHTTP2 extends ContainerLifeCycle impleme
         public HTTP2(HTTP2Client http2Client)
         {
             super(new ClientConnectionFactoryOverHTTP2(http2Client));
-        }
-
-        @Override
-        public void setHttpClient(HttpClient httpClient)
-        {
-            ClientConnectionFactoryOverHTTP2 factory = (ClientConnectionFactoryOverHTTP2)getClientConnectionFactory();
-            factory.setHttpClient(httpClient);
         }
 
         @Override

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/ClientConnectionFactoryOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/ClientConnectionFactoryOverHTTP2.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jetty.client.Connection;
+import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.HttpClientTransport;
 import org.eclipse.jetty.client.transport.HttpClientConnectionFactory;
 import org.eclipse.jetty.client.transport.HttpClientTransportDynamic;
@@ -35,7 +36,7 @@ import org.eclipse.jetty.io.ssl.SslConnection;
 import org.eclipse.jetty.util.Promise;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
 
-public class ClientConnectionFactoryOverHTTP2 extends ContainerLifeCycle implements ClientConnectionFactory
+public class ClientConnectionFactoryOverHTTP2 extends ContainerLifeCycle implements ClientConnectionFactory, HttpClient.Aware
 {
     private final ClientConnectionFactory factory = new HTTP2ClientConnectionFactory();
     private final HTTP2Client http2Client;
@@ -44,6 +45,12 @@ public class ClientConnectionFactoryOverHTTP2 extends ContainerLifeCycle impleme
     {
         this.http2Client = http2Client;
         installBean(http2Client);
+    }
+
+    @Override
+    public void setHttpClient(HttpClient httpClient)
+    {
+        HttpClientTransportOverHTTP2.configure(httpClient, http2Client);
     }
 
     @Override
@@ -61,7 +68,7 @@ public class ClientConnectionFactoryOverHTTP2 extends ContainerLifeCycle impleme
      *
      * @see HttpClientConnectionFactory#HTTP11
      */
-    public static class HTTP2 extends Info
+    public static class HTTP2 extends Info implements HttpClient.Aware
     {
         private static final List<String> protocols = List.of("h2", "h2c");
         private static final List<String> h2c = List.of("h2c");
@@ -69,6 +76,13 @@ public class ClientConnectionFactoryOverHTTP2 extends ContainerLifeCycle impleme
         public HTTP2(HTTP2Client http2Client)
         {
             super(new ClientConnectionFactoryOverHTTP2(http2Client));
+        }
+
+        @Override
+        public void setHttpClient(HttpClient httpClient)
+        {
+            ClientConnectionFactoryOverHTTP2 factory = (ClientConnectionFactoryOverHTTP2)getClientConnectionFactory();
+            factory.setHttpClient(httpClient);
         }
 
         @Override

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/HttpClientTransportOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/HttpClientTransportOverHTTP2.java
@@ -87,20 +87,23 @@ public class HttpClientTransportOverHTTP2 extends AbstractHttpClientTransport
     protected void doStart() throws Exception
     {
         if (!http2Client.isStarted())
-        {
-            HttpClient httpClient = getHttpClient();
-            http2Client.setExecutor(httpClient.getExecutor());
-            http2Client.setScheduler(httpClient.getScheduler());
-            http2Client.setByteBufferPool(httpClient.getByteBufferPool());
-            http2Client.setConnectTimeout(httpClient.getConnectTimeout());
-            http2Client.setIdleTimeout(httpClient.getIdleTimeout());
-            http2Client.setInputBufferSize(httpClient.getResponseBufferSize());
-            http2Client.setUseInputDirectByteBuffers(httpClient.isUseInputDirectByteBuffers());
-            http2Client.setUseOutputDirectByteBuffers(httpClient.isUseOutputDirectByteBuffers());
-            http2Client.setConnectBlocking(httpClient.isConnectBlocking());
-            http2Client.setBindAddress(httpClient.getBindAddress());
-        }
+            configure(getHttpClient(), getHTTP2Client());
         super.doStart();
+    }
+
+    static void configure(HttpClient httpClient, HTTP2Client http2Client)
+    {
+        http2Client.setExecutor(httpClient.getExecutor());
+        http2Client.setScheduler(httpClient.getScheduler());
+        http2Client.setByteBufferPool(httpClient.getByteBufferPool());
+        http2Client.setConnectTimeout(httpClient.getConnectTimeout());
+        http2Client.setIdleTimeout(httpClient.getIdleTimeout());
+        http2Client.setInputBufferSize(httpClient.getResponseBufferSize());
+        http2Client.setUseInputDirectByteBuffers(httpClient.isUseInputDirectByteBuffers());
+        http2Client.setUseOutputDirectByteBuffers(httpClient.isUseOutputDirectByteBuffers());
+        http2Client.setConnectBlocking(httpClient.isConnectBlocking());
+        http2Client.setBindAddress(httpClient.getBindAddress());
+        http2Client.setMaxResponseHeadersSize(httpClient.getMaxResponseHeadersSize());
     }
 
     @Override

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HTTP2Test.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HTTP2Test.java
@@ -1068,6 +1068,7 @@ public class HTTP2Test extends AbstractTest
     @Test
     public void testServerSendsLargeHeader() throws Exception
     {
+        int maxResponseHeadersSize = 8 * 1024;
         CompletableFuture<Throwable> serverFailureFuture = new CompletableFuture<>();
         CompletableFuture<String> serverCloseReasonFuture = new CompletableFuture<>();
         start(new ServerSessionListener()
@@ -1076,9 +1077,9 @@ public class HTTP2Test extends AbstractTest
             public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
             {
                 HTTP2Session session = (HTTP2Session)stream.getSession();
-                session.getGenerator().getHpackEncoder().setMaxHeaderListSize(1024 * 1024);
+                session.getGenerator().getHpackEncoder().setMaxHeaderListSize(2 * maxResponseHeadersSize);
 
-                String value = "x".repeat(8 * 1024);
+                String value = "x".repeat(maxResponseHeadersSize);
                 HttpFields fields = HttpFields.build().put("custom", value);
                 MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, fields);
                 stream.headers(new HeadersFrame(stream.getId(), response, null, true));
@@ -1100,6 +1101,7 @@ public class HTTP2Test extends AbstractTest
             }
         });
 
+        http2Client.setMaxResponseHeadersSize(maxResponseHeadersSize);
         CompletableFuture<Throwable> clientFailureFuture = new CompletableFuture<>();
         CompletableFuture<String> clientCloseReasonFuture = new CompletableFuture<>();
         Session.Listener listener = new Session.Listener()

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
@@ -40,11 +40,13 @@ import org.eclipse.jetty.client.Connection;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.Destination;
 import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.HttpClientTransport;
 import org.eclipse.jetty.client.HttpProxy;
 import org.eclipse.jetty.client.InputStreamResponseListener;
 import org.eclipse.jetty.client.Origin;
 import org.eclipse.jetty.client.Response;
 import org.eclipse.jetty.client.Result;
+import org.eclipse.jetty.client.transport.HttpClientTransportDynamic;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
@@ -60,6 +62,7 @@ import org.eclipse.jetty.http2.api.Session;
 import org.eclipse.jetty.http2.api.Stream;
 import org.eclipse.jetty.http2.api.server.ServerSessionListener;
 import org.eclipse.jetty.http2.client.HTTP2Client;
+import org.eclipse.jetty.http2.client.transport.ClientConnectionFactoryOverHTTP2;
 import org.eclipse.jetty.http2.client.transport.HttpClientTransportOverHTTP2;
 import org.eclipse.jetty.http2.client.transport.internal.HttpChannelOverHTTP2;
 import org.eclipse.jetty.http2.client.transport.internal.HttpConnectionOverHTTP2;
@@ -105,10 +108,24 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class HttpClientTransportOverHTTP2Test extends AbstractTest
 {
     @Test
-    public void testPropertiesAreForwarded() throws Exception
+    public void testPropertiesAreForwardedOverHTTP2() throws Exception
     {
-        HTTP2Client http2Client = new HTTP2Client();
-        try (HttpClient httpClient = new HttpClient(new HttpClientTransportOverHTTP2(http2Client)))
+        ClientConnector clientConnector = new ClientConnector();
+        HTTP2Client http2Client = new HTTP2Client(clientConnector);
+        testPropertiesAreForwarded(http2Client, new HttpClientTransportOverHTTP2(http2Client));
+    }
+
+    @Test
+    public void testPropertiesAreForwardedDynamic() throws Exception
+    {
+        ClientConnector clientConnector = new ClientConnector();
+        HTTP2Client http2Client = new HTTP2Client(clientConnector);
+        testPropertiesAreForwarded(http2Client, new HttpClientTransportDynamic(clientConnector, new ClientConnectionFactoryOverHTTP2.HTTP2(http2Client)));
+    }
+
+    private void testPropertiesAreForwarded(HTTP2Client http2Client, HttpClientTransport httpClientTransport) throws Exception
+    {
+        try (HttpClient httpClient = new HttpClient(httpClientTransport))
         {
             Executor executor = new QueuedThreadPool();
             httpClient.setExecutor(executor);
@@ -127,6 +144,7 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
             assertEquals(httpClient.getIdleTimeout(), http2Client.getIdleTimeout());
             assertEquals(httpClient.isUseInputDirectByteBuffers(), http2Client.isUseInputDirectByteBuffers());
             assertEquals(httpClient.isUseOutputDirectByteBuffers(), http2Client.isUseOutputDirectByteBuffers());
+            assertEquals(httpClient.getMaxResponseHeadersSize(), http2Client.getMaxResponseHeadersSize());
         }
         assertTrue(http2Client.isStopped());
     }

--- a/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/ClientConnectionFactoryOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/ClientConnectionFactoryOverHTTP3.java
@@ -58,7 +58,7 @@ public class ClientConnectionFactoryOverHTTP3 extends ContainerLifeCycle impleme
      *
      * @see HttpClientConnectionFactory#HTTP11
      */
-    public static class HTTP3 extends Info implements ProtocolSession.Factory, HttpClient.Aware
+    public static class HTTP3 extends Info implements ProtocolSession.Factory
     {
         private static final List<String> protocols = List.of("h3");
 
@@ -68,13 +68,6 @@ public class ClientConnectionFactoryOverHTTP3 extends ContainerLifeCycle impleme
         {
             super(new ClientConnectionFactoryOverHTTP3(client));
             http3Client = client;
-        }
-
-        @Override
-        public void setHttpClient(HttpClient httpClient)
-        {
-            ClientConnectionFactoryOverHTTP3 factory = (ClientConnectionFactoryOverHTTP3)getClientConnectionFactory();
-            factory.setHttpClient(httpClient);
         }
 
         public HTTP3Client getHTTP3Client()

--- a/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/HttpClientTransportOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/HttpClientTransportOverHTTP3.java
@@ -66,22 +66,25 @@ public class HttpClientTransportOverHTTP3 extends AbstractHttpClientTransport im
     protected void doStart() throws Exception
     {
         if (!http3Client.isStarted())
-        {
-            HttpClient httpClient = getHttpClient();
-            ClientConnector clientConnector = this.http3Client.getClientConnector();
-            clientConnector.setExecutor(httpClient.getExecutor());
-            clientConnector.setScheduler(httpClient.getScheduler());
-            clientConnector.setByteBufferPool(httpClient.getByteBufferPool());
-            clientConnector.setConnectTimeout(Duration.ofMillis(httpClient.getConnectTimeout()));
-            clientConnector.setConnectBlocking(httpClient.isConnectBlocking());
-            clientConnector.setBindAddress(httpClient.getBindAddress());
-            clientConnector.setIdleTimeout(Duration.ofMillis(httpClient.getIdleTimeout()));
-            HTTP3Configuration configuration = http3Client.getHTTP3Configuration();
-            configuration.setInputBufferSize(httpClient.getResponseBufferSize());
-            configuration.setUseInputDirectByteBuffers(httpClient.isUseInputDirectByteBuffers());
-            configuration.setUseOutputDirectByteBuffers(httpClient.isUseOutputDirectByteBuffers());
-        }
+            configure(getHttpClient(), http3Client);
         super.doStart();
+    }
+
+    static void configure(HttpClient httpClient, HTTP3Client http3Client)
+    {
+        ClientConnector clientConnector = http3Client.getClientConnector();
+        clientConnector.setExecutor(httpClient.getExecutor());
+        clientConnector.setScheduler(httpClient.getScheduler());
+        clientConnector.setByteBufferPool(httpClient.getByteBufferPool());
+        clientConnector.setConnectTimeout(Duration.ofMillis(httpClient.getConnectTimeout()));
+        clientConnector.setConnectBlocking(httpClient.isConnectBlocking());
+        clientConnector.setBindAddress(httpClient.getBindAddress());
+        clientConnector.setIdleTimeout(Duration.ofMillis(httpClient.getIdleTimeout()));
+        HTTP3Configuration configuration = http3Client.getHTTP3Configuration();
+        configuration.setInputBufferSize(httpClient.getResponseBufferSize());
+        configuration.setUseInputDirectByteBuffers(httpClient.isUseInputDirectByteBuffers());
+        configuration.setUseOutputDirectByteBuffers(httpClient.isUseOutputDirectByteBuffers());
+        configuration.setMaxResponseHeadersSize(httpClient.getMaxResponseHeadersSize());
     }
 
     @Override

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ClientConnectionFactory.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ClientConnectionFactory.java
@@ -73,7 +73,7 @@ public interface ClientConnectionFactory
         public Info(ClientConnectionFactory factory)
         {
             this.factory = factory;
-            addBean(factory);
+            installBean(factory);
         }
 
         /**

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/Container.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/Container.java
@@ -130,15 +130,14 @@ public interface Container
 
     /**
      * @param clazz the class of the beans
-     * @param <T> the Bean type
-     * @return the list of beans of the given class from the entire Container hierarchy.
-     *         The order is by depth first and then the order beans were added.
+     * @param <T> the bean type
+     * @return the collection of beans of the given class from the {@code Container} hierarchy
      */
     <T> Collection<T> getContainedBeans(Class<T> clazz);
 
     /**
      * Get the beans added to the container that are EventListeners.
-     * This is essentially equivalent to <code>getBeans(EventListener.class);</code>,
+     * This is essentially equivalent to {@code getBeans(EventListener.class)},
      * except that: <ul>
      *     <li>The result may be precomputed, so it can be more efficient</li>
      *     <li>The result is ordered by the order added.</li>

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/ContainerLifeCycle.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/ContainerLifeCycle.java
@@ -813,6 +813,11 @@ public class ContainerLifeCycle extends AbstractLifeCycle implements Container, 
             return _managed == Managed.MANAGED;
         }
 
+        /**
+         * @return {@code true} if this bean {@link #isManaged() is managed};
+         * {@code true} if this bean will be managed if it were to be started;
+         * {@code false} otherwise
+         */
         public boolean isManageable()
         {
             return switch (_managed)

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/ContainerLifeCycle.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/ContainerLifeCycle.java
@@ -19,7 +19,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EventListener;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -882,7 +882,7 @@ public class ContainerLifeCycle extends AbstractLifeCycle implements Container, 
     @Override
     public <T> Collection<T> getContainedBeans(Class<T> clazz)
     {
-        Set<T> beans = new HashSet<>();
+        Set<T> beans = new LinkedHashSet<>();
         getContainedBeans(clazz, beans);
         return beans;
     }


### PR DESCRIPTION
Fixed initialization for HTTP/2 and HTTP/3.