### PR TITLE
Issue #12453 - Allow AnnotationParser to work with Resources types that do not support Path

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/FileID.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/FileID.java
@@ -19,6 +19,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 /**
@@ -38,6 +39,7 @@ public class FileID
      */
     public static String getBasename(Path path)
     {
+        Objects.requireNonNull(path);
         Path filename = path.getFileName();
         if (filename == null)
             return "";
@@ -366,11 +368,27 @@ public class FileID
      */
     public static boolean isClassFile(Path path)
     {
+        if (path == null)
+            return false;
+
         Path fileNamePath = path.getFileName();
         if (fileNamePath == null)
             return false;
-        
-        String filename = fileNamePath.toString();
+
+        return isClassFile(fileNamePath.toString());
+    }
+
+    /**
+     * Predicate to test for class files
+     *
+     * @param filename the filename to test
+     * @return true if the filename ends with {@code .class}
+     */
+    public static boolean isClassFile(String filename)
+    {
+        if (StringUtil.isBlank(filename))
+            return false;
+
         // has to end in ".class"
         if (!StringUtil.asciiEndsWithIgnoreCase(filename, ".class"))
             return false;
@@ -404,6 +422,8 @@ public class FileID
      */
     public static boolean isHidden(Path path)
     {
+        Objects.requireNonNull(path);
+
         int count = path.getNameCount();
         for (int i = 0; i < count; i++)
         {
@@ -443,6 +463,9 @@ public class FileID
      */
     public static boolean isHidden(Path base, Path path)
     {
+        Objects.requireNonNull(base);
+        Objects.requireNonNull(path);
+
         // Work with the path in relative form, from the base onwards to the path
         return isHidden(base.relativize(path));
     }
@@ -492,6 +515,9 @@ public class FileID
      */
     public static boolean isMetaInfVersions(Path path)
     {
+        if (path == null)
+            return false;
+
         if (path.getNameCount() < 3)
             return false;
 
@@ -531,6 +557,9 @@ public class FileID
      */
     public static boolean isModuleInfoClass(Path path)
     {
+        if (path == null)
+            return false;
+
         Path filenameSegment = path.getFileName();
         if (filenameSegment == null)
             return false;

--- a/jetty-ee10/jetty-ee10-annotations/src/main/java/org/eclipse/jetty/ee10/annotations/AnnotationParser.java
+++ b/jetty-ee10/jetty-ee10-annotations/src/main/java/org/eclipse/jetty/ee10/annotations/AnnotationParser.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.eclipse.jetty.io.IOResources;
 import org.eclipse.jetty.util.ExceptionUtil;
 import org.eclipse.jetty.util.FileID;
 import org.eclipse.jetty.util.StringUtil;
@@ -550,21 +551,23 @@ public class AnnotationParser
         if (!r.exists())
             return;
 
-        if (FileID.isJavaArchive(r.getPath()))
-        {
-            parseJar(handlers, r);
-            return;
-        }
-
         if (r.isDirectory())
         {
             parseDir(handlers, r);
             return;
         }
-
-        if (FileID.isClassFile(r.getPath()))
+        else
         {
-            parseClass(handlers, null, r.getPath());
+            if (FileID.isJavaArchive(r.getFileName()))
+            {
+                parseJar(handlers, r);
+                return;
+            }
+
+            if (FileID.isClassFile(r.getFileName()))
+            {
+                parseClass(handlers, null, r);
+            }
         }
 
         if (LOG.isDebugEnabled())
@@ -606,7 +609,7 @@ public class AnnotationParser
 
             try
             {
-                parseClass(handlers, dirResource, candidate.getPath());
+                parseClass(handlers, dirResource, candidate);
             }
             catch (Exception ex)
             {
@@ -629,9 +632,6 @@ public class AnnotationParser
         if (jarResource == null)
             return;
 
-        /*        if (!FileID.isJavaArchive(jarResource.getPath()))
-            return;*/
-
         if (LOG.isDebugEnabled())
             LOG.debug("Scanning jar {}", jarResource);
 
@@ -649,27 +649,60 @@ public class AnnotationParser
      * @param containingResource the dir or jar that the class is contained within, can be null if not known
      * @param classFile the class file to parse
      * @throws IOException if unable to parse
+     * @deprecated use {@link #parseClass(Set, Resource, Resource)} instead (which uses {@link Resource} instead of {@link Path})
      */
+    @Deprecated(since = "12.0.16", forRemoval = true)
     protected void parseClass(Set<? extends Handler> handlers, Resource containingResource, Path classFile) throws IOException
     {
-        if (LOG.isDebugEnabled())
-            LOG.debug("Parse class from {}", classFile.toUri());
-
-        URI location = classFile.toUri();
-
-        try (InputStream in = Files.newInputStream(classFile))
+        try (InputStream inputStream = Files.newInputStream(classFile))
         {
-            ClassReader reader = new ClassReader(in);
+            parseClass(handlers, containingResource, classFile.toUri(), inputStream);
+        }
+    }
+
+    /**
+     * Use ASM on a class
+     *
+     * @param handlers the handlers to look for classes in
+     * @param containingResource the dir or jar that the class is contained within, can be null if not known
+     * @param classFile the class file to parse
+     * @throws IOException if unable to parse
+     */
+    protected void parseClass(Set<? extends Handler> handlers, Resource containingResource, Resource classFile) throws IOException
+    {
+        try (InputStream inputStream = IOResources.asInputStream(classFile))
+        {
+            parseClass(handlers, containingResource, classFile.getURI(), inputStream);
+        }
+    }
+
+    /**
+     * Use ASM on a class
+     *
+     * @param handlers the handlers to look for classes in
+     * @param containingResource the dir or jar that the class is contained within, can be null if not known
+     * @param classFileRef the URI reference to the classfile location
+     * @param inputStream the class file contents to parse
+     * @throws IOException if unable to parse
+     */
+    private void parseClass(Set<? extends Handler> handlers, Resource containingResource, URI classFileRef, InputStream inputStream) throws IOException
+    {
+        if (LOG.isDebugEnabled())
+            LOG.debug("Parse class from {}", classFileRef);
+
+        try
+        {
+            ClassReader reader = new ClassReader(inputStream);
             reader.accept(new MyClassVisitor(handlers, containingResource, _asmVersion), ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
 
             String classname = normalize(reader.getClassName());
-            URI existing = _parsedClassNames.putIfAbsent(classname, location);
+            URI existing = _parsedClassNames.putIfAbsent(classname, classFileRef);
             if (existing != null)
-                LOG.warn("{} scanned from multiple locations: {}, {}", classname, existing, location);
+                LOG.warn("{} scanned from multiple locations: {}, {}", classname, existing, classFileRef);
         }
         catch (IllegalArgumentException | IOException e)
         {
-            throw new IOException("Unable to parse class: " + classFile.toUri(), e);
+            throw new IOException("Unable to parse class: " + classFileRef, e);
         }
     }
     

--- a/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot/src/main/java/org/eclipse/jetty/ee10/osgi/annotations/AnnotationParser.java
+++ b/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot/src/main/java/org/eclipse/jetty/ee10/osgi/annotations/AnnotationParser.java
@@ -109,25 +109,28 @@ public class AnnotationParser extends org.eclipse.jetty.ee10.annotations.Annotat
         if (!r.exists())
             return;
 
-        if (FileID.isJavaArchive(r.getPath()))
-        {
-            parseJar(handlers, r);
-            return;
-        }
-
         if (r.isDirectory())
         {
             parseDir(handlers, r);
             return;
         }
-
-        if (FileID.isClassFile(r.getPath()))
+        else
         {
-            parseClass(handlers, null, r.getPath());
+            if (FileID.isJavaArchive(r.getFileName()))
+            {
+                parseJar(handlers, r);
+                return;
+            }
+
+            if (FileID.isClassFile(r.getFileName()))
+            {
+                parseClass(handlers, null, r);
+                return;
+            }
         }
 
-        //Not already parsed, it could be a file that actually is compressed but does not have
-        //.jar/.zip etc extension, such as equinox urls, so try to parse it
+        // Not already parsed, it could be a file that actually is compressed but does not have
+        // .jar/.zip etc extension, such as equinox urls, so try to parse it
         try
         {
             parseJar(handlers, r);

--- a/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot/src/main/java/org/eclipse/jetty/ee10/osgi/annotations/AnnotationParser.java
+++ b/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot/src/main/java/org/eclipse/jetty/ee10/osgi/annotations/AnnotationParser.java
@@ -88,7 +88,6 @@ public class AnnotationParser extends org.eclipse.jetty.ee10.annotations.Annotat
     public void parse(Set<? extends Handler> handlers, Bundle bundle)
         throws Exception
     {
-
         Resource bundleResource = _bundleToResource.get(bundle);
         if (bundleResource == null)
             return;

--- a/jetty-ee9/jetty-ee9-osgi/jetty-ee9-osgi-boot/src/main/java/org/eclipse/jetty/ee9/osgi/annotations/AnnotationParser.java
+++ b/jetty-ee9/jetty-ee9-osgi/jetty-ee9-osgi-boot/src/main/java/org/eclipse/jetty/ee9/osgi/annotations/AnnotationParser.java
@@ -83,14 +83,12 @@ public class AnnotationParser extends org.eclipse.jetty.ee9.annotations.Annotati
     public void parse(Set<? extends Handler> handlers, Bundle bundle)
         throws Exception
     {
-
         Resource bundleResource = _bundleToResource.get(bundle);
         if (bundleResource == null)
             return;
 
         if (!_parsed.add(_bundleToUri.get(bundle)))
             return;
-
 
         parse(handlers, bundleResource);
     }

--- a/jetty-ee9/jetty-ee9-osgi/jetty-ee9-osgi-boot/src/main/java/org/eclipse/jetty/ee9/osgi/annotations/AnnotationParser.java
+++ b/jetty-ee9/jetty-ee9-osgi/jetty-ee9-osgi-boot/src/main/java/org/eclipse/jetty/ee9/osgi/annotations/AnnotationParser.java
@@ -14,23 +14,15 @@
 package org.eclipse.jetty.ee9.osgi.annotations;
 
 import java.io.File;
-import java.io.InputStream;
 import java.net.URI;
-import java.net.URL;
-import java.util.Comparator;
-import java.util.Enumeration;
 import java.util.Set;
-import java.util.StringTokenizer;
-import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.jetty.osgi.util.BundleFileLocatorHelperFactory;
 import org.eclipse.jetty.util.FileID;
-import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.osgi.framework.Bundle;
-import org.osgi.framework.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -109,25 +101,31 @@ public class AnnotationParser extends org.eclipse.jetty.ee9.annotations.Annotati
         if (r == null)
             return;
 
-        if (FileID.isJavaArchive(r.getPath()))
-        {
-            parseJar(handlers, r);
+        if (!r.exists())
             return;
-        }
 
         if (r.isDirectory())
         {
             parseDir(handlers, r);
             return;
         }
-
-        if (FileID.isClassFile(r.getPath()))
+        else
         {
-            parseClass(handlers, null, r.getPath());
+            if (FileID.isJavaArchive(r.getFileName()))
+            {
+                parseJar(handlers, r);
+                return;
+            }
+
+            if (FileID.isClassFile(r.getFileName()))
+            {
+                parseClass(handlers, null, r);
+                return;
+            }
         }
         
-        //Not already parsed, it could be a file that actually is compressed but does not have
-        //.jar/.zip etc extension, such as equinox urls, so try to parse it
+        // Not already parsed, it could be a file that actually is compressed but does not have
+        // .jar/.zip etc extension, such as equinox urls, so try to parse it
         try
         {
             parseJar(handlers, r);


### PR DESCRIPTION
+ Improve null handling in `FileID`.
+ Improve `AnnotationParser.parse()` method to better utilize `Resource` object, don't rely on `Path` existing for things that don't require `Path` to function.

