### PR TITLE
WebSocket cleanups from PR #12441

### DIFF
--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/internal/DelegatedJettyClientUpgradeRequest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/internal/DelegatedJettyClientUpgradeRequest.java
@@ -41,10 +41,12 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class DelegatedJettyClientUpgradeRequest implements UpgradeRequest
 {
     private final CoreClientUpgradeRequest delegate;
+    private final Map<String, List<String>> headers;
 
     public DelegatedJettyClientUpgradeRequest(CoreClientUpgradeRequest delegate)
     {
         this.delegate = delegate;
+        this.headers = HttpFields.asMap(delegate.getHeaders());
     }
 
     @Override
@@ -79,7 +81,7 @@ public class DelegatedJettyClientUpgradeRequest implements UpgradeRequest
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        return HttpFields.asMap(delegate.getHeaders());
+        return headers;
     }
 
     @Override

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/internal/DelegatedJettyClientUpgradeResponse.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/internal/DelegatedJettyClientUpgradeResponse.java
@@ -32,10 +32,12 @@ import org.eclipse.jetty.websocket.api.UpgradeResponse;
 public class DelegatedJettyClientUpgradeResponse implements UpgradeResponse
 {
     private final Response delegate;
+    private final Map<String, List<String>> headers;
 
     public DelegatedJettyClientUpgradeResponse(Response response)
     {
         this.delegate = response;
+        this.headers = HttpFields.asMap(delegate.getHeaders());
     }
 
     @Override
@@ -65,7 +67,7 @@ public class DelegatedJettyClientUpgradeResponse implements UpgradeResponse
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        return HttpFields.asMap(delegate.getHeaders());
+        return headers;
     }
 
     @Override

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/internal/UpgradeRequestDelegate.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/internal/UpgradeRequestDelegate.java
@@ -35,10 +35,12 @@ import org.eclipse.jetty.websocket.core.server.ServerUpgradeRequest;
 class UpgradeRequestDelegate implements UpgradeRequest
 {
     private final ServerUpgradeRequest request;
+    private final Map<String, List<String>> headers;
 
     UpgradeRequestDelegate(ServerUpgradeRequest request)
     {
         this.request = request;
+        this.headers = HttpFields.asMap(request.getHeaders());
     }
 
     @Override
@@ -72,7 +74,7 @@ class UpgradeRequestDelegate implements UpgradeRequest
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        return HttpFields.asMap(request.getHeaders());
+        return headers;
     }
 
     @Override

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/internal/UpgradeResponseDelegate.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/internal/UpgradeResponseDelegate.java
@@ -27,10 +27,12 @@ import org.eclipse.jetty.websocket.core.server.ServerUpgradeResponse;
 class UpgradeResponseDelegate implements UpgradeResponse
 {
     private final ServerUpgradeResponse response;
+    private final Map<String, List<String>> headers;
 
     UpgradeResponseDelegate(ServerUpgradeResponse response)
     {
         this.response = response;
+        this.headers = HttpFields.asMap(response.getHeaders());
     }
 
     @Override
@@ -62,7 +64,7 @@ class UpgradeResponseDelegate implements UpgradeResponse
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        return HttpFields.asMap(response.getHeaders());
+        return headers;
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/server/internal/JsrHandshakeRequest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/server/internal/JsrHandshakeRequest.java
@@ -33,6 +33,7 @@ public class JsrHandshakeRequest implements HandshakeRequest
 {
     private final ServerUpgradeRequest delegate;
     private final HttpServletRequest httpServletRequest;
+    private final Map<String, List<String>> headers;
     private Map<String, List<String>> parameterMap;
 
     public JsrHandshakeRequest(ServerUpgradeRequest req)
@@ -40,12 +41,13 @@ public class JsrHandshakeRequest implements HandshakeRequest
         this.delegate = req;
         this.httpServletRequest = (HttpServletRequest)req
             .getAttribute(WebSocketConstants.WEBSOCKET_WRAPPED_REQUEST_ATTRIBUTE);
+        this.headers = HttpFields.asMap(delegate.getHeaders());
     }
 
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        return HttpFields.asMap(delegate.getHeaders());
+        return headers;
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/internal/DelegatedServerUpgradeRequest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/internal/DelegatedServerUpgradeRequest.java
@@ -47,6 +47,7 @@ public class DelegatedServerUpgradeRequest implements JettyServerUpgradeRequest
     private final ServerUpgradeRequest upgradeRequest;
     private final HttpServletRequest httpServletRequest;
     private final Principal userPrincipal;
+    private final Map<String, List<String>> headers;
     private List<HttpCookie> cookies;
     private Map<String, List<String>> parameterMap;
 
@@ -57,6 +58,7 @@ public class DelegatedServerUpgradeRequest implements JettyServerUpgradeRequest
         this.upgradeRequest = request;
         this.queryString = httpServletRequest.getQueryString();
         this.userPrincipal = httpServletRequest.getUserPrincipal();
+        this.headers = HttpFields.asMap(upgradeRequest.getHeaders());
 
         try
         {
@@ -121,7 +123,7 @@ public class DelegatedServerUpgradeRequest implements JettyServerUpgradeRequest
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        return HttpFields.asMap(upgradeRequest.getHeaders());
+        return headers;
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/internal/DelegatedServerUpgradeResponse.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/internal/DelegatedServerUpgradeResponse.java
@@ -14,7 +14,6 @@
 package org.eclipse.jetty.ee10.websocket.server.internal;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -35,22 +34,15 @@ public class DelegatedServerUpgradeResponse implements JettyServerUpgradeRespons
 {
     private final ServerUpgradeResponse upgradeResponse;
     private final HttpServletResponse httpServletResponse;
-    private final boolean isUpgraded;
     private final Map<String, List<String>> headers;
 
     public DelegatedServerUpgradeResponse(ServerUpgradeResponse response)
     {
-        this(response, false);
-    }
-
-    public DelegatedServerUpgradeResponse(ServerUpgradeResponse response, boolean isUpgraded)
-    {
         upgradeResponse = response;
-        this.isUpgraded = isUpgraded;
         ServletContextResponse servletContextResponse = Response.as(response, ServletContextResponse.class);
         this.httpServletResponse = (HttpServletResponse)servletContextResponse.getRequest()
             .getAttribute(WebSocketConstants.WEBSOCKET_WRAPPED_RESPONSE_ATTRIBUTE);
-        headers = HttpFields.asMap(upgradeResponse.getHeaders());
+        this.headers = HttpFields.asMap(upgradeResponse.getHeaders());
     }
 
     @Override
@@ -100,7 +92,7 @@ public class DelegatedServerUpgradeResponse implements JettyServerUpgradeRespons
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        return isUpgraded ? Collections.unmodifiableMap(headers) : headers;
+        return headers;
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/internal/JettyServerFrameHandlerFactory.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/internal/JettyServerFrameHandlerFactory.java
@@ -41,7 +41,7 @@ public class JettyServerFrameHandlerFactory extends JettyWebSocketFrameHandlerFa
     {
         JettyWebSocketFrameHandler frameHandler = super.newJettyFrameHandler(websocketPojo);
         frameHandler.setUpgradeRequest(new DelegatedServerUpgradeRequest(upgradeRequest));
-        frameHandler.setUpgradeResponse(new DelegatedServerUpgradeResponse(upgradeResponse, true));
+        frameHandler.setUpgradeResponse(new DelegatedServerUpgradeResponse(upgradeResponse));
         return frameHandler;
     }
 }

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/server/internal/JsrHandshakeRequest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/server/internal/JsrHandshakeRequest.java
@@ -33,6 +33,7 @@ public class JsrHandshakeRequest implements HandshakeRequest
 {
     private final ServerUpgradeRequest delegate;
     private final HttpServletRequest httpServletRequest;
+    private final Map<String, List<String>> headers;
     private Map<String, List<String>> parameterMap;
 
     public JsrHandshakeRequest(ServerUpgradeRequest req)
@@ -40,12 +41,13 @@ public class JsrHandshakeRequest implements HandshakeRequest
         this.delegate = req;
         this.httpServletRequest = (HttpServletRequest)req
             .getAttribute(WebSocketConstants.WEBSOCKET_WRAPPED_REQUEST_ATTRIBUTE);
+        this.headers = HttpFields.asMap(delegate.getHeaders());
     }
 
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        return HttpFields.asMap(delegate.getHeaders());
+        return headers;
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-client/src/main/java/org/eclipse/jetty/ee9/websocket/client/impl/DelegatedJettyClientUpgradeRequest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-client/src/main/java/org/eclipse/jetty/ee9/websocket/client/impl/DelegatedJettyClientUpgradeRequest.java
@@ -41,10 +41,12 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class DelegatedJettyClientUpgradeRequest implements UpgradeRequest
 {
     private final CoreClientUpgradeRequest delegate;
+    private final Map<String, List<String>> headers;
 
     public DelegatedJettyClientUpgradeRequest(CoreClientUpgradeRequest delegate)
     {
         this.delegate = delegate;
+        this.headers = HttpFields.asMap(delegate.getHeaders());
     }
 
     @Override
@@ -79,7 +81,7 @@ public class DelegatedJettyClientUpgradeRequest implements UpgradeRequest
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        return HttpFields.asMap(delegate.getHeaders());
+        return headers;
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-client/src/main/java/org/eclipse/jetty/ee9/websocket/client/impl/DelegatedJettyClientUpgradeResponse.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-client/src/main/java/org/eclipse/jetty/ee9/websocket/client/impl/DelegatedJettyClientUpgradeResponse.java
@@ -32,10 +32,12 @@ import org.eclipse.jetty.http.HttpHeader;
 public class DelegatedJettyClientUpgradeResponse implements UpgradeResponse
 {
     private final Response delegate;
+    private final Map<String, List<String>> headers;
 
     public DelegatedJettyClientUpgradeResponse(Response response)
     {
         this.delegate = response;
+        this.headers = HttpFields.asMap(delegate.getHeaders());
     }
 
     @Override
@@ -65,7 +67,7 @@ public class DelegatedJettyClientUpgradeResponse implements UpgradeResponse
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        return HttpFields.asMap(delegate.getHeaders());
+        return headers;
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/internal/DelegatedServerUpgradeRequest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/internal/DelegatedServerUpgradeRequest.java
@@ -46,6 +46,7 @@ public class DelegatedServerUpgradeRequest implements JettyServerUpgradeRequest
     private final String queryString;
     private final ServerUpgradeRequest upgradeRequest;
     private final HttpServletRequest httpServletRequest;
+    private final Map<String, List<String>> headers;
     private List<HttpCookie> cookies;
     private Map<String, List<String>> parameterMap;
 
@@ -55,6 +56,7 @@ public class DelegatedServerUpgradeRequest implements JettyServerUpgradeRequest
             .getAttribute(WebSocketConstants.WEBSOCKET_WRAPPED_REQUEST_ATTRIBUTE);
         this.upgradeRequest = request;
         this.queryString = httpServletRequest.getQueryString();
+        this.headers = HttpFields.asMap(upgradeRequest.getHeaders());
 
         try
         {
@@ -114,7 +116,7 @@ public class DelegatedServerUpgradeRequest implements JettyServerUpgradeRequest
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        return HttpFields.asMap(upgradeRequest.getHeaders());
+        return headers;
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/internal/DelegatedServerUpgradeResponse.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/internal/DelegatedServerUpgradeResponse.java
@@ -32,12 +32,14 @@ public class DelegatedServerUpgradeResponse implements JettyServerUpgradeRespons
 {
     private final ServerUpgradeResponse upgradeResponse;
     private final HttpServletResponse httpServletResponse;
+    private final Map<String, List<String>> headers;
 
     public DelegatedServerUpgradeResponse(ServerUpgradeResponse response)
     {
         this.upgradeResponse = response;
         this.httpServletResponse = (HttpServletResponse)response.getRequest()
             .getAttribute(WebSocketConstants.WEBSOCKET_WRAPPED_RESPONSE_ATTRIBUTE);
+        this.headers = HttpFields.asMap(upgradeResponse.getHeaders());
     }
 
     @Override
@@ -87,7 +89,7 @@ public class DelegatedServerUpgradeResponse implements JettyServerUpgradeRespons
     @Override
     public Map<String, List<String>> getHeaders()
     {
-        return HttpFields.asMap(upgradeResponse.getHeaders());
+        return headers;
     }
 
     @Override


### PR DESCRIPTION
after merging #12441 to 12.1 I saw a few things which could be cleaned up
- assign the `HttpFields.asMap` to field so they're not recreated every time `getHeaders()` is called.
- cleanup left unnecessary code in DelegatedServerUpgradeResponse