### PR TITLE
Fix incorrect maven coordinates

### DIFF
--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/pom.xml
@@ -80,36 +80,36 @@
       <artifactId>jetty-ee10-webapp</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.ee10.demos</groupId>
-      <artifactId>jetty-ee10-demo-async-rest-webapp</artifactId>
+      <groupId>org.eclipse.jetty.demos</groupId>
+      <artifactId>jetty-servlet5-demo-async-rest-webapp</artifactId>
       <version>${project.version}</version>
       <type>war</type>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.ee10.demos</groupId>
-      <artifactId>jetty-ee10-demo-jndi-webapp</artifactId>
+      <groupId>org.eclipse.jetty.demos</groupId>
+      <artifactId>jetty-servlet5-demo-jndi-webapp</artifactId>
       <version>${project.version}</version>
       <type>war</type>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.ee10.demos</groupId>
-      <artifactId>jetty-ee10-demo-jsp-webapp</artifactId>
+      <groupId>org.eclipse.jetty.demos</groupId>
+      <artifactId>jetty-servlet5-demo-jsp-webapp</artifactId>
       <version>${project.version}</version>
       <type>war</type>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.ee10.demos</groupId>
-      <artifactId>jetty-ee10-demo-mock-resources</artifactId>
+      <groupId>org.eclipse.jetty.demos</groupId>
+      <artifactId>jetty-servlet5-demo-mock-resources</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.ee10.demos</groupId>
-      <artifactId>jetty-ee10-demo-simple-webapp</artifactId>
+      <groupId>org.eclipse.jetty.demos</groupId>
+      <artifactId>jetty-servlet5-demo-simple-webapp</artifactId>
       <version>${project.version}</version>
       <type>war</type>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.ee10.demos</groupId>
-      <artifactId>jetty-ee10-demo-spec-webapp</artifactId>
+      <groupId>org.eclipse.jetty.demos</groupId>
+      <artifactId>jetty-servlet5-demo-spec-webapp</artifactId>
       <version>${project.version}</version>
       <type>war</type>
     </dependency>

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -1696,12 +1696,14 @@ public class DistributionTests extends AbstractJettyHomeTest
             };
 
             // Put war into ${jetty.base}/wars/ directory
-            Path srcWar = ("ee8".equals(env) 
-                    ?  distribution.resolveArtifact("org.eclipse.jetty.demos:jetty-servlet4-demo-simple-webapp:war:" + jettyVersion) : distribution.resolveArtifact("org.eclipse.jetty.demos:jetty-servlet5-demo-simple-webapp:war:" + jettyVersion));
+            String coordinates = "org.eclipse.jetty.demos:jetty-%s-demo-simple-webapp:war:%s".formatted(
+                "ee8".equals(env) ? "servlet4" : "servlet5",
+                jettyVersion
+            );
             Path warsDir = jettyBase.resolve("wars");
             FS.ensureDirExists(warsDir);
             Path destWar = warsDir.resolve("demo.war");
-            Files.copy(srcWar, destWar);
+            Files.copy(distribution.resolveArtifact(coordinates), destWar);
 
             // Create XML for deployable
             String xml = """
@@ -2169,7 +2171,7 @@ public class DistributionTests extends AbstractJettyHomeTest
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"ee8", "ee9", "ee10"})
+    @ValueSource(strings = {"ee8", "ee9", "ee10", "ee11"})
     public void testLimitHandlers(String env) throws Exception
     {
         String jettyVersion = System.getProperty("jettyVersion");
@@ -2196,8 +2198,11 @@ public class DistributionTests extends AbstractJettyHomeTest
                 """;
             Files.writeString(jettyLogging, loggingConfig, StandardOpenOption.TRUNCATE_EXISTING);
 
-            Path war = distribution.resolveArtifact("org.eclipse.jetty." + env + ".demos:jetty-" + env + "-demo-simple-webapp:war:" + jettyVersion);
-            distribution.installWar(war, "test");
+            String coordinates = "org.eclipse.jetty.demos:jetty-%s-demo-simple-webapp:war:%s".formatted(
+                "ee8".equals(env) ? "servlet4" : "servlet5",
+                jettyVersion
+            );
+            distribution.installWar(distribution.resolveArtifact(coordinates), "test");
 
             int port = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("jetty.http.selectors=1", "jetty.http.port=" + port))


### PR DESCRIPTION
`DistributionTests.testLimitHandlers()` tries to resolve an incorrect WAR demo artifact name; `jetty-ee10-demo-embedded` also depends on incorrect artifact names.

Since `jetty-ee10-demo-embedded` is disabled, it's normal that this has no effect on the build, so these changes are just about housekeeping.

But `DistributionTests.testLimitHandlers()` is running and doesn't seem to fail which I find surprising since it tries to lookup an artifact that does not exist.