### PR TITLE
Fixes #12553 - Execute immediately HTTP/2 failures.

### DIFF
--- a/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/ServerFCGIConnection.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/ServerFCGIConnection.java
@@ -408,25 +408,18 @@ public class ServerFCGIConnection extends AbstractMetaDataConnection implements 
     @Override
     public void close()
     {
-        if (stream != null)
+        try
         {
-            Runnable task = stream.getHttpChannel().onClose();
-            if (task != null)
+            if (stream != null)
             {
-                ThreadPool.executeImmediately(getExecutor(), () ->
-                {
-                    try
-                    {
-                        task.run();
-                    }
-                    finally
-                    {
-                        super.close();
-                    }
-                });
-                return;
+                Runnable task = stream.getHttpChannel().onClose();
+                if (task != null)
+                    task.run();
             }
         }
-        super.close();
+        finally
+        {
+            super.close();
+        }
     }
 }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -618,10 +618,16 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
     @Override
     public void close()
     {
-        Runnable task = _httpChannel.onClose();
-        if (task != null)
-            task.run();
-        super.close();
+        try
+        {
+            Runnable task = _httpChannel.onClose();
+            if (task != null)
+                task.run();
+        }
+        finally
+        {
+            super.close();
+        }
     }
 
     @Override

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ThreadPool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ThreadPool.java
@@ -108,6 +108,11 @@ public interface ThreadPool extends Executor
             task.run();
             return;
         }
+        if (invocationType == Invocable.InvocationType.EITHER)
+        {
+            Invocable.invokeNonBlocking(task);
+            return;
+        }
 
         if (executor instanceof TryExecutor tryExecutor && tryExecutor.tryExecute(task))
             return;
@@ -116,12 +121,6 @@ public interface ThreadPool extends Executor
         if (virtual != null)
         {
             virtual.execute(task);
-            return;
-        }
-
-        if (invocationType == Invocable.InvocationType.EITHER)
-        {
-            Invocable.invokeNonBlocking(task);
             return;
         }
 

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ThreadPool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ThreadPool.java
@@ -102,6 +102,13 @@ public interface ThreadPool extends Executor
         if (task == null)
             return;
 
+        Invocable.InvocationType invocationType = Invocable.getInvocationType(task);
+        if (invocationType == Invocable.InvocationType.NON_BLOCKING)
+        {
+            task.run();
+            return;
+        }
+
         if (executor instanceof TryExecutor tryExecutor && tryExecutor.tryExecute(task))
             return;
 
@@ -112,21 +119,19 @@ public interface ThreadPool extends Executor
             return;
         }
 
-        switch (Invocable.getInvocationType(task))
+        if (invocationType == Invocable.InvocationType.EITHER)
         {
-            case NON_BLOCKING -> task.run();
-            case EITHER -> Invocable.invokeNonBlocking(task);
-            default ->
-            {
-                try
-                {
-                    new Thread(task).start();
-                }
-                catch (Throwable ignored)
-                {
-                    task.run();
-                }
-            }
+            Invocable.invokeNonBlocking(task);
+            return;
+        }
+
+        try
+        {
+            new Thread(task, "jetty-immediate-executor").start();
+        }
+        catch (Throwable ignored)
+        {
+            task.run();
         }
     }
 }


### PR DESCRIPTION
Now idle timeouts and failures are executed immediately for HTTP/2 and HTTP/3, rather than feeding them to the execution strategy, where they may be queued and never run.