### PR TITLE
Issue #12403 - verify XML PublicID behaviors.

### DIFF
--- a/documentation/jetty/modules/operations-guide/pages/protocols/index.adoc
+++ b/documentation/jetty/modules/operations-guide/pages/protocols/index.adoc
@@ -616,7 +616,7 @@ Use the following file as example, copy it as `$JETTY_BASE/webapps/wordpress.xml
 [,xml,options=nowrap]
 ----
 <?xml version="1.0"  encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Mort Bay Consulting//DTD Configure//EN" "https://jetty.org/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 <Configure class="org.eclipse.jetty.server.handler.ContextHandler">
 
   <New id="root" class="java.lang.String">

--- a/jetty-core/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
+++ b/jetty-core/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
@@ -52,6 +52,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.xml.XMLConstants;
+import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
 import org.eclipse.jetty.util.ConcurrentPool;
@@ -2085,11 +2086,8 @@ public class XmlConfiguration
         }
 
         @Override
-        public void setValidating(boolean validating)
+        protected void configure(SAXParser saxParser)
         {
-            // Initialize the SAXParser and generic XmlParser behaviors.
-            super.setValidating(validating);
-
             try
             {
                 XMLReader xmlReader = getSAXParser().getXMLReader();

--- a/jetty-core/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlParser.java
+++ b/jetty-core/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlParser.java
@@ -112,7 +112,7 @@ public class XmlParser
         return SAXParserFactory.newInstance();
     }
 
-    protected void setFeature(SAXParserFactory factory, String name, boolean value)
+    protected static void setFeature(SAXParserFactory factory, String name, boolean value)
     {
         try
         {
@@ -124,7 +124,7 @@ public class XmlParser
         }
     }
 
-    protected void setFeature(XMLReader xmlReader, String name, boolean value)
+    protected static void setFeature(XMLReader xmlReader, String name, boolean value)
     {
         try
         {

--- a/jetty-core/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlParser.java
+++ b/jetty-core/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlParser.java
@@ -69,6 +69,7 @@ public class XmlParser
     private Object _xpaths;
     private String _dtd;
     private List<EntityResolver> _entityResolvers = new ArrayList<>();
+    private SAXParserFactory factory;
 
     /**
      * Construct XmlParser
@@ -112,6 +113,16 @@ public class XmlParser
         return SAXParserFactory.newInstance();
     }
 
+    protected SAXParser newSAXParser() throws ParserConfigurationException, SAXException
+    {
+        return factory.newSAXParser();
+    }
+
+    protected void configure(SAXParser saxParser)
+    {
+        /* override to configure sax parser at the right time */
+    }
+
     protected static void setFeature(SAXParserFactory factory, String name, boolean value)
     {
         try
@@ -140,9 +151,9 @@ public class XmlParser
     {
         try
         {
-            SAXParserFactory factory = newSAXParserFactory();
+            factory = newSAXParserFactory();
             factory.setValidating(validating);
-            _parser = factory.newSAXParser();
+            _parser = newSAXParser();
 
             try
             {
@@ -174,6 +185,10 @@ public class XmlParser
         {
             LOG.warn("Unable to set validating on XML Parser", e);
             throw new Error(e.toString());
+        }
+        finally
+        {
+            configure(_parser);
         }
     }
 

--- a/jetty-core/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlParser.java
+++ b/jetty-core/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlParser.java
@@ -31,6 +31,7 @@ import javax.xml.catalog.Catalog;
 import javax.xml.catalog.CatalogFeatures;
 import javax.xml.catalog.CatalogManager;
 import javax.xml.catalog.CatalogResolver;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
@@ -43,6 +44,8 @@ import org.xml.sax.ContentHandler;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
 import org.xml.sax.SAXParseException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
@@ -107,6 +110,30 @@ public class XmlParser
     protected SAXParserFactory newSAXParserFactory()
     {
         return SAXParserFactory.newInstance();
+    }
+
+    protected void setFeature(SAXParserFactory factory, String name, boolean value)
+    {
+        try
+        {
+            factory.setFeature(name, value);
+        }
+        catch (SAXNotSupportedException | SAXNotRecognizedException | ParserConfigurationException e)
+        {
+            LOG.warn("Unable to setFeature({}, {})", name, value, e);
+        }
+    }
+
+    protected void setFeature(XMLReader xmlReader, String name, boolean value)
+    {
+        try
+        {
+            xmlReader.setFeature(name, value);
+        }
+        catch (SAXNotSupportedException | SAXNotRecognizedException e)
+        {
+            LOG.warn("Unable to setFeature({}, {})", name, value, e);
+        }
     }
 
     public void setValidating(boolean validating)


### PR DESCRIPTION
* The XmlConfiguration instance should not use an XML parser from the classloader. As that XML parser can be broken when it comes to XML entity resolution behaviors. (We always want local entity resolution, never external) Switching to SAXParserFactory.newDefaultInstance() ensures this behavior that we want/need.
* More unit tests for behavior with and without XML PublicID's in the mix.