### PR TITLE
Fixes #12588 - oejhs.AbstractHTTP2ServerConnectionFactory installs the HTTP2SessionContainer bean twice.

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/ContainerLifeCycle.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/ContainerLifeCycle.java
@@ -452,12 +452,12 @@ public class ContainerLifeCycle extends AbstractLifeCycle implements Container, 
         if (o instanceof Container.Listener || !_listeners.isEmpty())
             throw new IllegalArgumentException("Cannot call Container.Listeners from constructor");
 
-        if (o instanceof EventListener eventListener)
-            addEventListener(eventListener);
-
         Bean newBean = new Bean(o);
         newBean._managed = managed;
         _beans.add(newBean);
+
+        if (o instanceof EventListener eventListener)
+            addEventListener(eventListener);
 
         if (LOG.isDebugEnabled())
             LOG.debug("{}@{} added {}", getClass().getSimpleName(), hashCode(), newBean);
@@ -499,8 +499,8 @@ public class ContainerLifeCycle extends AbstractLifeCycle implements Container, 
         {
             // If it is not yet a bean,
             if (!contains(listener))
-                // add it as a bean, we will be called back to add it as an event listener, but it will have
-                // already been added, so we will not enter this branch.
+                // add it as a bean, we will be called back to add it as an event listener,
+                // but it will have already been added, so we will not enter this branch.
                 addBean(listener);
 
             if (listener instanceof Container.Listener cl)

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/component/ContainerLifeCycleTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/component/ContainerLifeCycleTest.java
@@ -16,6 +16,8 @@ package org.eclipse.jetty.util.component;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.Collection;
+import java.util.EventListener;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -727,5 +729,19 @@ public class ContainerLifeCycleTest
         assertTrue(container.isStarted());
         assertTrue(bean.isFailed());
         assertTrue(container.isUnmanaged(bean));
+    }
+
+    @Test
+    public void testInstallBeanThatImplementsEventListener()
+    {
+        class Bean implements EventListener
+        {
+        }
+
+        ContainerLifeCycle container = new ContainerLifeCycle();
+        container.installBean(new Bean());
+
+        Collection<Bean> beans = container.getBeans(Bean.class);
+        assertEquals(1, beans.size());
     }
 }


### PR DESCRIPTION
Fixed ordering in `installBean()`: first add the bean, then add it as a listener, so the bean is not added twice.

This is now similar to what `addBean()` is doing.