### PR TITLE
Allow BadMessageException to propagate unwrapped through HttpInput

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpInput.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpInput.java
@@ -499,6 +499,10 @@ public class HttpInput extends ServletInputStream implements Runnable
         {
             return _interceptor.readFrom(content);
         }
+        catch (RuntimeException | Error x)
+        {
+            throw x;
+        }
         catch (Throwable x)
         {
             IOException failure = new IOException("Bad content", x);
@@ -1146,6 +1150,8 @@ public class HttpInput extends ServletInputStream implements Runnable
         {
             if (_error instanceof IOException)
                 throw (IOException)_error;
+            if (_error instanceof RuntimeException)
+                throw (RuntimeException)_error;
             throw new IOException(_error);
         }
 

--- a/jetty-server/src/test/java/org/eclipse/jetty/server/handler/SizeLimitHandlerTest.java
+++ b/jetty-server/src/test/java/org/eclipse/jetty/server/handler/SizeLimitHandlerTest.java
@@ -252,7 +252,7 @@ public class SizeLimitHandlerTest
             String text = new String(data, 0, 1024, Charset.defaultCharset());
 
             for (int i = 0; i < 9; i++)
-                endp.addInput("400\r\n" + text + "\r\n");
+                endp.addInput(Integer.toHexString(text.length()) + ";\r\n" + text + "\r\n");
 
             HttpTester.Response response = HttpTester.parseResponse(endp.getResponse());
 


### PR DESCRIPTION
Allow BadMessageException to propagate unwrapped through HttpInput. Whilst Jetty handling will correctly unwrap it, 3rd party handling may not.