### PR TITLE
Fixes #12496 - MultiPartFormData.Parser question.

### DIFF
--- a/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/migration/ServletToHandlerDocs.java
+++ b/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/migration/ServletToHandlerDocs.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.docs.programming.migration;
 
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
 import java.util.Locale;
@@ -27,9 +28,12 @@ import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpURI;
+import org.eclipse.jetty.http.MultiPartConfig;
+import org.eclipse.jetty.http.MultiPartFormData;
 import org.eclipse.jetty.http.Trailers;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.server.Context;
+import org.eclipse.jetty.server.FormFields;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
@@ -196,7 +200,7 @@ public class ServletToHandlerDocs
             Session session = request.getSession(create);
 
             callback.succeeded();
-            return false;
+            return true;
         }
     }
     // end::request[]
@@ -360,6 +364,75 @@ public class ServletToHandlerDocs
             return true;
         }
         // end::requestContent-source[]
+    }
+
+    @SuppressWarnings("InnerClassMayBeStatic")
+    public class RequestContentAPIsFormFields extends Handler.Abstract
+    {
+        // tag::requestContent-formFields[]
+        @Override
+        public boolean handle(Request request, Response response, Callback callback) throws Exception
+        {
+            FormFields.onFields(request, new Promise.Invocable<>()
+            {
+                @Override
+                public void succeeded(Fields fields)
+                {
+                    // Process the form fields here.
+
+                    // Implicitly respond with status code 200 and no content.
+                    callback.succeeded();
+                }
+
+                @Override
+                public void failed(Throwable failure)
+                {
+                    // Implicitly respond with status code 500.
+                    callback.failed(failure);
+                }
+            });
+
+            return true;
+        }
+        // end::requestContent-formFields[]
+    }
+
+    @SuppressWarnings("InnerClassMayBeStatic")
+    public class RequestContentAPIsMultiPart extends Handler.Abstract
+    {
+        // tag::requestContent-multiPart[]
+        @Override
+        public boolean handle(Request request, Response response, Callback callback) throws Exception
+        {
+            String contentType = request.getHeaders().get(HttpHeader.CONTENT_TYPE);
+
+            MultiPartConfig multiPartConfig = new MultiPartConfig.Builder()
+                // The directory where the parts content are saved.
+                .location(Path.of("/tmp"))
+                .build();
+
+            MultiPartFormData.onParts(request, request, contentType, multiPartConfig, new Promise.Invocable<>()
+            {
+                @Override
+                public void succeeded(MultiPartFormData.Parts parts)
+                {
+                    // Process the parts here.
+
+                    // Implicitly respond with status code 200 and no content.
+                    callback.succeeded();
+                }
+
+                @Override
+                public void failed(Throwable failure)
+                {
+                    // Implicitly respond with status code 500.
+                    callback.failed(failure);
+                }
+            });
+
+            return true;
+        }
+        // end::requestContent-multiPart[]
     }
 
     @SuppressWarnings("InnerClassMayBeStatic")

--- a/documentation/jetty/modules/programming-guide/pages/migration/11-to-12.adoc
+++ b/documentation/jetty/modules/programming-guide/pages/migration/11-to-12.adoc
@@ -133,6 +133,10 @@ include::code:example$src/main/java/org/eclipse/jetty/docs/programming/migration
 include::code:example$src/main/java/org/eclipse/jetty/docs/programming/migration/ServletToHandlerDocs.java[tags=requestContent-stream]
 
 include::code:example$src/main/java/org/eclipse/jetty/docs/programming/migration/ServletToHandlerDocs.java[tags=requestContent-source]
+
+include::code:example$src/main/java/org/eclipse/jetty/docs/programming/migration/ServletToHandlerDocs.java[tags=requestContent-formFields]
+
+include::code:example$src/main/java/org/eclipse/jetty/docs/programming/migration/ServletToHandlerDocs.java[tags=requestContent-multiPart]
 ----
 
 Refer also to the `Content.Source` APIs detailed in xref:arch/io.adoc#content-source[this section].

--- a/documentation/jetty/modules/programming-guide/pages/server/http.adoc
+++ b/documentation/jetty/modules/programming-guide/pages/server/http.adoc
@@ -1460,8 +1460,9 @@ For form parameters, typical of HTML form submissions, you can use the `FormFiel
 ----
 include::code:example$src/main/java/org/eclipse/jetty/docs/programming/server/http/HTTPServerDocs.java[tags=handlerForm]
 ----
-<1> If the `Content-Type` is `x-www-form-urlencoded`, read the request content with `FormFields`.
+<1> If the `Content-Type` is `application/x-www-form-urlencoded`, read the request content with `FormFields`.
 <2> When all the request content has arrived, process the `Fields`.
+<3> Specify that processing of the form fields is non-blocking.
 
 [WARNING]
 ====
@@ -1478,8 +1479,9 @@ For multipart form data, typical for HTML form file uploads, you can use the `Mu
 ----
 include::code:example$src/main/java/org/eclipse/jetty/docs/programming/server/http/HTTPServerDocs.java[tags=handlerMultiPart]
 ----
-<1> If the `Content-Type` is `multipart/form-data`, read the request content with `MultiPartFormData.Parser`.
+<1> If the `Content-Type` is `multipart/form-data`, parse the request content with `MultiPartFormData`.
 <2> When all the request content has arrived, process the `MultiPartFormData.Parts`.
+<3> Specify that processing of the parts is non-blocking.
 
 [WARNING]
 ====

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartFormData.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartFormData.java
@@ -43,12 +43,13 @@ import org.slf4j.LoggerFactory;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
 /**
- * <p>A {@link CompletableFuture} that is completed when a multipart/form-data content
- * has been parsed asynchronously from a {@link Content.Source}.</p>
- * <p>Once the parsing of the multipart/form-data content completes successfully,
- * objects of this class are completed with a {@link Parts} object.</p>
- * <p>Objects of this class may be configured to save multipart files in a configurable
- * directory, and configure the max size of such files, etc.</p>
+ * <p>A container class for {@code multipart/form-data} parsing and generation.</p>
+ * <p>Use {@link Parser} to parse {@code multipart/form-data}, and use
+ * {@link ContentSource} to generate {@code multipart/form-data} from parts.</p>
+ * <p>Once the parsing of the {@code multipart/form-data} content completes successfully,
+ * a {@link Parts} object is provided.</p>
+ * <p>{@link Parser} may be configured to save multipart files in a configurable
+ * directory, and configure the max size of such files, etc. via {@link MultiPartConfig}.</p>
  * <p>Typical usage:</p>
  * <pre>{@code
  * // Some headers that include Content-Type.
@@ -58,17 +59,51 @@ import static java.nio.charset.StandardCharsets.US_ASCII;
  * // Some multipart/form-data content.
  * Content.Source content = ...;
  *
- * // Create and configure MultiPartFormData.
- * MultiPartFormData.Parser formData = new MultiPartFormData.Parser(boundary);
+ * // Create and configure MultiPartFormData.Parser.
+ * MultiPartFormData.Parser parser = new MultiPartFormData.Parser(boundary);
  * // Where to store the files.
- * formData.setFilesDirectory(Path.of("/tmp"));
+ * parser.setFilesDirectory(Path.of("/tmp"));
  * // Max 1 MiB files.
- * formData.setMaxFileSize(1024 * 1024);
+ * parser.setMaxFileSize(1024 * 1024);
  *
  * // Parse the content.
- * formData.parse(content)
- *     // When complete, use the parts.
- *     .thenAccept(parts -> ...);
+ * parser.parse(content, new Promise.Invocable<>()
+ * {
+ *     @Override
+ *     public void succeeded(MultiPartFormData.Parts parts)
+ *     {
+ *         // Use the parts.
+ *     }
+ *
+ *     @Override
+ *     public void failed(Throwable x)
+ *     {
+ *         // Handle failure.
+ *     }
+ * }
+ * }</pre>
+ * <p>For usage within a server environment, use:</p>
+ * <pre>{@code
+ * Request request = ...;
+ * String contentType = request.getHeaders().get("Content-Type");
+ * MultiPartConfig config = new MultiPartConfig.Builder()
+ *     .location(Path.of("/tmp"))
+ *     .maxPartSize(1024 * 1024)
+ *     .build();
+ * MultiPartFormData.onParts(request, request, contentType, config, new Promise.Invocable<>()
+ * {
+ *     @Override
+ *     public void succeeded(MultiPartFormData.Parts parts)
+ *     {
+ *         // Use the parts.
+ *     }
+ *
+ *     @Override
+ *     public void failed(Throwable x)
+ *     {
+ *         // Handle failure.
+ *     }
+ * });
  * }</pre>
  *
  * @see Parts
@@ -228,6 +263,7 @@ public class MultiPartFormData
      *
      * @param attributes the attributes where the futureParts are tracked
      * @return the future parts
+     * @deprecated use {@link #getParts(Attributes)} instead
      */
     @SuppressWarnings("unchecked")
     @Deprecated(forRemoval = true, since = "12.0.15")
@@ -360,7 +396,6 @@ public class MultiPartFormData
         private long maxMemoryFileSize;
         private long maxLength = -1;
         private long length;
-        private Parts parts;
 
         public Parser(String boundary)
         {
@@ -378,9 +413,13 @@ public class MultiPartFormData
             parser = new MultiPart.Parser(Objects.requireNonNull(boundary), compliance, listener);
         }
 
+        /**
+         * @deprecated use {@link #parse(Content.Source, Promise.Invocable)} or
+         * {@link MultiPartFormData#onParts(Content.Source, Attributes, String, MultiPartConfig, Promise.Invocable)} instead.
+         */
+        @Deprecated(forRemoval = true, since = "12.0.16")
         public void parse(Content.Source content, Promise<Parts> immediate, Promise.Invocable<Parts> future)
         {
-            // TODO implement without CF
             CompletableFuture<Parts> cf = parse(content, future.getInvocationType());
             if (cf.isDone())
             {
@@ -409,30 +448,63 @@ public class MultiPartFormData
             }
         }
 
+        /**
+         * @deprecated use {@link #parse(Content.Source, Promise.Invocable)} or
+         * {@link MultiPartFormData#onParts(Content.Source, Attributes, String, MultiPartConfig, Promise.Invocable)} instead.
+         */
         @Deprecated(forRemoval = true, since = "12.0.15")
         public CompletableFuture<Parts> parse(Content.Source content)
         {
             return parse(content, InvocationType.NON_BLOCKING);
         }
 
+        /**
+         * @deprecated use {@link #parse(Content.Source, Promise.Invocable)} or
+         * {@link MultiPartFormData#onParts(Content.Source, Attributes, String, MultiPartConfig, Promise.Invocable)} instead.
+         */
         @Deprecated(forRemoval = true, since = "12.0.15")
         public CompletableFuture<Parts> parse(Content.Source content, InvocationType invocationType)
         {
-            ContentSourceCompletableFuture<Parts> futureParts = new ContentSourceCompletableFuture<>(content, invocationType)
+            CompletableFuture<Parts> completable = new CompletableFuture<>();
+            Promise.Invocable<Parts> futureParts = new Promise.Invocable<>()
+            {
+                @Override
+                public void succeeded(Parts result)
+                {
+                    completable.complete(result);
+                }
+
+                @Override
+                public void failed(Throwable x)
+                {
+                    completable.completeExceptionally(x);
+                }
+
+                @Override
+                public InvocationType getInvocationType()
+                {
+                    return invocationType;
+                }
+            };
+            parse(content, futureParts);
+            return completable;
+        }
+
+        public void parse(Content.Source content, Promise.Invocable<Parts> promise)
+        {
+            ContentSourceCompletableFuture<Parts> futureParts = new ContentSourceCompletableFuture<>(content, promise.getInvocationType())
             {
                 @Override
                 protected Parts parse(Content.Chunk chunk) throws Throwable
                 {
-                    if (listener.isFailed())
-                        throw listener.failure;
+                    listener.rethrowIfFailed();
                     length += chunk.getByteBuffer().remaining();
                     long max = getMaxLength();
                     if (max >= 0 && length > max)
                         throw new IllegalStateException("max length exceeded: %d".formatted(max));
                     parser.parse(chunk);
-                    if (listener.isFailed())
-                        throw listener.failure;
-                    return parts;
+                    listener.rethrowIfFailed();
+                    return listener.getParts();
                 }
 
                 @Override
@@ -445,7 +517,7 @@ public class MultiPartFormData
                 }
             };
             futureParts.parse();
-            return futureParts;
+            futureParts.whenComplete(promise);
         }
 
         /**
@@ -630,12 +702,13 @@ public class MultiPartFormData
         private class PartsListener extends MultiPart.AbstractPartsListener
         {
             private final AutoLock lock = new AutoLock();
-            private final List<MultiPart.Part> parts = new ArrayList<>();
+            private final List<MultiPart.Part> partList = new ArrayList<>();
             private final List<Content.Chunk> partChunks = new ArrayList<>();
             private long size;
             private Path filePath;
             private SeekableByteChannel fileChannel;
             private Throwable failure;
+            private Parts parts;
 
             @Override
             public void onPartContent(Content.Chunk chunk)
@@ -791,7 +864,7 @@ public class MultiPartFormData
                     partChunks.forEach(Content.Chunk::release);
                     partChunks.clear();
                     // Store the new part.
-                    parts.add(part);
+                    partList.add(part);
                 }
             }
 
@@ -802,8 +875,8 @@ public class MultiPartFormData
                 List<MultiPart.Part> result;
                 try (AutoLock ignored = lock.lock())
                 {
-                    result = List.copyOf(parts);
-                    Parser.this.parts = new Parts(result);
+                    result = List.copyOf(partList);
+                    parts = new Parts(result);
                 }
             }
 
@@ -811,7 +884,7 @@ public class MultiPartFormData
             {
                 try (AutoLock ignored = lock.lock())
                 {
-                    return parts.stream()
+                    return partList.stream()
                         .filter(part -> "_charset_".equals(part.getName()))
                         .map(part -> part.getContentAsString(US_ASCII))
                         .map(Charset::forName)
@@ -824,7 +897,7 @@ public class MultiPartFormData
             {
                 try (AutoLock ignored = lock.lock())
                 {
-                    return parts.size();
+                    return partList.size();
                 }
             }
 
@@ -857,8 +930,8 @@ public class MultiPartFormData
                     if (failure != null)
                         return;
                     failure = cause;
-                    partsToFail = List.copyOf(parts);
-                    parts.clear();
+                    partsToFail = List.copyOf(partList);
+                    partList.clear();
                     partChunks.forEach(Content.Chunk::release);
                     partChunks.clear();
                 }
@@ -897,11 +970,12 @@ public class MultiPartFormData
                 }
             }
 
-            private boolean isFailed()
+            private void rethrowIfFailed() throws Throwable
             {
                 try (AutoLock ignored = lock.lock())
                 {
-                    return failure != null;
+                    if (failure != null)
+                        throw failure;
                 }
             }
 
@@ -929,6 +1003,14 @@ public class MultiPartFormData
                 catch (Throwable x)
                 {
                     onFailure(x);
+                }
+            }
+
+            private Parts getParts()
+            {
+                try (AutoLock ignored = lock.lock())
+                {
+                    return parts;
                 }
             }
         }

--- a/jetty-core/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdAuthenticator.java
+++ b/jetty-core/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdAuthenticator.java
@@ -21,7 +21,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.CompletionException;
 import java.util.function.Function;
 
 import org.eclipse.jetty.http.HttpFields;
@@ -390,16 +390,9 @@ public class OpenIdAuthenticator extends LoginAuthenticator
 
     protected Fields getParameters(Request request)
     {
-        try
-        {
-            Fields queryFields = Request.extractQueryParameters(request);
-            Fields formFields = FormFields.from(request).get();
-            return Fields.combine(queryFields, formFields);
-        }
-        catch (InterruptedException | ExecutionException e)
-        {
-            throw new RuntimeException(e);
-        }
+        Fields queryFields = Request.extractQueryParameters(request);
+        Fields formFields = FormFields.getFields(request);
+        return Fields.combine(queryFields, formFields);
     }
 
     @Override
@@ -583,13 +576,13 @@ public class OpenIdAuthenticator extends LoginAuthenticator
                     {
                         try
                         {
-                            session.setAttribute(J_POST, FormFields.from(request).get());
+                            session.setAttribute(J_POST, FormFields.getFields(request));
                         }
-                        catch (ExecutionException e)
+                        catch (CompletionException e)
                         {
                             throw new ServerAuthException(e.getCause());
                         }
-                        catch (InterruptedException e)
+                        catch (Exception e)
                         {
                             throw new ServerAuthException(e);
                         }

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/jaas/callback/DefaultCallbackHandler.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/jaas/callback/DefaultCallbackHandler.java
@@ -21,7 +21,6 @@ import javax.security.auth.callback.UnsupportedCallbackException;
 
 import org.eclipse.jetty.server.FormFields;
 import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.util.ExceptionUtil;
 import org.eclipse.jetty.util.Fields;
 
 /**
@@ -63,7 +62,7 @@ public class DefaultCallbackHandler extends AbstractCallbackHandler
                 {
                     RequestParameterCallback rpc = (RequestParameterCallback)callback;
                     Fields queryFields = Request.extractQueryParameters(_request);
-                    Fields formFields = ExceptionUtil.get(FormFields.from(_request));
+                    Fields formFields = FormFields.getFields(_request);
                     Fields fields = Fields.combine(queryFields, formFields);
                     rpc.setParameterValues(fields.getValues(rpc.getParameterName()));
                 }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/FormFields.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/FormFields.java
@@ -82,6 +82,7 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
      * Set a {@link Fields} or related failure for the request
      * @param request The request to which to associate the fields with
      * @param fields A {@link CompletableFuture} that will provide either the fields or a failure.
+     * @deprecated do not use it, no replacement.
      */
     @Deprecated(forRemoval = true, since = "12.0.15")
     public static void set(Request request, CompletableFuture<Fields> fields)
@@ -174,6 +175,22 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
     {
         int maxFields = getContextAttribute(request.getContext(), FormFields.MAX_FIELDS_ATTRIBUTE, FormFields.MAX_FIELDS_DEFAULT);
         int maxLength = getContextAttribute(request.getContext(), FormFields.MAX_LENGTH_ATTRIBUTE, FormFields.MAX_LENGTH_DEFAULT);
+        onFields(request, charset, maxFields, maxLength, promise);
+    }
+
+    /**
+     * <p>Asynchronously reads and parses {@link FormFields} from a {@link Request}.</p>
+     * <p>Calls to {@code onFields} and {@code getFields} methods are idempotent, and
+     * can be called multiple times, with subsequent calls returning the results of the first call.</p>
+     *
+     * @param request The request to get or read the Fields from
+     * @param charset The {@link Charset} of the request content, if previously extracted.
+     * @param maxFields The maximum number of fields to accept
+     * @param maxLength The maximum length of fields
+     * @param promise The action to take when the FormFields are available.
+     */
+    public static void onFields(Request request, Charset charset, int maxFields, int maxLength, Promise.Invocable<Fields> promise)
+    {
         from(request, promise.getInvocationType(), request, charset, maxFields, maxLength).whenComplete(promise);
     }
 
@@ -181,7 +198,7 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
      * @param request The request to enquire from
      * @return A {@link CompletableFuture} that will provide either the fields or a failure, or null if none set.
      * @see #from(Request)
-     *
+     * @deprecated use {@link #getFields(Request)} instead.
      */
     @Deprecated(forRemoval = true, since = "12.0.15")
     public static CompletableFuture<Fields> get(Request request)
@@ -200,6 +217,7 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
      *                using the classname as the attribute name, else the request is used
      *                as a {@link Content.Source} from which to read the fields and set the attribute.
      * @return A {@link CompletableFuture} that will provide the {@link Fields} or a failure.
+     * @deprecated use {@link #onFields(Request, Promise.Invocable)} instead.
      */
     @Deprecated(forRemoval = true, since = "12.0.15")
     public static CompletableFuture<Fields> from(Request request)
@@ -216,6 +234,7 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
      *                as a {@link Content.Source} from which to read the fields and set the attribute.
      * @param charset the {@link Charset} to use for byte to string conversion.
      * @return A {@link CompletableFuture} that will provide the {@link Fields} or a failure.
+     * @deprecated use {@link #onFields(Request, Charset, Promise.Invocable)} instead.
      */
     @Deprecated(forRemoval = true, since = "12.0.15")
     public static CompletableFuture<Fields> from(Request request, Charset charset)
@@ -233,6 +252,7 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
      * @param maxFields The maximum number of fields to be parsed
      * @param maxLength The maximum total size of the fields
      * @return A {@link CompletableFuture} that will provide the {@link Fields} or a failure.
+     * @deprecated use {@link #onFields(Request, Charset, int, int, Promise.Invocable)} instead.
      */
     @Deprecated(forRemoval = true, since = "12.0.15")
     public static CompletableFuture<Fields> from(Request request, int maxFields, int maxLength)
@@ -249,6 +269,7 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
      * @param maxFields The maximum number of fields to be parsed
      * @param maxLength The maximum total size of the fields
      * @return A {@link CompletableFuture} that will provide the {@link Fields} or a failure.
+     * @deprecated use {@link #onFields(Request, Charset, int, int, Promise.Invocable)} instead.
      */
     @Deprecated(forRemoval = true, since = "12.0.15")
     public static CompletableFuture<Fields> from(Request request, Charset charset, int maxFields, int maxLength)

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -51,10 +51,12 @@ import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.server.internal.CompletionStreamWrapper;
 import org.eclipse.jetty.server.internal.HttpChannelState;
 import org.eclipse.jetty.util.Attributes;
+import org.eclipse.jetty.util.Blocker;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.Fields;
 import org.eclipse.jetty.util.HostPort;
 import org.eclipse.jetty.util.NanoTime;
+import org.eclipse.jetty.util.Promise;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.UrlEncoded;
@@ -570,14 +572,53 @@ public interface Request extends Attributes, Content.Source
 
     static Fields getParameters(Request request) throws Exception
     {
-        return getParametersAsync(request).get();
+        try (Blocker.Promise<Fields> promise = Blocker.promise())
+        {
+            onParameters(request, promise);
+            return promise.block();
+        }
     }
 
+    /**
+     * @deprecated use {@link #onParameters(Request, Promise.Invocable)} instead.
+     */
+    @Deprecated(forRemoval = true, since = "12.0.16")
     static CompletableFuture<Fields> getParametersAsync(Request request)
     {
         Fields queryFields = Request.extractQueryParameters(request);
         CompletableFuture<Fields> contentFields = FormFields.from(request);
         return contentFields.thenApply(formFields -> Fields.combine(queryFields, formFields));
+    }
+
+    /**
+     * Asynchronous version of {@link #getParameters(Request)}.
+     *
+     * @param request the request
+     * @param promise the promise that will be completed with the parameters
+     */
+    static void onParameters(Request request, Promise.Invocable<Fields> promise)
+    {
+        Fields queryFields = Request.extractQueryParameters(request);
+        FormFields.onFields(request, new Promise.Invocable<>()
+        {
+            @Override
+            public void succeeded(Fields result)
+            {
+                promise.succeeded(Fields.combine(queryFields, result));
+            }
+
+            @Override
+            public void failed(Throwable x)
+            {
+                promise.failed(x);
+            }
+
+            @Override
+            public InvocationType getInvocationType()
+            {
+                return promise.getInvocationType();
+            }
+        });
     }
 
     @SuppressWarnings("unchecked")

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Blocker.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Blocker.java
@@ -206,7 +206,7 @@ public class Blocker
         };
     }
 
-    public interface Promise<C> extends org.eclipse.jetty.util.Promise<C>, AutoCloseable, Invocable
+    public interface Promise<C> extends org.eclipse.jetty.util.Promise.Invocable<C>, AutoCloseable
     {
         C block() throws IOException;
 

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/ManyHandlers.java
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/ManyHandlers.java
@@ -73,7 +73,7 @@ public class ManyHandlers
         public boolean handle(Request request, Response response, Callback callback) throws Exception
         {
             Fields queryFields = Request.extractQueryParameters(request);
-            Fields formFields = FormFields.from(request).get();
+            Fields formFields = FormFields.getFields(request);
 
             response.getHeaders().put(HttpHeader.CONTENT_TYPE, MimeTypes.Type.TEXT_JSON.asString());
             response.write(true,

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
@@ -470,7 +470,7 @@ public class Request implements HttpServletRequest
             {
                 try
                 {
-                    _contentParameters = FormFields.get(_coreRequest).get();
+                    _contentParameters = FormFields.getFields(_coreRequest);
                     return;
                 }
                 catch (RuntimeException e)


### PR DESCRIPTION
* Deprecated MultiPartFormData.Parser.parse() with 2 Promises, a leftover from previous experiments.
* Added `@deprecated` javadoc tag to deprecated methods, indicating what to use instead.
* Updated documentation to use non-deprecated APIs.
* Updated source code to use non-deprecated APIs.
* Updated class javadocs with usage examples that were outdated.
* Made Blocker.Promise extends Promise.Invocable, so it can be use to block while using asynchronous APIs.
* Added missing methods that perform asynchronous operation using a Promise rather than CompletableFuture.