### PR TITLE
Addendum to #12395.

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -620,20 +620,7 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
     {
         Runnable task = _httpChannel.onClose();
         if (task != null)
-        {
-            ThreadPool.executeImmediately(getExecutor(), () ->
-            {
-                try
-                {
-                    task.run();
-                }
-                finally
-                {
-                    super.close();
-                }
-            });
-            return;
-        }
+            task.run();
         super.close();
     }
 


### PR DESCRIPTION
Restored synchronous behavior for `HttpConnection.close()`. 
This allows to send a response for suspended requests while the server is being stopped.
See also #12435.