### PR TITLE
Fix `IllegalStateException` in `ResourceServlet` when serving content async when a filter already called `startAsync()`

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ResourceServlet.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ResourceServlet.java
@@ -518,7 +518,7 @@ public class ResourceServlet extends HttpServlet
                     (contentLength < 0 || contentLength > coreRequest.getConnectionMetaData().getHttpConfiguration().getOutputBufferSize()))
                 {
                     // send the content asynchronously
-                    AsyncContext asyncContext = httpServletRequest.startAsync();
+                    AsyncContext asyncContext = httpServletRequest.isAsyncStarted() ? httpServletRequest.getAsyncContext() : httpServletRequest.startAsync();
                     Callback callback = new AsyncContextCallback(asyncContext, httpServletResponse);
                     _resourceService.doGet(coreRequest, coreResponse, callback, content);
                 }

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ResourceServletTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ResourceServletTest.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
@@ -38,6 +39,7 @@ import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
+import jakarta.servlet.AsyncContext;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
@@ -3771,6 +3773,39 @@ public class ResourceServletTest
         assertThat(response.get(HttpHeader.CONTENT_LENGTH), is("18"));
         assertThat(response.get(HttpHeader.ACCEPT_RANGES), is("none"));
         assertThat(response.getContent(), is("Test 2 to too two\n"));
+    }
+
+    @Test
+    public void testServeResourceAsyncWhileStartAsyncAlreadyCalled() throws Exception
+    {
+        // The OutputBufferSize must be smaller than the content length otherwise the request is not served async.
+        connector.getConnectionFactory(HttpConfiguration.ConnectionFactory.class).getHttpConfiguration().setOutputBufferSize(0);
+
+        AtomicBoolean filterCalled = new AtomicBoolean();
+        context.addFilter((request, response, chain) ->
+        {
+            filterCalled.set(true);
+            AsyncContext asyncContext = request.startAsync();
+            chain.doFilter(request, response);
+            asyncContext.complete();
+        }, "/*", EnumSet.of(DispatcherType.REQUEST));
+
+        ResourceServlet resourceServlet = new ResourceServlet();
+        context.addServlet(resourceServlet, "/*");
+        Resource memResource = ResourceFactory.of(context).newMemoryResource(getClass().getResource("/contextResources/test.txt"));
+        resourceServlet.getResourceService().setHttpContentFactory(path -> new ResourceHttpContent(memResource, "text/plain"));
+
+        String rawResponse = connector.getResponse("""
+            GET /context/ HTTP/1.1\r
+            Host: local\r
+            Connection: close\r
+            \r
+            """);
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.toString(), response.getStatus(), is(HttpStatus.OK_200));
+        assertThat(response.get(HttpHeader.CONTENT_LENGTH), is("18"));
+        assertThat(response.getContent(), is("Test 2 to too two\n"));
+        assertThat(filterCalled.get(), is(true));
     }
 
     public static class WriterFilter implements Filter

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ResourceService.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ResourceService.java
@@ -735,7 +735,7 @@ public class ResourceService
                 // write the content asynchronously if supported
                 if (request.isAsyncSupported())
                 {
-                    final AsyncContext context = request.startAsync();
+                    AsyncContext context = request.isAsyncStarted() ? request.getAsyncContext() : request.startAsync();
                     context.setTimeout(0);
 
                     ((HttpOutput)out).sendContent(content, new Callback()


### PR DESCRIPTION
Fixes #12153