### PR TITLE
Jetty 12.1.x fix context handler test

### DIFF
--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
@@ -74,7 +74,6 @@ import org.eclipse.jetty.util.component.Graceful;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -862,7 +861,7 @@ public class ContextHandlerTest
         ensureWritable(TEST_BAD);
         FS.ensureDeleted(TEST_BAD.toPath());
         assertFalse(TEST_BAD.exists());
-        assertTrue(TEST_BAD.mkdir());
+        assertTrue(TEST_BAD.mkdirs());
         TEST_BAD.deleteOnExit();
 
         File notDirectory = new File(TEST_BAD, "notDirectory.txt");
@@ -888,7 +887,6 @@ public class ContextHandlerTest
         );
     }
 
-    @Disabled // TODO doesn't work on jenkins?
     @ParameterizedTest
     @MethodSource("badTempDirs")
     public void testSetTempDirectoryBad(boolean persistent, File badTempDir)

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
@@ -74,6 +74,7 @@ import org.eclipse.jetty.util.component.Graceful;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -887,6 +888,7 @@ public class ContextHandlerTest
         );
     }
 
+    @Tag("flaky")
     @ParameterizedTest
     @MethodSource("badTempDirs")
     public void testSetTempDirectoryBad(boolean persistent, File badTempDir)


### PR DESCRIPTION
Remove `@Disabled` from `ContextHandlerTest.testSetTempDirectoryBad` method.