### PR TITLE
Undisable WebAppContextTest.testGetResourcePaths

### DIFF
--- a/jetty-ee8/jetty-ee8-webapp/pom.xml
+++ b/jetty-ee8/jetty-ee8-webapp/pom.xml
@@ -117,6 +117,10 @@
                   <directory>${maven.multiModuleProjectDirectory}/jetty-ee9/jetty-ee9-webapp/src/test/webapp-alt-jsp</directory>
                   <targetPath>webapp-alt-jsp</targetPath>
                 </resource>
+                <resource>
+                  <directory>${maven.multiModuleProjectDirectory}/jetty-ee9/jetty-ee9-webapp/src/test/webapp-with-resources</directory>
+                  <targetPath>webapp-with-resources</targetPath>
+                </resource>
               </resources>
             </configuration>
           </execution>
@@ -127,6 +131,8 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>@{argLine} ${jetty.surefire.argLine}
+               --add-exports org.eclipse.jetty.ee8.webapp/org.acme.webapp=org.eclipse.jetty.ee8.servlet
+               --add-exports org.eclipse.jetty.ee8.webapp/org.acme.webapp=org.eclipse.jetty.ee8.nested
                --add-reads org.eclipse.jetty.ee8.webapp=org.eclipse.jetty.logging</argLine>
           <useManifestOnlyJar>false</useManifestOnlyJar>
           <additionalClasspathElements>

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
@@ -1910,10 +1910,10 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
         @Override
         public String getRealPath(String path)
         {
-            // This is an API call from the application which may pass non-canonical paths.
-            // Thus, we canonicalize here, to avoid the enforcement of canonical paths in
+            // This is an API call from the application which may pass non-normalized paths.
+            // Thus, we normalize here, to avoid the enforcement of normalized paths in
             // ContextHandler.this.getResource(path).
-            path = URIUtil.canonicalPath(path);
+            path = URIUtil.normalizePath(path);
             if (path == null)
                 return null;
             if (path.length() == 0)
@@ -1957,10 +1957,10 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
         @Override
         public URL getResource(String path) throws MalformedURLException
         {
-            // This is an API call from the application which may pass non-canonical paths.
-            // Thus, we canonicalize here, to avoid the enforcement of canonical paths in
+            // This is an API call from the application which may pass non-normalized paths.
+            // Thus, we normalize here, to avoid the enforcement of normalized paths in
             // ContextHandler.this.getResource(path).
-            path = URIUtil.canonicalPath(path);
+            path = URIUtil.normalizePath(path);
             if (path == null)
                 return null;
             Resource resource = ContextHandler.this.getResource(path);
@@ -1993,10 +1993,10 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
         @Override
         public Set<String> getResourcePaths(String path)
         {
-            // This is an API call from the application which may pass non-canonical paths.
-            // Thus, we canonicalize here, to avoid the enforcement of canonical paths in
+            // This is an API call from the application which may pass non-normalized paths.
+            // Thus, we normalize here, to avoid the enforcement of normalized paths in
             // ContextHandler.this.getResource(path).
-            path = URIUtil.canonicalPath(path);
+            path = URIUtil.normalizePath(path);
             if (path == null)
                 return null;
             return ContextHandler.this.getResourcePaths(path);

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppContextTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppContextTest.java
@@ -63,7 +63,6 @@ import org.eclipse.jetty.util.resource.Resources;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Isolated;
@@ -117,7 +116,6 @@ public class WebAppContextTest
      * @param tempDir the directory into which the war will be generated
      * @param name the name of the war
      * @return the Path of the generated war
-     *
      * @throws Exception if the war cannot be created
      */
     private Path createWar(Path tempDir, String name) throws Exception
@@ -350,17 +348,17 @@ public class WebAppContextTest
      * @throws Exception on test failure
      */
     @Test
-    @Disabled // No cross context dispatch
     public void testContextWhiteList() throws Exception
     {
         Server server = newServer();
         Handler.Sequence handlers = new Handler.Sequence();
         WebAppContext contextA = new WebAppContext(".", "/A");
+        contextA.setCrossContextDispatchSupported(true);
 
         contextA.addServlet(ServletA.class, "/s");
         handlers.addHandler(contextA);
         WebAppContext contextB = new WebAppContext(".", "/B");
-
+        contextB.setCrossContextDispatchSupported(true);
         contextB.addServlet(ServletB.class, "/s");
         contextB.setContextWhiteList("/doesnotexist", "/B/s");
         handlers.addHandler(contextB);
@@ -456,7 +454,7 @@ public class WebAppContextTest
         assertThat(HttpTester.parseResponse(connector.getResponse("GET //WEB-INF/test.xml HTTP/1.1\r\nHost: localhost:8080\r\nConnection: close\r\n\r\n")).getStatus(), is(HttpStatus.NOT_FOUND_404));
         assertThat(HttpTester.parseResponse(connector.getResponse("GET /WEB-INF%2ftest.xml HTTP/1.1\r\nHost: localhost:8080\r\nConnection: close\r\n\r\n")).getStatus(), is(HttpStatus.NOT_FOUND_404));
     }
-        
+
     @ParameterizedTest
     @ValueSource(strings = {
         "/WEB-INF",
@@ -652,7 +650,6 @@ public class WebAppContextTest
     }
 
     @Test
-    @Disabled("There is extra decoding of the nested-reserved paths that is getting in the way")
     public void testGetResourcePaths() throws Exception
     {
         Server server = newServer();
@@ -697,8 +694,6 @@ public class WebAppContextTest
 
         assertThat(response1.getStatus(), is(HttpStatus.OK_200));
         assertThat(response1.getContent(), containsString("/WEB-INF"));
-        assertThat(response1.getContent(), containsString("/WEB-INF/lib"));
-        assertThat(response1.getContent(), containsString("/WEB-INF/lib/odd-resource.jar"));
         assertThat(response1.getContent(), containsString("/nested-reserved-!#\\\\$%&()*+,:=?@[]-meta-inf-resource.txt"));
 
         HttpTester.Response response2 = HttpTester.parseResponse(connector.getResponse("""
@@ -877,8 +872,10 @@ public class WebAppContextTest
         assertThat("Should have environment specific test pattern", serverClasses, hasItem(testPattern));
         assertThat("Should have pattern from defaults", serverClasses, hasItem("org.eclipse.jetty."));
         assertThat("Should have pattern from JaasConfiguration", serverClasses, hasItem("-org.eclipse.jetty.security.jaas."));
-        for (String defaultServerClass: WebAppClassLoading.DEFAULT_HIDDEN_CLASSES)
+        for (String defaultServerClass : WebAppClassLoading.DEFAULT_HIDDEN_CLASSES)
+        {
             assertThat("Should have default patterns", serverClasses, hasItem(defaultServerClass));
+        }
         assertThat("deprecated API", serverClasses, hasItem("org.deprecated.api."));
     }
 
@@ -911,7 +908,9 @@ public class WebAppContextTest
         assertThat("Should have pattern from defaults", systemClasses, hasItem("jakarta."));
         assertThat("Should have pattern from JaasConfiguration", systemClasses, hasItem("org.eclipse.jetty.security.jaas."));
         for (String defaultSystemClass : WebAppClassLoading.DEFAULT_PROTECTED_CLASSES)
+        {
             assertThat("Should have default patterns", systemClasses, hasItem(defaultSystemClass));
+        }
         assertThat("deprecated API", systemClasses, hasItem("org.deprecated.api."));
     }
 }

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppContextTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppContextTest.java
@@ -656,7 +656,8 @@ public class WebAppContextTest
         LocalConnector connector = new LocalConnector(server);
         server.addConnector(connector);
 
-        Path warRoot = MavenPaths.findTestResourceDir("webapp-with-resources");
+
+        Path warRoot = MavenTestingUtils.getTargetPath("test-classes/webapp-with-resources");
         assertTrue(Files.isDirectory(warRoot), "Unable to find directory: " + warRoot);
         WebAppContext context = new WebAppContext();
         Resource warResource = context.getResourceFactory().newResource(warRoot);


### PR DESCRIPTION
Undisable the `ee9` `WebAppContextTest.testGetResourcePaths` test.

I discovered that in `ee9` we have kept the call to `URIUtil.canonicalizePath` method in the `ContextHandler.Context.getResource*()` methods, however the _meaning_ of this method  changed in jetty-12: in older jetty versions it did the same as the new `URIUtil.normalizePath` method, but in jetty-12 it really does do the full canonicalization. I believe these `ee9` methods need to use `URIUtil.normalizePath` methods instead.  Worth noting that the `ee10` `ServletContextHander.ServletContextAPI` methods _do_ use `URIUtil.normalizePath` instead.