### PR TITLE
Start of a testcases for ByteBufferPool contract

### DIFF
--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ByteBufferPoolTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ByteBufferPoolTest.java
@@ -1,0 +1,50 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.io;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests of various {@link ByteBufferPool} implementations to ensure
+ * that they satisfy the {@link ByteBufferPool} contracts.
+ */
+public class ByteBufferPoolTest
+{
+    public static Stream<ByteBufferPool> implementations()
+    {
+        return Stream.of(
+            new ArrayByteBufferPool(),
+            new ArrayByteBufferPool.Tracking()
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("implementations")
+    public void testResetOrder(ByteBufferPool pool)
+    {
+        RetainableByteBuffer.Mutable retainableByteBuffer = pool.acquire(2048, true);
+        ByteBuffer buffer = retainableByteBuffer.getByteBuffer();
+        Assertions.assertEquals(ByteOrder.BIG_ENDIAN, buffer.order());
+        buffer.order(ByteOrder.LITTLE_ENDIAN);
+        Assertions.assertEquals(ByteOrder.LITTLE_ENDIAN, buffer.order());
+        retainableByteBuffer.release();
+        Assertions.assertEquals(ByteOrder.BIG_ENDIAN, buffer.order());
+    }
+}


### PR DESCRIPTION
As pointed out at https://github.com/jetty/jetty.project/pull/12075#discussion_r1791615754 it seems we lack tests for the ByteBuffer.order() reset of the ByteBufferPool implementations.

This is just a simple testcase that tests that, but it likely needs more implementations to test.