### PR TITLE
Issue #12430 remove erroneous comment from PrivilegedThreadFactory

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/PrivilegedThreadFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/PrivilegedThreadFactory.java
@@ -33,10 +33,6 @@ import org.eclipse.jetty.util.security.SecurityUtils;
  * For this reason, {@code Thread}s must be created in a privileged
  * action, which restricts the calling context to just the caller
  * frame, not all the frames in the stack.</p>
- * <p>Since Java 18 and the removal of the Java security manager
- * and related classes by JEP 411, {@code Thread}s do not retain
- * the calling context, so there is no need to create them in a
- * privileged action.</p>
  */
 class PrivilegedThreadFactory
 {


### PR DESCRIPTION
Closes #12430 

The comment in `PrivilegedThreadFactory` implies that the class is no longer needed due to deprecation of  `SecurityManager` however even jdk23 exhibits the problem for which `PrivilegedThreadFactory` is the solution. I've updated the comment.