### PR TITLE
Fixes #12323 - AsyncMiddleManServlet response flushing.

### DIFF
--- a/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/AsyncMiddleManServlet.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/AsyncMiddleManServlet.java
@@ -595,10 +595,10 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
     protected class ProxyWriter extends IteratingCallback implements WriteListener
     {
         private final AutoLock lock = new AutoLock();
-        private final Queue<Chunk> chunks = new ArrayDeque<>();
+        private final Queue<BufferWithCallback> chunks = new ArrayDeque<>();
         private final HttpServletRequest clientRequest;
         private final Response serverResponse;
-        private Chunk chunk;
+        private BufferWithCallback chunk;
         private boolean writePending;
 
         protected ProxyWriter(HttpServletRequest clientRequest, Response serverResponse)
@@ -613,7 +613,7 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
                 _log.debug("{} proxying content to downstream: {} bytes {}", getRequestId(clientRequest), content.remaining(), callback);
             try (AutoLock ignored = lock.lock())
             {
-                return chunks.offer(new Chunk(content, callback));
+                return chunks.offer(new BufferWithCallback(content, callback));
             }
         }
 
@@ -622,7 +622,7 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
         {
             ServletOutputStream output = clientRequest.getAsyncContext().getResponse().getOutputStream();
 
-            Chunk chunk;
+            BufferWithCallback chunk;
             try (AutoLock ignored = lock.lock())
             {
                 chunk = this.chunk = chunks.poll();
@@ -650,10 +650,11 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
         @Override
         protected void onSuccess()
         {
-            Chunk chunk;
+            BufferWithCallback chunk;
             try (AutoLock ignored = lock.lock())
             {
                 chunk = this.chunk;
+                this.chunk = null;
             }
             if (_log.isDebugEnabled())
                 _log.debug("{} async write complete of {} on {}", getRequestId(clientRequest), chunk, this);
@@ -663,10 +664,11 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
         @Override
         protected void onCompleteFailure(Throwable failure)
         {
-            Chunk chunk;
+            BufferWithCallback chunk;
             try (AutoLock ignored = lock.lock())
             {
                 chunk = this.chunk;
+                this.chunk = null;
             }
             if (chunk != null)
                 chunk.callback.failed(failure);
@@ -872,7 +874,7 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
         }
     }
 
-    private record Chunk(ByteBuffer buffer, Callback callback)
+    private record BufferWithCallback(ByteBuffer buffer, Callback callback)
     {
         @Override
         public String toString()

--- a/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/AsyncMiddleManServlet.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/AsyncMiddleManServlet.java
@@ -53,6 +53,7 @@ import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.CountingCallback;
 import org.eclipse.jetty.util.IteratingCallback;
 import org.eclipse.jetty.util.component.Destroyable;
+import org.eclipse.jetty.util.thread.AutoLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -196,7 +197,7 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
         return input.read(buffer);
     }
 
-    void writeProxyResponseContent(ServletOutputStream output, ByteBuffer content) throws IOException
+    protected void writeProxyResponseContent(ServletOutputStream output, ByteBuffer content) throws IOException
     {
         write(output, content);
     }
@@ -594,6 +595,7 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
 
     protected class ProxyWriter implements WriteListener
     {
+        private final AutoLock lock = new AutoLock();
         private final Queue<Chunk> chunks = new ArrayDeque<>();
         private final HttpServletRequest clientRequest;
         private final Response serverResponse;
@@ -610,7 +612,10 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
         {
             if (_log.isDebugEnabled())
                 _log.debug("{} proxying content to downstream: {} bytes {}", getRequestId(clientRequest), content.remaining(), callback);
-            return chunks.offer(new Chunk(content, callback));
+            try (AutoLock ignored = lock.lock())
+            {
+                return chunks.offer(new Chunk(content, callback));
+            }
         }
 
         @Override
@@ -640,7 +645,10 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
                         return;
                 }
 
-                this.chunk = chunk = chunks.poll();
+                try (AutoLock ignored = lock.lock())
+                {
+                    this.chunk = chunk = chunks.poll();
+                }
                 if (chunk == null)
                     return;
 

--- a/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/AsyncMiddleManServlet.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/AsyncMiddleManServlet.java
@@ -21,7 +21,6 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPOutputStream;
@@ -496,7 +495,7 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
 
                 if (committed)
                 {
-                    proxyWriter.onWritePossible();
+                    proxyWriter.iterate();
                 }
                 else
                 {
@@ -555,7 +554,7 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
                         if (_log.isDebugEnabled())
                             _log.debug("{} downstream content transformation to {} bytes", getRequestId(clientRequest), newContentBytes);
 
-                        proxyWriter.onWritePossible();
+                        proxyWriter.iterate();
                     }
                 }
                 else
@@ -593,7 +592,7 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
         }
     }
 
-    protected class ProxyWriter implements WriteListener
+    protected class ProxyWriter extends IteratingCallback implements WriteListener
     {
         private final AutoLock lock = new AutoLock();
         private final Queue<Chunk> chunks = new ArrayDeque<>();
@@ -619,73 +618,80 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
         }
 
         @Override
-        public void onWritePossible() throws IOException
+        protected Action process() throws Throwable
         {
             ServletOutputStream output = clientRequest.getAsyncContext().getResponse().getOutputStream();
 
-            // If we had a pending write, let's succeed it.
-            if (writePending)
+            Chunk chunk;
+            try (AutoLock ignored = lock.lock())
             {
-                if (_log.isDebugEnabled())
-                    _log.debug("{} pending async write complete of {} on {}", getRequestId(clientRequest), chunk, output);
-                writePending = false;
-                if (succeed(chunk.callback))
-                    return;
+                chunk = this.chunk = chunks.poll();
             }
+            if (chunk == null)
+                return Action.IDLE;
 
-            int length = 0;
-            Chunk chunk = null;
-            while (output.isReady())
-            {
-                if (chunk != null)
-                {
-                    if (_log.isDebugEnabled())
-                        _log.debug("{} async write complete of {} ({} bytes) on {}", getRequestId(clientRequest), chunk, length, output);
-                    if (succeed(chunk.callback))
-                        return;
-                }
-
-                try (AutoLock ignored = lock.lock())
-                {
-                    this.chunk = chunk = chunks.poll();
-                }
-                if (chunk == null)
-                    return;
-
-                length = chunk.buffer.remaining();
-                if (length > 0)
-                    writeProxyResponseContent(output, chunk.buffer);
-            }
-
+            int length = chunk.buffer.remaining();
             if (_log.isDebugEnabled())
-                _log.debug("{} async write pending of {} ({} bytes) on {}", getRequestId(clientRequest), chunk, length, output);
-            writePending = true;
+                _log.debug("{} async write of {} ({} bytes) on {}", getRequestId(clientRequest), chunk, length, this);
+            if (length > 0)
+                writeProxyResponseContent(output, chunk.buffer);
+
+            boolean complete = output.isReady();
+            try (AutoLock ignored = lock.lock())
+            {
+                writePending = !complete;
+            }
+            if (complete)
+                succeeded();
+
+            return Action.SCHEDULED;
         }
 
-        private boolean succeed(Callback callback)
+        @Override
+        protected void onSuccess()
         {
-            // Succeeding the callback may cause to reenter in onWritePossible()
-            // because typically the callback is the one that controls whether the
-            // content received from the server has been consumed, so succeeding
-            // the callback causes more content to be received from the server,
-            // and hence more to be written to the client by onWritePossible().
-            // A reentrant call to onWritePossible() performs another write,
-            // which may remain pending, which means that the reentrant call
-            // to onWritePossible() returns all the way back to just after the
-            // succeed of the callback. There, we cannot just loop attempting
-            // write, but we need to check whether we are write pending.
-            callback.succeeded();
-            return writePending;
+            Chunk chunk;
+            try (AutoLock ignored = lock.lock())
+            {
+                chunk = this.chunk;
+            }
+            if (_log.isDebugEnabled())
+                _log.debug("{} async write complete of {} on {}", getRequestId(clientRequest), chunk, this);
+            chunk.callback.succeeded();
+        }
+
+        @Override
+        protected void onCompleteFailure(Throwable failure)
+        {
+            Chunk chunk;
+            try (AutoLock ignored = lock.lock())
+            {
+                chunk = this.chunk;
+            }
+            if (chunk != null)
+                chunk.callback.failed(failure);
+            else
+                serverResponse.abort(failure);
+        }
+
+        @Override
+        public void onWritePossible()
+        {
+            boolean pending;
+            try (AutoLock ignored = lock.lock())
+            {
+                pending = writePending;
+            }
+            if (pending)
+                succeeded();
+            else
+                iterate();
         }
 
         @Override
         public void onError(Throwable failure)
         {
-            Chunk chunk = this.chunk;
-            if (chunk != null)
-                chunk.callback.failed(failure);
-            else
-                serverResponse.abort(failure);
+            failed(failure);
         }
     }
 
@@ -866,15 +872,12 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
         }
     }
 
-    private static class Chunk
+    private record Chunk(ByteBuffer buffer, Callback callback)
     {
-        private final ByteBuffer buffer;
-        private final Callback callback;
-
-        private Chunk(ByteBuffer buffer, Callback callback)
+        @Override
+        public String toString()
         {
-            this.buffer = Objects.requireNonNull(buffer);
-            this.callback = Objects.requireNonNull(callback);
+            return "%s@%x[buffer=%s,callback=%s]".formatted(getClass().getSimpleName(), hashCode(), buffer, callback);
         }
     }
 }

--- a/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/AsyncMiddleManServletTest.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/AsyncMiddleManServletTest.java
@@ -18,6 +18,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
@@ -1636,6 +1637,58 @@ public class AsyncMiddleManServletTest
         IO.copy(zipIn, out2);
         assertArrayEquals(content2, out2.toByteArray());
         assertNull(zipIn.getNextEntry());
+    }
+
+    @Test
+    public void testProxyResponseContentFlush() throws Exception
+    {
+        CountDownLatch serverLatch = new CountDownLatch(1);
+        startServer(new HttpServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
+            {
+                try
+                {
+                    ServletOutputStream output = response.getOutputStream();
+                    output.write(new byte[16]);
+                    output.flush();
+                    serverLatch.await(5, TimeUnit.SECONDS);
+                    output.write(new byte[32]);
+                }
+                catch (InterruptedException x)
+                {
+                    throw new InterruptedIOException();
+                }
+            }
+        });
+        startProxy(new AsyncMiddleManServlet()
+        {
+            @Override
+            protected void writeProxyResponseContent(ServletOutputStream output, ByteBuffer content) throws IOException
+            {
+                super.writeProxyResponseContent(output, content);
+                // Force a flush for every write, to avoid
+                // buffering it in the ServletOutputStream.
+                if (output.isReady())
+                    output.flush();
+            }
+        });
+        startClient();
+
+        CountDownLatch clientLatch = new CountDownLatch(1);
+        client.newRequest("localhost", serverConnector.getLocalPort())
+            // Tell the server to continue to send data only if we receive the first small chunk.
+            .onResponseContent((response, content) -> serverLatch.countDown())
+            .timeout(10, TimeUnit.SECONDS)
+            .send(result ->
+            {
+                assertTrue(result.isSucceeded());
+                assertEquals(HttpStatus.OK_200, result.getResponse().getStatus());
+                clientLatch.countDown();
+            });
+
+        assertTrue(clientLatch.await(5, TimeUnit.SECONDS));
     }
 
     private void sleep(long delay)

--- a/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/AsyncMiddleManServlet.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/AsyncMiddleManServlet.java
@@ -595,10 +595,10 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
     protected class ProxyWriter extends IteratingCallback implements WriteListener
     {
         private final AutoLock lock = new AutoLock();
-        private final Queue<Chunk> chunks = new ArrayDeque<>();
+        private final Queue<BufferWithCallback> chunks = new ArrayDeque<>();
         private final HttpServletRequest clientRequest;
         private final Response serverResponse;
-        private Chunk chunk;
+        private BufferWithCallback chunk;
         private boolean writePending;
 
         protected ProxyWriter(HttpServletRequest clientRequest, Response serverResponse)
@@ -613,7 +613,7 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
                 _log.debug("{} proxying content to downstream: {} bytes {}", getRequestId(clientRequest), content.remaining(), callback);
             try (AutoLock ignored = lock.lock())
             {
-                return chunks.offer(new Chunk(content, callback));
+                return chunks.offer(new BufferWithCallback(content, callback));
             }
         }
 
@@ -622,7 +622,7 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
         {
             ServletOutputStream output = clientRequest.getAsyncContext().getResponse().getOutputStream();
 
-            Chunk chunk;
+            BufferWithCallback chunk;
             try (AutoLock ignored = lock.lock())
             {
                 chunk = this.chunk = chunks.poll();
@@ -650,10 +650,11 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
         @Override
         protected void onSuccess()
         {
-            Chunk chunk;
+            BufferWithCallback chunk;
             try (AutoLock ignored = lock.lock())
             {
                 chunk = this.chunk;
+                this.chunk = null;
             }
             if (_log.isDebugEnabled())
                 _log.debug("{} async write complete of {} on {}", getRequestId(clientRequest), chunk, this);
@@ -663,10 +664,11 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
         @Override
         protected void onCompleteFailure(Throwable failure)
         {
-            Chunk chunk;
+            BufferWithCallback chunk;
             try (AutoLock ignored = lock.lock())
             {
                 chunk = this.chunk;
+                this.chunk = null;
             }
             if (chunk != null)
                 chunk.callback.failed(failure);
@@ -872,7 +874,7 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
         }
     }
 
-    private record Chunk(ByteBuffer buffer, Callback callback)
+    private record BufferWithCallback(ByteBuffer buffer, Callback callback)
     {
         @Override
         public String toString()

--- a/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/AsyncMiddleManServlet.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/AsyncMiddleManServlet.java
@@ -53,6 +53,7 @@ import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.CountingCallback;
 import org.eclipse.jetty.util.IteratingCallback;
 import org.eclipse.jetty.util.component.Destroyable;
+import org.eclipse.jetty.util.thread.AutoLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -196,7 +197,7 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
         return input.read(buffer);
     }
 
-    void writeProxyResponseContent(ServletOutputStream output, ByteBuffer content) throws IOException
+    protected void writeProxyResponseContent(ServletOutputStream output, ByteBuffer content) throws IOException
     {
         write(output, content);
     }
@@ -594,6 +595,7 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
 
     protected class ProxyWriter implements WriteListener
     {
+        private final AutoLock lock = new AutoLock();
         private final Queue<Chunk> chunks = new ArrayDeque<>();
         private final HttpServletRequest clientRequest;
         private final Response serverResponse;
@@ -610,7 +612,10 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
         {
             if (_log.isDebugEnabled())
                 _log.debug("{} proxying content to downstream: {} bytes {}", getRequestId(clientRequest), content.remaining(), callback);
-            return chunks.offer(new Chunk(content, callback));
+            try (AutoLock ignored = lock.lock())
+            {
+                return chunks.offer(new Chunk(content, callback));
+            }
         }
 
         @Override
@@ -640,7 +645,10 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
                         return;
                 }
 
-                this.chunk = chunk = chunks.poll();
+                try (AutoLock ignored = lock.lock())
+                {
+                    this.chunk = chunk = chunks.poll();
+                }
                 if (chunk == null)
                     return;
 

--- a/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/AsyncMiddleManServlet.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/AsyncMiddleManServlet.java
@@ -21,7 +21,6 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPOutputStream;
@@ -496,7 +495,7 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
 
                 if (committed)
                 {
-                    proxyWriter.onWritePossible();
+                    proxyWriter.iterate();
                 }
                 else
                 {
@@ -555,7 +554,7 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
                         if (_log.isDebugEnabled())
                             _log.debug("{} downstream content transformation to {} bytes", getRequestId(clientRequest), newContentBytes);
 
-                        proxyWriter.onWritePossible();
+                        proxyWriter.iterate();
                     }
                 }
                 else
@@ -593,7 +592,7 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
         }
     }
 
-    protected class ProxyWriter implements WriteListener
+    protected class ProxyWriter extends IteratingCallback implements WriteListener
     {
         private final AutoLock lock = new AutoLock();
         private final Queue<Chunk> chunks = new ArrayDeque<>();
@@ -619,73 +618,80 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
         }
 
         @Override
-        public void onWritePossible() throws IOException
+        protected Action process() throws Throwable
         {
             ServletOutputStream output = clientRequest.getAsyncContext().getResponse().getOutputStream();
 
-            // If we had a pending write, let's succeed it.
-            if (writePending)
+            Chunk chunk;
+            try (AutoLock ignored = lock.lock())
             {
-                if (_log.isDebugEnabled())
-                    _log.debug("{} pending async write complete of {} on {}", getRequestId(clientRequest), chunk, output);
-                writePending = false;
-                if (succeed(chunk.callback))
-                    return;
+                chunk = this.chunk = chunks.poll();
             }
+            if (chunk == null)
+                return Action.IDLE;
 
-            int length = 0;
-            Chunk chunk = null;
-            while (output.isReady())
-            {
-                if (chunk != null)
-                {
-                    if (_log.isDebugEnabled())
-                        _log.debug("{} async write complete of {} ({} bytes) on {}", getRequestId(clientRequest), chunk, length, output);
-                    if (succeed(chunk.callback))
-                        return;
-                }
-
-                try (AutoLock ignored = lock.lock())
-                {
-                    this.chunk = chunk = chunks.poll();
-                }
-                if (chunk == null)
-                    return;
-
-                length = chunk.buffer.remaining();
-                if (length > 0)
-                    writeProxyResponseContent(output, chunk.buffer);
-            }
-
+            int length = chunk.buffer.remaining();
             if (_log.isDebugEnabled())
-                _log.debug("{} async write pending of {} ({} bytes) on {}", getRequestId(clientRequest), chunk, length, output);
-            writePending = true;
+                _log.debug("{} async write of {} ({} bytes) on {}", getRequestId(clientRequest), chunk, length, this);
+            if (length > 0)
+                writeProxyResponseContent(output, chunk.buffer);
+
+            boolean complete = output.isReady();
+            try (AutoLock ignored = lock.lock())
+            {
+                writePending = !complete;
+            }
+            if (complete)
+                succeeded();
+
+            return Action.SCHEDULED;
         }
 
-        private boolean succeed(Callback callback)
+        @Override
+        protected void onSuccess()
         {
-            // Succeeding the callback may cause to reenter in onWritePossible()
-            // because typically the callback is the one that controls whether the
-            // content received from the server has been consumed, so succeeding
-            // the callback causes more content to be received from the server,
-            // and hence more to be written to the client by onWritePossible().
-            // A reentrant call to onWritePossible() performs another write,
-            // which may remain pending, which means that the reentrant call
-            // to onWritePossible() returns all the way back to just after the
-            // succeed of the callback. There, we cannot just loop attempting
-            // write, but we need to check whether we are write pending.
-            callback.succeeded();
-            return writePending;
+            Chunk chunk;
+            try (AutoLock ignored = lock.lock())
+            {
+                chunk = this.chunk;
+            }
+            if (_log.isDebugEnabled())
+                _log.debug("{} async write complete of {} on {}", getRequestId(clientRequest), chunk, this);
+            chunk.callback.succeeded();
+        }
+
+        @Override
+        protected void onCompleteFailure(Throwable failure)
+        {
+            Chunk chunk;
+            try (AutoLock ignored = lock.lock())
+            {
+                chunk = this.chunk;
+            }
+            if (chunk != null)
+                chunk.callback.failed(failure);
+            else
+                serverResponse.abort(failure);
+        }
+
+        @Override
+        public void onWritePossible()
+        {
+            boolean pending;
+            try (AutoLock ignored = lock.lock())
+            {
+                pending = writePending;
+            }
+            if (pending)
+                succeeded();
+            else
+                iterate();
         }
 
         @Override
         public void onError(Throwable failure)
         {
-            Chunk chunk = this.chunk;
-            if (chunk != null)
-                chunk.callback.failed(failure);
-            else
-                serverResponse.abort(failure);
+            failed(failure);
         }
     }
 
@@ -783,8 +789,8 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
             try
             {
                 this.transformer = transformer;
-                ByteBufferPool byteBufferPool = httpClient == null ? null : httpClient.getByteBufferPool();
-                this.decoder = new GZIPContentDecoder(byteBufferPool, GZIPContentDecoder.DEFAULT_BUFFER_SIZE);
+                ByteBufferPool bufferPool = httpClient == null ? null : httpClient.getByteBufferPool();
+                this.decoder = new GZIPContentDecoder(bufferPool, GZIPContentDecoder.DEFAULT_BUFFER_SIZE);
                 this.out = new ByteArrayOutputStream();
                 this.gzipOut = new GZIPOutputStream(out);
             }
@@ -866,15 +872,12 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
         }
     }
 
-    private static class Chunk
+    private record Chunk(ByteBuffer buffer, Callback callback)
     {
-        private final ByteBuffer buffer;
-        private final Callback callback;
-
-        private Chunk(ByteBuffer buffer, Callback callback)
+        @Override
+        public String toString()
         {
-            this.buffer = Objects.requireNonNull(buffer);
-            this.callback = Objects.requireNonNull(callback);
+            return "%s@%x[buffer=%s,callback=%s]".formatted(getClass().getSimpleName(), hashCode(), buffer, callback);
         }
     }
 }

--- a/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/AsyncMiddleManServletTest.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/AsyncMiddleManServletTest.java
@@ -18,6 +18,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
@@ -1641,6 +1642,58 @@ public class AsyncMiddleManServletTest
         IO.copy(zipIn, out2);
         assertArrayEquals(content2, out2.toByteArray());
         assertNull(zipIn.getNextEntry());
+    }
+
+    @Test
+    public void testProxyResponseContentFlush() throws Exception
+    {
+        CountDownLatch serverLatch = new CountDownLatch(1);
+        startServer(new HttpServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
+            {
+                try
+                {
+                    ServletOutputStream output = response.getOutputStream();
+                    output.write(new byte[16]);
+                    output.flush();
+                    serverLatch.await(5, TimeUnit.SECONDS);
+                    output.write(new byte[32]);
+                }
+                catch (InterruptedException x)
+                {
+                    throw new InterruptedIOException();
+                }
+            }
+        });
+        startProxy(new AsyncMiddleManServlet()
+        {
+            @Override
+            protected void writeProxyResponseContent(ServletOutputStream output, ByteBuffer content) throws IOException
+            {
+                super.writeProxyResponseContent(output, content);
+                // Force a flush for every write, to avoid
+                // buffering it in the ServletOutputStream.
+                if (output.isReady())
+                    output.flush();
+            }
+        });
+        startClient();
+
+        CountDownLatch clientLatch = new CountDownLatch(1);
+        client.newRequest("localhost", serverConnector.getLocalPort())
+            // Tell the server to continue to send data only if we receive the first small chunk.
+            .onResponseContent((response, content) -> serverLatch.countDown())
+            .timeout(10, TimeUnit.SECONDS)
+            .send(result ->
+            {
+                assertTrue(result.isSucceeded());
+                assertEquals(HttpStatus.OK_200, result.getResponse().getStatus());
+                clientLatch.countDown();
+            });
+
+        assertTrue(clientLatch.await(5, TimeUnit.SECONDS));
     }
 
     private void sleep(long delay)


### PR DESCRIPTION
* Fixed `ProxyWriter.chunks` locking.
* Made `writeProxyResponseContent()` protected so it can be overridden to flush the response content.
* Added test case.