### PR TITLE
Add extra error logging for WebSocket client tests in DistributionTests

### DIFF
--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -479,7 +479,7 @@ public class DistributionTests extends AbstractJettyHomeTest
                 startHttpClient(ssl);
                 URI serverUri = URI.create(scheme + "://localhost:" + port + "/test");
                 ContentResponse response = client.GET(serverUri);
-                assertEquals(HttpStatus.OK_200, response.getStatus());
+                assertEquals(HttpStatus.OK_200, response.getStatus(), response.getContentAsString());
                 String content = response.getContentAsString();
                 assertThat(content, containsString("WebSocketEcho: success"));
                 assertThat(content, containsString("ConnectTimeout: 4999"));
@@ -528,7 +528,7 @@ public class DistributionTests extends AbstractJettyHomeTest
                 startHttpClient(scheme.equals("https"));
                 URI serverUri = URI.create(scheme + "://localhost:" + port + "/test");
                 ContentResponse response = client.GET(serverUri);
-                assertEquals(HttpStatus.OK_200, response.getStatus());
+                assertEquals(HttpStatus.OK_200, response.getStatus(), response.getContentAsString());
                 String content = response.getContentAsString();
                 assertThat(content, containsString("WebSocketEcho: success"));
                 assertThat(content, containsString("ConnectTimeout: 4999"));


### PR DESCRIPTION
I have seen these tests failing in CI but I cant reproduce locally, so this will hopefully provide more information for next time they fail.