### PR TITLE
Fix #12448 Flaky testHoldContent

### DIFF
--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestBase.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestBase.java
@@ -1980,13 +1980,13 @@ public abstract class HttpServerTestBase extends HttpServerTestFixture
             }
             else
             {
-                HttpTester.Response response = HttpTester.parseResponse(client.getInputStream());
+                HttpTester.Input input = HttpTester.from(client.getInputStream());
+                HttpTester.Response response = HttpTester.parseResponse(input);
                 assertNotNull(response);
                 assertThat(response.getStatus(), is(200));
-
                 if (pipeline)
                 {
-                    response = HttpTester.parseResponse(client.getInputStream());
+                    response = HttpTester.parseResponse(input);
                     assertNotNull(response);
                     assertThat(response.getStatus(), is(200));
                 }


### PR DESCRIPTION
Fixed the HttpTester usage to avoid discarding send response content that arrived with first read