### PR TITLE
Make `HttpOutput.println()` simpler and faster

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/HttpOutputTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/HttpOutputTest.java
@@ -1057,6 +1057,7 @@ public class HttpOutputTest
         assertThat(expected, not(emptyString()));
         assertThat(response.replace("\r\n", System.lineSeparator()), containsString(expected));
     }
+
     @Test
     public void testReset() throws Exception
     {

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/HttpOutputTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/HttpOutputTest.java
@@ -51,8 +51,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -149,7 +151,7 @@ public class HttpOutputTest
         _contentServlet._contentInputStream = IOResources.asInputStream(big);
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
     }
 
@@ -203,7 +205,7 @@ public class HttpOutputTest
         _contentServlet._contentChannel = Files.newByteChannel(big.getPath());
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
     }
 
@@ -227,7 +229,7 @@ public class HttpOutputTest
         _contentServlet._contentResource = big;
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
     }
 
@@ -315,7 +317,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
     }
 
@@ -330,7 +332,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
     }
 
@@ -345,7 +347,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
     }
 
@@ -360,7 +362,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
     }
 
@@ -458,7 +460,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_contentServlet._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -474,7 +476,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_contentServlet._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -490,7 +492,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_contentServlet._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -555,7 +557,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_contentServlet._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -572,7 +574,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_contentServlet._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -589,7 +591,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_contentServlet._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -606,7 +608,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_contentServlet._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -627,7 +629,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(_contentServlet._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
 
@@ -643,7 +645,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_contentServlet._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -660,7 +662,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_contentServlet._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -677,7 +679,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_contentServlet._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -695,7 +697,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_contentServlet._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -714,9 +716,9 @@ public class HttpOutputTest
         String response = _connector.getResponse("HEAD / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(_contentServlet._owp.get() - start, Matchers.greaterThan(0));
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
-        assertThat(response, Matchers.not(containsString("1\tThis is a big file")));
-        assertThat(response, Matchers.not(containsString("400\tThis is a big file")));
+        assertThat(response, not(containsString("Content-Length")));
+        assertThat(response, not(containsString("1\tThis is a big file")));
+        assertThat(response, not(containsString("400\tThis is a big file")));
     }
 
     @Test
@@ -753,7 +755,7 @@ public class HttpOutputTest
         assertThat(_contentServlet._owp.get() - start, Matchers.equalTo(1));
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, containsString("Content-Length: 11"));
-        assertThat(response, Matchers.not(containsString("simple text")));
+        assertThat(response, not(containsString("simple text")));
     }
 
     @Test
@@ -1004,13 +1006,13 @@ public class HttpOutputTest
     public void testPrint() throws Exception
     {
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
-        PrintWriter exp = new PrintWriter(bout);
+        PrintWriter exp = new PrintWriter(bout, true, StandardCharsets.UTF_8);
         HttpServlet servlet = new HttpServlet()
         {
             @Override
-            protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+            protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
             {
-                response.setCharacterEncoding("UTF8");
+                response.setCharacterEncoding("UTF-8");
                 HttpOutput out = (HttpOutput)response.getOutputStream();
 
                 // @checkstyle-disable-check : AvoidEscapedUnicodeCharactersCheck
@@ -1048,11 +1050,13 @@ public class HttpOutputTest
         };
         _servletContextHandler.addServlet(servlet, "/test");
         _server.start();
-        String response = _connector.getResponse("GET /test HTTP/1.0\nHost: localhost:80\n\n");
+        ByteBuffer responseBuf = _connector.getResponse(ByteBuffer.wrap("GET /test HTTP/1.0\nHost: localhost:80\n\n".getBytes(StandardCharsets.UTF_8)));
+        String response = BufferUtil.toString(responseBuf, StandardCharsets.UTF_8);
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, containsString(bout.toString()));
+        String expected = bout.toString(StandardCharsets.UTF_8);
+        assertThat(expected, not(emptyString()));
+        assertThat(response.replace("\r\n", System.lineSeparator()), containsString(expected));
     }
-
     @Test
     public void testReset() throws Exception
     {

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/HttpOutput.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/HttpOutput.java
@@ -1128,7 +1128,7 @@ public class HttpOutput extends ServletOutputStream
 
             // If there is enough room left in the aggregation buffer, just fill it;
             // otherwise either do 2 writes if blocking or copy into a bigger byte array if async.
-            boolean canAggregate = false;
+            boolean aggregated = false;
             boolean blocking = false;
             try (AutoLock ignored = _channelState.lock())
             {
@@ -1138,16 +1138,14 @@ public class HttpOutput extends ServletOutputStream
                     if (len <= maximizeAggregateSpace())
                     {
                         BufferUtil.fill(_aggregate.getByteBuffer(), bytes, 0, bytes.length);
-                        canAggregate = true;
+                        aggregated = true;
                     }
                 }
-                else if (_apiState == ApiState.BLOCKING)
-                {
+                if (!aggregated && _apiState == ApiState.BLOCKING)
                     blocking = true;
-                }
             }
 
-            if (canAggregate)
+            if (aggregated)
             {
                 write(IO.CRLF_BYTES);
             }

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/HttpOutput.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/HttpOutput.java
@@ -16,13 +16,8 @@ package org.eclipse.jetty.ee11.servlet;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritePendingException;
-import java.nio.charset.Charset;
-import java.nio.charset.CharsetEncoder;
-import java.nio.charset.CoderResult;
-import java.nio.charset.CodingErrorAction;
 import java.util.concurrent.CancellationException;
 
 import jakarta.servlet.RequestDispatcher;
@@ -44,7 +39,6 @@ import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.IteratingCallback;
 import org.eclipse.jetty.util.NanoTime;
 import org.eclipse.jetty.util.thread.AutoLock;
-import org.eclipse.jetty.util.thread.ThreadIdPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -123,7 +117,6 @@ public class HttpOutput extends ServletOutputStream
     }
     
     private static final Logger LOG = LoggerFactory.getLogger(HttpOutput.class);
-    private static final ThreadIdPool<CharsetEncoder> _encoder = new ThreadIdPool<>();
 
     private final ServletChannel _servletChannel;
     private final ServletChannelState _channelState;
@@ -1120,73 +1113,56 @@ public class HttpOutput extends ServletOutputStream
             throw new IOException("Closed");
 
         s = String.valueOf(s);
-
         String charset = _servletChannel.getServletContextResponse().getCharacterEncoding(false);
-        CharsetEncoder encoder = _encoder.take();
-        if (encoder == null || !encoder.charset().name().equalsIgnoreCase(charset))
+        // String.getBytes() is much faster than a CharsetEncoder.encode() loop that would also need to estimate
+        // the destination buffer size, so this compensates for the rare extra copy that needs to be done when
+        // the aggregation buffer is full.
+        byte[] bytes = s.getBytes(charset);
+        if (!eoln)
         {
-            encoder = Charset.forName(charset).newEncoder();
-            encoder.onMalformedInput(CodingErrorAction.REPLACE);
-            encoder.onUnmappableCharacter(CodingErrorAction.REPLACE);
+            write(bytes);
         }
-        ByteBufferPool pool = _servletChannel.getRequest().getComponents().getByteBufferPool();
-        RetainableByteBuffer out = pool.acquire((int)(1 + (s.length() + 2) * encoder.averageBytesPerChar()), false);
-        try
+        else
         {
-            CharBuffer in = CharBuffer.wrap(s);
-            CharBuffer crlf = eoln ? CharBuffer.wrap("\r\n") : null;
-            ByteBuffer byteBuffer = out.getByteBuffer();
-            BufferUtil.flipToFill(byteBuffer);
+            int len = bytes.length + IO.CRLF_BYTES.length;
 
-            while (true)
+            // If there is enough room left in the aggregation buffer, just fill it;
+            // otherwise either do 2 writes if blocking or copy into a bigger byte array if async.
+            boolean canAggregate = false;
+            boolean blocking = false;
+            try (AutoLock ignored = _channelState.lock())
             {
-                CoderResult result;
-                if (in.hasRemaining())
+                if (len <= _bufferSize)
                 {
-                    result = encoder.encode(in, byteBuffer, crlf == null);
-                    if (result.isUnderflow())
-                        if (crlf == null)
-                            break;
-                        else
-                            continue;
-                }
-                else if (crlf != null && crlf.hasRemaining())
-                {
-                    result = encoder.encode(crlf, byteBuffer, true);
-                    if (result.isUnderflow())
+                    lockedAcquireBuffer();
+                    if (len <= maximizeAggregateSpace())
                     {
-                        if (!encoder.flush(byteBuffer).isUnderflow())
-                            result.throwException();
-                        break;
+                        BufferUtil.fill(_aggregate.getByteBuffer(), bytes, 0, bytes.length);
+                        canAggregate = true;
                     }
                 }
-                else
-                    break;
-
-                if (result.isOverflow())
+                else if (_apiState == ApiState.BLOCKING)
                 {
-                    BufferUtil.flipToFlush(byteBuffer, 0);
-                    RetainableByteBuffer bigger = pool.acquire(out.capacity() + s.length() + 2, out.isDirect());
-                    BufferUtil.flipToFill(bigger.getByteBuffer());
-                    bigger.getByteBuffer().put(byteBuffer);
-                    out.release();
-                    BufferUtil.flipToFill(bigger.getByteBuffer());
-                    out = bigger;
-                    byteBuffer = bigger.getByteBuffer();
-                    continue;
+                    blocking = true;
                 }
-
-                result.throwException();
             }
 
-            BufferUtil.flipToFlush(byteBuffer, 0);
-            write(byteBuffer.array(), byteBuffer.arrayOffset(), byteBuffer.remaining());
-        }
-        finally
-        {
-            out.release();
-            encoder.reset();
-            _encoder.offer(encoder);
+            if (canAggregate)
+            {
+                write(IO.CRLF_BYTES);
+            }
+            else if (blocking)
+            {
+                write(bytes);
+                write(IO.CRLF_BYTES);
+            }
+            else
+            {
+                byte[] bytesWithCrLf = new byte[len];
+                System.arraycopy(bytes, 0, bytesWithCrLf, 0, bytes.length);
+                System.arraycopy(IO.CRLF_BYTES, 0, bytesWithCrLf, bytes.length, IO.CRLF_BYTES.length);
+                write(bytesWithCrLf);
+            }
         }
     }
 

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/HttpOutputTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/HttpOutputTest.java
@@ -51,8 +51,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -149,7 +151,7 @@ public class HttpOutputTest
         _contentServlet._contentInputStream = IOResources.asInputStream(big);
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
     }
 
@@ -203,7 +205,7 @@ public class HttpOutputTest
         _contentServlet._contentChannel = Files.newByteChannel(big.getPath());
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
     }
 
@@ -227,7 +229,7 @@ public class HttpOutputTest
         _contentServlet._contentResource = big;
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
     }
 
@@ -315,7 +317,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
     }
 
@@ -330,7 +332,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
     }
 
@@ -345,7 +347,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
     }
 
@@ -360,7 +362,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
     }
 
@@ -458,7 +460,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_contentServlet._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -474,7 +476,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_contentServlet._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -490,7 +492,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_contentServlet._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -555,7 +557,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_contentServlet._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -572,7 +574,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_contentServlet._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -589,7 +591,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_contentServlet._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -606,7 +608,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_contentServlet._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -627,7 +629,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(_contentServlet._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
 
@@ -643,7 +645,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_contentServlet._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -660,7 +662,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_contentServlet._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -677,7 +679,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_contentServlet._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -695,7 +697,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_contentServlet._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -714,9 +716,9 @@ public class HttpOutputTest
         String response = _connector.getResponse("HEAD / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(_contentServlet._owp.get() - start, Matchers.greaterThan(0));
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
-        assertThat(response, Matchers.not(containsString("1\tThis is a big file")));
-        assertThat(response, Matchers.not(containsString("400\tThis is a big file")));
+        assertThat(response, not(containsString("Content-Length")));
+        assertThat(response, not(containsString("1\tThis is a big file")));
+        assertThat(response, not(containsString("400\tThis is a big file")));
     }
 
     @Test
@@ -753,7 +755,7 @@ public class HttpOutputTest
         assertThat(_contentServlet._owp.get() - start, Matchers.equalTo(1));
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, containsString("Content-Length: 11"));
-        assertThat(response, Matchers.not(containsString("simple text")));
+        assertThat(response, not(containsString("simple text")));
     }
 
     @Test
@@ -1004,13 +1006,13 @@ public class HttpOutputTest
     public void testPrint() throws Exception
     {
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
-        PrintWriter exp = new PrintWriter(bout);
+        PrintWriter exp = new PrintWriter(bout, true, StandardCharsets.UTF_8);
         HttpServlet servlet = new HttpServlet()
         {
             @Override
-            protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+            protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
             {
-                response.setCharacterEncoding("UTF8");
+                response.setCharacterEncoding("UTF-8");
                 HttpOutput out = (HttpOutput)response.getOutputStream();
 
                 // @checkstyle-disable-check : AvoidEscapedUnicodeCharactersCheck
@@ -1048,9 +1050,12 @@ public class HttpOutputTest
         };
         _servletContextHandler.addServlet(servlet, "/test");
         _server.start();
-        String response = _connector.getResponse("GET /test HTTP/1.0\nHost: localhost:80\n\n");
+        ByteBuffer responseBuf = _connector.getResponse(ByteBuffer.wrap("GET /test HTTP/1.0\nHost: localhost:80\n\n".getBytes(StandardCharsets.UTF_8)));
+        String response = BufferUtil.toString(responseBuf, StandardCharsets.UTF_8);
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, containsString(bout.toString()));
+        String expected = bout.toString(StandardCharsets.UTF_8);
+        assertThat(expected, not(emptyString()));
+        assertThat(response.replace("\r\n", System.lineSeparator()), containsString(expected));
     }
 
     @Test

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/HttpOutputTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/HttpOutputTest.java
@@ -1059,6 +1059,41 @@ public class HttpOutputTest
     }
 
     @Test
+    public void testPrintlnSmallBuffer() throws Exception
+    {
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        PrintWriter exp = new PrintWriter(bout, true, StandardCharsets.UTF_8);
+        HttpServlet servlet = new HttpServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
+            {
+                response.setCharacterEncoding("UTF-8");
+                HttpOutput out = (HttpOutput)response.getOutputStream();
+
+                exp.println("a".repeat(8));
+                out.println("a".repeat(8));
+                exp.println("a".repeat(9));
+                out.println("a".repeat(9));
+                exp.println("a".repeat(10));
+                out.println("a".repeat(10));
+                exp.println("a".repeat(11));
+                out.println("a".repeat(11));
+            }
+        };
+        _servletContextHandler.addServlet(servlet, "/test");
+        ((HttpConnectionFactory)_connector.getDefaultConnectionFactory()).getHttpConfiguration().setOutputBufferSize(10);
+        ((HttpConnectionFactory)_connector.getDefaultConnectionFactory()).getHttpConfiguration().setOutputAggregationSize(10);
+        _server.start();
+        ByteBuffer responseBuf = _connector.getResponse(ByteBuffer.wrap("GET /test HTTP/1.0\nHost: localhost:80\n\n".getBytes(StandardCharsets.UTF_8)));
+        String response = BufferUtil.toString(responseBuf, StandardCharsets.UTF_8);
+        assertThat(response, containsString("HTTP/1.1 200 OK"));
+        String expected = bout.toString(StandardCharsets.UTF_8);
+        assertThat(expected, not(emptyString()));
+        assertThat(response.replace("\r\n", System.lineSeparator()), containsString(expected));
+    }
+
+    @Test
     public void testReset() throws Exception
     {
         ByteArrayOutputStream exp = new ByteArrayOutputStream();

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/HttpOutputTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/HttpOutputTest.java
@@ -51,8 +51,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -151,7 +153,7 @@ public class HttpOutputTest
         _handler._contentInputStream = IOResources.asInputStream(big);
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
     }
 
@@ -203,7 +205,7 @@ public class HttpOutputTest
         _handler._contentChannel = Files.newByteChannel(big.getPath());
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
     }
 
@@ -225,7 +227,7 @@ public class HttpOutputTest
         _handler._contentResource = big;
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
     }
 
@@ -314,7 +316,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
     }
 
@@ -328,7 +330,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
     }
 
@@ -342,7 +344,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
     }
 
@@ -356,7 +358,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
     }
 
@@ -448,7 +450,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -463,7 +465,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -478,7 +480,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -539,7 +541,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -555,7 +557,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -571,7 +573,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -587,7 +589,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -607,7 +609,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
 
@@ -622,7 +624,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -638,7 +640,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -654,7 +656,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -671,7 +673,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, endsWith(toUTF8String(big)));
         assertThat(_handler._closedAfterWrite.get(10, TimeUnit.SECONDS), is(false));
     }
@@ -689,9 +691,9 @@ public class HttpOutputTest
         String response = _connector.getResponse("HEAD / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(_handler._owp.get() - start, Matchers.greaterThan(0));
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
-        assertThat(response, Matchers.not(containsString("1\tThis is a big file")));
-        assertThat(response, Matchers.not(containsString("400\tThis is a big file")));
+        assertThat(response, not(containsString("Content-Length")));
+        assertThat(response, not(containsString("1\tThis is a big file")));
+        assertThat(response, not(containsString("400\tThis is a big file")));
     }
 
     @Test
@@ -726,7 +728,7 @@ public class HttpOutputTest
         assertThat(_handler._owp.get() - start, Matchers.equalTo(1));
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, containsString("Content-Length: 11"));
-        assertThat(response, Matchers.not(containsString("simple text")));
+        assertThat(response, not(containsString("simple text")));
     }
 
     @Test
@@ -762,7 +764,7 @@ public class HttpOutputTest
 
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, Matchers.not(containsString("Content-Length")));
+        assertThat(response, not(containsString("Content-Length")));
         assertThat(response, containsString("400\tTHIS IS A BIGGER FILE"));
     }
 
@@ -1054,14 +1056,14 @@ public class HttpOutputTest
     public void testPrint() throws Exception
     {
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
-        PrintWriter exp = new PrintWriter(bout);
+        PrintWriter exp = new PrintWriter(bout, true, StandardCharsets.UTF_8);
         _swap.setHandler(new AbstractHandler()
         {
             @Override
-            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException
             {
                 baseRequest.setHandled(true);
-                response.setCharacterEncoding("UTF8");
+                response.setCharacterEncoding("UTF-8");
                 HttpOutput out = (HttpOutput)response.getOutputStream();
 
                 // @checkstyle-disable-check : AvoidEscapedUnicodeCharactersCheck
@@ -1098,9 +1100,12 @@ public class HttpOutputTest
             }
         });
         _swap.getHandler().start();
-        String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
+        ByteBuffer responseBuf = _connector.getResponse(ByteBuffer.wrap("GET / HTTP/1.0\nHost: localhost:80\n\n".getBytes(StandardCharsets.UTF_8)));
+        String response = BufferUtil.toString(responseBuf, StandardCharsets.UTF_8);
         assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, containsString(bout.toString()));
+        String expected = bout.toString(StandardCharsets.UTF_8);
+        assertThat(expected, not(emptyString()));
+        assertThat(response.replace("\r\n", System.lineSeparator()), containsString(expected));
     }
 
     @Test


### PR DESCRIPTION
This PR improves `HttpOutput.println()` by simplifying it, making it faster in most cases and fixes a too early buffer release.
