### PR TITLE
Fixed #12603 Errors logged after cross context dispatch

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
@@ -176,6 +176,15 @@ public class HttpOutput extends ServletOutputStream
         return _written;
     }
 
+    /**
+     * Used by ServletCoreResponse when it bypasses HttpOutput to update bytes written.
+     * @param written The bytes written
+     */
+    void addBytesWritten(int written)
+    {
+        _written += written;
+    }
+
     public void reopen()
     {
         try (AutoLock l = _channelState.lock())

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletCoreResponse.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletCoreResponse.java
@@ -138,6 +138,8 @@ public class ServletCoreResponse implements Response
         {
             if (!_wrapped && !_servletContextResponse.isWritingOrStreaming())
             {
+                // We can bypass the HttpOutput stream, but we need to update its bytes written
+                _servletContextResponse.getHttpOutput().addBytesWritten(byteBuffer.remaining());
                 _servletContextResponse.write(last, byteBuffer, callback);
             }
             else

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
@@ -56,7 +56,6 @@ import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
-import org.eclipse.jetty.util.ExceptionUtil;
 import org.eclipse.jetty.util.HostPort;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.SharedBlockingCallback.Blocker;
@@ -561,16 +560,7 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
                         {
                             if (LOG.isDebugEnabled())
                                 LOG.debug("Could not perform ERROR dispatch, aborting", x);
-                            try
-                            {
-                                _response.resetContent();
-                                sendResponseAndComplete();
-                            }
-                            catch (Throwable t)
-                            {
-                                ExceptionUtil.addSuppressedIfNotAssociated(x, t);
-                                throw x;
-                            }
+                            abort(x);
                         }
                         finally
                         {

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpOutput.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpOutput.java
@@ -241,6 +241,15 @@ public class HttpOutput extends ServletOutputStream implements Runnable
         return _written;
     }
 
+    /**
+     * Used by ServletCoreResponse when it bypasses HttpOutput to update bytes written.
+     * @param written The bytes written
+     */
+    void setBytesWritten(int written)
+    {
+        _written = written;
+    }
+
     public void reopen()
     {
         try (AutoLock l = _channelState.lock())

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpOutput.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpOutput.java
@@ -245,9 +245,9 @@ public class HttpOutput extends ServletOutputStream implements Runnable
      * Used by ServletCoreResponse when it bypasses HttpOutput to update bytes written.
      * @param written The bytes written
      */
-    void setBytesWritten(int written)
+    void addBytesWritten(int written)
     {
-        _written = written;
+        _written += written;
     }
 
     public void reopen()

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ServletCoreResponse.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ServletCoreResponse.java
@@ -137,10 +137,10 @@ public class ServletCoreResponse implements org.eclipse.jetty.server.Response
             last = false;
         try
         {
-            if (last && !_wrapped && !_baseResponse.isWritingOrStreaming())
+            if (!_wrapped && !_baseResponse.isWritingOrStreaming())
             {
                 // We can bypass the HttpOutput stream, but we need to update its bytes written
-                _baseResponse.getHttpOutput().setBytesWritten(byteBuffer.remaining());
+                _baseResponse.getHttpOutput().addBytesWritten(byteBuffer.remaining());
                 _coreResponse.write(last, byteBuffer, callback);
             }
             else


### PR DESCRIPTION
Fixed #12603 Errors logged after cross context dispatch:
 + Update bytes written in HttpOutput when bypassed by optimization
 + abort if error dispatch throws