### PR TITLE
Fixes #5888 - Limit usage of HTTP/2 connections.

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
@@ -341,7 +341,7 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
 
                 int maxUsage = getMaxUsage();
                 if (connection instanceof MaxUsable maxUsable)
-                    maxUsage = maxUsable.getMaxUsage();
+                    maxUsage = Math.min(maxUsage, maxUsable.getMaxUsage());
                 if (maxUsage > 0)
                 {
                     EntryHolder holder = (EntryHolder)((Attachable)connection).getAttachment();

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpConnectionOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpConnectionOverHTTP2.java
@@ -50,7 +50,7 @@ import org.eclipse.jetty.util.thread.Sweeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.Sweepable, ConnectionPool.MaxMultiplexable
+public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.Sweepable, ConnectionPool.MaxMultiplexable, ConnectionPool.MaxUsable
 {
     private static final Logger LOG = LoggerFactory.getLogger(HttpConnectionOverHTTP2.class);
 
@@ -106,6 +106,15 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
     public int getMaxMultiplex()
     {
         return ((HTTP2Session)session).getMaxLocalStreams();
+    }
+
+    @Override
+    public int getMaxUsage()
+    {
+        // SPEC: stream numbers can go up to 2^31-1;
+        // clients start at 1 and increment by 2, so a
+        // connection can only be used (2^31-2)/2 times.
+        return (Integer.MAX_VALUE - 1) / 2;
     }
 
     @Override

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpConnectionOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpConnectionOverHTTP2.java
@@ -111,10 +111,12 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
     @Override
     public int getMaxUsage()
     {
-        // SPEC: stream numbers can go up to 2^31-1;
-        // clients start at 1 and increment by 2, so a
-        // connection can only be used (2^31-2)/2 times.
-        return (Integer.MAX_VALUE - 1) / 2;
+        return ((HTTP2Session)session).getMaxTotalLocalStreams();
+    }
+
+    void setMaxUsage(int maxUsage)
+    {
+        ((HTTP2Session)session).setMaxTotalLocalStreams(maxUsage);
     }
 
     @Override

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -2292,7 +2292,8 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
                                 }
                                 else
                                 {
-                                    failure = new IllegalArgumentException("invalid stream id " + streamId);
+                                    reservedStreamId = streamId;
+                                    slots.offer(slot);
                                     break;
                                 }
                             }

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -2120,6 +2120,10 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
                 })));
                 flush();
             }
+            else if (streamId < 0)
+            {
+                close(ErrorCode.NO_ERROR.code, "max_streams_exceeded", Callback.NOOP);
+            }
             return streamId;
         }
 
@@ -2140,6 +2144,10 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
                 if (createLocalStream(slot, frames, promise, listener, streamId))
                     return;
                 freeSlot(slot, streamId);
+            }
+            else if (streamId < 0)
+            {
+                close(ErrorCode.NO_ERROR.code, "max_streams_exceeded", Callback.NOOP);
             }
         }
 
@@ -2183,13 +2191,17 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
         private void push(PushPromiseFrame frame, Promise<Stream> promise, Stream.Listener listener)
         {
             Slot slot = new Slot();
-            int streamId = reserveSlot(slot, 0, promise::failed);
+            int streamId = reserveSlot(slot, frame.getPromisedStreamId(), promise::failed);
             if (streamId > 0)
             {
                 frame = frame.withStreamId(streamId);
                 if (createLocalStream(slot, Collections.singletonList(frame), promise, listener, streamId))
                     return;
                 freeSlot(slot, streamId);
+            }
+            else if (streamId < 0)
+            {
+                close(ErrorCode.NO_ERROR.code, "max_streams_exceeded", Callback.NOOP);
             }
         }
 
@@ -2237,19 +2249,61 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
 
         private int reserveSlot(Slot slot, int streamId, Consumer<Throwable> fail)
         {
+            if (streamId < 0 || (streamId > 0 && !isLocalStream(streamId)))
+            {
+                fail.accept(new IllegalArgumentException("invalid stream id " + streamId));
+                return 0;
+            }
+
+            int reservedStreamId = 0;
             Throwable failure = null;
-            boolean reserved = false;
             try (AutoLock ignored = lock.lock())
             {
                 // SPEC: cannot create new streams after receiving a GOAWAY.
                 if (closed == CloseState.NOT_CLOSED)
                 {
-                    if (streamId <= 0)
+                    if (streamId == 0)
                     {
-                        streamId = localStreamIds.getAndAdd(2);
-                        reserved = true;
+                        // Stream id generated internally.
+                        reservedStreamId = localStreamIds.getAndAdd(2);
+                        // Check for overflow.
+                        if (reservedStreamId > 0)
+                            slots.offer(slot);
+                        else
+                            failure = new IllegalStateException("max streams exceeded");
                     }
-                    slots.offer(slot);
+                    else
+                    {
+                        // Stream id is given.
+                        while (true)
+                        {
+                            int nextStreamId = localStreamIds.get();
+                            if (nextStreamId > 0)
+                            {
+                                if (streamId >= nextStreamId)
+                                {
+                                    int newNextStreamId = streamId + 2;
+                                    if (localStreamIds.compareAndSet(nextStreamId, newNextStreamId))
+                                    {
+                                        reservedStreamId = streamId;
+                                        slots.offer(slot);
+                                        break;
+                                    }
+                                }
+                                else
+                                {
+                                    failure = new IllegalArgumentException("invalid stream id " + streamId);
+                                    break;
+                                }
+                            }
+                            else
+                            {
+                                reservedStreamId = nextStreamId;
+                                failure = new IllegalStateException("max streams exceeded");
+                                break;
+                            }
+                        }
+                    }
                 }
                 else
                 {
@@ -2259,16 +2313,10 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
                 }
             }
             if (failure == null)
-            {
-                if (reserved)
-                    HTTP2Session.this.onStreamCreated(streamId);
-                return streamId;
-            }
+                HTTP2Session.this.onStreamCreated(streamId);
             else
-            {
                 fail.accept(failure);
-                return 0;
-            }
+            return reservedStreamId;
         }
 
         private void freeSlot(Slot slot, int streamId)

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -82,6 +82,8 @@ import org.slf4j.LoggerFactory;
 public abstract class HTTP2Session extends ContainerLifeCycle implements Session, Parser.Listener
 {
     private static final Logger LOG = LoggerFactory.getLogger(HTTP2Session.class);
+    // SPEC: stream numbers can go up to 2^31-1, but increment by 2.
+    private static final int MAX_TOTAL_LOCAL_STREAMS = Integer.MAX_VALUE / 2;
 
     private final Map<Integer, HTTP2Stream> streams = new ConcurrentHashMap<>();
     private final Set<Integer> priorityStreams = ConcurrentHashMap.newKeySet();
@@ -95,6 +97,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
     private final AtomicInteger sendWindow = new AtomicInteger();
     private final AtomicInteger recvWindow = new AtomicInteger();
     private final AtomicLong bytesWritten = new AtomicLong();
+    private final AtomicInteger totalLocalStreams = new AtomicInteger();
     private final EndPoint endPoint;
     private final Parser parser;
     private final Generator generator;
@@ -104,6 +107,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
     private final StreamTimeouts streamTimeouts;
     private int maxLocalStreams;
     private int maxRemoteStreams;
+    private int maxTotalLocalStreams;
     private long streamIdleTimeout;
     private int initialSessionRecvWindow;
     private int writeThreshold;
@@ -122,6 +126,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
         this.streamTimeouts = new StreamTimeouts(scheduler);
         this.maxLocalStreams = -1;
         this.maxRemoteStreams = -1;
+        this.maxTotalLocalStreams = MAX_TOTAL_LOCAL_STREAMS;
         this.localStreamIds.set(initialStreamId);
         this.sendWindow.set(FlowControlStrategy.DEFAULT_WINDOW_SIZE);
         this.recvWindow.set(FlowControlStrategy.DEFAULT_WINDOW_SIZE);
@@ -165,6 +170,20 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
     public void setMaxLocalStreams(int maxLocalStreams)
     {
         this.maxLocalStreams = maxLocalStreams;
+    }
+
+    @ManagedAttribute("The maximum number of local streams that can be opened")
+    public int getMaxTotalLocalStreams()
+    {
+        return maxTotalLocalStreams;
+    }
+
+    public void setMaxTotalLocalStreams(int maxTotalLocalStreams)
+    {
+        if (maxTotalLocalStreams > MAX_TOTAL_LOCAL_STREAMS)
+            throw new IllegalArgumentException("Invalid max total local streams " + maxTotalLocalStreams);
+        if (maxTotalLocalStreams > 0)
+            this.maxTotalLocalStreams = maxTotalLocalStreams;
     }
 
     @ManagedAttribute("The maximum number of concurrent remote streams")
@@ -2137,19 +2156,19 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
             Slot slot = new Slot();
             int currentStreamId = frameList.getStreamId();
             int streamId = reserveSlot(slot, currentStreamId, promise::failed);
-            if (streamId > 0)
+            if (streamId <= 0)
+                return;
+
+            List<StreamFrame> frames = frameList.getFrames();
+            if (currentStreamId <= 0)
             {
-                List<StreamFrame> frames = frameList.getFrames();
-                if (currentStreamId <= 0)
-                {
-                    frames = frames.stream()
-                        .map(frame -> frame.withStreamId(streamId))
-                        .collect(Collectors.toList());
-                }
-                if (createLocalStream(slot, frames, promise, listener, streamId))
-                    return;
-                freeSlot(slot, streamId);
+                frames = frames.stream()
+                    .map(frame -> frame.withStreamId(streamId))
+                    .collect(Collectors.toList());
             }
+            if (createLocalStream(slot, frames, promise, listener, streamId))
+                return;
+            freeSlot(slot, streamId);
         }
 
         private Stream newUpgradeStream(HeadersFrame frame, Stream.Listener listener, Consumer<Throwable> failFn)
@@ -2193,13 +2212,13 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
         {
             Slot slot = new Slot();
             int streamId = reserveSlot(slot, frame.getPromisedStreamId(), promise::failed);
-            if (streamId > 0)
-            {
-                frame = frame.withStreamId(streamId);
-                if (createLocalStream(slot, Collections.singletonList(frame), promise, listener, streamId))
-                    return;
-                freeSlot(slot, streamId);
-            }
+            if (streamId <= 0)
+                return;
+
+            frame = frame.withStreamId(streamId);
+            if (createLocalStream(slot, Collections.singletonList(frame), promise, listener, streamId))
+                return;
+            freeSlot(slot, streamId);
         }
 
         private boolean createLocalStream(Slot slot, List<StreamFrame> frames, Promise<Stream> promise, Stream.Listener listener, int streamId)
@@ -2252,6 +2271,8 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
                 return 0;
             }
 
+            int maxTotal = getMaxTotalLocalStreams();
+
             boolean created = false;
             int reservedStreamId = 0;
             Throwable failure = null;
@@ -2262,17 +2283,31 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
                 {
                     if (streamId == 0)
                     {
-                        // Stream id generated internally.
-                        reservedStreamId = localStreamIds.getAndAdd(2);
-                        // Check for overflow.
-                        if (reservedStreamId > 0)
+                        int total = totalLocalStreams.updateAndGet(v ->
                         {
-                            slots.offer(slot);
-                            created = true;
+                            if (v <= maxTotal)
+                                return v + 1;
+                            return v;
+                        });
+                        if (total <= maxTotal)
+                        {
+                            // Stream id generated internally.
+                            reservedStreamId = localStreamIds.getAndAdd(2);
+                            if (reservedStreamId > 0)
+                            {
+                                slots.offer(slot);
+                                created = true;
+                            }
+                            else
+                            {
+                                totalLocalStreams.decrementAndGet();
+                                failure = new IllegalStateException("max stream id exceeded");
+                            }
                         }
                         else
                         {
-                            failure = new IllegalStateException("max streams exceeded");
+                            totalLocalStreams.decrementAndGet();
+                            failure = new IllegalStateException("max total streams exceeded");
                         }
                     }
                     else
@@ -2285,12 +2320,33 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
                             {
                                 if (streamId >= nextStreamId)
                                 {
-                                    int newNextStreamId = streamId + 2;
-                                    if (localStreamIds.compareAndSet(nextStreamId, newNextStreamId))
+                                    int total = totalLocalStreams.updateAndGet(v ->
                                     {
-                                        reservedStreamId = streamId;
-                                        slots.offer(slot);
-                                        created = true;
+                                        if (v <= maxTotal)
+                                            return v + 1;
+                                        return v;
+                                    });
+                                    if (total <= maxTotal)
+                                    {
+                                        // This may overflow, but it's ok as the current streamId
+                                        // is valid; it is the next streamId that will be invalid.
+                                        int newNextStreamId = streamId + 2;
+                                        if (localStreamIds.compareAndSet(nextStreamId, newNextStreamId))
+                                        {
+                                            reservedStreamId = streamId;
+                                            slots.offer(slot);
+                                            created = true;
+                                            break;
+                                        }
+                                        else
+                                        {
+                                            totalLocalStreams.decrementAndGet();
+                                        }
+                                    }
+                                    else
+                                    {
+                                        totalLocalStreams.decrementAndGet();
+                                        failure = new IllegalStateException("max total streams exceeded");
                                         break;
                                     }
                                 }
@@ -2311,7 +2367,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
                             else
                             {
                                 reservedStreamId = nextStreamId;
-                                failure = new IllegalStateException("max streams exceeded");
+                                failure = new IllegalStateException("max stream id exceeded");
                                 break;
                             }
                         }
@@ -2332,8 +2388,6 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
             else
             {
                 fail.accept(failure);
-                if (reservedStreamId < 0)
-                    close(ErrorCode.NO_ERROR.code, "max_streams_exceeded", Callback.NOOP);
             }
             return reservedStreamId;
         }

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
@@ -83,6 +84,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
     private static final Logger LOG = LoggerFactory.getLogger(HTTP2Session.class);
 
     private final Map<Integer, HTTP2Stream> streams = new ConcurrentHashMap<>();
+    private final Set<Integer> priorityStreams = ConcurrentHashMap.newKeySet();
     private final AtomicLong streamsOpened = new AtomicLong();
     private final AtomicLong streamsClosed = new AtomicLong();
     private final StreamsState streamsState = new StreamsState();
@@ -836,21 +838,13 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
         }
 
         HTTP2Stream stream = newStream(streamId, request, true);
-
-        HTTP2Stream newStream = streams.compute(streamId, (k, v) ->
+        if (streams.putIfAbsent(streamId, stream) == null)
         {
-            if (v == null || v.isPlaceHolder())
-                return stream;
-            return null;
-        });
-
-        if (newStream != null)
-        {
-            newStream.setIdleTimeout(getStreamIdleTimeout());
-            flowControl.onStreamCreated(newStream);
+            stream.setIdleTimeout(getStreamIdleTimeout());
+            flowControl.onStreamCreated(stream);
             if (LOG.isDebugEnabled())
-                LOG.debug("Created local {} for {}", newStream, this);
-            return newStream;
+                LOG.debug("Created local {} for {}", stream, this);
+            return stream;
         }
         else
         {
@@ -924,6 +918,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
     public boolean removeStream(Stream stream)
     {
         int streamId = stream.getId();
+        priorityStreams.remove(streamId);
         HTTP2Stream removed = streams.remove(streamId);
         if (removed == null)
             return false;
@@ -2117,32 +2112,24 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
             Slot slot = new Slot();
             int currentStreamId = frame.getStreamId();
             int streamId = reserveSlot(slot, currentStreamId, callback::failed);
-            if (streamId > 0)
-            {
-                HTTP2Stream stream;
-                if (currentStreamId > 0)
-                {
-                    stream = streams.get(streamId);
-                }
-                else
-                {
-                    frame = frame.withStreamId(streamId);
-                    // Create a placeholder stream, replaced when a follow-up HEADERS frame will be sent.
-                    stream = HTTP2Session.this.createLocalStream(streamId, null, callback::failed);
-                }
+            if (streamId <= 0)
+                return 0;
 
-                if (stream != null)
-                {
-                    slot.entries = List.of(newEntry(frame, stream, Callback.from(callback::succeeded, x ->
-                    {
-                        HTTP2Session.this.onStreamDestroyed(streamId);
-                        callback.failed(x);
-                    })));
-                    flush();
-                    return streamId;
-                }
+            if (!priorityStreams.add(streamId))
+            {
+                callback.failed(new IllegalStateException("Duplicate stream " + streamId));
+                return 0;
             }
-            return 0;
+
+            if (currentStreamId <= 0)
+                frame = frame.withStreamId(streamId);
+            slot.entries = List.of(newEntry(frame, null, Callback.from(callback::succeeded, x ->
+            {
+                HTTP2Session.this.onStreamDestroyed(streamId);
+                callback.failed(x);
+            })));
+            flush();
+            return streamId;
         }
 
         private void newLocalStream(HTTP2Stream.FrameList frameList, Promise<Stream> promise, Stream.Listener listener)
@@ -2309,7 +2296,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
                                 }
                                 else
                                 {
-                                    if (streams.containsKey(streamId))
+                                    if (streams.containsKey(streamId) || priorityStreams.contains(streamId))
                                     {
                                         reservedStreamId = streamId;
                                         slots.offer(slot);

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -934,6 +934,17 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
             remoteStreamCount.add(deltaStreams, deltaClosing);
     }
 
+    private boolean removeStream(int streamId)
+    {
+        HTTP2Stream removed = streams.get(streamId);
+        if (removed != null)
+            return removeStream(removed);
+        priorityStreams.remove(streamId);
+        onStreamClosed(streamId);
+        onStreamDestroyed(streamId);
+        return true;
+    }
+
     public boolean removeStream(Stream stream)
     {
         int streamId = stream.getId();
@@ -1095,6 +1106,11 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
     {
         if (LOG.isDebugEnabled())
             LOG.debug("Closed stream {} for {}", stream, this);
+        onStreamClosed(stream.getId());
+    }
+
+    private void onStreamClosed(int streamId)
+    {
         streamsClosed.incrementAndGet();
     }
 
@@ -2144,7 +2160,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
                 frame = frame.withStreamId(streamId);
             slot.entries = List.of(newEntry(frame, null, Callback.from(callback::succeeded, x ->
             {
-                HTTP2Session.this.onStreamDestroyed(streamId);
+                removeStream(streamId);
                 callback.failed(x);
             })));
             flush();
@@ -2177,7 +2193,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
             HTTP2Session.this.onStreamCreated(streamId);
             HTTP2Stream stream = HTTP2Session.this.createLocalStream(streamId, (MetaData.Request)frame.getMetaData(), x ->
             {
-                HTTP2Session.this.onStreamDestroyed(streamId);
+                removeStream(streamId);
                 failFn.accept(x);
             });
             if (stream != null)
@@ -2235,7 +2251,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
 
             Callback streamCallback = Callback.from(Invocable.InvocationType.NON_BLOCKING, () -> promise.succeeded(stream), x ->
             {
-                HTTP2Session.this.onStreamDestroyed(streamId);
+                removeStream(stream);
                 promise.failed(x);
             });
             int count = frames.size();
@@ -2283,16 +2299,16 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
                 {
                     if (streamId == 0)
                     {
-                        int total = totalLocalStreams.updateAndGet(v ->
-                        {
-                            if (v <= maxTotal)
-                                return v + 1;
-                            return v;
-                        });
+                        int total = incrementTotalLocalStreams(maxTotal);
                         if (total <= maxTotal)
                         {
                             // Stream id generated internally.
-                            reservedStreamId = localStreamIds.getAndAdd(2);
+                            reservedStreamId = localStreamIds.getAndUpdate(v ->
+                            {
+                                if (v >= 0)
+                                    return v + 2;
+                                return v;
+                            });
                             if (reservedStreamId > 0)
                             {
                                 slots.offer(slot);
@@ -2300,14 +2316,12 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
                             }
                             else
                             {
-                                totalLocalStreams.decrementAndGet();
-                                failure = new IllegalStateException("max stream id exceeded");
+                                failure = decrementTotalLocalStreams("max stream id exceeded");
                             }
                         }
                         else
                         {
-                            totalLocalStreams.decrementAndGet();
-                            failure = new IllegalStateException("max total streams exceeded");
+                            failure = decrementTotalLocalStreams("max total streams exceeded");
                         }
                     }
                     else
@@ -2320,12 +2334,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
                             {
                                 if (streamId >= nextStreamId)
                                 {
-                                    int total = totalLocalStreams.updateAndGet(v ->
-                                    {
-                                        if (v <= maxTotal)
-                                            return v + 1;
-                                        return v;
-                                    });
+                                    int total = incrementTotalLocalStreams(maxTotal);
                                     if (total <= maxTotal)
                                     {
                                         // This may overflow, but it's ok as the current streamId
@@ -2345,8 +2354,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
                                     }
                                     else
                                     {
-                                        totalLocalStreams.decrementAndGet();
-                                        failure = new IllegalStateException("max total streams exceeded");
+                                        failure = decrementTotalLocalStreams("max total streams exceeded");
                                         break;
                                     }
                                 }
@@ -2400,6 +2408,22 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
             }
             HTTP2Session.this.onStreamDestroyed(streamId);
             flush();
+        }
+
+        private int incrementTotalLocalStreams(int maxTotal)
+        {
+            return totalLocalStreams.updateAndGet(v ->
+            {
+                if (v <= maxTotal)
+                    return v + 1;
+                return v;
+            });
+        }
+
+        private Throwable decrementTotalLocalStreams(String message)
+        {
+            totalLocalStreams.decrementAndGet();
+            return new IllegalStateException(message);
         }
 
         /**

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -836,13 +836,21 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
         }
 
         HTTP2Stream stream = newStream(streamId, request, true);
-        if (streams.putIfAbsent(streamId, stream) == null)
+
+        HTTP2Stream newStream = streams.compute(streamId, (k, v) ->
         {
-            stream.setIdleTimeout(getStreamIdleTimeout());
-            flowControl.onStreamCreated(stream);
+            if (v == null || v.isPlaceHolder())
+                return stream;
+            return null;
+        });
+
+        if (newStream != null)
+        {
+            newStream.setIdleTimeout(getStreamIdleTimeout());
+            flowControl.onStreamCreated(newStream);
             if (LOG.isDebugEnabled())
-                LOG.debug("Created local {} for {}", stream, this);
-            return stream;
+                LOG.debug("Created local {} for {}", newStream, this);
+            return newStream;
         }
         else
         {
@@ -2111,20 +2119,30 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
             int streamId = reserveSlot(slot, currentStreamId, callback::failed);
             if (streamId > 0)
             {
-                if (currentStreamId <= 0)
-                    frame = frame.withStreamId(streamId);
-                slot.entries = List.of(newEntry(frame, null, Callback.from(callback::succeeded, x ->
+                HTTP2Stream stream;
+                if (currentStreamId > 0)
                 {
-                    HTTP2Session.this.onStreamDestroyed(streamId);
-                    callback.failed(x);
-                })));
-                flush();
+                    stream = streams.get(streamId);
+                }
+                else
+                {
+                    frame = frame.withStreamId(streamId);
+                    // Create a placeholder stream, replaced when a follow-up HEADERS frame will be sent.
+                    stream = HTTP2Session.this.createLocalStream(streamId, null, callback::failed);
+                }
+
+                if (stream != null)
+                {
+                    slot.entries = List.of(newEntry(frame, stream, Callback.from(callback::succeeded, x ->
+                    {
+                        HTTP2Session.this.onStreamDestroyed(streamId);
+                        callback.failed(x);
+                    })));
+                    flush();
+                    return streamId;
+                }
             }
-            else if (streamId < 0)
-            {
-                close(ErrorCode.NO_ERROR.code, "max_streams_exceeded", Callback.NOOP);
-            }
-            return streamId;
+            return 0;
         }
 
         private void newLocalStream(HTTP2Stream.FrameList frameList, Promise<Stream> promise, Stream.Listener listener)
@@ -2144,10 +2162,6 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
                 if (createLocalStream(slot, frames, promise, listener, streamId))
                     return;
                 freeSlot(slot, streamId);
-            }
-            else if (streamId < 0)
-            {
-                close(ErrorCode.NO_ERROR.code, "max_streams_exceeded", Callback.NOOP);
             }
         }
 
@@ -2198,10 +2212,6 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
                 if (createLocalStream(slot, Collections.singletonList(frame), promise, listener, streamId))
                     return;
                 freeSlot(slot, streamId);
-            }
-            else if (streamId < 0)
-            {
-                close(ErrorCode.NO_ERROR.code, "max_streams_exceeded", Callback.NOOP);
             }
         }
 
@@ -2255,6 +2265,7 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
                 return 0;
             }
 
+            boolean created = false;
             int reservedStreamId = 0;
             Throwable failure = null;
             try (AutoLock ignored = lock.lock())
@@ -2268,9 +2279,14 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
                         reservedStreamId = localStreamIds.getAndAdd(2);
                         // Check for overflow.
                         if (reservedStreamId > 0)
+                        {
                             slots.offer(slot);
+                            created = true;
+                        }
                         else
+                        {
                             failure = new IllegalStateException("max streams exceeded");
+                        }
                     }
                     else
                     {
@@ -2287,13 +2303,21 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
                                     {
                                         reservedStreamId = streamId;
                                         slots.offer(slot);
+                                        created = true;
                                         break;
                                     }
                                 }
                                 else
                                 {
-                                    reservedStreamId = streamId;
-                                    slots.offer(slot);
+                                    if (streams.containsKey(streamId))
+                                    {
+                                        reservedStreamId = streamId;
+                                        slots.offer(slot);
+                                    }
+                                    else
+                                    {
+                                        failure = new IllegalArgumentException("invalid stream id " + streamId);
+                                    }
                                     break;
                                 }
                             }
@@ -2314,9 +2338,16 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
                 }
             }
             if (failure == null)
-                HTTP2Session.this.onStreamCreated(streamId);
+            {
+                if (created)
+                    HTTP2Session.this.onStreamCreated(streamId);
+            }
             else
+            {
                 fail.accept(failure);
+                if (reservedStreamId < 0)
+                    close(ErrorCode.NO_ERROR.code, "max_streams_exceeded", Callback.NOOP);
+            }
             return reservedStreamId;
         }
 

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
@@ -110,11 +110,6 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
         return streamId;
     }
 
-    boolean isPlaceHolder()
-    {
-        return request == null;
-    }
-
     @Override
     public Object getAttachment()
     {

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
@@ -110,6 +110,11 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
         return streamId;
     }
 
+    boolean isPlaceHolder()
+    {
+        return request == null;
+    }
+
     @Override
     public Object getAttachment()
     {
@@ -959,7 +964,7 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
     @Override
     public String toString()
     {
-        return String.format("%s#%d@%x{sendWindow=%s,recvWindow=%s,queue=%d,demand=%b,reset=%b/%b,%s,age=%d,attachment=%s}",
+        return String.format("%s#%d@%x{sendWindow=%s,recvWindow=%s,queue=%d,demand=%b,reset=%b/%b,%s,age=%d,request=%s,attachment=%s}",
             getClass().getSimpleName(),
             getId(),
             session.hashCode(),
@@ -971,6 +976,7 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
             remoteReset,
             closeState,
             NanoTime.millisSince(creationNanoTime),
+            request,
             attachment);
     }
 

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HTTP2Test.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HTTP2Test.java
@@ -41,6 +41,7 @@ import org.eclipse.jetty.http2.api.server.ServerSessionListener;
 import org.eclipse.jetty.http2.frames.DataFrame;
 import org.eclipse.jetty.http2.frames.GoAwayFrame;
 import org.eclipse.jetty.http2.frames.HeadersFrame;
+import org.eclipse.jetty.http2.frames.PushPromiseFrame;
 import org.eclipse.jetty.http2.frames.ResetFrame;
 import org.eclipse.jetty.http2.frames.SettingsFrame;
 import org.eclipse.jetty.http2.hpack.HpackException;
@@ -1137,6 +1138,113 @@ public class HTTP2Test extends AbstractTest
         Throwable failure = clientFailureFuture.get(5, TimeUnit.SECONDS);
         assertThat(failure, instanceOf(IOException.class));
         assertThat(failure.getMessage(), containsString("invalid_hpack_block"));
+    }
+
+    @Test
+    public void testClientCreatesStreamsWithExplicitStreamId() throws Exception
+    {
+        start(new ServerSessionListener() {});
+
+        Session session = newClientSession(new Session.Listener() {});
+
+        int evenStreamId = 128;
+        MetaData.Request request = newRequest("GET", HttpFields.EMPTY);
+        assertThrows(ExecutionException.class, () -> session.newStream(new HeadersFrame(evenStreamId, request, null, true), new Stream.Listener() {})
+            .get(5, TimeUnit.SECONDS));
+
+        // Equivalent to Integer.MAX_VALUE + 2.
+        int negativeStreamId = Integer.MIN_VALUE + 1;
+        assertThrows(ExecutionException.class, () -> session.newStream(new HeadersFrame(negativeStreamId, request, null, true), new Stream.Listener() {})
+            .get(5, TimeUnit.SECONDS));
+
+        int explicitStreamId = 127;
+        Stream stream = session.newStream(new HeadersFrame(explicitStreamId, request, null, true), new Stream.Listener() {})
+            .get(5, TimeUnit.SECONDS);
+        assertThat(stream.getId(), equalTo(explicitStreamId));
+
+        stream = session.newStream(new HeadersFrame(request, null, true), new Stream.Listener() {})
+            .get(5, TimeUnit.SECONDS);
+        assertThat(stream.getId(), equalTo(explicitStreamId + 2));
+
+        // Cannot create streams with smaller id.
+        int smallerStreamId = explicitStreamId - 2;
+        assertThrows(ExecutionException.class, () -> session.newStream(new HeadersFrame(smallerStreamId, request, null, true), new Stream.Listener() {})
+            .get(5, TimeUnit.SECONDS));
+
+        // Should be possible to create the stream with the max id.
+        explicitStreamId = Integer.MAX_VALUE;
+        session.newStream(new HeadersFrame(explicitStreamId, request, null, true), new Stream.Listener() {})
+            .get(5, TimeUnit.SECONDS);
+
+        // After the stream with the max id, cannot create more streams on this connection.
+        assertThrows(ExecutionException.class, () -> session.newStream(new HeadersFrame(request, null, true), new Stream.Listener() {})
+            .get(5, TimeUnit.SECONDS));
+        // Session should be closed.
+        assertTrue(session.isClosed());
+    }
+
+    @Test
+    public void testServerPushesStreamsWithExplicitStreamId() throws Exception
+    {
+        CountDownLatch latch = new CountDownLatch(1);
+        start(new ServerSessionListener()
+        {
+            @Override
+            public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
+            {
+                try
+                {
+                    int oddStreamId = 129;
+                    MetaData.Request request = newRequest("GET", HttpFields.EMPTY);
+                    assertThrows(ExecutionException.class, () -> stream.push(new PushPromiseFrame(stream.getId(), oddStreamId, request), new Stream.Listener() {})
+                        .get(5, TimeUnit.SECONDS));
+
+                    int negativeStreamId = Integer.MIN_VALUE;
+                    assertThrows(ExecutionException.class, () -> stream.push(new PushPromiseFrame(stream.getId(), negativeStreamId, request), new Stream.Listener() {})
+                        .get(5, TimeUnit.SECONDS));
+
+                    int explicitStreamId = 128;
+                    Stream pushedStream = stream.push(new PushPromiseFrame(stream.getId(), explicitStreamId, request), new Stream.Listener() {})
+                        .get(5, TimeUnit.SECONDS);
+                    assertThat(pushedStream.getId(), equalTo(explicitStreamId));
+
+                    pushedStream = stream.push(new PushPromiseFrame(stream.getId(), 0, request), new Stream.Listener() {})
+                        .get(5, TimeUnit.SECONDS);
+                    assertThat(pushedStream.getId(), equalTo(explicitStreamId + 2));
+
+                    // Cannot push streams with smaller id.
+                    int smallerStreamId = explicitStreamId - 2;
+                    assertThrows(ExecutionException.class, () -> stream.push(new PushPromiseFrame(stream.getId(), smallerStreamId, request), new Stream.Listener() {})
+                        .get(5, TimeUnit.SECONDS));
+
+                    // Should be possible to push the stream with the max id.
+                    explicitStreamId = Integer.MAX_VALUE - 1;
+                    stream.push(new PushPromiseFrame(stream.getId(), explicitStreamId, request), new Stream.Listener() {})
+                        .get(5, TimeUnit.SECONDS);
+
+                    // After the stream with the max id, cannot push more streams on this connection.
+                    assertThrows(ExecutionException.class, () -> stream.push(new PushPromiseFrame(stream.getId(), 0, request), new Stream.Listener() {})
+                        .get(5, TimeUnit.SECONDS));
+                    // Session should be closed.
+                    assertTrue(stream.getSession().isClosed());
+
+                    latch.countDown();
+
+                    return null;
+                }
+                catch (Throwable x)
+                {
+                    throw new RuntimeException(x);
+                }
+            }
+        });
+
+        Session session = newClientSession(new Session.Listener() {});
+        MetaData.Request request = newRequest("GET", HttpFields.EMPTY);
+        session.newStream(new HeadersFrame(request, null, true), new Stream.Listener() {})
+            .get(5, TimeUnit.SECONDS);
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
     }
 
     private static void sleep(long time)

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HTTP2Test.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HTTP2Test.java
@@ -1141,6 +1141,50 @@ public class HTTP2Test extends AbstractTest
     }
 
     @Test
+    public void testClientExceedsConnectionMaxUsage() throws Exception
+    {
+        start(new ServerSessionListener() {});
+
+        Session session = newClientSession(new Session.Listener() {});
+        ((HTTP2Session)session).setMaxTotalLocalStreams(1);
+
+        MetaData.Request request = newRequest("GET", HttpFields.EMPTY);
+        session.newStream(new HeadersFrame(request, null, true), new Stream.Listener() {});
+
+        // Must not be able to create more streams than allowed.
+        assertThrows(ExecutionException.class, () -> session.newStream(new HeadersFrame(request, null, true), new Stream.Listener() {})
+            .get(5, TimeUnit.SECONDS));
+
+        // Must not be able to create more streams than allowed with an explicit streamId.
+        int explicitStreamId = Integer.MAX_VALUE;
+        assertThrows(ExecutionException.class, () -> session.newStream(new HeadersFrame(explicitStreamId, request, null, true), new Stream.Listener() {})
+            .get(5, TimeUnit.SECONDS));
+
+        // Session must still be valid.
+        assertFalse(session.isClosed());
+    }
+
+    @Test
+    public void testClientExceedsMaxStreamId() throws Exception
+    {
+        start(new ServerSessionListener() {});
+
+        Session session = newClientSession(new Session.Listener() {});
+
+        // Use the max possible streamId.
+        int explicitStreamId = Integer.MAX_VALUE;
+        MetaData.Request request = newRequest("GET", HttpFields.EMPTY);
+        session.newStream(new HeadersFrame(explicitStreamId, request, null, true), new Stream.Listener() {});
+
+        // Must not be able to create more streams.
+        assertThrows(ExecutionException.class, () -> session.newStream(new HeadersFrame(request, null, true), new Stream.Listener() {})
+            .get(5, TimeUnit.SECONDS));
+
+        // Session must still be valid.
+        assertFalse(session.isClosed());
+    }
+
+    @Test
     public void testClientCreatesStreamsWithExplicitStreamId() throws Exception
     {
         start(new ServerSessionListener() {});
@@ -1179,8 +1223,8 @@ public class HTTP2Test extends AbstractTest
         // After the stream with the max id, cannot create more streams on this connection.
         assertThrows(ExecutionException.class, () -> session.newStream(new HeadersFrame(request, null, true), new Stream.Listener() {})
             .get(5, TimeUnit.SECONDS));
-        // Session should be closed.
-        assertTrue(session.isClosed());
+        // Session must still be valid.
+        assertFalse(session.isClosed());
     }
 
     @Test
@@ -1225,8 +1269,8 @@ public class HTTP2Test extends AbstractTest
                     // After the stream with the max id, cannot push more streams on this connection.
                     assertThrows(ExecutionException.class, () -> stream.push(new PushPromiseFrame(stream.getId(), 0, request), new Stream.Listener() {})
                         .get(5, TimeUnit.SECONDS));
-                    // Session should be closed.
-                    assertTrue(stream.getSession().isClosed());
+                    // Session must still be valid.
+                    assertFalse(stream.getSession().isClosed());
 
                     latch.countDown();
 

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HTTP2Test.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HTTP2Test.java
@@ -1180,6 +1180,9 @@ public class HTTP2Test extends AbstractTest
         assertThrows(ExecutionException.class, () -> session.newStream(new HeadersFrame(request, null, true), new Stream.Listener() {})
             .get(5, TimeUnit.SECONDS));
 
+        assertThrows(ExecutionException.class, () -> session.newStream(new HeadersFrame(explicitStreamId, request, null, true), new Stream.Listener() {})
+            .get(5, TimeUnit.SECONDS));
+
         // Session must still be valid.
         assertFalse(session.isClosed());
     }


### PR DESCRIPTION
* Made the high-level HttpConnectionOverHTTP2 implement MaxUsable, so it cannot be used to open more streams than allowed.
* Implemented low-level handling of explicit stream ids provided by applications.
* Implemented low-level handling of stream id overflow.
* Added test cases.