### PR TITLE
Issue #12429 - case-insensitive headers for websocket

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -934,17 +933,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
      */
     static Map<String, List<String>> asMap(HttpFields fields)
     {
-        Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-        for (HttpField f : fields)
-        {
-            if (!headers.containsKey(f.getName()))
-            {
-                HttpHeader header = f.getHeader();
-                List<String> values = header == null ? fields.getValuesList(f.getName()) : fields.getValuesList(header);
-                headers.put(f.getName(), Collections.unmodifiableList(values));
-            }
-        }
-        return Collections.unmodifiableMap(headers);
+        return new HttpFieldsMap.Immutable(fields);
     }
 
     /**
@@ -953,7 +942,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
      */
     static Map<String, List<String>> asMutableMap(HttpFields.Mutable fields)
     {
-        return new HttpFieldsMap(fields);
+        return new HttpFieldsMap.Mutable(fields);
     }
 
     /**

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -928,21 +928,18 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
     }
 
     /**
+     * <p>Wraps an instance of {@link HttpFields} as a {@link Map}.</p>
+     * <p>If the provided {@link HttpFields} is an instance of {@link HttpFields.Mutable} then changes to the
+     * {@link Map} will be reflected in the underlying {@link HttpFields}.
+     * Otherwise, any modification to the {@link Map} will throw {@link UnsupportedOperationException}.</p>
      * @param fields the {@link HttpFields} to convert to a {@link Map}.
-     * @return an unmodifiable {@link Map} representing the contents of the {@link HttpFields}.
+     * @return an {@link Map} representing the contents of the {@link HttpFields}.
      */
     static Map<String, List<String>> asMap(HttpFields fields)
     {
-        return new HttpFieldsMap.Immutable(fields);
-    }
-
-    /**
-     * @param fields the {@link HttpFields} to convert to a {@link Map}.
-     * @return a {@link Map} where changes to the contents will be reflected in the supplied {@link HttpFields}.
-     */
-    static Map<String, List<String>> asMutableMap(HttpFields.Mutable fields)
-    {
-        return new HttpFieldsMap.Mutable(fields);
+        return (fields instanceof HttpFields.Mutable mutable)
+            ? new HttpFieldsMap.Mutable(mutable)
+            : new HttpFieldsMap.Immutable(fields);
     }
 
     /**

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -928,6 +928,10 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
         return size;
     }
 
+    /**
+     * @param fields the {@link HttpFields} to convert to a {@link Map}.
+     * @return an unmodifiable {@link Map} representing the contents of the {@link HttpFields}.
+     */
     static Map<String, List<String>> asMap(HttpFields fields)
     {
         Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
@@ -936,10 +940,20 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
             if (!headers.containsKey(f.getName()))
             {
                 HttpHeader header = f.getHeader();
-                headers.put(f.getName(), header == null ? fields.getValuesList(f.getName()) : fields.getValuesList(header));
+                List<String> values = header == null ? fields.getValuesList(f.getName()) : fields.getValuesList(header);
+                headers.put(f.getName(), Collections.unmodifiableList(values));
             }
         }
-        return headers;
+        return Collections.unmodifiableMap(headers);
+    }
+
+    /**
+     * @param fields the {@link HttpFields} to convert to a {@link Map}.
+     * @return a {@link Map} where changes to the contents will be reflected in the supplied {@link HttpFields}.
+     */
+    static Map<String, List<String>> asMap(HttpFields.Mutable fields)
+    {
+        return new HttpFieldsMap(fields);
     }
 
     /**

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -951,7 +951,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
      * @param fields the {@link HttpFields} to convert to a {@link Map}.
      * @return a {@link Map} where changes to the contents will be reflected in the supplied {@link HttpFields}.
      */
-    static Map<String, List<String>> asMap(HttpFields.Mutable fields)
+    static Map<String, List<String>> asMutableMap(HttpFields.Mutable fields)
     {
         return new HttpFieldsMap(fields);
     }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -931,7 +931,14 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
     static Map<String, List<String>> asMap(HttpFields fields)
     {
         Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-        fields.getFieldNamesCollection().forEach(name -> headers.putIfAbsent(name, fields.getValuesList(name)));
+        for (HttpField f : fields)
+        {
+            if (!headers.containsKey(f.getName()))
+            {
+                HttpHeader header = f.getHeader();
+                headers.put(f.getName(), header == null ? fields.getValuesList(f.getName()) : fields.getValuesList(header));
+            }
+        }
         return headers;
     }
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -925,6 +926,13 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
             size++;
         }
         return size;
+    }
+
+    static Map<String, List<String>> asMap(HttpFields fields)
+    {
+        Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        fields.getFieldNamesCollection().forEach(name -> headers.putIfAbsent(name, fields.getValuesList(name)));
+        return headers;
     }
 
     /**

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFieldsMap.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFieldsMap.java
@@ -22,6 +22,10 @@ import java.util.Set;
 
 import org.eclipse.jetty.util.StringUtil;
 
+/**
+ * A {@link java.util.Map} which is backed by an instance of {@link HttpFields.Mutable}, such that any changes to the
+ * {@link java.util.Map} are reflected in the underlying instance of {@link HttpFields.Mutable}.
+ */
 class HttpFieldsMap extends AbstractMap<String, List<String>>
 {
     private final HttpFields.Mutable httpFields;

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFieldsMap.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFieldsMap.java
@@ -1,0 +1,151 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.http;
+
+import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import org.eclipse.jetty.util.StringUtil;
+
+class HttpFieldsMap extends AbstractMap<String, List<String>>
+{
+    private final HttpFields.Mutable httpFields;
+
+    public HttpFieldsMap(HttpFields.Mutable httpFields)
+    {
+        this.httpFields = httpFields;
+    }
+
+    @Override
+    public List<String> get(Object key)
+    {
+        if (key instanceof String s)
+            return httpFields.getValuesList(s);
+        return null;
+    }
+
+    @Override
+    public List<String> put(String key, List<String> value)
+    {
+        List<String> oldValue = get(key);
+        httpFields.put(key, value);
+        return oldValue;
+    }
+
+    @Override
+    public List<String> remove(Object key)
+    {
+        if (key instanceof String s)
+        {
+            List<String> oldValue = get(s);
+            httpFields.remove(s);
+            return oldValue;
+        }
+        return null;
+    }
+
+    @Override
+    public Set<Entry<String, List<String>>> entrySet()
+    {
+        return new AbstractSet<>()
+        {
+            @Override
+            public Iterator<Entry<String, List<String>>> iterator()
+            {
+                return new Iterator<>()
+                {
+                    private final Iterator<String> iterator = httpFields.getFieldNamesCollection().iterator();
+                    private String name = null;
+
+                    @Override
+                    public boolean hasNext()
+                    {
+                        return iterator.hasNext();
+                    }
+
+                    @Override
+                    public Entry<String, List<String>> next()
+                    {
+                        name = iterator.next();
+                        return new HttpFieldsEntry(name);
+                    }
+
+                    @Override
+                    public void remove()
+                    {
+                        if (name != null)
+                        {
+                            HttpFieldsMap.this.remove(name);
+                            name = null;
+                        }
+                    }
+                };
+            }
+
+            @Override
+            public int size()
+            {
+                return httpFields.getFieldNamesCollection().size();
+            }
+        };
+    }
+
+    private class HttpFieldsEntry implements Entry<String, List<String>>
+    {
+        private final String _name;
+
+        public HttpFieldsEntry(String name)
+        {
+            _name = name;
+        }
+
+        @Override
+        public String getKey()
+        {
+            return _name;
+        }
+
+        @Override
+        public List<String> getValue()
+        {
+            return HttpFieldsMap.this.get(_name);
+        }
+
+        @Override
+        public List<String> setValue(List<String> value)
+        {
+            return HttpFieldsMap.this.put(_name, value);
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o)
+                return true;
+            if (o instanceof HttpFieldsEntry other)
+                return StringUtil.asciiEqualsIgnoreCase(_name, other.getKey());
+            return false;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(StringUtil.asciiToLowerCase(_name));
+        }
+    }
+}

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFieldsMap.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFieldsMap.java
@@ -23,90 +23,172 @@ import java.util.Set;
 import org.eclipse.jetty.util.StringUtil;
 
 /**
- * A {@link java.util.Map} which is backed by an instance of {@link HttpFields.Mutable}, such that any changes to the
- * {@link java.util.Map} are reflected in the underlying instance of {@link HttpFields.Mutable}.
+ * <p>A {@link java.util.Map} which is backed by an instance of {@link HttpFields.Mutable}.</p>
+ * @see HttpFieldsMap.Mutable
+ * @see HttpFieldsMap.Immutable
  */
-class HttpFieldsMap extends AbstractMap<String, List<String>>
+abstract class HttpFieldsMap extends AbstractMap<String, List<String>>
 {
-    private final HttpFields.Mutable httpFields;
-
-    public HttpFieldsMap(HttpFields.Mutable httpFields)
+    /**
+     * <p>A {@link java.util.Map} which is backed by an instance of {@link HttpFields.Mutable}.</p>
+     * <p>Any changes to the {@link java.util.Map} will be reflected in the underlying instance of {@link HttpFields.Mutable}.</p>
+     */
+    public static class Mutable extends HttpFieldsMap
     {
-        this.httpFields = httpFields;
-    }
+        private final HttpFields.Mutable httpFields;
 
-    @Override
-    public List<String> get(Object key)
-    {
-        if (key instanceof String s)
-            return httpFields.getValuesList(s);
-        return null;
-    }
-
-    @Override
-    public List<String> put(String key, List<String> value)
-    {
-        List<String> oldValue = get(key);
-        httpFields.put(key, value);
-        return oldValue;
-    }
-
-    @Override
-    public List<String> remove(Object key)
-    {
-        if (key instanceof String s)
+        public Mutable(HttpFields.Mutable httpFields)
         {
-            List<String> oldValue = get(s);
-            httpFields.remove(s);
+            this.httpFields = httpFields;
+        }
+
+        @Override
+        public List<String> get(Object key)
+        {
+            if (key instanceof String s)
+                return httpFields.getValuesList(s);
+            return null;
+        }
+
+        @Override
+        public List<String> put(String key, List<String> value)
+        {
+            List<String> oldValue = get(key);
+            httpFields.put(key, value);
             return oldValue;
         }
-        return null;
+
+        @Override
+        public List<String> remove(Object key)
+        {
+            if (key instanceof String s)
+            {
+                List<String> oldValue = get(s);
+                httpFields.remove(s);
+                return oldValue;
+            }
+            return null;
+        }
+
+        @Override
+        public Set<Entry<String, List<String>>> entrySet()
+        {
+            return new AbstractSet<>()
+            {
+                @Override
+                public Iterator<Entry<String, List<String>>> iterator()
+                {
+                    return new Iterator<>()
+                    {
+                        private final Iterator<String> iterator = httpFields.getFieldNamesCollection().iterator();
+                        private String name = null;
+
+                        @Override
+                        public boolean hasNext()
+                        {
+                            return iterator.hasNext();
+                        }
+
+                        @Override
+                        public Entry<String, List<String>> next()
+                        {
+                            name = iterator.next();
+                            return new HttpFieldsEntry(name);
+                        }
+
+                        @Override
+                        public void remove()
+                        {
+                            if (name != null)
+                            {
+                                Mutable.this.remove(name);
+                                name = null;
+                            }
+                        }
+                    };
+                }
+
+                @Override
+                public int size()
+                {
+                    return httpFields.getFieldNamesCollection().size();
+                }
+            };
+        }
     }
 
-    @Override
-    public Set<Entry<String, List<String>>> entrySet()
+    /**
+     * <p>A {@link java.util.Map} which is backed by an instance of {@link HttpFields.Mutable}.</p>
+     * <p>Any attempt to modify the map will throw {@link UnsupportedOperationException}.</p>
+     */
+    public static class Immutable extends HttpFieldsMap
     {
-        return new AbstractSet<>()
+        private final HttpFields httpFields;
+
+        public Immutable(HttpFields httpFields)
         {
-            @Override
-            public Iterator<Entry<String, List<String>>> iterator()
+            this.httpFields = httpFields;
+        }
+
+        @Override
+        public List<String> get(Object key)
+        {
+            if (key instanceof String s)
+                return httpFields.getValuesList(s);
+            return null;
+        }
+
+        @Override
+        public List<String> put(String key, List<String> value)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<String> remove(Object key)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Set<Entry<String, List<String>>> entrySet()
+        {
+            return new AbstractSet<>()
             {
-                return new Iterator<>()
+                @Override
+                public Iterator<Entry<String, List<String>>> iterator()
                 {
-                    private final Iterator<String> iterator = httpFields.getFieldNamesCollection().iterator();
-                    private String name = null;
-
-                    @Override
-                    public boolean hasNext()
+                    return new Iterator<>()
                     {
-                        return iterator.hasNext();
-                    }
+                        private final Iterator<String> iterator = httpFields.getFieldNamesCollection().iterator();
 
-                    @Override
-                    public Entry<String, List<String>> next()
-                    {
-                        name = iterator.next();
-                        return new HttpFieldsEntry(name);
-                    }
-
-                    @Override
-                    public void remove()
-                    {
-                        if (name != null)
+                        @Override
+                        public boolean hasNext()
                         {
-                            HttpFieldsMap.this.remove(name);
-                            name = null;
+                            return iterator.hasNext();
                         }
-                    }
-                };
-            }
 
-            @Override
-            public int size()
-            {
-                return httpFields.getFieldNamesCollection().size();
-            }
-        };
+                        @Override
+                        public Entry<String, List<String>> next()
+                        {
+                            return new HttpFieldsEntry(iterator.next());
+                        }
+
+                        @Override
+                        public void remove()
+                        {
+                            throw new UnsupportedOperationException();
+                        }
+                    };
+                }
+
+                @Override
+                public int size()
+                {
+                    return httpFields.getFieldNamesCollection().size();
+                }
+            };
+        }
     }
 
     private class HttpFieldsEntry implements Entry<String, List<String>>

--- a/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/CreatorNegotiator.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/CreatorNegotiator.java
@@ -15,7 +15,9 @@ package org.eclipse.jetty.websocket.core.server.internal;
 
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.Context;
+import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.websocket.core.FrameHandler;
 import org.eclipse.jetty.websocket.core.server.FrameHandlerFactory;
@@ -59,7 +61,7 @@ public class CreatorNegotiator extends WebSocketNegotiator.AbstractNegotiator
         }
         catch (Throwable t)
         {
-            callback.failed(t);
+            Response.writeError(request, response, callback, HttpStatus.INTERNAL_SERVER_ERROR_500, t.getMessage());
             return null;
         }
 
@@ -68,7 +70,7 @@ public class CreatorNegotiator extends WebSocketNegotiator.AbstractNegotiator
 
         FrameHandler frameHandler = factory.newFrameHandler(websocketPojo, request, response);
         if (frameHandler == null)
-            callback.failed(new IllegalStateException("No WebSocket FrameHandler was created"));
+            Response.writeError(request, response, callback, HttpStatus.INTERNAL_SERVER_ERROR_500, "No WebSocket FrameHandler was created");
         return frameHandler;
     }
 

--- a/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/CreatorNegotiator.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/CreatorNegotiator.java
@@ -15,9 +15,7 @@ package org.eclipse.jetty.websocket.core.server.internal;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.Context;
-import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.websocket.core.FrameHandler;
 import org.eclipse.jetty.websocket.core.server.FrameHandlerFactory;
@@ -61,7 +59,7 @@ public class CreatorNegotiator extends WebSocketNegotiator.AbstractNegotiator
         }
         catch (Throwable t)
         {
-            Response.writeError(request, response, callback, HttpStatus.INTERNAL_SERVER_ERROR_500, t.getMessage());
+            callback.failed(t);
             return null;
         }
 
@@ -70,7 +68,7 @@ public class CreatorNegotiator extends WebSocketNegotiator.AbstractNegotiator
 
         FrameHandler frameHandler = factory.newFrameHandler(websocketPojo, request, response);
         if (frameHandler == null)
-            Response.writeError(request, response, callback, HttpStatus.INTERNAL_SERVER_ERROR_500, "No WebSocket FrameHandler was created");
+            callback.failed(new IllegalStateException("No WebSocket FrameHandler was created"));
         return frameHandler;
     }
 

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/internal/DelegatedJettyClientUpgradeRequest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/internal/DelegatedJettyClientUpgradeRequest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.io.EndPoint;
@@ -78,7 +79,7 @@ public class DelegatedJettyClientUpgradeRequest implements UpgradeRequest
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        return null;
+        return Collections.unmodifiableMap(HttpFields.asMap(delegate.getHeaders()));
     }
 
     @Override

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/internal/DelegatedJettyClientUpgradeRequest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/internal/DelegatedJettyClientUpgradeRequest.java
@@ -79,7 +79,7 @@ public class DelegatedJettyClientUpgradeRequest implements UpgradeRequest
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        return Collections.unmodifiableMap(HttpFields.asMap(delegate.getHeaders()));
+        return HttpFields.asMap(delegate.getHeaders());
     }
 
     @Override

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/internal/DelegatedJettyClientUpgradeResponse.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/internal/DelegatedJettyClientUpgradeResponse.java
@@ -65,7 +65,7 @@ public class DelegatedJettyClientUpgradeResponse implements UpgradeResponse
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        return Collections.unmodifiableMap(HttpFields.asMap(delegate.getHeaders()));
+        return HttpFields.asMap(delegate.getHeaders());
     }
 
     @Override

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/internal/DelegatedJettyClientUpgradeResponse.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/internal/DelegatedJettyClientUpgradeResponse.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.websocket.client.internal;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -21,6 +20,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.eclipse.jetty.client.Response;
+import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.websocket.api.ExtensionConfig;
 import org.eclipse.jetty.websocket.api.UpgradeResponse;
@@ -65,9 +65,7 @@ public class DelegatedJettyClientUpgradeResponse implements UpgradeResponse
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        Map<String, List<String>> headers = getHeaderNames().stream()
-            .collect(Collectors.toMap((name) -> name, (name) -> new ArrayList<>(getHeaders(name))));
-        return Collections.unmodifiableMap(headers);
+        return Collections.unmodifiableMap(HttpFields.asMap(delegate.getHeaders()));
     }
 
     @Override

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/ServerWebSocketContainer.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/ServerWebSocketContainer.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 
-import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.pathmap.PathSpec;
 import org.eclipse.jetty.server.Context;
 import org.eclipse.jetty.server.Handler;
@@ -365,8 +364,8 @@ public class ServerWebSocketContainer extends ContainerLifeCycle implements WebS
             catch (Throwable x)
             {
                 if (LOG.isDebugEnabled())
-                    LOG.debug("Could not create WebSocket endpoint");
-                Response.writeError(rq, rs, cb, HttpStatus.INTERNAL_SERVER_ERROR_500, "Could not create WebSocket endpoint");
+                    LOG.debug("Could not create WebSocket endpoint", x);
+                cb.failed(x);
                 return null;
             }
         };

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/ServerWebSocketContainer.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/ServerWebSocketContainer.java
@@ -364,7 +364,8 @@ public class ServerWebSocketContainer extends ContainerLifeCycle implements WebS
             }
             catch (Throwable x)
             {
-                LOG.warn("Could not create WebSocket endpoint");
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Could not create WebSocket endpoint");
                 Response.writeError(rq, rs, cb, HttpStatus.INTERNAL_SERVER_ERROR_500, "Could not create WebSocket endpoint");
                 return null;
             }

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/ServerWebSocketContainer.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/ServerWebSocketContainer.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.pathmap.PathSpec;
 import org.eclipse.jetty.server.Context;
 import org.eclipse.jetty.server.Handler;
@@ -359,14 +360,12 @@ public class ServerWebSocketContainer extends ContainerLifeCycle implements WebS
         {
             try
             {
-                Object webSocket = creator.createWebSocket(new ServerUpgradeRequestDelegate(rq), new ServerUpgradeResponseDelegate(rq, rs), cb);
-                if (webSocket == null)
-                    cb.succeeded();
-                return webSocket;
+                return creator.createWebSocket(new ServerUpgradeRequestDelegate(rq), new ServerUpgradeResponseDelegate(rq, rs), cb);
             }
             catch (Throwable x)
             {
-                cb.failed(x);
+                LOG.warn("Could not create WebSocket endpoint");
+                Response.writeError(rq, rs, cb, HttpStatus.INTERNAL_SERVER_ERROR_500, "Could not create WebSocket endpoint");
                 return null;
             }
         };

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/internal/UpgradeRequestDelegate.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/internal/UpgradeRequestDelegate.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpScheme;
@@ -73,14 +72,7 @@ class UpgradeRequestDelegate implements UpgradeRequest
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        Map<String, List<String>> result = new LinkedHashMap<>();
-        HttpFields headers = request.getHeaders();
-        for (HttpField header : headers)
-        {
-            String name = header.getName();
-            result.put(name, headers.getValuesList(name));
-        }
-        return result;
+        return HttpFields.asMap(request.getHeaders());
     }
 
     @Override

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/internal/UpgradeRequestDelegate.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/internal/UpgradeRequestDelegate.java
@@ -16,7 +16,6 @@ package org.eclipse.jetty.websocket.server.internal;
 import java.net.HttpCookie;
 import java.net.URI;
 import java.security.Principal;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -73,7 +72,7 @@ class UpgradeRequestDelegate implements UpgradeRequest
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        return Collections.unmodifiableMap(HttpFields.asMap(request.getHeaders()));
+        return HttpFields.asMap(request.getHeaders());
     }
 
     @Override

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/internal/UpgradeRequestDelegate.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/internal/UpgradeRequestDelegate.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.websocket.server.internal;
 import java.net.HttpCookie;
 import java.net.URI;
 import java.security.Principal;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -72,7 +73,7 @@ class UpgradeRequestDelegate implements UpgradeRequest
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        return HttpFields.asMap(request.getHeaders());
+        return Collections.unmodifiableMap(HttpFields.asMap(request.getHeaders()));
     }
 
     @Override

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/internal/UpgradeResponseDelegate.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/internal/UpgradeResponseDelegate.java
@@ -13,13 +13,11 @@
 
 package org.eclipse.jetty.websocket.server.internal;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.websocket.api.ExtensionConfig;
 import org.eclipse.jetty.websocket.api.UpgradeResponse;
@@ -64,14 +62,7 @@ class UpgradeResponseDelegate implements UpgradeResponse
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        Map<String, List<String>> result = new LinkedHashMap<>();
-        HttpFields.Mutable headers = response.getHeaders();
-        for (HttpField header : headers)
-        {
-            String name = header.getName();
-            result.put(name, headers.getValuesList(name));
-        }
-        return result;
+        return HttpFields.asMap(response.getHeaders());
     }
 
     @Override

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/internal/UpgradeResponseDelegate.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/internal/UpgradeResponseDelegate.java
@@ -63,7 +63,7 @@ class UpgradeResponseDelegate implements UpgradeResponse
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        return Collections.unmodifiableMap(HttpFields.asMutableMap(response.getHeaders()));
+        return Collections.unmodifiableMap(HttpFields.asMap(response.getHeaders()));
     }
 
     @Override

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/internal/UpgradeResponseDelegate.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/internal/UpgradeResponseDelegate.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.websocket.server.internal;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -63,7 +62,7 @@ class UpgradeResponseDelegate implements UpgradeResponse
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        return Collections.unmodifiableMap(HttpFields.asMap(response.getHeaders()));
+        return HttpFields.asMap(response.getHeaders());
     }
 
     @Override

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/internal/UpgradeResponseDelegate.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/internal/UpgradeResponseDelegate.java
@@ -63,7 +63,7 @@ class UpgradeResponseDelegate implements UpgradeResponse
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        return Collections.unmodifiableMap(HttpFields.asMap(response.getHeaders()));
+        return Collections.unmodifiableMap(HttpFields.asMutableMap(response.getHeaders()));
     }
 
     @Override

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/internal/UpgradeResponseDelegate.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/internal/UpgradeResponseDelegate.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.websocket.server.internal;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -62,7 +63,7 @@ class UpgradeResponseDelegate implements UpgradeResponse
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        return HttpFields.asMap(response.getHeaders());
+        return Collections.unmodifiableMap(HttpFields.asMap(response.getHeaders()));
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-client/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/client/internal/JsrUpgradeListener.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-client/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/client/internal/JsrUpgradeListener.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.ee10.websocket.jakarta.client.internal;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -39,16 +38,11 @@ public class JsrUpgradeListener implements UpgradeListener
         if (configurator == null)
             return;
 
-        // Give headers to configurator
-        HttpFields fields = request.getHeaders();
-        Map<String, List<String>> originalHeaders = HttpFields.asMap(fields);
-        configurator.beforeRequest(originalHeaders);
-
-        // Reset headers on HttpRequest per configurator
         request.headers(headers ->
         {
-            headers.clear();
-            originalHeaders.forEach(headers::put);
+            // Give headers to configurator
+            Map<String, List<String>> headersMap = HttpFields.asMap(headers);
+            configurator.beforeRequest(headersMap);
         });
     }
 
@@ -58,7 +52,7 @@ public class JsrUpgradeListener implements UpgradeListener
         if (configurator == null)
             return;
 
-        HandshakeResponse handshakeResponse = () -> Collections.unmodifiableMap(HttpFields.asMap(response.getHeaders()));
+        HandshakeResponse handshakeResponse = () -> HttpFields.asMap(response.getHeaders());
         configurator.afterResponse(handshakeResponse);
     }
 }

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-client/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/client/internal/JsrUpgradeListener.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-client/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/client/internal/JsrUpgradeListener.java
@@ -13,9 +13,6 @@
 
 package org.eclipse.jetty.ee10.websocket.jakarta.client.internal;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -41,16 +38,9 @@ public class JsrUpgradeListener implements UpgradeListener
         if (configurator == null)
             return;
 
-        HttpFields fields = request.getHeaders();
-        Map<String, List<String>> originalHeaders = new HashMap<>();
-        fields.forEach(field ->
-        {
-            originalHeaders.putIfAbsent(field.getName(), new ArrayList<>());
-            List<String> values = originalHeaders.get(field.getName());
-            Collections.addAll(values, field.getValues());
-        });
-
         // Give headers to configurator
+        HttpFields fields = request.getHeaders();
+        Map<String, List<String>> originalHeaders = HttpFields.asMap(fields);
         configurator.beforeRequest(originalHeaders);
 
         // Reset headers on HttpRequest per configurator
@@ -67,18 +57,7 @@ public class JsrUpgradeListener implements UpgradeListener
         if (configurator == null)
             return;
 
-        HandshakeResponse handshakeResponse = () ->
-        {
-            Map<String, List<String>> ret = new HashMap<>();
-            response.getHeaders().forEach(field ->
-            {
-                ret.putIfAbsent(field.getName(), new ArrayList<>());
-                List<String> values = ret.get(field.getName());
-                Collections.addAll(values, field.getValues());
-            });
-            return ret;
-        };
-
+        HandshakeResponse handshakeResponse = () -> HttpFields.asMap(response.getHeaders());
         configurator.afterResponse(handshakeResponse);
     }
 }

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-client/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/client/internal/JsrUpgradeListener.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-client/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/client/internal/JsrUpgradeListener.java
@@ -41,7 +41,7 @@ public class JsrUpgradeListener implements UpgradeListener
         request.headers(headers ->
         {
             // Give headers to configurator
-            Map<String, List<String>> headersMap = HttpFields.asMutableMap(headers);
+            Map<String, List<String>> headersMap = HttpFields.asMap(headers);
             configurator.beforeRequest(headersMap);
         });
     }

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-client/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/client/internal/JsrUpgradeListener.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-client/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/client/internal/JsrUpgradeListener.java
@@ -41,7 +41,7 @@ public class JsrUpgradeListener implements UpgradeListener
         request.headers(headers ->
         {
             // Give headers to configurator
-            Map<String, List<String>> headersMap = HttpFields.asMap(headers);
+            Map<String, List<String>> headersMap = HttpFields.asMutableMap(headers);
             configurator.beforeRequest(headersMap);
         });
     }

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-client/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/client/internal/JsrUpgradeListener.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-client/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/client/internal/JsrUpgradeListener.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.ee10.websocket.jakarta.client.internal;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -57,7 +58,7 @@ public class JsrUpgradeListener implements UpgradeListener
         if (configurator == null)
             return;
 
-        HandshakeResponse handshakeResponse = () -> HttpFields.asMap(response.getHeaders());
+        HandshakeResponse handshakeResponse = () -> Collections.unmodifiableMap(HttpFields.asMap(response.getHeaders()));
         configurator.afterResponse(handshakeResponse);
     }
 }

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/server/JakartaWebSocketServerContainer.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/server/JakartaWebSocketServerContainer.java
@@ -322,9 +322,9 @@ public class JakartaWebSocketServerContainer extends JakartaWebSocketClientConta
             servletContextRequest.setAttribute(WebSocketConstants.WEBSOCKET_WRAPPED_RESPONSE_ATTRIBUTE, response);
 
             if (handshaker.upgradeRequest(negotiator, servletContextRequest, servletContextResponse, callback, components, defaultCustomizer))
-            {
                 callback.block();
-            }
+            else
+                throw new IllegalStateException("Invalid WebSocket Upgrade Request");
         }
         finally
         {

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/server/internal/JakartaWebSocketCreator.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/server/internal/JakartaWebSocketCreator.java
@@ -166,7 +166,8 @@ public class JakartaWebSocketCreator implements WebSocketCreator
         }
         catch (Throwable x)
         {
-            LOG.warn("Unable to create websocket: {}", config.getEndpointClass().getName(), x);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Unable to create websocket: {}", config.getEndpointClass().getName(), x);
             Response.writeError(request, response, callback, HttpStatus.INTERNAL_SERVER_ERROR_500, "Unable to create WebSocket");
             return null;
         }

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/server/internal/JakartaWebSocketCreator.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/server/internal/JakartaWebSocketCreator.java
@@ -169,7 +169,7 @@ public class JakartaWebSocketCreator implements WebSocketCreator
         catch (Throwable x)
         {
             LOG.warn("Unable to create websocket: {}", config.getEndpointClass().getName(), x);
-            callback.failed(x);
+            Response.writeError(request, response, callback, HttpStatus.INTERNAL_SERVER_ERROR_500, "Unable to create WebSocket");
             return null;
         }
     }

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/server/internal/JakartaWebSocketCreator.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/server/internal/JakartaWebSocketCreator.java
@@ -156,8 +156,6 @@ public class JakartaWebSocketCreator implements WebSocketCreator
 
         // [JSR] Step 5: Call modifyHandshake
         configurator.modifyHandshake(config, jsrHandshakeRequest, jsrHandshakeResponse);
-        // Set modified headers Map back into response properly
-        jsrHandshakeResponse.setHeaders(jsrHandshakeResponse.getHeaders());
 
         try
         {

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/server/internal/JakartaWebSocketCreator.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/server/internal/JakartaWebSocketCreator.java
@@ -168,7 +168,7 @@ public class JakartaWebSocketCreator implements WebSocketCreator
         {
             if (LOG.isDebugEnabled())
                 LOG.debug("Unable to create websocket: {}", config.getEndpointClass().getName(), x);
-            Response.writeError(request, response, callback, HttpStatus.INTERNAL_SERVER_ERROR_500, "Unable to create WebSocket");
+            callback.failed(x);
             return null;
         }
     }

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/server/internal/JsrHandshakeRequest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/server/internal/JsrHandshakeRequest.java
@@ -15,7 +15,6 @@ package org.eclipse.jetty.ee10.websocket.jakarta.server.internal;
 
 import java.net.URI;
 import java.security.Principal;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +45,7 @@ public class JsrHandshakeRequest implements HandshakeRequest
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        return Collections.unmodifiableMap(HttpFields.asMap(delegate.getHeaders()));
+        return HttpFields.asMap(delegate.getHeaders());
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/server/internal/JsrHandshakeRequest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/server/internal/JsrHandshakeRequest.java
@@ -15,16 +15,15 @@ package org.eclipse.jetty.ee10.websocket.jakarta.server.internal;
 
 import java.net.URI;
 import java.security.Principal;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.websocket.server.HandshakeRequest;
 import org.eclipse.jetty.ee10.websocket.jakarta.server.JakartaWebSocketServerContainer;
+import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.pathmap.PathSpec;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.util.Fields;
@@ -47,9 +46,7 @@ public class JsrHandshakeRequest implements HandshakeRequest
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        Map<String, List<String>> headers = delegate.getHeaders().getFieldNamesCollection().stream()
-            .collect(Collectors.toMap((name) -> name, (name) -> new ArrayList<>(delegate.getHeaders().getValuesList(name))));
-        return Collections.unmodifiableMap(headers);
+        return Collections.unmodifiableMap(HttpFields.asMap(delegate.getHeaders()));
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/server/internal/JsrHandshakeResponse.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/server/internal/JsrHandshakeResponse.java
@@ -22,23 +22,16 @@ import org.eclipse.jetty.websocket.core.server.ServerUpgradeResponse;
 
 public class JsrHandshakeResponse implements HandshakeResponse
 {
-    private final ServerUpgradeResponse delegate;
     private final Map<String, List<String>> headers;
 
     public JsrHandshakeResponse(ServerUpgradeResponse resp)
     {
-        this.delegate = resp;
-        this.headers = HttpFields.asMap(delegate.getHeaders());
+        this.headers = HttpFields.asMap(resp.getHeaders());
     }
 
     @Override
     public Map<String, List<String>> getHeaders()
     {
         return headers;
-    }
-
-    public void setHeaders(Map<String, List<String>> headers)
-    {
-        headers.forEach((key, values) -> delegate.getHeaders().put(key, values));
     }
 }

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/server/internal/JsrHandshakeResponse.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/server/internal/JsrHandshakeResponse.java
@@ -26,7 +26,7 @@ public class JsrHandshakeResponse implements HandshakeResponse
 
     public JsrHandshakeResponse(ServerUpgradeResponse resp)
     {
-        this.headers = HttpFields.asMap(resp.getHeaders());
+        this.headers = HttpFields.asMutableMap(resp.getHeaders());
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/server/internal/JsrHandshakeResponse.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/server/internal/JsrHandshakeResponse.java
@@ -26,7 +26,7 @@ public class JsrHandshakeResponse implements HandshakeResponse
 
     public JsrHandshakeResponse(ServerUpgradeResponse resp)
     {
-        this.headers = HttpFields.asMutableMap(resp.getHeaders());
+        this.headers = HttpFields.asMap(resp.getHeaders());
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/server/internal/JsrHandshakeResponse.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/server/internal/JsrHandshakeResponse.java
@@ -13,12 +13,11 @@
 
 package org.eclipse.jetty.ee10.websocket.jakarta.server.internal;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import jakarta.websocket.HandshakeResponse;
+import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.websocket.core.server.ServerUpgradeResponse;
 
 public class JsrHandshakeResponse implements HandshakeResponse
@@ -29,8 +28,7 @@ public class JsrHandshakeResponse implements HandshakeResponse
     public JsrHandshakeResponse(ServerUpgradeResponse resp)
     {
         this.delegate = resp;
-        this.headers = delegate.getHeaders().getFieldNamesCollection().stream()
-            .collect(Collectors.toMap((name) -> name, (name) -> new ArrayList<>(delegate.getHeaders().getValuesList(name))));
+        this.headers = HttpFields.asMap(delegate.getHeaders());
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/UpgradeHeadersTest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/UpgradeHeadersTest.java
@@ -1,0 +1,138 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee10.websocket.jakarta.tests;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.websocket.ClientEndpointConfig;
+import jakarta.websocket.Endpoint;
+import jakarta.websocket.EndpointConfig;
+import jakarta.websocket.HandshakeResponse;
+import jakarta.websocket.Session;
+import jakarta.websocket.server.HandshakeRequest;
+import jakarta.websocket.server.ServerEndpointConfig;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.websocket.jakarta.client.JakartaWebSocketClientContainer;
+import org.eclipse.jetty.ee10.websocket.jakarta.server.config.JakartaWebSocketServletContainerInitializer;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class UpgradeHeadersTest
+{
+    private Server _server;
+    private JakartaWebSocketClientContainer _client;
+    private ServerConnector _connector;
+
+    public static class MyEndpoint extends Endpoint
+    {
+        @Override
+        public void onOpen(Session session, EndpointConfig config)
+        {
+        }
+    }
+
+    public void start(ServerEndpointConfig.Configurator configurator) throws Exception
+    {
+        _server = new Server();
+        _connector = new ServerConnector(_server);
+        _server.addConnector(_connector);
+
+        ServletContextHandler contextHandler = new ServletContextHandler();
+        _server.setHandler(contextHandler);
+        JakartaWebSocketServletContainerInitializer.configure(contextHandler, (context, container) ->
+        {
+            container.addEndpoint(ServerEndpointConfig.Builder
+                .create(MyEndpoint.class, "/")
+                .configurator(configurator)
+                .build());
+        });
+
+        _server.start();
+        _client = new JakartaWebSocketClientContainer();
+        _client.start();
+    }
+
+    @AfterEach
+    public void after() throws Exception
+    {
+        _client.stop();
+        _server.stop();
+    }
+
+    @Test
+    public void testCaseInsensitiveUpgradeHeaders() throws Exception
+    {
+        ClientEndpointConfig.Configurator configurator = new ClientEndpointConfig.Configurator()
+        {
+            @Override
+            public void beforeRequest(Map<String, List<String>> headers)
+            {
+                // Verify that existing headers can be accessed in a case-insensitive way.
+                if (headers.get("cOnnEcTiOn") == null)
+                    throw new IllegalStateException("No Connection Header on client Request");
+                headers.put("sentHeader", List.of("value123"));
+            }
+
+            @Override
+            public void afterResponse(HandshakeResponse hr)
+            {
+                if (hr.getHeaders().get("MyHeAdEr") == null)
+                    throw new IllegalStateException("No custom Header on HandshakeResponse");
+                if (hr.getHeaders().get("cOnnEcTiOn") == null)
+                    throw new IllegalStateException("No Connection Header on HandshakeRequest");
+            }
+        };
+
+        start(new ServerEndpointConfig.Configurator()
+        {
+            @Override
+            public void modifyHandshake(ServerEndpointConfig sec, HandshakeRequest request, HandshakeResponse response)
+            {
+                // Verify that existing headers can be accessed in a case-insensitive way.
+                if (request.getHeaders().get("cOnnEcTiOn") == null)
+                    throw new IllegalStateException("No Connection Header on HandshakeRequest");
+                if (response.getHeaders().get("sErVeR") == null)
+                    throw new IllegalStateException("No Server Header on HandshakeResponse");
+
+                // Verify custom header sent from client.
+                if (request.getHeaders().get("SeNtHeadEr") == null)
+                    throw new IllegalStateException("No sent Header on HandshakeResponse");
+
+                // Add custom response header.
+                response.getHeaders().put("myHeader", List.of("foobar"));
+                if (response.getHeaders().get("MyHeAdEr") == null)
+                    throw new IllegalStateException("No custom Header on HandshakeResponse");
+
+                super.modifyHandshake(sec, request, response);
+            }
+        });
+
+        WSEndpointTracker clientEndpoint = new WSEndpointTracker(){};
+        ClientEndpointConfig clientConfig = ClientEndpointConfig.Builder.create().configurator(configurator).build();
+        URI uri = URI.create("ws://localhost:" + _connector.getLocalPort());
+
+        // If any of the above throw it would fail to upgrade to websocket.
+        Session session = _client.connectToServer(clientEndpoint, clientConfig, uri);
+        assertTrue(clientEndpoint.openLatch.await(5, TimeUnit.SECONDS));
+        session.close();
+        assertTrue(clientEndpoint.closeLatch.await(5, TimeUnit.SECONDS));
+    }
+}

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/client/AnnotatedClientEndpointTest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/client/AnnotatedClientEndpointTest.java
@@ -21,7 +21,6 @@ import jakarta.websocket.ClientEndpoint;
 import jakarta.websocket.ClientEndpointConfig;
 import jakarta.websocket.ContainerProvider;
 import jakarta.websocket.EndpointConfig;
-import jakarta.websocket.HandshakeResponse;
 import jakarta.websocket.OnMessage;
 import jakarta.websocket.OnOpen;
 import jakarta.websocket.Session;
@@ -74,11 +73,6 @@ public class AnnotatedClientEndpointTest
 
     public static class AnnotatedEndpointConfigurator extends ClientEndpointConfig.Configurator
     {
-        @Override
-        public void afterResponse(HandshakeResponse hr)
-        {
-            super.afterResponse(hr);
-        }
     }
 
     private static CoreServer server;

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/client/AnnotatedClientEndpointTest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/client/AnnotatedClientEndpointTest.java
@@ -15,7 +15,6 @@ package org.eclipse.jetty.ee10.websocket.jakarta.tests.client;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Collections;
 import java.util.Date;
 
 import jakarta.websocket.ClientEndpoint;
@@ -78,7 +77,6 @@ public class AnnotatedClientEndpointTest
         @Override
         public void afterResponse(HandshakeResponse hr)
         {
-            hr.getHeaders().put("X-Test", Collections.singletonList("Extra"));
             super.afterResponse(hr);
         }
     }

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/JettyWebSocketServerContainer.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/JettyWebSocketServerContainer.java
@@ -32,9 +32,7 @@ import org.eclipse.jetty.ee10.websocket.server.internal.DelegatedServerUpgradeRe
 import org.eclipse.jetty.ee10.websocket.server.internal.DelegatedServerUpgradeResponse;
 import org.eclipse.jetty.ee10.websocket.server.internal.JettyServerFrameHandlerFactory;
 import org.eclipse.jetty.ee10.websocket.servlet.WebSocketUpgradeFilter;
-import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.pathmap.PathSpec;
-import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Blocker;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
 import org.eclipse.jetty.util.component.Dumpable;
@@ -162,7 +160,7 @@ public class JettyWebSocketServerContainer extends ContainerLifeCycle implements
             {
                 if (LOG.isDebugEnabled())
                     LOG.debug("Could not create WebSocket endpoint", t);
-                Response.writeError(req, resp, cb, HttpStatus.INTERNAL_SERVER_ERROR_500, "Could not create WebSocket endpoint");
+                cb.failed(t);
                 return null;
             }
         };
@@ -215,7 +213,7 @@ public class JettyWebSocketServerContainer extends ContainerLifeCycle implements
             {
                 if (LOG.isDebugEnabled())
                     LOG.debug("Could not create WebSocket endpoint", t);
-                Response.writeError(req, resp, cb, HttpStatus.INTERNAL_SERVER_ERROR_500, "Could not create WebSocket endpoint");
+                cb.failed(t);
                 return null;
             }
         };

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/JettyWebSocketServerContainer.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/JettyWebSocketServerContainer.java
@@ -160,7 +160,8 @@ public class JettyWebSocketServerContainer extends ContainerLifeCycle implements
             }
             catch (Throwable t)
             {
-                LOG.warn("Could not create WebSocket endpoint", t);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Could not create WebSocket endpoint", t);
                 Response.writeError(req, resp, cb, HttpStatus.INTERNAL_SERVER_ERROR_500, "Could not create WebSocket endpoint");
                 return null;
             }
@@ -212,7 +213,8 @@ public class JettyWebSocketServerContainer extends ContainerLifeCycle implements
             }
             catch (Throwable t)
             {
-                LOG.warn("Could not create WebSocket endpoint", t);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Could not create WebSocket endpoint", t);
                 Response.writeError(req, resp, cb, HttpStatus.INTERNAL_SERVER_ERROR_500, "Could not create WebSocket endpoint");
                 return null;
             }

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/JettyWebSocketServlet.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/JettyWebSocketServlet.java
@@ -303,7 +303,8 @@ public abstract class JettyWebSocketServlet extends HttpServlet
             try
             {
                 Object webSocket = creator.createWebSocket(request, response);
-                callback.succeeded();
+                if (webSocket == null)
+                    callback.succeeded();
                 return webSocket;
             }
             catch (Throwable t)

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/internal/DelegatedServerUpgradeRequest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/internal/DelegatedServerUpgradeRequest.java
@@ -18,7 +18,6 @@ import java.net.SocketAddress;
 import java.net.URI;
 import java.security.Principal;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -33,6 +32,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import org.eclipse.jetty.ee10.websocket.server.JettyServerUpgradeRequest;
 import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.websocket.api.ExtensionConfig;
@@ -121,9 +121,7 @@ public class DelegatedServerUpgradeRequest implements JettyServerUpgradeRequest
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        Map<String, List<String>> headers = upgradeRequest.getHeaders().getFieldNamesCollection().stream()
-            .collect(Collectors.toMap((name) -> name, (name) -> new ArrayList<>(getHeaders(name))));
-        return Collections.unmodifiableMap(headers);
+        return Collections.unmodifiableMap(HttpFields.asMap(upgradeRequest.getHeaders()));
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/internal/DelegatedServerUpgradeRequest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/internal/DelegatedServerUpgradeRequest.java
@@ -121,7 +121,7 @@ public class DelegatedServerUpgradeRequest implements JettyServerUpgradeRequest
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        return Collections.unmodifiableMap(HttpFields.asMap(upgradeRequest.getHeaders()));
+        return HttpFields.asMap(upgradeRequest.getHeaders());
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/internal/DelegatedServerUpgradeResponse.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/internal/DelegatedServerUpgradeResponse.java
@@ -50,7 +50,7 @@ public class DelegatedServerUpgradeResponse implements JettyServerUpgradeRespons
         ServletContextResponse servletContextResponse = Response.as(response, ServletContextResponse.class);
         this.httpServletResponse = (HttpServletResponse)servletContextResponse.getRequest()
             .getAttribute(WebSocketConstants.WEBSOCKET_WRAPPED_RESPONSE_ATTRIBUTE);
-        headers = HttpFields.asMap(upgradeResponse.getHeaders());
+        headers = HttpFields.asMutableMap(upgradeResponse.getHeaders());
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/internal/DelegatedServerUpgradeResponse.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/internal/DelegatedServerUpgradeResponse.java
@@ -14,7 +14,6 @@
 package org.eclipse.jetty.ee10.websocket.server.internal;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -24,6 +23,7 @@ import java.util.stream.Collectors;
 import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.ee10.servlet.ServletContextResponse;
 import org.eclipse.jetty.ee10.websocket.server.JettyServerUpgradeResponse;
+import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.websocket.api.ExtensionConfig;
@@ -91,9 +91,7 @@ public class DelegatedServerUpgradeResponse implements JettyServerUpgradeRespons
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        Map<String, List<String>> headers = getHeaderNames().stream()
-            .collect(Collectors.toMap((name) -> name, (name) -> new ArrayList<>(getHeaders(name))));
-        return Collections.unmodifiableMap(headers);
+        return Collections.unmodifiableMap(HttpFields.asMap(upgradeResponse.getHeaders()));
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/internal/DelegatedServerUpgradeResponse.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/internal/DelegatedServerUpgradeResponse.java
@@ -35,13 +35,22 @@ public class DelegatedServerUpgradeResponse implements JettyServerUpgradeRespons
 {
     private final ServerUpgradeResponse upgradeResponse;
     private final HttpServletResponse httpServletResponse;
+    private final boolean isUpgraded;
+    private final Map<String, List<String>> headers;
 
     public DelegatedServerUpgradeResponse(ServerUpgradeResponse response)
     {
+        this(response, false);
+    }
+
+    public DelegatedServerUpgradeResponse(ServerUpgradeResponse response, boolean isUpgraded)
+    {
         upgradeResponse = response;
+        this.isUpgraded = isUpgraded;
         ServletContextResponse servletContextResponse = Response.as(response, ServletContextResponse.class);
         this.httpServletResponse = (HttpServletResponse)servletContextResponse.getRequest()
             .getAttribute(WebSocketConstants.WEBSOCKET_WRAPPED_RESPONSE_ATTRIBUTE);
+        headers = HttpFields.asMap(upgradeResponse.getHeaders());
     }
 
     @Override
@@ -55,13 +64,13 @@ public class DelegatedServerUpgradeResponse implements JettyServerUpgradeRespons
     @Override
     public void setHeader(String name, String value)
     {
-        upgradeResponse.getHeaders().put(name, value);
+        headers.put(name, List.of(value));
     }
 
     @Override
     public void setHeader(String name, List<String> values)
     {
-        upgradeResponse.getHeaders().put(name, values);
+        headers.put(name, values);
     }
 
     @Override
@@ -91,7 +100,7 @@ public class DelegatedServerUpgradeResponse implements JettyServerUpgradeRespons
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        return Collections.unmodifiableMap(HttpFields.asMap(upgradeResponse.getHeaders()));
+        return isUpgraded ? Collections.unmodifiableMap(headers) : headers;
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/internal/DelegatedServerUpgradeResponse.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/internal/DelegatedServerUpgradeResponse.java
@@ -50,7 +50,7 @@ public class DelegatedServerUpgradeResponse implements JettyServerUpgradeRespons
         ServletContextResponse servletContextResponse = Response.as(response, ServletContextResponse.class);
         this.httpServletResponse = (HttpServletResponse)servletContextResponse.getRequest()
             .getAttribute(WebSocketConstants.WEBSOCKET_WRAPPED_RESPONSE_ATTRIBUTE);
-        headers = HttpFields.asMutableMap(upgradeResponse.getHeaders());
+        headers = HttpFields.asMap(upgradeResponse.getHeaders());
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/internal/JettyServerFrameHandlerFactory.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/internal/JettyServerFrameHandlerFactory.java
@@ -41,7 +41,7 @@ public class JettyServerFrameHandlerFactory extends JettyWebSocketFrameHandlerFa
     {
         JettyWebSocketFrameHandler frameHandler = super.newJettyFrameHandler(websocketPojo);
         frameHandler.setUpgradeRequest(new DelegatedServerUpgradeRequest(upgradeRequest));
-        frameHandler.setUpgradeResponse(new DelegatedServerUpgradeResponse(upgradeResponse));
+        frameHandler.setUpgradeResponse(new DelegatedServerUpgradeResponse(upgradeResponse, true));
         return frameHandler;
     }
 }

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee10/websocket/tests/UpgradeHeadersTest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee10/websocket/tests/UpgradeHeadersTest.java
@@ -1,0 +1,124 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee10.websocket.tests;
+
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.client.Request;
+import org.eclipse.jetty.client.Response;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.websocket.server.JettyWebSocketCreator;
+import org.eclipse.jetty.ee10.websocket.server.config.JettyWebSocketServletContainerInitializer;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
+import org.eclipse.jetty.websocket.client.JettyUpgradeListener;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class UpgradeHeadersTest
+{
+    private Server _server;
+    private WebSocketClient _client;
+    private ServerConnector _connector;
+
+    public void start(JettyWebSocketCreator creator) throws Exception
+    {
+        _server = new Server();
+        _connector = new ServerConnector(_server);
+        _server.addConnector(_connector);
+
+        ServletContextHandler contextHandler = new ServletContextHandler();
+        JettyWebSocketServletContainerInitializer.configure(contextHandler, (servletContext, container) ->
+            container.addMapping("/", creator));
+        _server.setHandler(contextHandler);
+
+        _server.start();
+        _client = new WebSocketClient();
+        _client.start();
+    }
+
+    @AfterEach
+    public void after() throws Exception
+    {
+        _client.stop();
+        _server.stop();
+    }
+
+    @Test
+    public void testCaseInsensitiveUpgradeHeaders() throws Exception
+    {
+        start((request, response) ->
+        {
+            // Verify that existing headers can be accessed in a case-insensitive way.
+            if (request.getHeaders().get("cOnnEcTiOn") == null)
+                throw new IllegalStateException("No Connection Header on HandshakeRequest");
+            if (response.getHeaders().get("sErVeR") == null)
+                throw new IllegalStateException("No Server Header on HandshakeResponse");
+
+            // Verify custom header sent from client.
+            if (request.getHeaders().get("SeNtHeadEr") == null)
+                throw new IllegalStateException("No sent Header on HandshakeResponse");
+
+            // Add custom response header.
+            response.getHeaders().put("myHeader", List.of("foobar"));
+            if (response.getHeaders().get("MyHeAdEr") == null)
+                throw new IllegalStateException("No custom Header on HandshakeResponse");
+
+            return new EchoSocket();
+        });
+
+        EventSocket clientEndpoint = new EventSocket();
+        URI uri = URI.create("ws://localhost:" + _connector.getLocalPort());
+
+        ClientUpgradeRequest clientUpgradeRequest = new ClientUpgradeRequest();
+        clientUpgradeRequest.getHeaders().put("sentHeader", List.of("value123"));
+        if (clientUpgradeRequest.getHeaders().get("SenTHeaDer") == null)
+            throw new IllegalStateException("No custom Header on ClientUpgradeRequest");
+
+        JettyUpgradeListener upgradeListener = new JettyUpgradeListener()
+        {
+            @Override
+            public void onHandshakeRequest(Request request)
+            {
+                // Verify that existing headers can be accessed in a case-insensitive way.
+                if (request.getHeaders().get("cOnnEcTiOn") == null)
+                    throw new IllegalStateException("No Connection Header on client Request");
+                if (request.getHeaders().get("SenTHeaDer") == null)
+                    throw new IllegalStateException("No custom Header on ClientUpgradeRequest");
+            }
+
+            @Override
+            public void onHandshakeResponse(Request request, Response response)
+            {
+                if (response.getHeaders().get("MyHeAdEr") == null)
+                    throw new IllegalStateException("No custom Header on HandshakeResponse");
+                if (response.getHeaders().get("cOnnEcTiOn") == null)
+                    throw new IllegalStateException("No Connection Header on HandshakeRequest");
+            }
+        };
+
+        // If any of the above throw it would fail to upgrade to websocket.
+        assertNotNull(_client.connect(clientEndpoint, uri, clientUpgradeRequest, upgradeListener).get(5, TimeUnit.SECONDS));
+        assertTrue(clientEndpoint.openLatch.await(5, TimeUnit.SECONDS));
+        clientEndpoint.session.close();
+        assertTrue(clientEndpoint.closeLatch.await(5, TimeUnit.SECONDS));
+    }
+}

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-client/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/client/internal/JsrUpgradeListener.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-client/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/client/internal/JsrUpgradeListener.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.ee9.websocket.jakarta.client.internal;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -57,7 +58,7 @@ public class JsrUpgradeListener implements UpgradeListener
         if (configurator == null)
             return;
 
-        HandshakeResponse handshakeResponse = () -> HttpFields.asMap(response.getHeaders());
+        HandshakeResponse handshakeResponse = () -> Collections.unmodifiableMap(HttpFields.asMap(response.getHeaders()));
         configurator.afterResponse(handshakeResponse);
     }
 }

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-client/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/client/internal/JsrUpgradeListener.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-client/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/client/internal/JsrUpgradeListener.java
@@ -13,9 +13,6 @@
 
 package org.eclipse.jetty.ee9.websocket.jakarta.client.internal;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -41,16 +38,9 @@ public class JsrUpgradeListener implements UpgradeListener
         if (configurator == null)
             return;
 
-        HttpFields fields = request.getHeaders();
-        Map<String, List<String>> originalHeaders = new HashMap<>();
-        fields.forEach(field ->
-        {
-            originalHeaders.putIfAbsent(field.getName(), new ArrayList<>());
-            List<String> values = originalHeaders.get(field.getName());
-            Collections.addAll(values, field.getValues());
-        });
-
         // Give headers to configurator
+        HttpFields fields = request.getHeaders();
+        Map<String, List<String>> originalHeaders = HttpFields.asMap(fields);
         configurator.beforeRequest(originalHeaders);
 
         // Reset headers on HttpRequest per configurator
@@ -67,18 +57,7 @@ public class JsrUpgradeListener implements UpgradeListener
         if (configurator == null)
             return;
 
-        HandshakeResponse handshakeResponse = () ->
-        {
-            Map<String, List<String>> ret = new HashMap<>();
-            response.getHeaders().forEach(field ->
-            {
-                ret.putIfAbsent(field.getName(), new ArrayList<>());
-                List<String> values = ret.get(field.getName());
-                Collections.addAll(values, field.getValues());
-            });
-            return ret;
-        };
-
+        HandshakeResponse handshakeResponse = () -> HttpFields.asMap(response.getHeaders());
         configurator.afterResponse(handshakeResponse);
     }
 }

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-client/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/client/internal/JsrUpgradeListener.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-client/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/client/internal/JsrUpgradeListener.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.ee9.websocket.jakarta.client.internal;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -39,16 +38,11 @@ public class JsrUpgradeListener implements UpgradeListener
         if (configurator == null)
             return;
 
-        // Give headers to configurator
-        HttpFields fields = request.getHeaders();
-        Map<String, List<String>> originalHeaders = HttpFields.asMap(fields);
-        configurator.beforeRequest(originalHeaders);
-
-        // Reset headers on HttpRequest per configurator
         request.headers(headers ->
         {
-            headers.clear();
-            originalHeaders.forEach(headers::put);
+            // Give headers to configurator
+            Map<String, List<String>> headersMap = HttpFields.asMap(headers);
+            configurator.beforeRequest(headersMap);
         });
     }
 
@@ -58,7 +52,7 @@ public class JsrUpgradeListener implements UpgradeListener
         if (configurator == null)
             return;
 
-        HandshakeResponse handshakeResponse = () -> Collections.unmodifiableMap(HttpFields.asMap(response.getHeaders()));
+        HandshakeResponse handshakeResponse = () -> HttpFields.asMap(response.getHeaders());
         configurator.afterResponse(handshakeResponse);
     }
 }

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-client/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/client/internal/JsrUpgradeListener.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-client/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/client/internal/JsrUpgradeListener.java
@@ -41,7 +41,7 @@ public class JsrUpgradeListener implements UpgradeListener
         request.headers(headers ->
         {
             // Give headers to configurator
-            Map<String, List<String>> headersMap = HttpFields.asMutableMap(headers);
+            Map<String, List<String>> headersMap = HttpFields.asMap(headers);
             configurator.beforeRequest(headersMap);
         });
     }

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-client/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/client/internal/JsrUpgradeListener.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-client/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/client/internal/JsrUpgradeListener.java
@@ -41,7 +41,7 @@ public class JsrUpgradeListener implements UpgradeListener
         request.headers(headers ->
         {
             // Give headers to configurator
-            Map<String, List<String>> headersMap = HttpFields.asMap(headers);
+            Map<String, List<String>> headersMap = HttpFields.asMutableMap(headers);
             configurator.beforeRequest(headersMap);
         });
     }

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/server/JakartaWebSocketServerContainer.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/server/JakartaWebSocketServerContainer.java
@@ -323,9 +323,9 @@ public class JakartaWebSocketServerContainer extends JakartaWebSocketClientConta
             baseRequest.setAttribute(WebSocketConstants.WEBSOCKET_WRAPPED_RESPONSE_ATTRIBUTE, response);
 
             if (handshaker.upgradeRequest(negotiator, baseRequest, baseResponse, callback, components, defaultCustomizer))
-            {
                 callback.block();
-            }
+            else
+                throw new IllegalStateException("Invalid WebSocket Upgrade Request");
         }
         finally
         {

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/server/internal/JakartaWebSocketCreator.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/server/internal/JakartaWebSocketCreator.java
@@ -166,7 +166,8 @@ public class JakartaWebSocketCreator implements WebSocketCreator
         }
         catch (Throwable x)
         {
-            LOG.warn("Unable to create WebSocket: {}", config.getEndpointClass().getName(), x);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Unable to create WebSocket: {}", config.getEndpointClass().getName(), x);
             Response.writeError(request, response, callback, HttpStatus.INTERNAL_SERVER_ERROR_500, "Unable to create WebSocket");
             return null;
         }

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/server/internal/JakartaWebSocketCreator.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/server/internal/JakartaWebSocketCreator.java
@@ -168,8 +168,8 @@ public class JakartaWebSocketCreator implements WebSocketCreator
         }
         catch (Throwable x)
         {
-            LOG.warn("Unable to create websocket: {}", config.getEndpointClass().getName(), x);
-            callback.failed(x);
+            LOG.warn("Unable to create WebSocket: {}", config.getEndpointClass().getName(), x);
+            Response.writeError(request, response, callback, HttpStatus.INTERNAL_SERVER_ERROR_500, "Unable to create WebSocket");
             return null;
         }
     }

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/server/internal/JakartaWebSocketCreator.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/server/internal/JakartaWebSocketCreator.java
@@ -168,7 +168,7 @@ public class JakartaWebSocketCreator implements WebSocketCreator
         {
             if (LOG.isDebugEnabled())
                 LOG.debug("Unable to create WebSocket: {}", config.getEndpointClass().getName(), x);
-            Response.writeError(request, response, callback, HttpStatus.INTERNAL_SERVER_ERROR_500, "Unable to create WebSocket");
+            callback.failed(x);
             return null;
         }
     }

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/server/internal/JakartaWebSocketCreator.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/server/internal/JakartaWebSocketCreator.java
@@ -156,8 +156,6 @@ public class JakartaWebSocketCreator implements WebSocketCreator
 
         // [JSR] Step 5: Call modifyHandshake
         configurator.modifyHandshake(config, jsrHandshakeRequest, jsrHandshakeResponse);
-        // Set modified headers Map back into response properly
-        jsrHandshakeResponse.setHeaders(jsrHandshakeResponse.getHeaders());
 
         try
         {

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/server/internal/JsrHandshakeRequest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/server/internal/JsrHandshakeRequest.java
@@ -15,16 +15,15 @@ package org.eclipse.jetty.ee9.websocket.jakarta.server.internal;
 
 import java.net.URI;
 import java.security.Principal;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.websocket.server.HandshakeRequest;
 import org.eclipse.jetty.ee9.websocket.jakarta.server.JakartaWebSocketServerContainer;
+import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.pathmap.PathSpec;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.util.Fields;
@@ -47,9 +46,7 @@ public class JsrHandshakeRequest implements HandshakeRequest
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        Map<String, List<String>> headers = delegate.getHeaders().getFieldNamesCollection().stream()
-            .collect(Collectors.toMap((name) -> name, (name) -> new ArrayList<>(delegate.getHeaders().getValuesList(name))));
-        return Collections.unmodifiableMap(headers);
+        return Collections.unmodifiableMap(HttpFields.asMap(delegate.getHeaders()));
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/server/internal/JsrHandshakeRequest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/server/internal/JsrHandshakeRequest.java
@@ -15,7 +15,6 @@ package org.eclipse.jetty.ee9.websocket.jakarta.server.internal;
 
 import java.net.URI;
 import java.security.Principal;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +45,7 @@ public class JsrHandshakeRequest implements HandshakeRequest
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        return Collections.unmodifiableMap(HttpFields.asMap(delegate.getHeaders()));
+        return HttpFields.asMap(delegate.getHeaders());
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/server/internal/JsrHandshakeResponse.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/server/internal/JsrHandshakeResponse.java
@@ -13,12 +13,11 @@
 
 package org.eclipse.jetty.ee9.websocket.jakarta.server.internal;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import jakarta.websocket.HandshakeResponse;
+import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.websocket.core.server.ServerUpgradeResponse;
 
 public class JsrHandshakeResponse implements HandshakeResponse
@@ -29,8 +28,7 @@ public class JsrHandshakeResponse implements HandshakeResponse
     public JsrHandshakeResponse(ServerUpgradeResponse resp)
     {
         this.delegate = resp;
-        this.headers = delegate.getHeaders().getFieldNamesCollection().stream()
-            .collect(Collectors.toMap((name) -> name, (name) -> new ArrayList<>(delegate.getHeaders().getValuesList(name))));
+        this.headers = HttpFields.asMap(delegate.getHeaders());
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/server/internal/JsrHandshakeResponse.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/server/internal/JsrHandshakeResponse.java
@@ -22,23 +22,16 @@ import org.eclipse.jetty.websocket.core.server.ServerUpgradeResponse;
 
 public class JsrHandshakeResponse implements HandshakeResponse
 {
-    private final ServerUpgradeResponse delegate;
     private final Map<String, List<String>> headers;
 
     public JsrHandshakeResponse(ServerUpgradeResponse resp)
     {
-        this.delegate = resp;
-        this.headers = HttpFields.asMap(delegate.getHeaders());
+        this.headers = HttpFields.asMap(resp.getHeaders());
     }
 
     @Override
     public Map<String, List<String>> getHeaders()
     {
         return headers;
-    }
-
-    public void setHeaders(Map<String, List<String>> headers)
-    {
-        headers.forEach((key, values) -> delegate.getHeaders().put(key, values));
     }
 }

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/server/internal/JsrHandshakeResponse.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/server/internal/JsrHandshakeResponse.java
@@ -26,7 +26,7 @@ public class JsrHandshakeResponse implements HandshakeResponse
 
     public JsrHandshakeResponse(ServerUpgradeResponse resp)
     {
-        this.headers = HttpFields.asMap(resp.getHeaders());
+        this.headers = HttpFields.asMutableMap(resp.getHeaders());
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/server/internal/JsrHandshakeResponse.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/server/internal/JsrHandshakeResponse.java
@@ -26,7 +26,7 @@ public class JsrHandshakeResponse implements HandshakeResponse
 
     public JsrHandshakeResponse(ServerUpgradeResponse resp)
     {
-        this.headers = HttpFields.asMutableMap(resp.getHeaders());
+        this.headers = HttpFields.asMap(resp.getHeaders());
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/UpgradeHeadersTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/UpgradeHeadersTest.java
@@ -1,0 +1,138 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee9.websocket.jakarta.tests;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.websocket.ClientEndpointConfig;
+import jakarta.websocket.Endpoint;
+import jakarta.websocket.EndpointConfig;
+import jakarta.websocket.HandshakeResponse;
+import jakarta.websocket.Session;
+import jakarta.websocket.server.HandshakeRequest;
+import jakarta.websocket.server.ServerEndpointConfig;
+import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee9.websocket.jakarta.client.JakartaWebSocketClientContainer;
+import org.eclipse.jetty.ee9.websocket.jakarta.server.config.JakartaWebSocketServletContainerInitializer;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class UpgradeHeadersTest
+{
+    private Server _server;
+    private JakartaWebSocketClientContainer _client;
+    private ServerConnector _connector;
+
+    public static class MyEndpoint extends Endpoint
+    {
+        @Override
+        public void onOpen(Session session, EndpointConfig config)
+        {
+        }
+    }
+
+    public void start(ServerEndpointConfig.Configurator configurator) throws Exception
+    {
+        _server = new Server();
+        _connector = new ServerConnector(_server);
+        _server.addConnector(_connector);
+
+        ServletContextHandler contextHandler = new ServletContextHandler();
+        _server.setHandler(contextHandler);
+        JakartaWebSocketServletContainerInitializer.configure(contextHandler, (context, container) ->
+        {
+            container.addEndpoint(ServerEndpointConfig.Builder
+                .create(MyEndpoint.class, "/")
+                .configurator(configurator)
+                .build());
+        });
+
+        _server.start();
+        _client = new JakartaWebSocketClientContainer();
+        _client.start();
+    }
+
+    @AfterEach
+    public void after() throws Exception
+    {
+        _client.stop();
+        _server.stop();
+    }
+
+    @Test
+    public void testCaseInsensitiveUpgradeHeaders() throws Exception
+    {
+        ClientEndpointConfig.Configurator configurator = new ClientEndpointConfig.Configurator()
+        {
+            @Override
+            public void beforeRequest(Map<String, List<String>> headers)
+            {
+                // Verify that existing headers can be accessed in a case-insensitive way.
+                if (headers.get("cOnnEcTiOn") == null)
+                    throw new IllegalStateException("No Connection Header on client Request");
+                headers.put("sentHeader", List.of("value123"));
+            }
+
+            @Override
+            public void afterResponse(HandshakeResponse hr)
+            {
+                if (hr.getHeaders().get("MyHeAdEr") == null)
+                    throw new IllegalStateException("No custom Header on HandshakeResponse");
+                if (hr.getHeaders().get("cOnnEcTiOn") == null)
+                    throw new IllegalStateException("No Connection Header on HandshakeRequest");
+            }
+        };
+
+        start(new ServerEndpointConfig.Configurator()
+        {
+            @Override
+            public void modifyHandshake(ServerEndpointConfig sec, HandshakeRequest request, HandshakeResponse response)
+            {
+                // Verify that existing headers can be accessed in a case-insensitive way.
+                if (request.getHeaders().get("cOnnEcTiOn") == null)
+                    throw new IllegalStateException("No Connection Header on HandshakeRequest");
+                if (response.getHeaders().get("sErVeR") == null)
+                    throw new IllegalStateException("No Server Header on HandshakeResponse");
+
+                // Verify custom header sent from client.
+                if (request.getHeaders().get("SeNtHeadEr") == null)
+                    throw new IllegalStateException("No sent Header on HandshakeResponse");
+
+                // Add custom response header.
+                response.getHeaders().put("myHeader", List.of("foobar"));
+                if (response.getHeaders().get("MyHeAdEr") == null)
+                    throw new IllegalStateException("No custom Header on HandshakeResponse");
+
+                super.modifyHandshake(sec, request, response);
+            }
+        });
+
+        WSEndpointTracker clientEndpoint = new WSEndpointTracker(){};
+        ClientEndpointConfig clientConfig = ClientEndpointConfig.Builder.create().configurator(configurator).build();
+        URI uri = URI.create("ws://localhost:" + _connector.getLocalPort());
+
+        // If any of the above throw it would fail to upgrade to websocket.
+        Session session = _client.connectToServer(clientEndpoint, clientConfig, uri);
+        assertTrue(clientEndpoint.openLatch.await(5, TimeUnit.SECONDS));
+        session.close();
+        assertTrue(clientEndpoint.closeLatch.await(5, TimeUnit.SECONDS));
+    }
+}

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/client/AnnotatedClientEndpointTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/client/AnnotatedClientEndpointTest.java
@@ -21,7 +21,6 @@ import jakarta.websocket.ClientEndpoint;
 import jakarta.websocket.ClientEndpointConfig;
 import jakarta.websocket.ContainerProvider;
 import jakarta.websocket.EndpointConfig;
-import jakarta.websocket.HandshakeResponse;
 import jakarta.websocket.OnMessage;
 import jakarta.websocket.OnOpen;
 import jakarta.websocket.Session;
@@ -74,11 +73,6 @@ public class AnnotatedClientEndpointTest
 
     public static class AnnotatedEndpointConfigurator extends ClientEndpointConfig.Configurator
     {
-        @Override
-        public void afterResponse(HandshakeResponse hr)
-        {
-            super.afterResponse(hr);
-        }
     }
 
     private static CoreServer server;

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/client/AnnotatedClientEndpointTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/client/AnnotatedClientEndpointTest.java
@@ -15,7 +15,6 @@ package org.eclipse.jetty.ee9.websocket.jakarta.tests.client;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Collections;
 import java.util.Date;
 
 import jakarta.websocket.ClientEndpoint;
@@ -78,7 +77,6 @@ public class AnnotatedClientEndpointTest
         @Override
         public void afterResponse(HandshakeResponse hr)
         {
-            hr.getHeaders().put("X-Test", Collections.singletonList("Extra"));
             super.afterResponse(hr);
         }
     }

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-client/src/main/java/org/eclipse/jetty/ee9/websocket/client/impl/DelegatedJettyClientUpgradeRequest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-client/src/main/java/org/eclipse/jetty/ee9/websocket/client/impl/DelegatedJettyClientUpgradeRequest.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 import org.eclipse.jetty.ee9.websocket.api.ExtensionConfig;
 import org.eclipse.jetty.ee9.websocket.api.UpgradeRequest;
 import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.io.EndPoint;
@@ -78,7 +79,7 @@ public class DelegatedJettyClientUpgradeRequest implements UpgradeRequest
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        return null;
+        return Collections.unmodifiableMap(HttpFields.asMap(delegate.getHeaders()));
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-client/src/main/java/org/eclipse/jetty/ee9/websocket/client/impl/DelegatedJettyClientUpgradeRequest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-client/src/main/java/org/eclipse/jetty/ee9/websocket/client/impl/DelegatedJettyClientUpgradeRequest.java
@@ -79,7 +79,7 @@ public class DelegatedJettyClientUpgradeRequest implements UpgradeRequest
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        return Collections.unmodifiableMap(HttpFields.asMap(delegate.getHeaders()));
+        return HttpFields.asMap(delegate.getHeaders());
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-client/src/main/java/org/eclipse/jetty/ee9/websocket/client/impl/DelegatedJettyClientUpgradeResponse.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-client/src/main/java/org/eclipse/jetty/ee9/websocket/client/impl/DelegatedJettyClientUpgradeResponse.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.ee9.websocket.client.impl;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -23,6 +22,7 @@ import java.util.stream.Collectors;
 import org.eclipse.jetty.client.Response;
 import org.eclipse.jetty.ee9.websocket.api.ExtensionConfig;
 import org.eclipse.jetty.ee9.websocket.api.UpgradeResponse;
+import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 
 /**
@@ -65,9 +65,7 @@ public class DelegatedJettyClientUpgradeResponse implements UpgradeResponse
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        Map<String, List<String>> headers = getHeaderNames().stream()
-            .collect(Collectors.toMap((name) -> name, (name) -> new ArrayList<>(getHeaders(name))));
-        return Collections.unmodifiableMap(headers);
+        return Collections.unmodifiableMap(HttpFields.asMap(delegate.getHeaders()));
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-client/src/main/java/org/eclipse/jetty/ee9/websocket/client/impl/DelegatedJettyClientUpgradeResponse.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-client/src/main/java/org/eclipse/jetty/ee9/websocket/client/impl/DelegatedJettyClientUpgradeResponse.java
@@ -65,7 +65,7 @@ public class DelegatedJettyClientUpgradeResponse implements UpgradeResponse
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        return Collections.unmodifiableMap(HttpFields.asMap(delegate.getHeaders()));
+        return HttpFields.asMap(delegate.getHeaders());
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/JettyWebSocketServerContainer.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/JettyWebSocketServerContainer.java
@@ -37,7 +37,6 @@ import org.eclipse.jetty.ee9.websocket.server.internal.DelegatedServerUpgradeReq
 import org.eclipse.jetty.ee9.websocket.server.internal.DelegatedServerUpgradeResponse;
 import org.eclipse.jetty.ee9.websocket.server.internal.JettyServerFrameHandlerFactory;
 import org.eclipse.jetty.ee9.websocket.servlet.WebSocketUpgradeFilter;
-import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.pathmap.PathSpec;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
@@ -164,7 +163,7 @@ public class JettyWebSocketServerContainer extends ContainerLifeCycle implements
             {
                 if (LOG.isDebugEnabled())
                     LOG.debug("Could not create WebSocket endpoint", t);
-                Response.writeError(req, resp, cb, HttpStatus.INTERNAL_SERVER_ERROR_500, "Could not create WebSocket endpoint");
+                cb.failed(t);
                 return null;
             }
         };
@@ -210,14 +209,14 @@ public class JettyWebSocketServerContainer extends ContainerLifeCycle implements
             {
                 Object webSocket = creator.createWebSocket(new DelegatedServerUpgradeRequest(req), new DelegatedServerUpgradeResponse(resp));
                 if (webSocket == null)
-                    Response.writeError(req, resp, cb, HttpStatus.INTERNAL_SERVER_ERROR_500, "Could not create WebSocket endpoint");
+                    cb.succeeded();
                 return webSocket;
             }
             catch (Throwable t)
             {
                 if (LOG.isDebugEnabled())
                     LOG.debug("Could not create WebSocket endpoint", t);
-                Response.writeError(req, resp, cb, HttpStatus.INTERNAL_SERVER_ERROR_500, "Could not create WebSocket endpoint");
+                cb.failed(t);
                 return null;
             }
         };

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/JettyWebSocketServerContainer.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/JettyWebSocketServerContainer.java
@@ -37,6 +37,7 @@ import org.eclipse.jetty.ee9.websocket.server.internal.DelegatedServerUpgradeReq
 import org.eclipse.jetty.ee9.websocket.server.internal.DelegatedServerUpgradeResponse;
 import org.eclipse.jetty.ee9.websocket.server.internal.JettyServerFrameHandlerFactory;
 import org.eclipse.jetty.ee9.websocket.servlet.WebSocketUpgradeFilter;
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.pathmap.PathSpec;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
@@ -155,12 +156,14 @@ public class JettyWebSocketServerContainer extends ContainerLifeCycle implements
             try
             {
                 Object webSocket = creator.createWebSocket(new DelegatedServerUpgradeRequest(req), new DelegatedServerUpgradeResponse(resp));
-                cb.succeeded();
+                if (webSocket == null)
+                    cb.succeeded();
                 return webSocket;
             }
             catch (Throwable t)
             {
-                cb.failed(t);
+                LOG.warn("Could not create WebSocket endpoint", t);
+                Response.writeError(req, resp, cb, HttpStatus.INTERNAL_SERVER_ERROR_500, "Could not create WebSocket endpoint");
                 return null;
             }
         };
@@ -205,12 +208,14 @@ public class JettyWebSocketServerContainer extends ContainerLifeCycle implements
             try
             {
                 Object webSocket = creator.createWebSocket(new DelegatedServerUpgradeRequest(req), new DelegatedServerUpgradeResponse(resp));
-                cb.succeeded();
+                if (webSocket == null)
+                    Response.writeError(req, resp, cb, HttpStatus.INTERNAL_SERVER_ERROR_500, "Could not create WebSocket endpoint");
                 return webSocket;
             }
             catch (Throwable t)
             {
-                cb.failed(t);
+                LOG.warn("Could not create WebSocket endpoint", t);
+                Response.writeError(req, resp, cb, HttpStatus.INTERNAL_SERVER_ERROR_500, "Could not create WebSocket endpoint");
                 return null;
             }
         };

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/JettyWebSocketServerContainer.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/JettyWebSocketServerContainer.java
@@ -162,7 +162,8 @@ public class JettyWebSocketServerContainer extends ContainerLifeCycle implements
             }
             catch (Throwable t)
             {
-                LOG.warn("Could not create WebSocket endpoint", t);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Could not create WebSocket endpoint", t);
                 Response.writeError(req, resp, cb, HttpStatus.INTERNAL_SERVER_ERROR_500, "Could not create WebSocket endpoint");
                 return null;
             }
@@ -214,7 +215,8 @@ public class JettyWebSocketServerContainer extends ContainerLifeCycle implements
             }
             catch (Throwable t)
             {
-                LOG.warn("Could not create WebSocket endpoint", t);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Could not create WebSocket endpoint", t);
                 Response.writeError(req, resp, cb, HttpStatus.INTERNAL_SERVER_ERROR_500, "Could not create WebSocket endpoint");
                 return null;
             }

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/JettyWebSocketServlet.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/JettyWebSocketServlet.java
@@ -314,7 +314,6 @@ public abstract class JettyWebSocketServlet extends HttpServlet
             try
             {
                 Object webSocket = creator.createWebSocket(request, response);
-                response.copyHeaders();
                 if (webSocket == null)
                     callback.succeeded();
                 return webSocket;

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/JettyWebSocketServlet.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/JettyWebSocketServlet.java
@@ -30,7 +30,6 @@ import org.eclipse.jetty.ee9.websocket.server.internal.DelegatedServerUpgradeReq
 import org.eclipse.jetty.ee9.websocket.server.internal.DelegatedServerUpgradeResponse;
 import org.eclipse.jetty.ee9.websocket.server.internal.JettyServerFrameHandlerFactory;
 import org.eclipse.jetty.ee9.websocket.servlet.WebSocketUpgradeFilter;
-import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
@@ -320,15 +319,7 @@ public abstract class JettyWebSocketServlet extends HttpServlet
             }
             catch (Throwable t)
             {
-                try
-                {
-                    response.sendError(HttpStatus.INTERNAL_SERVER_ERROR_500, "Could not create WebSocket endpoint");
-                    callback.succeeded();
-                }
-                catch (Throwable x)
-                {
-                    callback.failed(x);
-                }
+                callback.failed(t);
                 return null;
             }
         }

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/internal/DelegatedServerUpgradeRequest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/internal/DelegatedServerUpgradeRequest.java
@@ -114,7 +114,7 @@ public class DelegatedServerUpgradeRequest implements JettyServerUpgradeRequest
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        return Collections.unmodifiableMap(HttpFields.asMap(upgradeRequest.getHeaders()));
+        return HttpFields.asMap(upgradeRequest.getHeaders());
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/internal/DelegatedServerUpgradeRequest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/internal/DelegatedServerUpgradeRequest.java
@@ -18,7 +18,6 @@ import java.net.SocketAddress;
 import java.net.URI;
 import java.security.Principal;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -35,6 +34,7 @@ import org.eclipse.jetty.ee9.websocket.api.ExtensionConfig;
 import org.eclipse.jetty.ee9.websocket.common.JettyExtensionConfig;
 import org.eclipse.jetty.ee9.websocket.server.JettyServerUpgradeRequest;
 import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.websocket.core.WebSocketConstants;
@@ -114,9 +114,7 @@ public class DelegatedServerUpgradeRequest implements JettyServerUpgradeRequest
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        Map<String, List<String>> headers = upgradeRequest.getHeaders().getFieldNamesCollection().stream()
-            .collect(Collectors.toMap((name) -> name, (name) -> new ArrayList<>(getHeaders(name))));
-        return Collections.unmodifiableMap(headers);
+        return Collections.unmodifiableMap(HttpFields.asMap(upgradeRequest.getHeaders()));
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/internal/DelegatedServerUpgradeResponse.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/internal/DelegatedServerUpgradeResponse.java
@@ -87,7 +87,7 @@ public class DelegatedServerUpgradeResponse implements JettyServerUpgradeRespons
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        return HttpFields.asMap(upgradeResponse.getHeaders());
+        return HttpFields.asMutableMap(upgradeResponse.getHeaders());
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/internal/DelegatedServerUpgradeResponse.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/internal/DelegatedServerUpgradeResponse.java
@@ -14,7 +14,6 @@
 package org.eclipse.jetty.ee9.websocket.server.internal;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -33,17 +32,10 @@ public class DelegatedServerUpgradeResponse implements JettyServerUpgradeRespons
 {
     private final ServerUpgradeResponse upgradeResponse;
     private final HttpServletResponse httpServletResponse;
-    private final boolean isUpgraded;
 
     public DelegatedServerUpgradeResponse(ServerUpgradeResponse response)
     {
-        this(response, false);
-    }
-
-    public DelegatedServerUpgradeResponse(ServerUpgradeResponse response, boolean isUpgraded)
-    {
         this.upgradeResponse = response;
-        this.isUpgraded = isUpgraded;
         this.httpServletResponse = (HttpServletResponse)response.getRequest()
             .getAttribute(WebSocketConstants.WEBSOCKET_WRAPPED_RESPONSE_ATTRIBUTE);
     }
@@ -54,11 +46,6 @@ public class DelegatedServerUpgradeResponse implements JettyServerUpgradeRespons
         // TODO: This should go to the httpServletResponse for headers but then it won't do interception of the websocket headers
         //  which are done through the jetty-core Response wrapping ServerUpgradeResponse done by websocket-core.
         upgradeResponse.getHeaders().add(name, value);
-    }
-
-    public void copyHeaders()
-    {
-        headers.forEach((key, values) -> upgradeResponse.getHeaders().put(key, values));
     }
 
     @Override
@@ -100,10 +87,7 @@ public class DelegatedServerUpgradeResponse implements JettyServerUpgradeRespons
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        if (isUpgraded)
-            return Collections.unmodifiableMap(HttpFields.asMap(upgradeResponse.getHeaders()));
-        else
-            return HttpFields.asMap(upgradeResponse.getHeaders());
+        return HttpFields.asMap(upgradeResponse.getHeaders());
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/internal/DelegatedServerUpgradeResponse.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/internal/DelegatedServerUpgradeResponse.java
@@ -87,7 +87,7 @@ public class DelegatedServerUpgradeResponse implements JettyServerUpgradeRespons
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        return HttpFields.asMutableMap(upgradeResponse.getHeaders());
+        return HttpFields.asMap(upgradeResponse.getHeaders());
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/internal/DelegatedServerUpgradeResponse.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/internal/DelegatedServerUpgradeResponse.java
@@ -14,7 +14,6 @@
 package org.eclipse.jetty.ee9.websocket.server.internal;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -25,6 +24,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.ee9.websocket.api.ExtensionConfig;
 import org.eclipse.jetty.ee9.websocket.common.JettyExtensionConfig;
 import org.eclipse.jetty.ee9.websocket.server.JettyServerUpgradeResponse;
+import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.websocket.core.WebSocketConstants;
 import org.eclipse.jetty.websocket.core.server.ServerUpgradeResponse;
@@ -88,9 +88,7 @@ public class DelegatedServerUpgradeResponse implements JettyServerUpgradeRespons
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        Map<String, List<String>> headers = getHeaderNames().stream()
-            .collect(Collectors.toMap((name) -> name, (name) -> new ArrayList<>(getHeaders(name))));
-        return Collections.unmodifiableMap(headers);
+        return Collections.unmodifiableMap(HttpFields.asMap(upgradeResponse.getHeaders()));
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/internal/JettyServerFrameHandlerFactory.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/internal/JettyServerFrameHandlerFactory.java
@@ -41,7 +41,7 @@ public class JettyServerFrameHandlerFactory extends JettyWebSocketFrameHandlerFa
     {
         JettyWebSocketFrameHandler frameHandler = super.newJettyFrameHandler(websocketPojo);
         frameHandler.setUpgradeRequest(new DelegatedServerUpgradeRequest(upgradeRequest));
-        frameHandler.setUpgradeResponse(new DelegatedServerUpgradeResponse(upgradeResponse));
+        frameHandler.setUpgradeResponse(new DelegatedServerUpgradeResponse(upgradeResponse, true));
         return frameHandler;
     }
 }

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/internal/JettyServerFrameHandlerFactory.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/internal/JettyServerFrameHandlerFactory.java
@@ -41,7 +41,7 @@ public class JettyServerFrameHandlerFactory extends JettyWebSocketFrameHandlerFa
     {
         JettyWebSocketFrameHandler frameHandler = super.newJettyFrameHandler(websocketPojo);
         frameHandler.setUpgradeRequest(new DelegatedServerUpgradeRequest(upgradeRequest));
-        frameHandler.setUpgradeResponse(new DelegatedServerUpgradeResponse(upgradeResponse, true));
+        frameHandler.setUpgradeResponse(new DelegatedServerUpgradeResponse(upgradeResponse));
         return frameHandler;
     }
 }

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/UpgradeHeadersTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/UpgradeHeadersTest.java
@@ -1,0 +1,124 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee9.websocket.tests;
+
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.client.Request;
+import org.eclipse.jetty.client.Response;
+import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee9.websocket.client.ClientUpgradeRequest;
+import org.eclipse.jetty.ee9.websocket.client.JettyUpgradeListener;
+import org.eclipse.jetty.ee9.websocket.client.WebSocketClient;
+import org.eclipse.jetty.ee9.websocket.server.JettyWebSocketCreator;
+import org.eclipse.jetty.ee9.websocket.server.config.JettyWebSocketServletContainerInitializer;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class UpgradeHeadersTest
+{
+    private Server _server;
+    private WebSocketClient _client;
+    private ServerConnector _connector;
+
+    public void start(JettyWebSocketCreator creator) throws Exception
+    {
+        _server = new Server();
+        _connector = new ServerConnector(_server);
+        _server.addConnector(_connector);
+
+        ServletContextHandler contextHandler = new ServletContextHandler();
+        JettyWebSocketServletContainerInitializer.configure(contextHandler, (servletContext, container) ->
+            container.addMapping("/", creator));
+        _server.setHandler(contextHandler);
+
+        _server.start();
+        _client = new WebSocketClient();
+        _client.start();
+    }
+
+    @AfterEach
+    public void after() throws Exception
+    {
+        _client.stop();
+        _server.stop();
+    }
+
+    @Test
+    public void testCaseInsensitiveUpgradeHeaders() throws Exception
+    {
+        start((request, response) ->
+        {
+            // Verify that existing headers can be accessed in a case-insensitive way.
+            if (request.getHeaders().get("cOnnEcTiOn") == null)
+                throw new IllegalStateException("No Connection Header on HandshakeRequest");
+            if (response.getHeaders().get("sErVeR") == null)
+                throw new IllegalStateException("No Server Header on HandshakeResponse");
+
+            // Verify custom header sent from client.
+            if (request.getHeaders().get("SeNtHeadEr") == null)
+                throw new IllegalStateException("No sent Header on HandshakeResponse");
+
+            // Add custom response header.
+            response.getHeaders().put("myHeader", List.of("foobar"));
+            if (response.getHeaders().get("MyHeAdEr") == null)
+                throw new IllegalStateException("No custom Header on HandshakeResponse");
+
+            return new EchoSocket();
+        });
+
+        EventSocket clientEndpoint = new EventSocket();
+        URI uri = URI.create("ws://localhost:" + _connector.getLocalPort());
+
+        ClientUpgradeRequest clientUpgradeRequest = new ClientUpgradeRequest();
+        clientUpgradeRequest.getHeaders().put("sentHeader", List.of("value123"));
+        if (clientUpgradeRequest.getHeaders().get("SenTHeaDer") == null)
+            throw new IllegalStateException("No custom Header on ClientUpgradeRequest");
+
+        JettyUpgradeListener upgradeListener = new JettyUpgradeListener()
+        {
+            @Override
+            public void onHandshakeRequest(Request request)
+            {
+                // Verify that existing headers can be accessed in a case-insensitive way.
+                if (request.getHeaders().get("cOnnEcTiOn") == null)
+                    throw new IllegalStateException("No Connection Header on client Request");
+                if (request.getHeaders().get("SenTHeaDer") == null)
+                    throw new IllegalStateException("No custom Header on ClientUpgradeRequest");
+            }
+
+            @Override
+            public void onHandshakeResponse(Request request, Response response)
+            {
+                if (response.getHeaders().get("MyHeAdEr") == null)
+                    throw new IllegalStateException("No custom Header on HandshakeResponse");
+                if (response.getHeaders().get("cOnnEcTiOn") == null)
+                    throw new IllegalStateException("No Connection Header on HandshakeRequest");
+            }
+        };
+
+        // If any of the above throw it would fail to upgrade to websocket.
+        assertNotNull(_client.connect(clientEndpoint, uri, clientUpgradeRequest, upgradeListener).get(5, TimeUnit.SECONDS));
+        assertTrue(clientEndpoint.openLatch.await(5, TimeUnit.SECONDS));
+        clientEndpoint.session.close();
+        assertTrue(clientEndpoint.closeLatch.await(5, TimeUnit.SECONDS));
+    }
+}


### PR DESCRIPTION
## Issue #12429

Add a new static method `HttpFields.asMap(HttpFields fields)` and use it everywhere in WebSocket where the `HttpFields` are converted into a `Map<String, List<String>>` so that the headers in the map are treated as case-insensitive.