### PR TITLE
Fixes #12436 - Allow headers size extend to maxRequestHeadersSize in http client.

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -135,6 +135,7 @@ public class HttpClient extends ContainerLifeCycle implements AutoCloseable
     private String defaultRequestContentType = "application/octet-stream";
     private boolean useInputDirectByteBuffers = true;
     private boolean useOutputDirectByteBuffers = true;
+    private int maxRequestHeadersSize = 8192;
     private int maxResponseHeadersSize = -1;
     private Sweeper destinationSweeper;
 
@@ -1069,6 +1070,24 @@ public class HttpClient extends ContainerLifeCycle implements AutoCloseable
     public void setUseInputDirectByteBuffers(boolean useInputDirectByteBuffers)
     {
         this.useInputDirectByteBuffers = useInputDirectByteBuffers;
+    }
+
+    /**
+     * @return the max size in bytes of the request headers
+     */
+    @ManagedAttribute("The max size in bytes of the request headers")
+    public int getMaxRequestHeadersSize()
+    {
+        return maxRequestHeadersSize;
+    }
+
+    /**
+     * Set the max size in bytes of the request headers.
+     * @param maxRequestHeadersSize the max size in bytes of the request headers
+     */
+    public void setMaxRequestHeadersSize(int maxRequestHeadersSize)
+    {
+        this.maxRequestHeadersSize = maxRequestHeadersSize;
     }
 
     /**

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpClientTransportOverHTTP.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpClientTransportOverHTTP.java
@@ -39,6 +39,8 @@ public class HttpClientTransportOverHTTP extends AbstractConnectorHttpClientTran
     private int headerCacheSize = 1024;
     private boolean headerCacheCaseSensitive;
 
+    private int maxRequestHeadersSize = 32 * 1024;
+
     public HttpClientTransportOverHTTP()
     {
         this(1);
@@ -126,5 +128,19 @@ public class HttpClientTransportOverHTTP extends AbstractConnectorHttpClientTran
     public void setInitializeConnections(boolean initialize)
     {
         factory.setInitializeConnections(initialize);
+    }
+
+    /**
+     * @return The maximum allowed size in bytes for the HTTP request headers
+     */
+    @ManagedAttribute("The maximum allowed size in bytes for the HTTP request headers")
+    public int getMaxRequestHeadersSize()
+    {
+        return maxRequestHeadersSize;
+    }
+
+    public void setMaxRequestHeadersSize(int maxRequestHeadersSize)
+    {
+        this.maxRequestHeadersSize = maxRequestHeadersSize;
     }
 }

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpClientTransportOverHTTP.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpClientTransportOverHTTP.java
@@ -39,8 +39,6 @@ public class HttpClientTransportOverHTTP extends AbstractConnectorHttpClientTran
     private int headerCacheSize = 1024;
     private boolean headerCacheCaseSensitive;
 
-    private int maxRequestHeadersSize = 32 * 1024;
-
     public HttpClientTransportOverHTTP()
     {
         this(1);
@@ -128,19 +126,5 @@ public class HttpClientTransportOverHTTP extends AbstractConnectorHttpClientTran
     public void setInitializeConnections(boolean initialize)
     {
         factory.setInitializeConnections(initialize);
-    }
-
-    /**
-     * @return The maximum allowed size in bytes for the HTTP request headers
-     */
-    @ManagedAttribute("The maximum allowed size in bytes for the HTTP request headers")
-    public int getMaxRequestHeadersSize()
-    {
-        return maxRequestHeadersSize;
-    }
-
-    public void setMaxRequestHeadersSize(int maxRequestHeadersSize)
-    {
-        this.maxRequestHeadersSize = maxRequestHeadersSize;
     }
 }

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -56,6 +57,7 @@ import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.io.ByteArrayEndPoint;
 import org.eclipse.jetty.io.ClientConnector;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.EndPoint;
@@ -76,6 +78,7 @@ import org.eclipse.jetty.util.SocketAddressResolver;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
@@ -2011,5 +2014,209 @@ public class HttpClientTest extends AbstractHttpClientServerTest
                 .body(new StringRequestContent("0123456789ABCDEF"))
                 .send(this);
         }
+    }
+
+    private static Random rnd = new Random();
+    private static final String CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890";
+
+    public static final int CHARS_LENGTH = CHARS.length();
+
+    protected static String getRandomString(int size)
+    {
+        StringBuilder sb = new StringBuilder(size);
+        while (sb.length() < size)
+        { // length of the random string.
+            int index = rnd.nextInt(CHARS_LENGTH);
+            sb.append(CHARS.charAt(index));
+        }
+        return sb.toString();
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testSmallHeadersSize(Scenario scenario) throws Exception
+    {
+        startClient(scenario);
+        ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
+        HttpDestination destination = new HttpDestination(client, new Origin("http", "localhost", 8080));
+        destination.start();
+        HttpConnectionOverHTTP connection = new HttpConnectionOverHTTP(endPoint, destination, new Promise.Adapter<Connection>());
+        Request request = client.newRequest(URI.create("http://localhost/"));
+        request.agent(getRandomString(888)); //More than the request buffer size, but less than the default max request headers size
+        final CountDownLatch headersLatch = new CountDownLatch(1);
+        final CountDownLatch successLatch = new CountDownLatch(1);
+        final CountDownLatch failureLatch = new CountDownLatch(1);
+        request.listener(new Request.Listener()
+        {
+            @Override
+            public void onHeaders(Request request)
+            {
+                headersLatch.countDown();
+            }
+
+            @Override
+            public void onSuccess(Request request)
+            {
+                successLatch.countDown();
+            }
+
+            @Override
+            public void onFailure(Request request, Throwable failure)
+            {
+                failureLatch.countDown();
+            }
+        });
+        connection.send(request, null);
+
+        String requestString = endPoint.takeOutputString();
+        assertTrue(requestString.startsWith("GET / HTTP/1.1\r\nAccept-Encoding: gzip\r\n"));
+        assertTrue(headersLatch.await(5, TimeUnit.SECONDS));
+        assertTrue(successLatch.await(5, TimeUnit.SECONDS));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testMaxRequestHeadersSize(Scenario scenario) throws Exception
+    {
+        startClient(scenario);
+        byte[] buffer = new byte[32 * 1024];
+        ByteArrayEndPoint endPoint = new ByteArrayEndPoint(buffer, buffer.length);
+        HttpDestination destination = new HttpDestination(client, new Origin("http", "localhost", 8080));
+        destination.start();
+        HttpConnectionOverHTTP connection = new HttpConnectionOverHTTP(endPoint, destination, new Promise.Adapter<Connection>());
+        Request request = client.newRequest(URI.create("http://localhost/"));
+        //More than the request buffer size, but less than the default max request headers size
+
+        int desiredHeadersSize = 20 * 1024;
+        int currentHeadersSize = 0;
+        int i = 0;
+        while (currentHeadersSize < desiredHeadersSize)
+        {
+            final int index = i++;
+            final String headerValue = getRandomString(800);
+            final int headerSize = headerValue.length();
+            currentHeadersSize += headerSize;
+            request.cookie(new HttpCookie()
+            {
+                @Override
+                public String getName()
+                {
+                    return "large" + index;
+                }
+
+                @Override
+                public String getValue()
+                {
+                    return headerValue;
+                }
+
+                @Override
+                public int getVersion()
+                {
+                    return 0;
+                }
+
+                @Override
+                public Map<String, String> getAttributes()
+                {
+                    return new HashMap<>();
+                }
+            });
+        }
+
+        final CountDownLatch headersLatch = new CountDownLatch(1);
+        final CountDownLatch successLatch = new CountDownLatch(1);
+        request.listener(new Request.Listener()
+        {
+            @Override
+            public void onHeaders(Request request)
+            {
+                headersLatch.countDown();
+            }
+
+            @Override
+            public void onSuccess(Request request)
+            {
+                successLatch.countDown();
+            }
+        });
+        connection.send(request, null);
+
+        String requestString = endPoint.takeOutputString();
+        assertTrue(requestString.startsWith("GET / HTTP/1.1\r\nAccept-Encoding: gzip\r\n"));
+        assertTrue(headersLatch.await(5, TimeUnit.SECONDS));
+        assertTrue(successLatch.await(5, TimeUnit.SECONDS));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testMaxRequestHeadersSizeOverflow(Scenario scenario) throws Exception
+    {
+        startClient(scenario);
+        byte[] buffer = new byte[32 * 1024];
+        ByteArrayEndPoint endPoint = new ByteArrayEndPoint(buffer, buffer.length);
+        HttpDestination destination = new HttpDestination(client, new Origin("http", "localhost", 8080));
+        destination.start();
+        HttpConnectionOverHTTP connection = new HttpConnectionOverHTTP(endPoint, destination, new Promise.Adapter<Connection>());
+        Request request = client.newRequest(URI.create("http://localhost/"));
+        //More than the request buffer size, but less than the default max request headers size
+
+        int desiredHeadersSize = 35 * 1024;
+        int currentHeadersSize = 0;
+        int i = 0;
+        while (currentHeadersSize < desiredHeadersSize)
+        {
+            final int index = i++;
+            final String headerValue = getRandomString(800);
+            final int headerSize = headerValue.length();
+            currentHeadersSize += headerSize;
+            request.cookie(new HttpCookie()
+            {
+                @Override
+                public String getName()
+                {
+                    return "large" + index;
+                }
+
+                @Override
+                public String getValue()
+                {
+                    return headerValue;
+                }
+
+                @Override
+                public int getVersion()
+                {
+                    return 0;
+                }
+
+                @Override
+                public Map<String, String> getAttributes()
+                {
+                    return new HashMap<>();
+                }
+            });
+        }
+
+        final CountDownLatch headersLatch = new CountDownLatch(1);
+        final CountDownLatch failureLatch = new CountDownLatch(1);
+        request.listener(new Request.Listener()
+        {
+            @Override
+            public void onHeaders(Request request)
+            {
+                headersLatch.countDown();
+            }
+
+            @Override
+            public void onFailure(Request request, Throwable failure)
+            {
+                failureLatch.countDown();
+            }
+        });
+        connection.send(request, null);
+
+        assertTrue(headersLatch.await(5, TimeUnit.SECONDS));
+        assertTrue(failureLatch.await(5, TimeUnit.SECONDS));
     }
 }

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/HttpClientTransportOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/HttpClientTransportOverHTTP2.java
@@ -103,7 +103,7 @@ public class HttpClientTransportOverHTTP2 extends AbstractHttpClientTransport
         http2Client.setUseOutputDirectByteBuffers(httpClient.isUseOutputDirectByteBuffers());
         http2Client.setConnectBlocking(httpClient.isConnectBlocking());
         http2Client.setBindAddress(httpClient.getBindAddress());
-        http2Client.setMaxRequestHeadersSize(httpClient.getRequestBufferSize());
+        http2Client.setMaxRequestHeadersSize(httpClient.getMaxRequestHeadersSize());
         http2Client.setMaxResponseHeadersSize(httpClient.getMaxResponseHeadersSize());
     }
 

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
@@ -145,7 +145,7 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
             assertEquals(httpClient.getIdleTimeout(), http2Client.getIdleTimeout());
             assertEquals(httpClient.isUseInputDirectByteBuffers(), http2Client.isUseInputDirectByteBuffers());
             assertEquals(httpClient.isUseOutputDirectByteBuffers(), http2Client.isUseOutputDirectByteBuffers());
-            assertEquals(httpClient.getRequestBufferSize(), http2Client.getMaxRequestHeadersSize());
+            assertEquals(httpClient.getMaxRequestHeadersSize(), http2Client.getMaxRequestHeadersSize());
             assertEquals(httpClient.getMaxResponseHeadersSize(), http2Client.getMaxResponseHeadersSize());
         }
         assertTrue(http2Client.isStopped());

--- a/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/HttpClientTransportOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/HttpClientTransportOverHTTP3.java
@@ -83,6 +83,7 @@ public class HttpClientTransportOverHTTP3 extends AbstractHttpClientTransport im
         configuration.setInputBufferSize(httpClient.getResponseBufferSize());
         configuration.setUseInputDirectByteBuffers(httpClient.isUseInputDirectByteBuffers());
         configuration.setUseOutputDirectByteBuffers(httpClient.isUseOutputDirectByteBuffers());
+        configuration.setMaxRequestHeadersSize(httpClient.getMaxRequestHeadersSize());
         configuration.setMaxResponseHeadersSize(httpClient.getMaxResponseHeadersSize());
     }
 

--- a/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/HttpClientTransportOverHTTP3Test.java
+++ b/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/HttpClientTransportOverHTTP3Test.java
@@ -92,6 +92,7 @@ public class HttpClientTransportOverHTTP3Test extends AbstractClientServerTest
             HTTP3Configuration http3Configuration = http3Client.getHTTP3Configuration();
             assertEquals(httpClient.isUseInputDirectByteBuffers(), http3Configuration.isUseInputDirectByteBuffers());
             assertEquals(httpClient.isUseOutputDirectByteBuffers(), http3Configuration.isUseOutputDirectByteBuffers());
+            assertEquals(httpClient.getMaxRequestHeadersSize(), http3Configuration.getMaxRequestHeadersSize());
             assertEquals(httpClient.getMaxResponseHeadersSize(), http3Configuration.getMaxResponseHeadersSize());
         }
         assertTrue(http3Client.isStopped());


### PR DESCRIPTION
Initially contributed by @shaoxt, but reworked in light of #12351.

For HTTP/1, headers are initially generated using `HttpClient.getRequestBufferSize()`.
If that overflows, headers are generated again with `HttpClient.getMaxRequestHeadersSize()`.
This allows most of the requests to use a smaller buffer.