### PR TITLE
Issue #7515 backport to 9.4 - Fix for connection limit problem

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/ConnectionLimit.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/ConnectionLimit.java
@@ -28,6 +28,7 @@ import org.eclipse.jetty.io.Connection;
 import org.eclipse.jetty.io.Connection.Listener;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.io.SelectorManager;
+import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.annotation.ManagedObject;
 import org.eclipse.jetty.util.annotation.Name;
@@ -172,9 +173,10 @@ public class ConnectionLimit extends AbstractLifeCycle implements Listener, Sele
         }
     }
 
-    protected void check()
+    protected boolean check()
     {
-        if ((_accepting.size() + _connections) >= _maxConnections)
+        int total = _accepting.size() + _connections;
+        if (total >= _maxConnections)
         {
             if (!_limiting)
             {
@@ -182,6 +184,7 @@ public class ConnectionLimit extends AbstractLifeCycle implements Listener, Sele
                 LOG.info("Connection Limit({}) reached for {}", _maxConnections, _connectors);
                 limit();
             }
+            return total > _maxConnections;
         }
         else
         {
@@ -191,6 +194,7 @@ public class ConnectionLimit extends AbstractLifeCycle implements Listener, Sele
                 LOG.info("Connection Limit({}) cleared for {}", _maxConnections, _connectors);
                 unlimit();
             }
+            return false;
         }
     }
 
@@ -234,7 +238,8 @@ public class ConnectionLimit extends AbstractLifeCycle implements Listener, Sele
             _accepting.add(channel);
             if (LOG.isDebugEnabled())
                 LOG.debug("onAccepting ({}+{}) < {} {}", _accepting.size(), _connections, _maxConnections, channel);
-            check();
+            if (check())
+                IO.close(channel);
         }
     }
 


### PR DESCRIPTION
Backport PR #12320 (fixes #7515) to 9.4
  * Fixed `ManagedSelector.Accept` to emit the event "accept failed" when closed.
  * Fixed `ConnectionLimit` to close connections that exceed the maximum (may happen when the connector is configured with acceptors=0).
