### PR TITLE
restore abort for SendCallback.failed

### DIFF
--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
@@ -1435,6 +1435,13 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
                         _response.getHttpOutput().completed(null);
                         super.failed(x);
                     }
+
+                    @Override
+                    public void failed(Throwable th)
+                    {
+                        abort(x);
+                        super.failed(x);
+                    }
                 });
             }
             else


### PR DESCRIPTION
This abort was removed by https://github.com/jetty/jetty.project/pull/12370

but causes the failure to appengine-java-standard
when you run on PR https://github.com/GoogleCloudPlatform/appengine-java-standard/pull/313
```
mci -pl :runtime-test -Dtest=SizeLimitHandlerTest#testResponseContentAboveMaxLength[2]
```