### PR TITLE
Fixes #12488 - HTTP/2 headers may not be split in CONTINUATION frames.

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/HttpClientTransportOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/HttpClientTransportOverHTTP2.java
@@ -103,6 +103,7 @@ public class HttpClientTransportOverHTTP2 extends AbstractHttpClientTransport
         http2Client.setUseOutputDirectByteBuffers(httpClient.isUseOutputDirectByteBuffers());
         http2Client.setConnectBlocking(httpClient.isConnectBlocking());
         http2Client.setBindAddress(httpClient.getBindAddress());
+        http2Client.setMaxRequestHeadersSize(httpClient.getRequestBufferSize());
         http2Client.setMaxResponseHeadersSize(httpClient.getMaxResponseHeadersSize());
     }
 

--- a/jetty-core/jetty-http2/jetty-http2-client/src/main/java/org/eclipse/jetty/http2/client/HTTP2Client.java
+++ b/jetty-core/jetty-http2/jetty-http2-client/src/main/java/org/eclipse/jetty/http2/client/HTTP2Client.java
@@ -112,6 +112,7 @@ public class HTTP2Client extends ContainerLifeCycle implements AutoCloseable
     private int maxDecoderTableCapacity = HpackContext.DEFAULT_MAX_TABLE_CAPACITY;
     private int maxEncoderTableCapacity = HpackContext.DEFAULT_MAX_TABLE_CAPACITY;
     private int maxHeaderBlockFragment = 0;
+    private int maxRequestHeadersSize = 8 * 1024;
     private int maxResponseHeadersSize = 8 * 1024;
     private FlowControlStrategy.Factory flowControlStrategyFactory = () -> new BufferingFlowControlStrategy(0.5F);
     private long streamIdleTimeout;
@@ -354,6 +355,17 @@ public class HTTP2Client extends ContainerLifeCycle implements AutoCloseable
     public void setMaxHeaderBlockFragment(int maxHeaderBlockFragment)
     {
         this.maxHeaderBlockFragment = maxHeaderBlockFragment;
+    }
+
+    @ManagedAttribute("The max size of request headers")
+    public int getMaxRequestHeadersSize()
+    {
+        return maxRequestHeadersSize;
+    }
+
+    public void setMaxRequestHeadersSize(int maxRequestHeadersSize)
+    {
+        this.maxRequestHeadersSize = maxRequestHeadersSize;
     }
 
     @ManagedAttribute("The max size of response headers")

--- a/jetty-core/jetty-http2/jetty-http2-client/src/main/java/org/eclipse/jetty/http2/client/HTTP2ClientConnectionFactory.java
+++ b/jetty-core/jetty-http2/jetty-http2-client/src/main/java/org/eclipse/jetty/http2/client/HTTP2ClientConnectionFactory.java
@@ -57,7 +57,6 @@ public class HTTP2ClientConnectionFactory implements ClientConnectionFactory
         FlowControlStrategy flowControl = client.getFlowControlStrategyFactory().newFlowControlStrategy();
 
         Parser parser = new Parser(bufferPool, client.getMaxResponseHeadersSize());
-        parser.setMaxFrameSize(client.getMaxFrameSize());
         parser.setMaxSettingsKeys(client.getMaxSettingsKeys());
 
         HTTP2ClientSession session = new HTTP2ClientSession(client.getScheduler(), endPoint, parser, generator, listener, flowControl);

--- a/jetty-core/jetty-http2/jetty-http2-client/src/main/java/org/eclipse/jetty/http2/client/HTTP2ClientConnectionFactory.java
+++ b/jetty-core/jetty-http2/jetty-http2-client/src/main/java/org/eclipse/jetty/http2/client/HTTP2ClientConnectionFactory.java
@@ -54,6 +54,8 @@ public class HTTP2ClientConnectionFactory implements ClientConnectionFactory
         Promise<Session> sessionPromise = (Promise<Session>)context.get(SESSION_PROMISE_CONTEXT_KEY);
 
         Generator generator = new Generator(bufferPool, client.isUseOutputDirectByteBuffers(), client.getMaxHeaderBlockFragment());
+        generator.getHpackEncoder().setMaxHeaderListSize(client.getMaxRequestHeadersSize());
+
         FlowControlStrategy flowControl = client.getFlowControlStrategyFactory().newFlowControlStrategy();
 
         Parser parser = new Parser(bufferPool, client.getMaxResponseHeadersSize());

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/generator/FrameGenerator.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/generator/FrameGenerator.java
@@ -18,6 +18,7 @@ import java.nio.ByteBuffer;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.http2.frames.Frame;
 import org.eclipse.jetty.http2.frames.FrameType;
+import org.eclipse.jetty.http2.hpack.HpackContext;
 import org.eclipse.jetty.http2.hpack.HpackEncoder;
 import org.eclipse.jetty.http2.hpack.HpackException;
 import org.eclipse.jetty.io.ByteBufferPool;
@@ -52,7 +53,10 @@ public abstract class FrameGenerator
 
     protected RetainableByteBuffer encode(HpackEncoder encoder, MetaData metaData) throws HpackException
     {
-        RetainableByteBuffer hpacked = headerGenerator.getByteBufferPool().acquire(encoder.getMaxHeaderListSize(), isUseDirectByteBuffers());
+        int bufferSize = encoder.getMaxHeaderListSize();
+        if (bufferSize <= 0)
+            bufferSize = HpackContext.DEFAULT_MAX_HEADER_LIST_SIZE;
+        RetainableByteBuffer hpacked = headerGenerator.getByteBufferPool().acquire(bufferSize, isUseDirectByteBuffers());
         try
         {
             ByteBuffer byteBuffer = hpacked.getByteBuffer();

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/generator/FrameGenerator.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/generator/FrameGenerator.java
@@ -50,9 +50,9 @@ public abstract class FrameGenerator
         return headerGenerator.isUseDirectByteBuffers();
     }
 
-    protected RetainableByteBuffer encode(HpackEncoder encoder, MetaData metaData, int maxFrameSize) throws HpackException
+    protected RetainableByteBuffer encode(HpackEncoder encoder, MetaData metaData) throws HpackException
     {
-        RetainableByteBuffer hpacked = headerGenerator.getByteBufferPool().acquire(maxFrameSize, isUseDirectByteBuffers());
+        RetainableByteBuffer hpacked = headerGenerator.getByteBufferPool().acquire(encoder.getMaxHeaderListSize(), isUseDirectByteBuffers());
         try
         {
             ByteBuffer byteBuffer = hpacked.getByteBuffer();

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/generator/PushPromiseGenerator.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/generator/PushPromiseGenerator.java
@@ -50,17 +50,17 @@ public class PushPromiseGenerator extends FrameGenerator
         if (promisedStreamId < 0)
             throw new IllegalArgumentException("Invalid promised stream id: " + promisedStreamId);
 
-        int maxFrameSize = getMaxFrameSize();
-        // The promised streamId space.
-        int extraSpace = 4;
-        maxFrameSize -= extraSpace;
-
-        RetainableByteBuffer hpack = encode(encoder, metaData, maxFrameSize);
+        RetainableByteBuffer hpack = encode(encoder, metaData);
         ByteBuffer hpackByteBuffer = hpack.getByteBuffer();
-        int hpackLength = hpackByteBuffer.position();
         BufferUtil.flipToFlush(hpackByteBuffer, 0);
+        int hpackLength = hpackByteBuffer.remaining();
 
-        int length = hpackLength + extraSpace;
+        // No support for splitting in CONTINUATION frames,
+        // also PushPromiseBodyParser does not support it.
+
+        // The promised streamId length.
+        int promisedStreamIdLength = 4;
+        int length = hpackLength + promisedStreamIdLength;
         int flags = Flags.END_HEADERS;
 
         RetainableByteBuffer header = generateHeader(FrameType.PUSH_PROMISE, length, flags, streamId);

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/SettingsBodyParser.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/SettingsBodyParser.java
@@ -209,6 +209,10 @@ public class SettingsBodyParser extends BodyParser
         if (maxFrameSize != null && (maxFrameSize < Frame.DEFAULT_MAX_SIZE || maxFrameSize > Frame.MAX_MAX_SIZE))
             return connectionFailure(buffer, ErrorCode.PROTOCOL_ERROR.code, "invalid_settings_max_frame_size");
 
+        Integer maxHeaderListSize = settings.get(SettingsFrame.MAX_HEADER_LIST_SIZE);
+        if (maxHeaderListSize != null && maxHeaderListSize <= 0)
+            return connectionFailure(buffer, ErrorCode.PROTOCOL_ERROR.code, "invalid_settings_max_header_list_size");
+
         SettingsFrame frame = new SettingsFrame(settings, hasFlag(Flags.ACK));
         return onSettings(buffer, frame);
     }

--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackContext.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackContext.java
@@ -116,6 +116,7 @@ public class HpackContext
     private static final StaticEntry[] __staticTable = new StaticEntry[STATIC_TABLE.length];
     public static final int STATIC_SIZE = STATIC_TABLE.length - 1;
     public static final int DEFAULT_MAX_TABLE_CAPACITY = 4096;
+    public static final int DEFAULT_MAX_HEADER_LIST_SIZE = 4096;
 
     static
     {

--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackEncoder.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackEncoder.java
@@ -107,7 +107,7 @@ public class HpackEncoder
         _debug = LOG.isDebugEnabled();
         setMaxTableCapacity(HpackContext.DEFAULT_MAX_TABLE_CAPACITY);
         setTableCapacity(HpackContext.DEFAULT_MAX_TABLE_CAPACITY);
-        setMaxHeaderListSize(4096);
+        setMaxHeaderListSize(HpackContext.DEFAULT_MAX_HEADER_LIST_SIZE);
     }
 
     public int getMaxTableCapacity()

--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackEncoder.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackEncoder.java
@@ -107,6 +107,7 @@ public class HpackEncoder
         _debug = LOG.isDebugEnabled();
         setMaxTableCapacity(HpackContext.DEFAULT_MAX_TABLE_CAPACITY);
         setTableCapacity(HpackContext.DEFAULT_MAX_TABLE_CAPACITY);
+        setMaxHeaderListSize(4096);
     }
 
     public int getMaxTableCapacity()

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/AbstractHTTP2ServerConnectionFactory.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/AbstractHTTP2ServerConnectionFactory.java
@@ -286,10 +286,13 @@ public abstract class AbstractHTTP2ServerConnectionFactory extends AbstractConne
         int maxTableSize = getMaxDecoderTableCapacity();
         if (maxTableSize != HpackContext.DEFAULT_MAX_TABLE_CAPACITY)
             settings.put(SettingsFrame.HEADER_TABLE_SIZE, maxTableSize);
+        settings.put(SettingsFrame.MAX_CONCURRENT_STREAMS, getMaxConcurrentStreams());
         int initialStreamRecvWindow = getInitialStreamRecvWindow();
         if (initialStreamRecvWindow != FlowControlStrategy.DEFAULT_WINDOW_SIZE)
             settings.put(SettingsFrame.INITIAL_WINDOW_SIZE, initialStreamRecvWindow);
-        settings.put(SettingsFrame.MAX_CONCURRENT_STREAMS, getMaxConcurrentStreams());
+        int maxFrameSize = getMaxFrameSize();
+        if (maxFrameSize > Frame.DEFAULT_MAX_SIZE)
+            settings.put(SettingsFrame.MAX_FRAME_SIZE, maxFrameSize);
         int maxHeadersSize = getHttpConfiguration().getRequestHeaderSize();
         if (maxHeadersSize > 0)
             settings.put(SettingsFrame.MAX_HEADER_LIST_SIZE, maxHeadersSize);
@@ -303,11 +306,9 @@ public abstract class AbstractHTTP2ServerConnectionFactory extends AbstractConne
         ServerSessionListener listener = newSessionListener(connector, endPoint);
 
         Generator generator = new Generator(connector.getByteBufferPool(), isUseOutputDirectByteBuffers(), getMaxHeaderBlockFragment());
-        generator.getHpackEncoder().setMaxHeaderListSize(getHttpConfiguration().getResponseHeaderSize());
         FlowControlStrategy flowControl = getFlowControlStrategyFactory().newFlowControlStrategy();
 
         ServerParser parser = newServerParser(connector, getRateControlFactory().newRateControl(endPoint));
-        parser.setMaxFrameSize(getMaxFrameSize());
         parser.setMaxSettingsKeys(getMaxSettingsKeys());
 
         HTTP2ServerSession session = new HTTP2ServerSession(connector.getScheduler(), endPoint, parser, generator, listener, flowControl);

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/AbstractHTTP2ServerConnectionFactory.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/AbstractHTTP2ServerConnectionFactory.java
@@ -306,6 +306,8 @@ public abstract class AbstractHTTP2ServerConnectionFactory extends AbstractConne
         ServerSessionListener listener = newSessionListener(connector, endPoint);
 
         Generator generator = new Generator(connector.getByteBufferPool(), isUseOutputDirectByteBuffers(), getMaxHeaderBlockFragment());
+        generator.getHpackEncoder().setMaxHeaderListSize(getHttpConfiguration().getResponseHeaderSize());
+
         FlowControlStrategy flowControl = getFlowControlStrategyFactory().newFlowControlStrategy();
 
         ServerParser parser = newServerParser(connector, getRateControlFactory().newRateControl(endPoint));

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
@@ -144,6 +144,7 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
             assertEquals(httpClient.getIdleTimeout(), http2Client.getIdleTimeout());
             assertEquals(httpClient.isUseInputDirectByteBuffers(), http2Client.isUseInputDirectByteBuffers());
             assertEquals(httpClient.isUseOutputDirectByteBuffers(), http2Client.isUseOutputDirectByteBuffers());
+            assertEquals(httpClient.getRequestBufferSize(), http2Client.getMaxRequestHeadersSize());
             assertEquals(httpClient.getMaxResponseHeadersSize(), http2Client.getMaxResponseHeadersSize());
         }
         assertTrue(http2Client.isStopped());

--- a/jetty-core/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ReverseProxyTest.java
+++ b/jetty-core/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ReverseProxyTest.java
@@ -152,7 +152,8 @@ public class ReverseProxyTest extends AbstractProxyTest
             @Override
             public boolean handle(Request request, Response response, Callback callback)
             {
-                response.getHeaders().put("X-Large", "A".repeat(maxResponseHeadersSize));
+                // Use "+" because in HTTP/2 is Huffman encoded in more than 8 bits.
+                response.getHeaders().put("X-Large", "+".repeat(maxResponseHeadersSize));
 
                 // With HTTP/1.1, calling response.write() would fail the Handler callback
                 // which would trigger ErrorHandler and result in a 500 to the proxy.


### PR DESCRIPTION
* Removed unnecessary and wrong initialization of Parser and Generator properties, as they are initialized by SETTINGS frames (or they have default values already).
* Fixed headers generation, taking into account maxHeaderListSize and maxFrameSize correctly.