### PR TITLE
Fix CVE-2024-6763

### DIFF
--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCompliance.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCompliance.java
@@ -135,6 +135,7 @@ public enum HttpCompliance // TODO in Jetty-10 convert this enum to a class so t
                     HttpComplianceSection.NO_AMBIGUOUS_PATH_SEGMENTS,
                     HttpComplianceSection.NO_AMBIGUOUS_PATH_SEPARATORS,
                     HttpComplianceSection.NO_UTF16_ENCODINGS,
+                    HttpComplianceSection.NO_USER_INFO,
                     HttpComplianceSection.NO_AMBIGUOUS_EMPTY_SEGMENT,
                     HttpComplianceSection.NO_AMBIGUOUS_PATH_ENCODING));
                 break;
@@ -217,6 +218,7 @@ public enum HttpCompliance // TODO in Jetty-10 convert this enum to a class so t
     }
 
     private static final EnumMap<HttpURI.Violation, HttpComplianceSection> __uriViolations = new EnumMap<>(HttpURI.Violation.class);
+
     static
     {
         // create a map from Violation to compliance in a loop, so that any new violations added are detected with ISE
@@ -241,6 +243,9 @@ public enum HttpCompliance // TODO in Jetty-10 convert this enum to a class so t
                     break;
                 case UTF16:
                     __uriViolations.put(violation, HttpComplianceSection.NO_UTF16_ENCODINGS);
+                    break;
+                case USER_INFO:
+                    __uriViolations.put(violation, HttpComplianceSection.NO_USER_INFO);
                     break;
                 default:
                     throw new IllegalStateException();

--- a/jetty-http/src/main/java/org/eclipse/jetty/http/HttpComplianceSection.java
+++ b/jetty-http/src/main/java/org/eclipse/jetty/http/HttpComplianceSection.java
@@ -36,6 +36,7 @@ public enum HttpComplianceSection
     NO_AMBIGUOUS_PATH_SEPARATORS("https://tools.ietf.org/html/rfc3986#section-3.3", "No ambiguous URI path separators"),
     NO_AMBIGUOUS_PATH_PARAMETERS("https://tools.ietf.org/html/rfc3986#section-3.3", "No ambiguous URI path parameters"),
     NO_UTF16_ENCODINGS("https://www.w3.org/International/iri-edit/draft-duerst-iri.html#anchor29", "UTF16 encoding"),
+    NO_USER_INFO("https://datatracker.ietf.org/doc/html/rfc9110#name-deprecation-of-userinfo-in-", "User info in authority"),
     NO_AMBIGUOUS_EMPTY_SEGMENT("https://tools.ietf.org/html/rfc3986#section-3.3", "Ambiguous URI empty segment"),
     NO_AMBIGUOUS_PATH_ENCODING("https://tools.ietf.org/html/rfc3986#section-3.3", "Ambiguous URI path encoding");
 


### PR DESCRIPTION
Back port the fix for [CVE-2024-6763](https://github.com/advisories/GHSA-qh8g-58pp-2wxh).

Better validation of authority in HttpURI.  No known exploits.