### PR TITLE
Issue #11413 - Conscrypt does not support server-side SNI.

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/SecureRequestCustomizer.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/SecureRequestCustomizer.java
@@ -238,7 +238,7 @@ public class SecureRequestCustomizer implements HttpConfiguration.Customizer
         // Quick retrieval of the SNI from a SSLSession attribute put by SniX509ExtendedKeyManager.
         String sniHost = (String)session.getValue(SslContextFactory.Server.SNI_HOST);
         if (sniHost != null)
-            return null;
+            return sniHost;
 
         // Some security providers (for example, Conscrypt) do not support
         // SSLSession attributes, so perform a more expensive SNI retrieval.


### PR DESCRIPTION
Addendum to #12549 to fix the silly mistake of returning null rather than the SNI host.

Thanks @brusdev for pointing that out.