### PR TITLE
limit dependabot for jboss threads jetty 10/11 and few more for 9.4.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -239,4 +239,7 @@ updates:
         versions: [ ">=3.12" ]
       - dependency-name: "org.junit.jupiter:*"
         versions: [ ">=5.11" ]
+      - dependency-name: "javax.websocket:*"
+        versions: [ ">=1.1"]
+
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -91,6 +91,8 @@ updates:
         versions: [ ">=10.0.0"]
       - dependency-name: "org.jboss.threads:*"
         versions: [ ">=3.7.0"]
+      - dependency-name: "com.hazelcast:*"
+        versions: [ ">=5.4"]
 
   - package-ecosystem: "maven"
     directory: "/"
@@ -189,6 +191,8 @@ updates:
         versions: [ ">=10.1.0"]
       - dependency-name: "org.jboss.threads:*"
         versions: [ ">=3.7.0"]
+      - dependency-name: "com.hazelcast:*"
+        versions: [ ">=5.4"]
 
   - package-ecosystem: "maven"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -241,5 +241,6 @@ updates:
         versions: [ ">=5.11" ]
       - dependency-name: "javax.websocket:*"
         versions: [ ">=1.1"]
-
+      - dependency-name: "org.infinispan.protostream:*"
+        versions: [ ">4.5" ]
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -243,4 +243,6 @@ updates:
         versions: [ ">=1.1"]
       - dependency-name: "org.infinispan.protostream:*"
         versions: [ ">4.5" ]
+      - dependency-name: "org.apache.avro:*"
+        versions: [ ">=1.12" ]
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -237,4 +237,6 @@ updates:
         versions: [ ">=2.3" ]
       - dependency-name: "org.eclipse.platform:org.eclipse.osgi.services"
         versions: [ ">=3.12" ]
+      - dependency-name: "org.junit.jupiter:*"
+        versions: [ ">=5.11" ]
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -89,6 +89,8 @@ updates:
         versions: [ ">=1.4.0"]
       - dependency-name: "org.mortbay.jasper:*"
         versions: [ ">=10.0.0"]
+      - dependency-name: "org.jboss.threads:*"
+        versions: [ ">=3.7.0"]
 
   - package-ecosystem: "maven"
     directory: "/"
@@ -185,6 +187,8 @@ updates:
         versions: [ ">=12" ]
       - dependency-name: "org.mortbay.jasper:*"
         versions: [ ">=10.1.0"]
+      - dependency-name: "org.jboss.threads:*"
+        versions: [ ">=3.7.0"]
 
   - package-ecosystem: "maven"
     directory: "/"


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>
