### PR TITLE
Update commons-io to address CVE

### DIFF
--- a/jetty-ee10/jetty-ee10-maven-plugin/src/it/it-parent-pom/pom.xml
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/it/it-parent-pom/pom.xml
@@ -17,7 +17,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.7</version>
+        <version>2.14.0</version>
       </dependency>
       <dependency>
         <groupId>jakarta.servlet</groupId>

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/it/it-parent-pom/pom.xml
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/it/it-parent-pom/pom.xml
@@ -17,7 +17,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>${commons-io.version}</version>
+        <version>@commons-io.version@</version>
       </dependency>
       <dependency>
         <groupId>jakarta.servlet</groupId>

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/it/it-parent-pom/pom.xml
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/it/it-parent-pom/pom.xml
@@ -17,7 +17,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.14.0</version>
+        <version>${commons-io.version}</version>
       </dependency>
       <dependency>
         <groupId>jakarta.servlet</groupId>

--- a/jetty-ee8/jetty-ee8-maven-plugin/src/it/it-parent-pom/pom.xml
+++ b/jetty-ee8/jetty-ee8-maven-plugin/src/it/it-parent-pom/pom.xml
@@ -17,7 +17,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.7</version>
+        <version>2.14.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.toolchain</groupId>

--- a/jetty-ee8/jetty-ee8-maven-plugin/src/it/it-parent-pom/pom.xml
+++ b/jetty-ee8/jetty-ee8-maven-plugin/src/it/it-parent-pom/pom.xml
@@ -17,7 +17,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>${commons-io.version}</version>
+        <version>@commons-io.version@</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.toolchain</groupId>

--- a/jetty-ee8/jetty-ee8-maven-plugin/src/it/it-parent-pom/pom.xml
+++ b/jetty-ee8/jetty-ee8-maven-plugin/src/it/it-parent-pom/pom.xml
@@ -17,7 +17,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.14.0</version>
+        <version>${commons-io.version}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.toolchain</groupId>

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/it/it-parent-pom/pom.xml
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/it/it-parent-pom/pom.xml
@@ -17,7 +17,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.7</version>
+        <version>2.14.0</version>
       </dependency>
       <dependency>
         <groupId>jakarta.servlet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,7 @@
     <buildnumber.maven.plugin.version>3.2.0</buildnumber.maven.plugin.version>
     <checkstyle.version>10.17.0</checkstyle.version>
     <commons-codec.version>1.17.0</commons-codec.version>
+    <commons-io.version>2.16.1</commons-io.version>
     <commons-lang3.version>3.14.0</commons-lang3.version>
     <commons.compress.version>1.26.2</commons.compress.version>
     <commons.io.version>2.16.1</commons.io.version>
@@ -479,6 +480,11 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
         <version>${commons.compress.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>${commons-io.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -437,6 +437,11 @@
         <version>${commons-codec.version}</version>
       </dependency>
       <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>${commons-io.version}</version>
+      </dependency>
+      <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-core</artifactId>
         <version>${grpc.version}</version>
@@ -480,11 +485,6 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
         <version>${commons.compress.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-io</groupId>
-        <artifactId>commons-io</artifactId>
-        <version>${commons-io.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
+ Fixes for CVE-2024-47554
+ The `commons-io` dependency is only used by the various maven-plugin IT test cases.