### PR TITLE
Alternative to #12395.

### DIFF
--- a/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/HttpStreamOverFCGI.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/HttpStreamOverFCGI.java
@@ -182,8 +182,12 @@ public class HttpStreamOverFCGI implements HttpStream
     private void notifyContentAvailable()
     {
         Runnable onContentAvailable = _httpChannel.onContentAvailable();
-        if (onContentAvailable != null)
+        if (onContentAvailable == null)
+            return;
+        if (Invocable.getInvocationType(onContentAvailable) == InvocationType.NON_BLOCKING)
             onContentAvailable.run();
+        else
+            execute(onContentAvailable);
     }
 
     public void onContent(Content.Chunk chunk)

--- a/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/ServerFCGIConnection.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/ServerFCGIConnection.java
@@ -411,9 +411,21 @@ public class ServerFCGIConnection extends AbstractMetaDataConnection implements 
         if (stream != null)
         {
             Runnable task = stream.getHttpChannel().onClose();
-            if (task != null)
-                task.run();
+            ThreadPool.executeImmediately(getExecutor(), () ->
+            {
+                try
+                {
+                    task.run();
+                }
+                finally
+                {
+                    super.close();
+                }
+            });
         }
-        super.close();
+        else
+        {
+            super.close();
+        }
     }
 }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPart.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPart.java
@@ -45,6 +45,7 @@ import org.eclipse.jetty.util.StaticException;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.Utf8StringBuilder;
 import org.eclipse.jetty.util.thread.AutoLock;
+import org.eclipse.jetty.util.thread.Invocable;
 import org.eclipse.jetty.util.thread.SerializedInvoker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -823,14 +824,7 @@ public class MultiPart
             }
             if (part != null)
             {
-                part.getContentSource().demand(() ->
-                {
-                    try (AutoLock ignoredAgain = lock.lock())
-                    {
-                        this.demand = null;
-                    }
-                    demandCallback.run();
-                });
+                part.getContentSource().demand(new DemandCallback(demandCallback));
             }
             else if (invoke)
             {
@@ -886,6 +880,32 @@ public class MultiPart
         private enum State
         {
             FIRST, MIDDLE, HEADERS, CONTENT, COMPLETE
+        }
+
+        private class DemandCallback implements Invocable.Task
+        {
+            private final Runnable demandCallback;
+
+            private DemandCallback(Runnable demandCallback)
+            {
+                this.demandCallback = demandCallback;
+            }
+
+            @Override
+            public void run()
+            {
+                try (AutoLock ignored = lock.lock())
+                {
+                    demand = null;
+                }
+                demandCallback.run();
+            }
+
+            @Override
+            public InvocationType getInvocationType()
+            {
+                return Invocable.getInvocationType(demandCallback, false);
+            }
         }
     }
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextRequest.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextRequest.java
@@ -59,7 +59,7 @@ public class ContextRequest extends Request.Wrapper implements Invocable
         return _context;
     }
 
-    private class OnContextDemand implements Runnable
+    private class OnContextDemand implements Invocable.Task
     {
         private final Runnable _demandCallback;
 
@@ -72,6 +72,12 @@ public class ContextRequest extends Request.Wrapper implements Invocable
         public void run()
         {
             _context.run(_demandCallback, ContextRequest.this);
+        }
+
+        @Override
+        public InvocationType getInvocationType()
+        {
+            return Invocable.getInvocationType(_demandCallback, false);
         }
     }
 }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/StateTrackingHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/StateTrackingHandler.java
@@ -771,7 +771,7 @@ public class StateTrackingHandler extends Handler.Wrapper
             @Override
             public InvocationType getInvocationType()
             {
-                return Invocable.getInvocationType(callback);
+                return Invocable.getInvocationType(callback, false);
             }
         }
     }

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ThreadStarvationTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ThreadStarvationTest.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -32,6 +33,7 @@ import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 
 import org.eclipse.jetty.io.ArrayByteBufferPool;
+import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.IO;
@@ -39,7 +41,6 @@ import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -50,7 +51,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Disabled // TODO
 public class ThreadStarvationTest
 {
     static final int BUFFER_SIZE = 1024 * 1024;
@@ -100,7 +100,7 @@ public class ThreadStarvationTest
         };
         ClientSocketProvider httpsClient = new ClientSocketProvider()
         {
-            private SSLContext sslContext;
+            private final SSLContext sslContext;
 
             {
                 try
@@ -128,23 +128,21 @@ public class ThreadStarvationTest
         return params.stream().map(Arguments::of);
     }
 
-    private QueuedThreadPool _threadPool;
     private Server _server;
     private ServerConnector _connector;
 
-    private Server prepareServer(Scenario scenario, Handler handler)
+    private void prepareServer(Scenario scenario, Handler handler)
     {
-        _threadPool = new QueuedThreadPool();
-        _threadPool.setMinThreads(THREADS);
-        _threadPool.setMaxThreads(THREADS);
-        _threadPool.setDetailedDump(true);
-        _server = new Server(_threadPool);
+        QueuedThreadPool threadPool = new QueuedThreadPool();
+        threadPool.setMinThreads(THREADS);
+        threadPool.setMaxThreads(THREADS);
+        threadPool.setDetailedDump(true);
+        _server = new Server(threadPool);
         int acceptors = 1;
         int selectors = 1;
         _connector = scenario.connectorProvider.newConnector(_server, acceptors, selectors);
         _server.addConnector(_connector);
         _server.setHandler(handler);
-        return _server;
     }
 
     @AfterEach
@@ -158,34 +156,6 @@ public class ThreadStarvationTest
         finally
         {
             LifeCycle.stop(_server);
-        }
-    }
-
-    @ParameterizedTest
-    @MethodSource("scenarios")
-    public void testReadInput(Scenario scenario) throws Exception
-    {
-        prepareServer(scenario, new ReadHandler()).start();
-
-        try (Socket client = scenario.clientSocketProvider.newSocket("localhost", _connector.getLocalPort()))
-        {
-            client.setSoTimeout(10000);
-            OutputStream os = client.getOutputStream();
-            InputStream is = client.getInputStream();
-
-            String request =
-                "GET / HTTP/1.0\r\n" +
-                    "Host: localhost\r\n" +
-                    "Content-Length: 10\r\n" +
-                    "\r\n" +
-                    "0123456789\r\n";
-            os.write(request.getBytes(StandardCharsets.UTF_8));
-            os.flush();
-
-            String response = IO.toString(is);
-            assertEquals(-1, is.read());
-            assertThat(response, containsString("200 OK"));
-            assertThat(response, containsString("Read Input 10"));
         }
     }
 
@@ -210,12 +180,12 @@ public class ThreadStarvationTest
                 {
                     client.setSoTimeout(10000);
 
-                    String request =
-                        "PUT / HTTP/1.0\r\n" +
-                            "host: localhost\r\n" +
-                            "content-length: 10\r\n" +
-                            "\r\n" +
-                            "1";
+                    String request = """
+                        PUT / HTTP/1.0\r
+                        host: localhost\r
+                        content-length: 10\r
+                        \r
+                        1""";
 
                     // Write partial request
                     out.write(request.getBytes(StandardCharsets.UTF_8));
@@ -257,18 +227,8 @@ public class ThreadStarvationTest
         public boolean handle(Request request, Response response, Callback callback) throws Exception
         {
             response.setStatus(200);
-            /* TODO
-
-            int l = request.getContentLength();
-            int r = 0;
-            while (r < l)
-            {
-                if (request.getInputStream().read() >= 0)
-                    r++;
-            }
-
-            response.write(true, callback, ByteBuffer.wrap(("Read Input " + r + "\r\n").getBytes()));
-            */
+            String string = Content.Source.asString(request);
+            response.write(true, ByteBuffer.wrap(("Read Input " + string.length() + "\r\n").getBytes()), callback);
             return true;
         }
     }
@@ -294,10 +254,11 @@ public class ThreadStarvationTest
                 {
                     client.setSoTimeout(30000);
 
-                    String request =
-                        "GET / HTTP/1.0\r\n" +
-                            "host: localhost\r\n" +
-                            "\r\n";
+                    String request = """
+                        GET / HTTP/1.0\r
+                        host: localhost\r
+                        \r
+                        """;
 
                     // Write GET request
                     out.write(request.getBytes(StandardCharsets.UTF_8));
@@ -361,30 +322,28 @@ public class ThreadStarvationTest
         @Override
         public boolean handle(Request request, Response response, Callback callback) throws Exception
         {
-            /* TODO
-            baseRequest.setHandled(true);
             response.setStatus(200);
 
-            response.setContentLength(BUFFERS * BUFFER_SIZE);
-            OutputStream out = response.getOutputStream();
-            for (int i = 0; i < BUFFERS; i++)
+            try (OutputStream out = Content.Sink.asOutputStream(response))
             {
-                out.write(content);
-                out.flush();
+                for (int i = 0; i < BUFFERS; i++)
+                {
+                    out.write(content);
+                    out.flush();
+                }
             }
 
-             */
             return true;
         }
     }
 
     public static class Scenario
     {
-        public final String testType;
-        public final ConnectorProvider connectorProvider;
-        public final ClientSocketProvider clientSocketProvider;
+        private final String testType;
+        private final ConnectorProvider connectorProvider;
+        private final ClientSocketProvider clientSocketProvider;
 
-        public Scenario(String testType, ConnectorProvider connectorProvider, ClientSocketProvider clientSocketProvider)
+        private Scenario(String testType, ConnectorProvider connectorProvider, ClientSocketProvider clientSocketProvider)
         {
             this.testType = testType;
             this.connectorProvider = connectorProvider;

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/EchoHandler.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/EchoHandler.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.server.handler;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
@@ -23,6 +24,7 @@ import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.IO;
+import org.eclipse.jetty.util.Promise;
 
 /**
  * Dump request handler.
@@ -136,12 +138,19 @@ public class EchoHandler extends Handler.Abstract
         @Override
         protected void copy(Request request, Response response, Callback callback)
         {
-            Content.Source.asByteBufferAsync(request).whenComplete((b, t) ->
+            Content.Source.asByteBuffer(request, new Promise<>()
             {
-                if (t == null)
-                    response.write(true, b, callback);
-                else
-                    callback.failed(t);
+                @Override
+                public void succeeded(ByteBuffer byteBuffer)
+                {
+                    response.write(true, byteBuffer, callback);
+                }
+
+                @Override
+                public void failed(Throwable x)
+                {
+                    callback.failed(x);
+                }
             });
         }
     }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/Invocable.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/Invocable.java
@@ -127,6 +127,8 @@ public interface Invocable
      */
     static Task from(InvocationType type, Runnable task)
     {
+        if (task instanceof Task t && t.getInvocationType() == type)
+            return t;
         return new ReadyTask(type, task);
     }
 
@@ -182,17 +184,40 @@ public interface Invocable
     }
 
     /**
-     * Get the invocation type of an Object.
+     * <p>Returns the {@link InvocationType} of the given object.</p>
+     * <p>If the object implements {@link Invocable}, returns the result
+     * of calling its {@link #getInvocationType()} method.</p>
+     * <p>Otherwise {@link InvocationType#BLOCKING} is returned.</p>
      *
-     * @param o The object to check the invocation type of.
-     * @return If the object is an Invocable, it is coerced and the {@link #getInvocationType()}
-     * used, otherwise {@link InvocationType#BLOCKING} is returned.
+     * @param o the object to test for its {@link InvocationType}
+     * @return the {@link InvocationType} of the object if it is an {@link Invocable},
+     * otherwise {@link InvocationType#BLOCKING}.
      */
     static InvocationType getInvocationType(Object o)
     {
+        return getInvocationType(o, true);
+    }
+
+    /**
+     * <p>Returns the {@link InvocationType} of the given object.</p>
+     * <p>If the object implements {@link Invocable}, returns the result
+     * of calling its {@link #getInvocationType()} method.</p>
+     * <p>Otherwise, returns {@link InvocationType#BLOCKING} or
+     * {@link InvocationType#NON_BLOCKING} depending on the
+     * {@code blocking} parameter.</p>
+     *
+     * @param o the object to test for its {@link InvocationType}
+     * @param blocking if the object is not an {@link Invocable}, whether to return
+     * {@link InvocationType#BLOCKING} or {@link InvocationType#NON_BLOCKING}.
+     * @return the {@link InvocationType} of the object if it is an {@link Invocable},
+     * otherwise {@link InvocationType#BLOCKING} or {@link InvocationType#NON_BLOCKING}
+     * depending on the {@code blocking} parameter.
+     */
+    static InvocationType getInvocationType(Object o, boolean blocking)
+    {
         if (o instanceof Invocable)
             return ((Invocable)o).getInvocationType();
-        return InvocationType.BLOCKING;
+        return blocking ? InvocationType.BLOCKING : InvocationType.NON_BLOCKING;
     }
 
     /**

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/SerializedInvoker.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/SerializedInvoker.java
@@ -212,7 +212,7 @@ public class SerializedInvoker
         @Override
         public InvocationType getInvocationType()
         {
-            return InvocationType.BLOCKING;
+            return Invocable.getInvocationType(_task);
         }
 
         Link next()
@@ -269,7 +269,7 @@ public class SerializedInvoker
         }
     }
 
-    private class NamedRunnable implements Runnable
+    private class NamedRunnable implements Runnable, Invocable
     {
         private static final Logger LOG = LoggerFactory.getLogger(NamedRunnable.class);
 
@@ -302,6 +302,12 @@ public class SerializedInvoker
         public void run()
         {
             delegate.run();
+        }
+
+        @Override
+        public InvocationType getInvocationType()
+        {
+            return Invocable.getInvocationType(delegate);
         }
 
         @Override

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
@@ -539,13 +539,13 @@ public class ServletChannel
 
                     case READ_CALLBACK:
                     {
-                        _context.run(() -> _servletContextRequest.getHttpInput().run());
+                        _context.run(_servletContextRequest.getHttpInput());
                         break;
                     }
 
                     case WRITE_CALLBACK:
                     {
-                        _context.run(() -> _servletContextRequest.getHttpOutput().run());
+                        _context.run(_servletContextRequest.getHttpOutput());
                         break;
                     }
 

--- a/jetty-ee10/jetty-ee10-servlets/src/test/java/org/eclipse/jetty/ee10/servlets/ThreadStarvationTest.java
+++ b/jetty-ee10/jetty-ee10-servlets/src/test/java/org/eclipse/jetty/ee10/servlets/ThreadStarvationTest.java
@@ -13,37 +13,57 @@
 
 package org.eclipse.jetty.ee10.servlets;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
+import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.Exchanger;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.ee10.servlet.DefaultServlet;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.servlet.ServletHolder;
+import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.io.ManagedSelector;
 import org.eclipse.jetty.io.SocketChannelEndPoint;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -59,7 +79,180 @@ public class ThreadStarvationTest
     }
 
     @Test
-    @Tag("flaky")
+    public void testReadStarvation() throws Exception
+    {
+        int maxThreads = 5;
+        int clients = maxThreads + 2;
+        QueuedThreadPool threadPool = new QueuedThreadPool(maxThreads, maxThreads);
+        threadPool.setDetailedDump(true);
+        _server = new Server(threadPool);
+
+        ServerConnector connector = new ServerConnector(_server, 1, 1);
+        _server.addConnector(connector);
+
+        ServletContextHandler context = new ServletContextHandler("/");
+        context.addServlet(new ServletHolder(new HttpServlet()
+        {
+            @Override
+            protected void doPut(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                IO.copy(req.getInputStream(), resp.getOutputStream());
+            }
+        }), "/*");
+        _server.setHandler(context);
+
+        _server.start();
+
+        ExecutorService clientExecutors = Executors.newFixedThreadPool(clients);
+
+        List<Callable<String>> clientTasks = new ArrayList<>();
+
+        for (int i = 0; i < clients; i++)
+        {
+            clientTasks.add(() ->
+            {
+                try (Socket client = new Socket("localhost", connector.getLocalPort());
+                     OutputStream out = client.getOutputStream();
+                     InputStream in = client.getInputStream())
+                {
+                    client.setSoTimeout(10000);
+
+                    String request = """
+                        PUT / HTTP/1.0\r
+                        host: localhost\r
+                        content-length: 10\r
+                        \r
+                        1""";
+
+                    // Write partial request
+                    out.write(request.getBytes(StandardCharsets.UTF_8));
+                    out.flush();
+
+                    // Finish Request
+                    Thread.sleep(1500);
+                    out.write(("234567890\r\n").getBytes(StandardCharsets.UTF_8));
+                    out.flush();
+
+                    // Read Response
+                    String response = IO.toString(in);
+                    assertEquals(-1, in.read());
+                    return response;
+                }
+            });
+        }
+
+        try
+        {
+            List<Future<String>> responses = clientExecutors.invokeAll(clientTasks, 60, TimeUnit.SECONDS);
+
+            for (Future<String> responseFut : responses)
+            {
+                String response = responseFut.get();
+                assertThat(response, containsString("200 OK"));
+                assertThat(response, containsString("1234567890"));
+            }
+        }
+        finally
+        {
+            clientExecutors.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testFormStarvation() throws Exception
+    {
+        int maxThreads = 5;
+        int clients = maxThreads + 2;
+        QueuedThreadPool threadPool = new QueuedThreadPool(maxThreads, maxThreads);
+        threadPool.setDetailedDump(true);
+        _server = new Server(threadPool);
+
+        ServerConnector connector = new ServerConnector(_server, 1, 1);
+        _server.addConnector(connector);
+
+        ServletContextHandler context = new ServletContextHandler("/");
+        context.addServlet(new ServletHolder(new HttpServlet()
+        {
+            @Override
+            protected void doPost(HttpServletRequest req, HttpServletResponse resp)
+            {
+                resp.setStatus(200);
+                req.getParameterMap().forEach((key, value) ->
+                {
+                    try
+                    {
+                        resp.getWriter().printf("%s=%s\n", key, Arrays.asList(value));
+                    }
+                    catch (IOException ex)
+                    {
+                        throw new RuntimeException(ex);
+                    }
+                });
+            }
+        }), "/*");
+        _server.setHandler(context);
+
+        _server.start();
+
+        ExecutorService clientExecutors = Executors.newFixedThreadPool(clients);
+
+        List<Callable<String>> clientTasks = new ArrayList<>();
+
+        for (int i = 0; i < clients; i++)
+        {
+            clientTasks.add(() ->
+            {
+                try (Socket client = new Socket("localhost", connector.getLocalPort());
+                     OutputStream out = client.getOutputStream();
+                     InputStream in = client.getInputStream())
+                {
+                    client.setSoTimeout(10000);
+
+                    String request = """
+                        POST / HTTP/1.0\r
+                        host: localhost\r
+                        content-type: application/x-www-form-urlencoded\r
+                        content-length: 11\r
+                        \r
+                        a=1&b""";
+
+                    // Write partial request
+                    out.write(request.getBytes(StandardCharsets.UTF_8));
+                    out.flush();
+
+                    // Finish Request
+                    Thread.sleep(1500);
+                    out.write(("=2&c=3\r\n").getBytes(StandardCharsets.UTF_8));
+                    out.flush();
+
+                    // Read Response
+                    String response = IO.toString(in);
+                    assertEquals(-1, in.read());
+                    return response;
+                }
+            });
+        }
+
+        try
+        {
+            List<Future<String>> responses = clientExecutors.invokeAll(clientTasks, 60, TimeUnit.SECONDS);
+
+            for (Future<String> responseFut : responses)
+            {
+                String response = responseFut.get();
+                assertThat(response, containsString("200 OK"));
+                assertThat(response, containsString("a=[1]"));
+                assertThat(response, containsString("b=[2]"));
+                assertThat(response, containsString("c=[3]"));
+            }
+        }
+        finally
+        {
+            clientExecutors.shutdownNow();
+        }
+    }
+
+    @Test
     public void testDefaultServletSuccess() throws Exception
     {
         int maxThreads = 6;
@@ -68,10 +261,10 @@ public class ThreadStarvationTest
         _server = new Server(threadPool);
 
         // Prepare a big file to download.
-        File directory = MavenTestingUtils.getTargetTestingDir();
-        Files.createDirectories(directory.toPath());
+        Path directory = MavenTestingUtils.getTargetTestingPath();
+        Files.createDirectories(directory);
         String resourceName = "resource.bin";
-        Path resourcePath = Paths.get(directory.getPath(), resourceName);
+        Path resourcePath = directory.resolve(resourceName);
         try (OutputStream output = Files.newOutputStream(resourcePath, StandardOpenOption.CREATE, StandardOpenOption.WRITE))
         {
             byte[] chunk = new byte[256 * 1024];
@@ -105,8 +298,8 @@ public class ThreadStarvationTest
         _server.addConnector(connector);
 
         ServletContextHandler context = new ServletContextHandler("/");
-        context.setBaseResourceAsPath(directory.toPath());
-        
+        context.setBaseResourceAsPath(directory);
+
         //TODO: Uses DefaultServlet, currently all commented out
         context.addServlet(DefaultServlet.class, "/*").setAsyncSupported(false);
         _server.setHandler(context);
@@ -121,8 +314,8 @@ public class ThreadStarvationTest
             OutputStream output = socket.getOutputStream();
             String request =
                 "GET /" + resourceName + " HTTP/1.1\r\n" +
-                    "Host: localhost\r\n" +
-                    "\r\n";
+                "Host: localhost\r\n" +
+                "\r\n";
             output.write(request.getBytes(StandardCharsets.UTF_8));
             output.flush();
         }
@@ -139,75 +332,71 @@ public class ThreadStarvationTest
             totals.add(x);
             final InputStream input = socket.getInputStream();
 
-            new Thread()
+            new Thread(() ->
             {
-                @Override
-                public void run()
+                long total = 0;
+                try
                 {
-                    long total = 0;
-                    try
+                    // look for CRLFCRLF
+                    StringBuilder header = new StringBuilder();
+                    int state = 0;
+                    while (state < 4 && header.length() < 2048)
                     {
-                        // look for CRLFCRLF
-                        StringBuilder header = new StringBuilder();
-                        int state = 0;
-                        while (state < 4 && header.length() < 2048)
+                        int ch = input.read();
+                        if (ch < 0)
+                            break;
+                        header.append((char)ch);
+                        switch (state)
                         {
-                            int ch = input.read();
-                            if (ch < 0)
+                            case 0:
+                                if (ch == '\r')
+                                    state = 1;
                                 break;
-                            header.append((char)ch);
-                            switch (state)
-                            {
-                                case 0:
-                                    if (ch == '\r')
-                                        state = 1;
-                                    break;
-                                case 1:
-                                    if (ch == '\n')
-                                        state = 2;
-                                    else
-                                        state = 0;
-                                    break;
-                                case 2:
-                                    if (ch == '\r')
-                                        state = 3;
-                                    else
-                                        state = 0;
-                                    break;
-                                case 3:
-                                    if (ch == '\n')
-                                        state = 4;
-                                    else
-                                        state = 0;
-                                    break;
-                            }
-                        }
-
-                        while (total < expected)
-                        {
-                            int read = input.read(buffer);
-                            if (read < 0)
+                            case 1:
+                                if (ch == '\n')
+                                    state = 2;
+                                else
+                                    state = 0;
                                 break;
-                            total += read;
+                            case 2:
+                                if (ch == '\r')
+                                    state = 3;
+                                else
+                                    state = 0;
+                                break;
+                            case 3:
+                                if (ch == '\n')
+                                    state = 4;
+                                else
+                                    state = 0;
+                                break;
                         }
                     }
-                    catch (IOException e)
+
+                    while (total < expected)
+                    {
+                        int read = input.read(buffer);
+                        if (read < 0)
+                            break;
+                        total += read;
+                    }
+                }
+                catch (IOException e)
+                {
+                    e.printStackTrace();
+                }
+                finally
+                {
+                    try
+                    {
+                        x.exchange(total);
+                    }
+                    catch (InterruptedException e)
                     {
                         e.printStackTrace();
                     }
-                    finally
-                    {
-                        try
-                        {
-                            x.exchange(total);
-                        }
-                        catch (InterruptedException e)
-                        {
-                            e.printStackTrace();
-                        }
-                    }
                 }
-            }.start();
+            }).start();
         }
 
         for (Exchanger<Long> x : totals)
@@ -223,172 +412,164 @@ public class ThreadStarvationTest
         }
     }
 
-    //TODO needs visibility of server.internal.HttpChannelState
-    /* @Test
+    @Test
     public void testFailureStarvation() throws Exception
     {
-        try (StacklessLogging stackless = new StacklessLogging(HttpChannelState.class))
+        int acceptors = 0;
+        int selectors = 1;
+        int maxThreads = 10;
+        final int barried = maxThreads - acceptors - selectors * 2;
+        final CyclicBarrier barrier = new CyclicBarrier(barried);
+
+        QueuedThreadPool threadPool = new QueuedThreadPool(maxThreads, maxThreads);
+        threadPool.setDetailedDump(true);
+        _server = new Server(threadPool);
+
+        ServerConnector connector = new ServerConnector(_server, acceptors, selectors)
         {
-            int acceptors = 0;
-            int selectors = 1;
-            int maxThreads = 10;
-            final int barried = maxThreads - acceptors - selectors * 2;
-            final CyclicBarrier barrier = new CyclicBarrier(barried);
-    
-            QueuedThreadPool threadPool = new QueuedThreadPool(maxThreads, maxThreads);
-            threadPool.setDetailedDump(true);
-            _server = new Server(threadPool);
-    
-            ServerConnector connector = new ServerConnector(_server, acceptors, selectors)
+            @Override
+            protected SocketChannelEndPoint newEndPoint(SocketChannel channel, ManagedSelector selectSet, SelectionKey key)
             {
-                @Override
-                protected SocketChannelEndPoint newEndPoint(SocketChannel channel, ManagedSelector selectSet, SelectionKey key)
-                {
-                    return new SocketChannelEndPoint(channel, selectSet, key, getScheduler())
-                    {
-                        @Override
-                        public boolean flush(ByteBuffer... buffers) throws IOException
-                        {
-                            super.flush(buffers[0]);
-                            throw new IOException("TEST FAILURE");
-                        }
-                    };
-                }
-            };
-            connector.setIdleTimeout(Long.MAX_VALUE);
-            _server.addConnector(connector);
-    
-            final AtomicInteger count = new AtomicInteger(0);
-            class TheHandler extends Handler.Abstract
-            {
-                @Override
-                public boolean handle(request request, Response response, Callback callback) throws Exception
-                {
-                    int c = count.getAndIncrement();
-                    try
-                    {
-                        if (c < barried)
-                        {
-                            barrier.await(10, TimeUnit.SECONDS);
-                        }
-                    }
-                    catch (InterruptedException | BrokenBarrierException | TimeoutException e)
-                    {
-                        throw new ServletException(e);
-                    }
-    
-                    response.setStatus(200);
-                    response.setContentLength(13);
-                    response.write(true, callback, "Hello World!\n");
-                    return true;
-                }
-            }
-            
-            _server.setHandler(new TheHandler());
-    
-            _server.start();
-    
-            List<Socket> sockets = new ArrayList<>();
-            for (int i = 0; i < maxThreads * 2; ++i)
-            {
-                Socket socket = new Socket("localhost", connector.getLocalPort());
-                sockets.add(socket);
-                OutputStream output = socket.getOutputStream();
-                String request =
-                    "GET / HTTP/1.1\r\n" +
-                        "Host: localhost\r\n" +
-                        //                    "Connection: close\r\n" +
-                        "\r\n";
-                output.write(request.getBytes(StandardCharsets.UTF_8));
-                output.flush();
-            }
-    
-            byte[] buffer = new byte[48 * 1024];
-            List<Exchanger<Integer>> totals = new ArrayList<>();
-            for (Socket socket : sockets)
-            {
-                final Exchanger<Integer> x = new Exchanger<>();
-                totals.add(x);
-                final InputStream input = socket.getInputStream();
-    
-                new Thread()
+                return new SocketChannelEndPoint(channel, selectSet, key, getScheduler())
                 {
                     @Override
-                    public void run()
+                    public boolean flush(ByteBuffer... buffers) throws IOException
                     {
-                        int read = 0;
-                        try
+                        super.flush(buffers[0]);
+                        throw new IOException("TEST FAILURE");
+                    }
+                };
+            }
+        };
+        connector.setIdleTimeout(Long.MAX_VALUE);
+        _server.addConnector(connector);
+
+        final AtomicInteger count = new AtomicInteger(0);
+        class TheHandler extends Handler.Abstract
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            {
+                int c = count.getAndIncrement();
+                try
+                {
+                    if (c < barried)
+                    {
+                        barrier.await(10, TimeUnit.SECONDS);
+                    }
+                }
+                catch (InterruptedException | BrokenBarrierException | TimeoutException e)
+                {
+                    throw new ServletException(e);
+                }
+
+                response.setStatus(200);
+                response.getHeaders().put(HttpHeader.CONTENT_LENGTH, 13L);
+                response.write(true, BufferUtil.toBuffer("Hello World!\n"), callback);
+                return true;
+            }
+        }
+
+        _server.setHandler(new TheHandler());
+
+        _server.start();
+
+        List<Socket> sockets = new ArrayList<>();
+        for (int i = 0; i < maxThreads * 2; ++i)
+        {
+            Socket socket = new Socket("localhost", connector.getLocalPort());
+            sockets.add(socket);
+            OutputStream output = socket.getOutputStream();
+            String request =
+                "GET / HTTP/1.1\r\n" +
+                "Host: localhost\r\n" +
+                //                    "Connection: close\r\n" +
+                "\r\n";
+            output.write(request.getBytes(StandardCharsets.UTF_8));
+            output.flush();
+        }
+
+        byte[] buffer = new byte[48 * 1024];
+        List<Exchanger<Integer>> totals = new ArrayList<>();
+        for (Socket socket : sockets)
+        {
+            final Exchanger<Integer> x = new Exchanger<>();
+            totals.add(x);
+            final InputStream input = socket.getInputStream();
+
+            new Thread(() ->
+            {
+                int read = 0;
+                try
+                {
+                    // look for CRLFCRLF
+                    StringBuilder header = new StringBuilder();
+                    int state = 0;
+                    while (state < 4 && header.length() < 2048)
+                    {
+                        int ch = input.read();
+                        if (ch < 0)
+                            break;
+                        header.append((char)ch);
+                        switch (state)
                         {
-                            // look for CRLFCRLF
-                            StringBuilder header = new StringBuilder();
-                            int state = 0;
-                            while (state < 4 && header.length() < 2048)
-                            {
-                                int ch = input.read();
-                                if (ch < 0)
-                                    break;
-                                header.append((char)ch);
-                                switch (state)
-                                {
-                                    case 0:
-                                        if (ch == '\r')
-                                            state = 1;
-                                        break;
-                                    case 1:
-                                        if (ch == '\n')
-                                            state = 2;
-                                        else
-                                            state = 0;
-                                        break;
-                                    case 2:
-                                        if (ch == '\r')
-                                            state = 3;
-                                        else
-                                            state = 0;
-                                        break;
-                                    case 3:
-                                        if (ch == '\n')
-                                            state = 4;
-                                        else
-                                            state = 0;
-                                        break;
-                                }
-                            }
-    
-                            read = input.read(buffer);
-                        }
-                        catch (IOException e)
-                        {
-                            // e.printStackTrace();
-                        }
-                        finally
-                        {
-                            try
-                            {
-                                x.exchange(read);
-                            }
-                            catch (InterruptedException e)
-                            {
-                                e.printStackTrace();
-                            }
+                            case 0:
+                                if (ch == '\r')
+                                    state = 1;
+                                break;
+                            case 1:
+                                if (ch == '\n')
+                                    state = 2;
+                                else
+                                    state = 0;
+                                break;
+                            case 2:
+                                if (ch == '\r')
+                                    state = 3;
+                                else
+                                    state = 0;
+                                break;
+                            case 3:
+                                if (ch == '\n')
+                                    state = 4;
+                                else
+                                    state = 0;
+                                break;
                         }
                     }
-                }.start();
-            }
-    
-            for (Exchanger<Integer> x : totals)
-            {
-                Integer read = x.exchange(-1, 10, TimeUnit.SECONDS);
-                assertEquals(-1, read.intValue());
-            }
-    
-            // We could read everything, good.
-            for (Socket socket : sockets)
-            {
-                socket.close();
-            }
-    
-            _server.stop();
+
+                    read = input.read(buffer);
+                }
+                catch (IOException e)
+                {
+                    e.printStackTrace();
+                }
+                finally
+                {
+                    try
+                    {
+                        x.exchange(read);
+                    }
+                    catch (InterruptedException e)
+                    {
+                        e.printStackTrace();
+                    }
+                }
+            }).start();
         }
-    }*/
+
+        for (Exchanger<Integer> x : totals)
+        {
+            Integer read = x.exchange(-1, 10, TimeUnit.SECONDS);
+            assertEquals(-1, read.intValue());
+        }
+
+        // We could read everything, good.
+        for (Socket socket : sockets)
+        {
+            socket.close();
+        }
+
+        _server.stop();
+    }
 }

--- a/jetty-ee9/jetty-ee9-servlets/src/test/java/org/eclipse/jetty/ee9/servlets/ThreadStarvationTest.java
+++ b/jetty-ee9/jetty-ee9-servlets/src/test/java/org/eclipse/jetty/ee9/servlets/ThreadStarvationTest.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.ee9.servlets;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -24,43 +23,48 @@ import java.nio.channels.SocketChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Exchanger;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.ee9.servlet.DefaultServlet;
 import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee9.servlet.ServletHolder;
 import org.eclipse.jetty.http.HttpHeader;
-import org.eclipse.jetty.http.HttpTester;
-import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.ManagedSelector;
 import org.eclipse.jetty.io.SocketChannelEndPoint;
-import org.eclipse.jetty.logging.StacklessLogging;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ThreadStarvationTest
@@ -75,7 +79,86 @@ public class ThreadStarvationTest
     }
 
     @Test
-    @Tag("flaky")
+    public void testReadStarvation() throws Exception
+    {
+        int maxThreads = 5;
+        int clients = maxThreads + 2;
+        QueuedThreadPool threadPool = new QueuedThreadPool(maxThreads, maxThreads);
+        threadPool.setDetailedDump(true);
+        _server = new Server(threadPool);
+
+        ServerConnector connector = new ServerConnector(_server, 1, 1);
+        _server.addConnector(connector);
+
+        ServletContextHandler context = new ServletContextHandler(_server, "/");
+        context.addServlet(new ServletHolder(new HttpServlet()
+        {
+            @Override
+            protected void doPut(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                IO.copy(req.getInputStream(), resp.getOutputStream());
+            }
+        }), "/*");
+        _server.setHandler(context);
+
+        _server.start();
+
+        ExecutorService clientExecutors = Executors.newFixedThreadPool(clients);
+
+        List<Callable<String>> clientTasks = new ArrayList<>();
+
+        for (int i = 0; i < clients; i++)
+        {
+            clientTasks.add(() ->
+            {
+                try (Socket client = new Socket("localhost", connector.getLocalPort());
+                     OutputStream out = client.getOutputStream();
+                     InputStream in = client.getInputStream())
+                {
+                    client.setSoTimeout(10000);
+
+                    String request = """
+                        PUT / HTTP/1.0\r
+                        host: localhost\r
+                        content-length: 10\r
+                        \r
+                        1""";
+
+                    // Write partial request
+                    out.write(request.getBytes(StandardCharsets.UTF_8));
+                    out.flush();
+
+                    // Finish Request
+                    Thread.sleep(1500);
+                    out.write(("234567890\r\n").getBytes(StandardCharsets.UTF_8));
+                    out.flush();
+
+                    // Read Response
+                    String response = IO.toString(in);
+                    assertEquals(-1, in.read());
+                    return response;
+                }
+            });
+        }
+
+        try
+        {
+            List<Future<String>> responses = clientExecutors.invokeAll(clientTasks, 60, TimeUnit.SECONDS);
+
+            for (Future<String> responseFut : responses)
+            {
+                String response = responseFut.get();
+                assertThat(response, containsString("200 OK"));
+                assertThat(response, containsString("1234567890"));
+            }
+        }
+        finally
+        {
+            clientExecutors.shutdownNow();
+        }
+    }
+
+    @Test
     public void testDefaultServletSuccess() throws Exception
     {
         int maxThreads = 6;
@@ -84,10 +167,10 @@ public class ThreadStarvationTest
         _server = new Server(threadPool);
 
         // Prepare a big file to download.
-        File directory = MavenTestingUtils.getTargetTestingDir();
-        Files.createDirectories(directory.toPath());
+        Path directory = MavenTestingUtils.getTargetTestingPath();
+        Files.createDirectories(directory);
         String resourceName = "resource.bin";
-        Path resourcePath = Paths.get(directory.getPath(), resourceName);
+        Path resourcePath = directory.resolve(resourceName);
         try (OutputStream output = Files.newOutputStream(resourcePath, StandardOpenOption.CREATE, StandardOpenOption.WRITE))
         {
             byte[] chunk = new byte[256 * 1024];
@@ -100,7 +183,7 @@ public class ThreadStarvationTest
             }
         }
 
-        CountDownLatch writePending = new CountDownLatch(1);
+        final CountDownLatch writePending = new CountDownLatch(1);
         ServerConnector connector = new ServerConnector(_server, 0, 1)
         {
             @Override
@@ -121,7 +204,7 @@ public class ThreadStarvationTest
         _server.addConnector(connector);
 
         ServletContextHandler context = new ServletContextHandler(_server, "/");
-        context.setResourceBase(directory.toURI().toString());
+        context.setBaseResourceAsPath(directory);
         context.addServlet(DefaultServlet.class, "/*").setAsyncSupported(false);
         _server.setHandler(context);
 
@@ -135,8 +218,8 @@ public class ThreadStarvationTest
             OutputStream output = socket.getOutputStream();
             String request =
                 "GET /" + resourceName + " HTTP/1.1\r\n" +
-                    "Host: localhost\r\n" +
-                    "\r\n";
+                "Host: localhost\r\n" +
+                "\r\n";
             output.write(request.getBytes(StandardCharsets.UTF_8));
             output.flush();
         }
@@ -144,37 +227,245 @@ public class ThreadStarvationTest
         // Wait for a thread on the servlet to block.
         assertTrue(writePending.await(5, TimeUnit.SECONDS));
 
-        ExecutorService executor = Executors.newCachedThreadPool();
-
         long expected = Files.size(resourcePath);
-        List<CompletableFuture<Integer>> totals = new ArrayList<>();
+        byte[] buffer = new byte[48 * 1024];
+        List<Exchanger<Long>> totals = new ArrayList<>();
         for (Socket socket : sockets)
         {
-            InputStream input = socket.getInputStream();
-            totals.add(CompletableFuture.supplyAsync(() ->
+            final Exchanger<Long> x = new Exchanger<>();
+            totals.add(x);
+            final InputStream input = socket.getInputStream();
+
+            new Thread(() ->
             {
+                long total = 0;
                 try
                 {
-                    HttpTester.Response response = HttpTester.parseResponse(HttpTester.from(input));
-                    if (response != null)
-                        return response.getContentBytes().length;
-                    return 0;
+                    // look for CRLFCRLF
+                    StringBuilder header = new StringBuilder();
+                    int state = 0;
+                    while (state < 4 && header.length() < 2048)
+                    {
+                        int ch = input.read();
+                        if (ch < 0)
+                            break;
+                        header.append((char)ch);
+                        switch (state)
+                        {
+                            case 0:
+                                if (ch == '\r')
+                                    state = 1;
+                                break;
+                            case 1:
+                                if (ch == '\n')
+                                    state = 2;
+                                else
+                                    state = 0;
+                                break;
+                            case 2:
+                                if (ch == '\r')
+                                    state = 3;
+                                else
+                                    state = 0;
+                                break;
+                            case 3:
+                                if (ch == '\n')
+                                    state = 4;
+                                else
+                                    state = 0;
+                                break;
+                        }
+                    }
+
+                    while (total < expected)
+                    {
+                        int read = input.read(buffer);
+                        if (read < 0)
+                            break;
+                        total += read;
+                    }
                 }
-                catch (IOException x)
+                catch (IOException e)
                 {
-                    x.printStackTrace();
-                    return -1;
+                    e.printStackTrace();
                 }
-            }, executor));
+                finally
+                {
+                    try
+                    {
+                        x.exchange(total);
+                    }
+                    catch (InterruptedException e)
+                    {
+                        e.printStackTrace();
+                    }
+                }
+            }).start();
         }
 
-        // Wait for all responses to arrive.
-        CompletableFuture.allOf(totals.toArray(new CompletableFuture[0])).get(20, TimeUnit.SECONDS);
-
-        for (CompletableFuture<Integer> total : totals)
+        for (Exchanger<Long> x : totals)
         {
-            assertFalse(total.isCompletedExceptionally());
-            assertEquals(expected, total.get().intValue());
+            Long total = x.exchange(-1L, 10000, TimeUnit.SECONDS);
+            assertEquals(expected, total.longValue());
+        }
+
+        // We could read everything, good.
+        for (Socket socket : sockets)
+        {
+            socket.close();
+        }
+    }
+
+    @Test
+    public void testFailureStarvation() throws Exception
+    {
+        int acceptors = 0;
+        int selectors = 1;
+        int maxThreads = 10;
+        final int barried = maxThreads - acceptors - selectors * 2;
+        final CyclicBarrier barrier = new CyclicBarrier(barried);
+
+        QueuedThreadPool threadPool = new QueuedThreadPool(maxThreads, maxThreads);
+        threadPool.setDetailedDump(true);
+        _server = new Server(threadPool);
+
+        ServerConnector connector = new ServerConnector(_server, acceptors, selectors)
+        {
+            @Override
+            protected SocketChannelEndPoint newEndPoint(SocketChannel channel, ManagedSelector selectSet, SelectionKey key)
+            {
+                return new SocketChannelEndPoint(channel, selectSet, key, getScheduler())
+                {
+                    @Override
+                    public boolean flush(ByteBuffer... buffers) throws IOException
+                    {
+                        super.flush(buffers[0]);
+                        throw new IOException("TEST FAILURE");
+                    }
+                };
+            }
+        };
+        connector.setIdleTimeout(Long.MAX_VALUE);
+        _server.addConnector(connector);
+
+        final AtomicInteger count = new AtomicInteger(0);
+        class TheHandler extends Handler.Abstract
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            {
+                int c = count.getAndIncrement();
+                try
+                {
+                    if (c < barried)
+                    {
+                        barrier.await(10, TimeUnit.SECONDS);
+                    }
+                }
+                catch (InterruptedException | BrokenBarrierException | TimeoutException e)
+                {
+                    throw new ServletException(e);
+                }
+
+                response.setStatus(200);
+                response.getHeaders().put(HttpHeader.CONTENT_LENGTH, 13L);
+                response.write(true, BufferUtil.toBuffer("Hello World!\n"), callback);
+                return true;
+            }
+        }
+
+        _server.setHandler(new TheHandler());
+
+        _server.start();
+
+        List<Socket> sockets = new ArrayList<>();
+        for (int i = 0; i < maxThreads * 2; ++i)
+        {
+            Socket socket = new Socket("localhost", connector.getLocalPort());
+            sockets.add(socket);
+            OutputStream output = socket.getOutputStream();
+            String request =
+                "GET / HTTP/1.1\r\n" +
+                "Host: localhost\r\n" +
+                //                    "Connection: close\r\n" +
+                "\r\n";
+            output.write(request.getBytes(StandardCharsets.UTF_8));
+            output.flush();
+        }
+
+        byte[] buffer = new byte[48 * 1024];
+        List<Exchanger<Integer>> totals = new ArrayList<>();
+        for (Socket socket : sockets)
+        {
+            final Exchanger<Integer> x = new Exchanger<>();
+            totals.add(x);
+            final InputStream input = socket.getInputStream();
+
+            new Thread(() ->
+            {
+                int read = 0;
+                try
+                {
+                    // look for CRLFCRLF
+                    StringBuilder header = new StringBuilder();
+                    int state = 0;
+                    while (state < 4 && header.length() < 2048)
+                    {
+                        int ch = input.read();
+                        if (ch < 0)
+                            break;
+                        header.append((char)ch);
+                        switch (state)
+                        {
+                            case 0:
+                                if (ch == '\r')
+                                    state = 1;
+                                break;
+                            case 1:
+                                if (ch == '\n')
+                                    state = 2;
+                                else
+                                    state = 0;
+                                break;
+                            case 2:
+                                if (ch == '\r')
+                                    state = 3;
+                                else
+                                    state = 0;
+                                break;
+                            case 3:
+                                if (ch == '\n')
+                                    state = 4;
+                                else
+                                    state = 0;
+                                break;
+                        }
+                    }
+
+                    read = input.read(buffer);
+                }
+                catch (IOException e)
+                {
+                    e.printStackTrace();
+                }
+                finally
+                {
+                    try
+                    {
+                        x.exchange(read);
+                    }
+                    catch (InterruptedException e)
+                    {
+                        e.printStackTrace();
+                    }
+                }
+            }).start();
+        }
+
+        for (Exchanger<Integer> x : totals)
+        {
+            Integer read = x.exchange(-1, 10, TimeUnit.SECONDS);
+            assertEquals(-1, read.intValue());
         }
 
         // We could read everything, good.
@@ -183,122 +474,6 @@ public class ThreadStarvationTest
             socket.close();
         }
 
-        executor.shutdown();
-
         _server.stop();
-    }
-
-    @Test
-    @Tag("flaky")
-    public void testFailureStarvation() throws Exception
-    {
-        Logger serverInternalLogger = LoggerFactory.getLogger("org.eclipse.jetty.server.internal");
-        try (StacklessLogging ignored = new StacklessLogging(serverInternalLogger))
-        {
-            int acceptors = 0;
-            int selectors = 1;
-            int maxThreads = 10;
-            int parties = maxThreads - acceptors - selectors * 2;
-            CyclicBarrier barrier = new CyclicBarrier(parties);
-
-            QueuedThreadPool threadPool = new QueuedThreadPool(maxThreads, maxThreads);
-            threadPool.setDetailedDump(true);
-            _server = new Server(threadPool);
-
-            ServerConnector connector = new ServerConnector(_server, acceptors, selectors)
-            {
-                @Override
-                protected SocketChannelEndPoint newEndPoint(SocketChannel channel, ManagedSelector selectSet, SelectionKey key)
-                {
-                    return new SocketChannelEndPoint(channel, selectSet, key, getScheduler())
-                    {
-                        @Override
-                        public boolean flush(ByteBuffer... buffers) throws IOException
-                        {
-                            // Write only the headers, then throw.
-                            super.flush(buffers[0]);
-                            throw new IOException("thrown by test");
-                        }
-                    };
-                }
-            };
-            connector.setIdleTimeout(Long.MAX_VALUE);
-            _server.addConnector(connector);
-
-            AtomicInteger count = new AtomicInteger(0);
-            _server.setHandler(new Handler.Abstract()
-            {
-                @Override
-                public boolean handle(Request request, Response response, Callback callback) throws Exception
-                {
-                    int c = count.getAndIncrement();
-                    if (c < parties)
-                        barrier.await(10, TimeUnit.SECONDS);
-                    response.setStatus(200);
-                    response.getHeaders().put(HttpHeader.CONTENT_LENGTH, 13);
-                    Content.Sink.write(response, true, "Hello World!\n", callback);
-                    return true;
-                }
-            });
-
-            _server.start();
-
-            List<Socket> sockets = new ArrayList<>();
-            for (int i = 0; i < maxThreads * 2; ++i)
-            {
-                Socket socket = new Socket("localhost", connector.getLocalPort());
-                sockets.add(socket);
-                OutputStream output = socket.getOutputStream();
-                String request = """
-                    GET / HTTP/1.1\r
-                    Host: localhost\r
-                    \r
-                    """;
-                output.write(request.getBytes(StandardCharsets.UTF_8));
-                output.flush();
-            }
-
-            ExecutorService executor = Executors.newCachedThreadPool();
-
-            List<CompletableFuture<Integer>> totals = new ArrayList<>();
-            for (Socket socket : sockets)
-            {
-                InputStream input = socket.getInputStream();
-                totals.add(CompletableFuture.supplyAsync(() ->
-                {
-                    try
-                    {
-                        HttpTester.Response response = HttpTester.parseResponse(HttpTester.from(input));
-                        if (response != null)
-                            return response.getContentBytes().length;
-                        return input.read();
-                    }
-                    catch (Exception x)
-                    {
-                        x.printStackTrace();
-                        return -1;
-                    }
-                }, executor));
-            }
-
-            // Wait for all responses to arrive.
-            CompletableFuture.allOf(totals.toArray(new CompletableFuture[0])).get(20, TimeUnit.SECONDS);
-
-            for (CompletableFuture<Integer> total : totals)
-            {
-                assertFalse(total.isCompletedExceptionally());
-                assertEquals(-1, total.get().intValue());
-            }
-
-            // We could read everything, good.
-            for (Socket socket : sockets)
-            {
-                socket.close();
-            }
-
-            executor.shutdown();
-
-            _server.stop();
-        }
     }
 }


### PR DESCRIPTION
Alternative to #12395
The main difference is assuming that the `Runnable` passed to `Content.Source.demand(Runnable)` is non-blocking unless explicitly declared so. This leaves most of the application code using lambdas and method references unchanged.

Deprecated usages of `CompletableFuture` APIs in `Content.Source`.