### PR TITLE
Fixes #12625 - Request.getBeginNanoTime returns invalid values.

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/Parser.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/Parser.java
@@ -120,8 +120,8 @@ public class Parser
     {
         if (!nanoTimeStored)
         {
-            beginNanoTime = NanoTime.now();
             nanoTimeStored = true;
+            beginNanoTime = NanoTime.now();
         }
     }
 
@@ -146,7 +146,8 @@ public class Parser
                 {
                     case HEADER:
                     {
-                        storeBeginNanoTime();
+                        if (buffer.hasRemaining())
+                            storeBeginNanoTime();
                         if (!parseHeader(buffer))
                             return;
                         break;

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/parser/MessageParser.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/parser/MessageParser.java
@@ -77,8 +77,8 @@ public class MessageParser
     {
         if (!beginNanoTimeStored)
         {
-            beginNanoTime = NanoTime.now();
             beginNanoTimeStored = true;
+            beginNanoTime = NanoTime.now();
         }
     }
 
@@ -120,7 +120,8 @@ public class MessageParser
                 {
                     case HEADER ->
                     {
-                        storeBeginNanoTime();
+                        if (buffer.hasRemaining())
+                            storeBeginNanoTime();
                         if (headerParser.parse(buffer))
                         {
                             state = State.BODY;

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/RequestNanoTimesTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/RequestNanoTimesTest.java
@@ -1,0 +1,67 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.test.client.transport;
+
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.client.ContentResponse;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.NanoTime;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RequestNanoTimesTest extends AbstractTest
+{
+    @ParameterizedTest
+    @MethodSource("transports")
+    public void testRequestNanoTimes(Transport transport) throws Exception
+    {
+        start(transport, new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                response.getHeaders().put("X-Request-BeginNanoTime", request.getBeginNanoTime());
+                response.getHeaders().put("X-Request-HeadersNanoTime", request.getHeadersNanoTime());
+                callback.succeeded();
+                return true;
+            }
+        });
+
+        for (int i = 0; i < 2; ++i)
+        {
+            long clientRequestNanoTime = NanoTime.now();
+            ContentResponse response = client.newRequest(newURI(transport))
+                .timeout(5, TimeUnit.SECONDS)
+                .send();
+
+            assertEquals(HttpStatus.OK_200, response.getStatus());
+            long serverRequestBeginNanoTime = response.getHeaders().getLongField("X-Request-BeginNanoTime");
+            long serverRequestHeadersNanoTime = response.getHeaders().getLongField("X-Request-HeadersNanoTime");
+
+            String reason = "request " + i;
+            assertThat(reason, NanoTime.elapsed(clientRequestNanoTime, serverRequestBeginNanoTime), greaterThan(0L));
+            assertThat(reason, NanoTime.elapsed(serverRequestBeginNanoTime, serverRequestHeadersNanoTime), greaterThanOrEqualTo(0L));
+        }
+    }
+}


### PR DESCRIPTION
The parser loop was calling `storeBeginNanoTime()` even if the buffer was consumed. The next request would then have "old" times, referring to the previous parser loop, rather than the new one.

Now only calling `storeBeginNanoTime()` if there are bytes to parse.