### PR TITLE
Issue #12387 Update to Apache Jasper 9.0.96 for EE8

### DIFF
--- a/jetty-ee8/pom.xml
+++ b/jetty-ee8/pom.xml
@@ -49,7 +49,7 @@
     <javax.mail.glassfish.version>1.4.1.v201005082020</javax.mail.glassfish.version>
     <javax.servlet.jsp.jstl.impl.version>1.2.5</javax.servlet.jsp.jstl.impl.version>
     <jetty.servlet.api.version>4.0.6</jetty.servlet.api.version>
-    <jsp.impl.version>9.0.90</jsp.impl.version>
+    <jsp.impl.version>9.0.96</jsp.impl.version>
     <modify-sources-plugin.version>1.0.10</modify-sources-plugin.version>
     <sonar.skip>true</sonar.skip>
     <weld.version>3.1.9.Final</weld.version>


### PR DESCRIPTION
Closes #12387 

Update to 9.0.96 from 9.0.90 for apache jasper in ee8.