### PR TITLE
Undisable ee9 BlockingTest and fix HttpChannel.produceContent

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -1320,7 +1320,7 @@ public class HttpChannelState implements HttpChannel, Components
                 _writeCallback = null;
                 httpChannel = _request._httpChannelState;
                 if (httpChannel != null)
-                   httpChannel.lockedStreamSendCompleted(true);
+                    httpChannel.lockedStreamSendCompleted(true);
             }
 
             if (callback != null)

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -1329,7 +1329,7 @@ public class HttpChannelState implements HttpChannel, Components
                     httpChannel._writeInvoker.run(callback::succeeded);
                 else
                     // Channel already completed, just fail the callback.
-                    HttpChannelState.failed(callback, new IllegalStateException("channel already completed"));
+                    HttpChannelState.failed(callback, new IOException("channel already completed"));
             }
         }
 
@@ -1366,7 +1366,7 @@ public class HttpChannelState implements HttpChannel, Components
                     httpChannel._writeInvoker.run(() -> HttpChannelState.failed(callback, x));
                 else
                     // Channel already completed, just fail the callback.
-                    HttpChannelState.failed(callback, ExceptionUtil.combine(x, new IllegalStateException("channel already completed")));
+                    HttpChannelState.failed(callback, ExceptionUtil.combine(x, new IOException("channel already completed")));
             }
         }
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -1318,19 +1318,12 @@ public class HttpChannelState implements HttpChannel, Components
             {
                 callback = _writeCallback;
                 _writeCallback = null;
-                httpChannel = _request._httpChannelState;
-                if (httpChannel != null)
-                    httpChannel.lockedStreamSendCompleted(true);
+                httpChannel = _request.lockedGetHttpChannelState();
+                httpChannel.lockedStreamSendCompleted(true);
             }
 
             if (callback != null)
-            {
-                if (httpChannel != null)
-                    httpChannel._writeInvoker.run(callback::succeeded);
-                else
-                    // Channel already completed, just fail the callback.
-                    HttpChannelState.failed(callback, new IOException("channel already completed"));
-            }
+                httpChannel._writeInvoker.run(callback::succeeded);
         }
 
         /**
@@ -1355,19 +1348,12 @@ public class HttpChannelState implements HttpChannel, Components
                 _writeFailure = x;
                 callback = _writeCallback;
                 _writeCallback = null;
-                httpChannel = _request._httpChannelState;
-                if (httpChannel != null)
-                    httpChannel.lockedStreamSendCompleted(false);
+                httpChannel = _request.lockedGetHttpChannelState();
+                httpChannel.lockedStreamSendCompleted(false);
             }
 
             if (callback != null)
-            {
-                if (httpChannel != null)
-                    httpChannel._writeInvoker.run(() -> HttpChannelState.failed(callback, x));
-                else
-                    // Channel already completed, just fail the callback.
-                    HttpChannelState.failed(callback, ExceptionUtil.combine(x, new IOException("channel already completed")));
-            }
+                httpChannel._writeInvoker.run(() -> HttpChannelState.failed(callback, x));
         }
 
         @Override

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -1587,9 +1587,6 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
             if (LOG.isDebugEnabled())
                 LOG.debug("aborting", x);
             abort(x);
-            _httpChannel.recycle();
-            _parser.reset();
-            _generator.reset();
             if (!_handling.compareAndSet(true, false))
                 resume();
         }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -1587,6 +1587,7 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
             if (LOG.isDebugEnabled())
                 LOG.debug("aborting", x);
             abort(x);
+            _httpChannel.setHttpStream(null);
             if (!_handling.compareAndSet(true, false))
                 resume();
         }

--- a/jetty-ee8/jetty-ee8-nested/pom.xml
+++ b/jetty-ee8/jetty-ee8-nested/pom.xml
@@ -49,6 +49,11 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-http-tools</artifactId>
       <scope>test</scope>

--- a/jetty-ee9/jetty-ee9-nested/pom.xml
+++ b/jetty-ee9/jetty-ee9-nested/pom.xml
@@ -48,6 +48,11 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-http-tools</artifactId>
       <scope>test</scope>

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
@@ -178,7 +178,7 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
     {
         ContextHandler.CoreContextRequest coreContextRequest = getCoreRequest();
         if (coreContextRequest == null)
-            return new HttpInput.ErrorContent(new IllegalStateException("Channel has been recycled"));
+            return new HttpInput.ErrorContent(new IOException("Channel has been recycled"));
         Content.Chunk chunk = coreContextRequest.read();
         if (chunk == null)
             return null;

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
@@ -172,7 +172,10 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
      */
     public HttpInput.Content produceContent()
     {
-        Content.Chunk chunk = getCoreRequest().read();
+        ContextHandler.CoreContextRequest coreContextRequest = getCoreRequest();
+        if (coreContextRequest == null)
+            return null;
+        Content.Chunk chunk = coreContextRequest.read();
         if (chunk == null)
             return null;
 

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
@@ -156,8 +156,12 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
      */
     public boolean needContent()
     {
+        ContextHandler.CoreContextRequest coreContextRequest = getCoreRequest();
+        // When coreContextRequest is null, produceContent() always immediately returns an error content.
+        if (coreContextRequest == null)
+            return true;
         // TODO: optimize by attempting a read?
-        getCoreRequest().demand(_needContentTask);
+        coreContextRequest.demand(_needContentTask);
         return false;
     }
 
@@ -174,7 +178,7 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
     {
         ContextHandler.CoreContextRequest coreContextRequest = getCoreRequest();
         if (coreContextRequest == null)
-            return null;
+            return new HttpInput.ErrorContent(new IllegalStateException("Channel has been recycled"));
         Content.Chunk chunk = coreContextRequest.read();
         if (chunk == null)
             return null;

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/BlockingTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/BlockingTest.java
@@ -39,7 +39,6 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -51,7 +50,6 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@Disabled // TODO
 public class BlockingTest
 {
     private Server server;

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/BlockingTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/BlockingTest.java
@@ -338,10 +338,7 @@ public class BlockingTest
 
             // Async thread should have stopped
             assertTrue(stopped.await(10, TimeUnit.SECONDS));
-            Throwable x = readException.get();
-            if (!(x instanceof IOException))
-                x.printStackTrace();
-            assertThat(x, instanceOf(IOException.class));
+            assertThat(readException.get(), instanceOf(IOException.class));
         }
     }
 

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/BlockingTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/BlockingTest.java
@@ -33,7 +33,6 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.awaitility.Awaitility;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
@@ -254,8 +253,6 @@ public class BlockingTest
     @Test
     public void testNormalCompleteThenBlockingRead() throws Exception
     {
-        Awaitility.setDefaultPollInterval(1, TimeUnit.MICROSECONDS);
-
         CountDownLatch started = new CountDownLatch(1);
         CountDownLatch completed = new CountDownLatch(1);
         CountDownLatch stopped = new CountDownLatch(1);

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/BlockingTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/BlockingTest.java
@@ -33,6 +33,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.awaitility.Awaitility;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
@@ -253,6 +254,8 @@ public class BlockingTest
     @Test
     public void testNormalCompleteThenBlockingRead() throws Exception
     {
+        Awaitility.setDefaultPollInterval(1, TimeUnit.MICROSECONDS);
+
         CountDownLatch started = new CountDownLatch(1);
         CountDownLatch completed = new CountDownLatch(1);
         CountDownLatch stopped = new CountDownLatch(1);
@@ -335,7 +338,10 @@ public class BlockingTest
 
             // Async thread should have stopped
             assertTrue(stopped.await(10, TimeUnit.SECONDS));
-            assertThat(readException.get(), instanceOf(IOException.class));
+            Throwable x = readException.get();
+            if (!(x instanceof IOException))
+                x.printStackTrace();
+            assertThat(x, instanceOf(IOException.class));
         }
     }
 


### PR DESCRIPTION
HttpChannel.produceContent throws NPE if the core request has already been finished when it is called. This caused some of the BlockingTests to fail. 