### PR TITLE
Issue #12397 - Add more default excludes to GzipHandler.

### DIFF
--- a/jetty-core/jetty-http/src/main/resources/org/eclipse/jetty/http/mime.properties
+++ b/jetty-core/jetty-http/src/main/resources/org/eclipse/jetty/http/mime.properties
@@ -200,3 +200,4 @@ xyz=chemical/x-xyz
 xz=application/x-xz
 z=application/compress
 zip=application/zip
+zst=application/zstd

--- a/jetty-core/jetty-server/src/main/java/module-info.java
+++ b/jetty-core/jetty-server/src/main/java/module-info.java
@@ -18,7 +18,6 @@ module org.eclipse.jetty.server
 
     // Only required if using JMX.
     requires static org.eclipse.jetty.jmx;
-    requires java.desktop;
 
     exports org.eclipse.jetty.server;
     exports org.eclipse.jetty.server.handler;

--- a/jetty-core/jetty-server/src/main/java/module-info.java
+++ b/jetty-core/jetty-server/src/main/java/module-info.java
@@ -18,6 +18,7 @@ module org.eclipse.jetty.server
 
     // Only required if using JMX.
     requires static org.eclipse.jetty.jmx;
+    requires java.desktop;
 
     exports org.eclipse.jetty.server;
     exports org.eclipse.jetty.server.handler;

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
@@ -85,13 +85,27 @@ public class GzipHandler extends Handler.Wrapper implements GzipFactory
                 type.startsWith("video/"))
                 _mimeTypes.exclude(type);
         }
+
         _mimeTypes.exclude("application/compress");
+        _paths.exclude("*.z");
         _mimeTypes.exclude("application/zip");
+        _paths.exclude("*.zip");
+        _mimeTypes.exclude("application/x-gtar");
+        _paths.exclude("*.tgz");
+        _mimeTypes.exclude("application/java-archive");
+        _paths.exclude("*.jar");
         _mimeTypes.exclude("application/gzip");
+        _paths.exclude("*.gz", "*.gzip");
         _mimeTypes.exclude("application/x-bzip2");
+        _paths.exclude("*.bz2", "*.bzip", "*.bz");
         _mimeTypes.exclude("application/brotli");
+        _paths.exclude("*.br", "*.brotli");
         _mimeTypes.exclude("application/x-xz");
+        _paths.exclude("*.xz");
         _mimeTypes.exclude("application/x-rar-compressed");
+        _paths.exclude("*.rar");
+        _mimeTypes.exclude("application/zstd");
+        _paths.exclude("*.zst", "*.zstd");
 
         // It is possible to use SSE with GzipHandler but you will need to set _synFlush to true which will impact performance.
         _mimeTypes.exclude("text/event-stream");


### PR DESCRIPTION
+ Exclude more compressed mime-types
+ Exclude more compressed path extensions
+ Add missing compressed file types to mime.properties

Fixes: #12397