### PR TITLE
Renamed AbstractTest.Transport to TransportType

### DIFF
--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AbstractTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AbstractTest.java
@@ -99,33 +99,33 @@ public class AbstractTest
     protected ArrayByteBufferPool.Tracking serverBufferPool;
     protected ArrayByteBufferPool.Tracking clientBufferPool;
 
-    public static Collection<Transport> transports()
+    public static Collection<TransportType> transports()
     {
-        EnumSet<Transport> transports = EnumSet.allOf(Transport.class);
+        EnumSet<TransportType> transportTypes = EnumSet.allOf(TransportType.class);
         if ("ci".equals(System.getProperty("env")))
-            transports.remove(Transport.H3);
-        return transports;
+            transportTypes.remove(TransportType.H3);
+        return transportTypes;
     }
 
-    public static Collection<Transport> transportsNoFCGI()
+    public static Collection<TransportType> transportsNoFCGI()
     {
-        Collection<Transport> transports = transports();
-        transports.remove(Transport.FCGI);
-        return transports;
+        Collection<TransportType> transportTypes = transports();
+        transportTypes.remove(TransportType.FCGI);
+        return transportTypes;
     }
 
-    public static Collection<Transport> transportsTCP()
+    public static Collection<TransportType> transportsTCP()
     {
-        Collection<Transport> transports = transports();
-        transports.remove(Transport.H3);
-        return transports;
+        Collection<TransportType> transportTypes = transports();
+        transportTypes.remove(TransportType.H3);
+        return transportTypes;
     }
 
-    public static Collection<Transport> transportsTLS()
+    public static Collection<TransportType> transportsTLS()
     {
-        Collection<Transport> transports = transports();
-        transports.retainAll(EnumSet.of(Transport.HTTPS, Transport.H2));
-        return transports;
+        Collection<TransportType> transportTypes = transports();
+        transportTypes.retainAll(EnumSet.of(TransportType.HTTPS, TransportType.H2));
+        return transportTypes;
     }
 
     @AfterEach
@@ -255,25 +255,25 @@ public class AbstractTest
         mxBeanClass.getMethod("dumpHeap", String.class, boolean.class).invoke(mxBean, dumpName, true);
     }
 
-    protected void start(Transport transport, Handler handler) throws Exception
+    protected void start(TransportType transportType, Handler handler) throws Exception
     {
-        startServer(transport, handler);
-        startClient(transport);
+        startServer(transportType, handler);
+        startClient(transportType);
     }
 
-    protected void startServer(Transport transport, Handler handler) throws Exception
+    protected void startServer(TransportType transportType, Handler handler) throws Exception
     {
-        prepareServer(transport, handler);
+        prepareServer(transportType, handler);
         server.start();
     }
 
-    protected void prepareServer(Transport transport, Handler handler) throws Exception
+    protected void prepareServer(TransportType transportType, Handler handler) throws Exception
     {
         sslContextFactoryServer = newSslContextFactoryServer();
         serverQuicConfig = new ServerQuicConfiguration(sslContextFactoryServer, workDir.getEmptyPathDir());
         if (server == null)
             server = newServer();
-        connector = newConnector(transport, server);
+        connector = newConnector(transportType, server);
         server.addConnector(connector);
         server.setHandler(handler);
     }
@@ -296,41 +296,41 @@ public class AbstractTest
         return ssl;
     }
 
-    protected void startClient(Transport transport) throws Exception
+    protected void startClient(TransportType transportType) throws Exception
     {
-        prepareClient(transport);
+        prepareClient(transportType);
         client.start();
     }
 
-    protected void prepareClient(Transport transport) throws Exception
+    protected void prepareClient(TransportType transportType) throws Exception
     {
         QueuedThreadPool clientThreads = new QueuedThreadPool();
         clientThreads.setName("client");
-        client = new HttpClient(newHttpClientTransport(transport));
+        client = new HttpClient(newHttpClientTransport(transportType));
         clientBufferPool = new ArrayByteBufferPool.Tracking();
         client.setByteBufferPool(clientBufferPool);
         client.setExecutor(clientThreads);
         client.setSocketAddressResolver(new SocketAddressResolver.Sync());
     }
 
-    public AbstractConnector newConnector(Transport transport, Server server)
+    public AbstractConnector newConnector(TransportType transportType, Server server)
     {
-        return switch (transport)
+        return switch (transportType)
         {
             case HTTP:
             case HTTPS:
             case H2C:
             case H2:
             case FCGI:
-                yield new ServerConnector(server, 1, 1, newServerConnectionFactory(transport));
+                yield new ServerConnector(server, 1, 1, newServerConnectionFactory(transportType));
             case H3:
-                yield new QuicServerConnector(server, serverQuicConfig, newServerConnectionFactory(transport));
+                yield new QuicServerConnector(server, serverQuicConfig, newServerConnectionFactory(transportType));
         };
     }
 
-    protected ConnectionFactory[] newServerConnectionFactory(Transport transport)
+    protected ConnectionFactory[] newServerConnectionFactory(TransportType transportType)
     {
-        List<ConnectionFactory> list = switch (transport)
+        List<ConnectionFactory> list = switch (transportType)
         {
             case HTTP -> List.of(new HttpConnectionFactory(httpConfig));
             case HTTPS ->
@@ -370,11 +370,11 @@ public class AbstractTest
         return new SslContextFactory.Client(true);
     }
 
-    protected HttpClientTransport newHttpClientTransport(Transport transport) throws Exception
+    protected HttpClientTransport newHttpClientTransport(TransportType transportType) throws Exception
     {
         clientConnector = new ClientConnector();
         clientConnector.setSelectors(1);
-        return switch (transport)
+        return switch (transportType)
         {
             case HTTP, HTTPS ->
             {
@@ -397,9 +397,9 @@ public class AbstractTest
         };
     }
 
-    protected URI newURI(Transport transport)
+    protected URI newURI(TransportType transportType)
     {
-        String scheme = transport.isSecure() ? "https" : "http";
+        String scheme = transportType.isSecure() ? "https" : "http";
         String uri = scheme + "://localhost";
         if (connector instanceof NetworkConnector networkConnector)
             uri += ":" + networkConnector.getLocalPort();
@@ -447,7 +447,7 @@ public class AbstractTest
         }
     }
 
-    public enum Transport
+    public enum TransportType
     {
         HTTP, HTTPS, H2C, H2, H3, FCGI;
 

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AbstractTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AbstractTest.java
@@ -103,7 +103,7 @@ public class AbstractTest
     {
         EnumSet<TransportType> transportTypes = EnumSet.allOf(TransportType.class);
         if ("ci".equals(System.getProperty("env")))
-            transportTypes.remove(TransportType.H3);
+            transportTypes.remove(TransportType.H3_QUICHE);
         return transportTypes;
     }
 
@@ -117,7 +117,7 @@ public class AbstractTest
     public static Collection<TransportType> transportsTCP()
     {
         Collection<TransportType> transportTypes = transports();
-        transportTypes.remove(TransportType.H3);
+        transportTypes.remove(TransportType.H3_QUICHE);
         return transportTypes;
     }
 
@@ -323,7 +323,7 @@ public class AbstractTest
             case H2:
             case FCGI:
                 yield new ServerConnector(server, 1, 1, newServerConnectionFactory(transportType));
-            case H3:
+            case H3_QUICHE:
                 yield new QuicServerConnector(server, serverQuicConfig, newServerConnectionFactory(transportType));
         };
     }
@@ -354,7 +354,7 @@ public class AbstractTest
                 SslConnectionFactory ssl = new SslConnectionFactory(sslContextFactoryServer, alpn.getProtocol());
                 yield List.of(ssl, alpn, h2);
             }
-            case H3 ->
+            case H3_QUICHE ->
             {
                 httpConfig.addCustomizer(new SecureRequestCustomizer());
                 httpConfig.addCustomizer(new HostHeaderCustomizer());
@@ -387,7 +387,7 @@ public class AbstractTest
                 HTTP2Client http2Client = new HTTP2Client(clientConnector);
                 yield new HttpClientTransportOverHTTP2(http2Client);
             }
-            case H3 ->
+            case H3_QUICHE ->
             {
                 SslContextFactory.Client sslClient = newSslContextFactoryClient();
                 HTTP3Client http3Client = new HTTP3Client(new ClientQuicConfiguration(sslClient, null), clientConnector);
@@ -449,14 +449,14 @@ public class AbstractTest
 
     public enum TransportType
     {
-        HTTP, HTTPS, H2C, H2, H3, FCGI;
+        HTTP, HTTPS, H2C, H2, H3_QUICHE, FCGI;
 
         public boolean isSecure()
         {
             return switch (this)
             {
                 case HTTP, H2C, FCGI -> false;
-                case HTTPS, H2, H3 -> true;
+                case HTTPS, H2, H3_QUICHE -> true;
             };
         }
 
@@ -465,7 +465,7 @@ public class AbstractTest
             return switch (this)
             {
                 case HTTP, HTTPS, FCGI -> false;
-                case H2C, H2, H3 -> true;
+                case H2C, H2, H3_QUICHE -> true;
             };
         }
     }

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AsyncRequestContentTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AsyncRequestContentTest.java
@@ -40,13 +40,13 @@ public class AsyncRequestContentTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transports")
-    public void testEmptyAsyncContent(Transport transport) throws Exception
+    public void testEmptyAsyncContent(TransportType transportType) throws Exception
     {
-        start(transport, new ConsumeInputHandler());
+        start(transportType, new ConsumeInputHandler());
 
         AsyncRequestContent content = new AsyncRequestContent();
         CountDownLatch latch = new CountDownLatch(1);
-        client.POST(newURI(transport))
+        client.POST(newURI(transportType))
             .body(content)
             .send(result ->
             {
@@ -61,13 +61,13 @@ public class AsyncRequestContentTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testAsyncContent(Transport transport) throws Exception
+    public void testAsyncContent(TransportType transportType) throws Exception
     {
-        start(transport, new ConsumeInputHandler());
+        start(transportType, new ConsumeInputHandler());
 
         AsyncRequestContent content = new AsyncRequestContent();
         CountDownLatch latch = new CountDownLatch(1);
-        client.POST(newURI(transport))
+        client.POST(newURI(transportType))
             .body(content)
             .send(result ->
             {
@@ -83,14 +83,14 @@ public class AsyncRequestContentTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testEmptyInputStream(Transport transport) throws Exception
+    public void testEmptyInputStream(TransportType transportType) throws Exception
     {
-        start(transport, new ConsumeInputHandler());
+        start(transportType, new ConsumeInputHandler());
 
         InputStreamRequestContent content =
             new InputStreamRequestContent(new ByteArrayInputStream(new byte[0]));
         CountDownLatch latch = new CountDownLatch(1);
-        client.POST(newURI(transport))
+        client.POST(newURI(transportType))
             .body(content)
             .send(result ->
             {
@@ -104,14 +104,14 @@ public class AsyncRequestContentTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testInputStream(Transport transport) throws Exception
+    public void testInputStream(TransportType transportType) throws Exception
     {
-        start(transport, new ConsumeInputHandler());
+        start(transportType, new ConsumeInputHandler());
 
         InputStreamRequestContent content =
             new InputStreamRequestContent(new ByteArrayInputStream(new byte[1]));
         CountDownLatch latch = new CountDownLatch(1);
-        client.POST(newURI(transport))
+        client.POST(newURI(transportType))
             .body(content)
             .send(result ->
             {
@@ -125,13 +125,13 @@ public class AsyncRequestContentTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testEmptyOutputStream(Transport transport) throws Exception
+    public void testEmptyOutputStream(TransportType transportType) throws Exception
     {
-        start(transport, new ConsumeInputHandler());
+        start(transportType, new ConsumeInputHandler());
 
         OutputStreamRequestContent content = new OutputStreamRequestContent();
         CountDownLatch latch = new CountDownLatch(1);
-        client.POST(newURI(transport))
+        client.POST(newURI(transportType))
             .body(content)
             .send(result ->
             {
@@ -146,13 +146,13 @@ public class AsyncRequestContentTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testOutputStream(Transport transport) throws Exception
+    public void testOutputStream(TransportType transportType) throws Exception
     {
-        start(transport, new ConsumeInputHandler());
+        start(transportType, new ConsumeInputHandler());
 
         OutputStreamRequestContent content = new OutputStreamRequestContent();
         CountDownLatch latch = new CountDownLatch(1);
-        client.POST(newURI(transport))
+        client.POST(newURI(transportType))
             .body(content)
             .send(result ->
             {
@@ -170,15 +170,15 @@ public class AsyncRequestContentTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testBufferReuseAfterCallbackCompleted(Transport transport) throws Exception
+    public void testBufferReuseAfterCallbackCompleted(TransportType transportType) throws Exception
     {
-        start(transport, new ConsumeInputHandler());
+        start(transportType, new ConsumeInputHandler());
 
         AsyncRequestContent content = new AsyncRequestContent();
 
         CountDownLatch latch = new CountDownLatch(1);
         List<Byte> requestContent = new ArrayList<>();
-        client.POST(newURI(transport))
+        client.POST(newURI(transportType))
             .onRequestContent(((request, buffer) -> requestContent.add(buffer.get())))
             .body(content)
             .send(result ->

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/ConnectListenerTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/ConnectListenerTest.java
@@ -37,22 +37,22 @@ public class ConnectListenerTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transportsTCP")
-    public void testBeginSuccessBlocking(Transport transport) throws Exception
+    public void testBeginSuccessBlocking(TransportType transportType) throws Exception
     {
-        testBeginSuccess(transport, true);
+        testBeginSuccess(transportType, true);
     }
 
     @ParameterizedTest
     @MethodSource("transportsTCP")
-    public void testBeginSuccessNonBlocking(Transport transport) throws Exception
+    public void testBeginSuccessNonBlocking(TransportType transportType) throws Exception
     {
-        testBeginSuccess(transport, false);
+        testBeginSuccess(transportType, false);
     }
 
-    private void testBeginSuccess(Transport transport, boolean blocking) throws Exception
+    private void testBeginSuccess(TransportType transportType, boolean blocking) throws Exception
     {
-        startServer(transport, new EmptyServerHandler());
-        prepareClient(transport);
+        startServer(transportType, new EmptyServerHandler());
+        prepareClient(transportType);
         client.setConnectBlocking(blocking);
         CountDownLatch beginLatch = new CountDownLatch(1);
         CountDownLatch successLatch = new CountDownLatch(1);
@@ -79,7 +79,7 @@ public class ConnectListenerTest extends AbstractTest
         });
         client.start();
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .timeout(5, TimeUnit.SECONDS)
             .send();
 
@@ -91,22 +91,22 @@ public class ConnectListenerTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsTCP")
-    public void testBeginFailureBlocking(Transport transport) throws Exception
+    public void testBeginFailureBlocking(TransportType transportType) throws Exception
     {
-        testBeginFailure(transport, true);
+        testBeginFailure(transportType, true);
     }
 
     @ParameterizedTest
     @MethodSource("transportsTCP")
-    public void testBeginFailureNonBlocking(Transport transport) throws Exception
+    public void testBeginFailureNonBlocking(TransportType transportType) throws Exception
     {
-        testBeginFailure(transport, false);
+        testBeginFailure(transportType, false);
     }
 
-    public void testBeginFailure(Transport transport, boolean blocking) throws Exception
+    public void testBeginFailure(TransportType transportType, boolean blocking) throws Exception
     {
-        startServer(transport, new EmptyServerHandler());
-        prepareClient(transport);
+        startServer(transportType, new EmptyServerHandler());
+        prepareClient(transportType);
         client.setConnectBlocking(blocking);
         CountDownLatch beginLatch = new CountDownLatch(1);
         CountDownLatch successLatch = new CountDownLatch(1);
@@ -133,7 +133,7 @@ public class ConnectListenerTest extends AbstractTest
         });
         client.start();
 
-        URI uri = newURI(transport);
+        URI uri = newURI(transportType);
         // Use a different port to fail the TCP connect.
         URI badURI = new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), freePort(), uri.getPath(), uri.getQuery(), uri.getFragment());
         ExecutionException failure = assertThrows(ExecutionException.class, () -> client.newRequest(badURI)

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/ConnectionPoolTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/ConnectionPoolTest.java
@@ -37,20 +37,20 @@ public class ConnectionPoolTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transports")
-    public void testPreCreateConnections(Transport transport) throws Exception
+    public void testPreCreateConnections(TransportType transportType) throws Exception
     {
         int maxConnectionsPerDestination = 8;
-        prepareServer(transport, new EmptyServerHandler());
+        prepareServer(transportType, new EmptyServerHandler());
         ConnectionListener serverConnections = new ConnectionListener();
         connector.addBean(serverConnections);
         server.start();
 
-        startClient(transport);
+        startClient(transportType);
         client.setMaxConnectionsPerDestination(maxConnectionsPerDestination);
-        if (transport == Transport.HTTPS)
+        if (transportType == TransportType.HTTPS)
             ((HttpClientTransportOverHTTP)client.getHttpClientTransport()).setInitializeConnections(true);
 
-        var request = client.newRequest(newURI(transport));
+        var request = client.newRequest(newURI(transportType));
         Destination destination = client.resolveDestination(request);
         destination.getConnectionPool().preCreateConnections(client.getMaxConnectionsPerDestination())
             .get(5, TimeUnit.SECONDS);
@@ -58,7 +58,7 @@ public class ConnectionPoolTest extends AbstractTest
         // Verify that server connections have been created.
         await().atMost(5, TimeUnit.SECONDS).untilAsserted(() ->
         {
-            switch (transport)
+            switch (transportType)
             {
                 case HTTP, HTTPS -> assertThat(serverConnections.filter(HttpConnection.class).size(), is(maxConnectionsPerDestination));
                 case H2C, H2 -> assertThat(serverConnections.filter(HTTP2ServerConnection.class).size(), is(maxConnectionsPerDestination));
@@ -68,7 +68,7 @@ public class ConnectionPoolTest extends AbstractTest
         });
 
         // Verify that TLS was performed.
-        List<Connection> sslConnections = switch (transport)
+        List<Connection> sslConnections = switch (transportType)
         {
             case HTTP, H2C, FCGI, H3 -> null;
             case HTTPS, H2 -> serverConnections.filter(SslConnection.class);

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/ConnectionPoolTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/ConnectionPoolTest.java
@@ -62,7 +62,7 @@ public class ConnectionPoolTest extends AbstractTest
             {
                 case HTTP, HTTPS -> assertThat(serverConnections.filter(HttpConnection.class).size(), is(maxConnectionsPerDestination));
                 case H2C, H2 -> assertThat(serverConnections.filter(HTTP2ServerConnection.class).size(), is(maxConnectionsPerDestination));
-                case H3 -> assertThat(serverConnections.filter(ServerQuicConnection.class).size(), is(1));
+                case H3_QUICHE -> assertThat(serverConnections.filter(ServerQuicConnection.class).size(), is(1));
                 case FCGI -> assertThat(serverConnections.filter(ServerFCGIConnection.class).size(), is(maxConnectionsPerDestination));
             }
         });
@@ -70,7 +70,7 @@ public class ConnectionPoolTest extends AbstractTest
         // Verify that TLS was performed.
         List<Connection> sslConnections = switch (transportType)
         {
-            case HTTP, H2C, FCGI, H3 -> null;
+            case HTTP, H2C, FCGI, H3_QUICHE -> null;
             case HTTPS, H2 -> serverConnections.filter(SslConnection.class);
         };
         if (sslConnections != null)

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/ConnectionStatisticsTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/ConnectionStatisticsTest.java
@@ -40,14 +40,14 @@ public class ConnectionStatisticsTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transports")
-    public void testConnectionStatistics(Transport transport) throws Exception
+    public void testConnectionStatistics(TransportType transportType) throws Exception
     {
         // Counting SslConnection opening/closing makes the test more complicated.
-        assumeTrue(!transport.isSecure());
+        assumeTrue(!transportType.isSecure());
         // FastCGI server does not have statistics.
-        assumeTrue(transport != Transport.FCGI);
+        assumeTrue(transportType != TransportType.FCGI);
 
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, Response response, Callback callback)
@@ -87,7 +87,7 @@ public class ConnectionStatisticsTest extends AbstractTest
 
         byte[] content = new byte[3072];
         long contentLength = content.length;
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.CONNECTION, HttpHeaderValue.CLOSE))
             .body(new BytesRequestContent(content))
             .timeout(5, TimeUnit.SECONDS)

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/EventsHandlerTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/EventsHandlerTest.java
@@ -57,7 +57,7 @@ public class EventsHandlerTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transports")
-    public void testEventsBufferAndChunkAreReadOnly(Transport transport) throws Exception
+    public void testEventsBufferAndChunkAreReadOnly(TransportType transportType) throws Exception
     {
         try (StacklessLogging ignored = new StacklessLogging(EventsHandler.class))
         {
@@ -99,10 +99,10 @@ public class EventsHandlerTest extends AbstractTest
                     }
                 }
             };
-            startServer(transport, eventsHandler);
-            startClient(transport);
+            startServer(transportType, eventsHandler);
+            startClient(transportType);
 
-            ContentResponse response = client.POST(newURI(transport))
+            ContentResponse response = client.POST(newURI(transportType))
                 .body(new StringRequestContent("ABCDEF"))
                 .send();
 
@@ -115,7 +115,7 @@ public class EventsHandlerTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testMultipleEventsHandlerChaining(Transport transport) throws Exception
+    public void testMultipleEventsHandlerChaining(TransportType transportType) throws Exception
     {
         String longString = "A".repeat(65536);
 
@@ -149,10 +149,10 @@ public class EventsHandlerTest extends AbstractTest
                     outerBytesCounter.addAndGet(content.remaining());
             }
         };
-        startServer(transport, outerEventsHandler);
-        startClient(transport);
+        startServer(transportType, outerEventsHandler);
+        startClient(transportType);
 
-        ContentResponse response = client.GET(newURI(transport));
+        ContentResponse response = client.GET(newURI(transportType));
         assertThat(response.getStatus(), is(200));
         assertThat(response.getContentAsString(), is(longString));
         assertThat(innerStringBuffer.toString(), is(longString));
@@ -161,7 +161,7 @@ public class EventsHandlerTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testWriteNullBuffer(Transport transport) throws Exception
+    public void testWriteNullBuffer(TransportType transportType) throws Exception
     {
         StringBuffer stringBuffer = new StringBuffer();
         List<Throwable> failures = new CopyOnWriteArrayList<>();
@@ -191,10 +191,10 @@ public class EventsHandlerTest extends AbstractTest
                     failures.add(failure);
             }
         };
-        startServer(transport, eventsHandler);
-        startClient(transport);
+        startServer(transportType, eventsHandler);
+        startClient(transportType);
 
-        ContentResponse response = client.GET(newURI(transport));
+        ContentResponse response = client.GET(newURI(transportType));
         assertThat(response.getStatus(), is(200));
         assertThat(response.getContentAsString(), is("ABCDEF"));
         assertThat(stringBuffer.toString(), is("ABCDEF"));
@@ -203,18 +203,18 @@ public class EventsHandlerTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testUsingEventsResponseAsContentSourceFails(Transport transport) throws Exception
+    public void testUsingEventsResponseAsContentSourceFails(TransportType transportType) throws Exception
     {
         TestForbiddenMethodsEventsHandler eventsHandler = new TestForbiddenMethodsEventsHandler(new EchoHandler());
-        startServer(transport, eventsHandler);
-        startClient(transport);
+        startServer(transportType, eventsHandler);
+        startClient(transportType);
 
-        ContentResponse response = client.POST(newURI(transport))
+        ContentResponse response = client.POST(newURI(transportType))
             .body(new StringRequestContent("ABCDEF"))
             .send();
 
         assertThat(response.getStatus(), is(200));
-        switch (transport)
+        switch (transportType)
         {
             // Two reads, maybe one null read, two writes, two writes complete.
             case HTTP:
@@ -229,22 +229,22 @@ public class EventsHandlerTest extends AbstractTest
                 await().atMost(5, TimeUnit.SECONDS).until(() -> eventsHandler.exceptions.size() / 4, allOf(greaterThanOrEqualTo(7), lessThanOrEqualTo(8)));
                 break;
             default:
-                fail("Missing assertion for transport " + transport);
+                fail("Missing assertion for transport " + transportType);
         }
     }
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testUsingEventsResponseAsContentSourceFailsWithTrailers(Transport transport) throws Exception
+    public void testUsingEventsResponseAsContentSourceFailsWithTrailers(TransportType transportType) throws Exception
     {
         TestForbiddenMethodsEventsHandler eventsHandler = new TestForbiddenMethodsEventsHandler(new EchoHandler());
-        startServer(transport, eventsHandler);
-        startClient(transport);
+        startServer(transportType, eventsHandler);
+        startClient(transportType);
 
         AtomicInteger status = new AtomicInteger();
         AsyncRequestContent asyncRequestContent = new AsyncRequestContent();
         CountDownLatch latch = new CountDownLatch(1);
-        client.POST(newURI(transport))
+        client.POST(newURI(transportType))
             .body(asyncRequestContent)
             .trailersSupplier(() -> HttpFields.build().put("Extra-Stuff", "xyz"))
             .send(result ->
@@ -262,7 +262,7 @@ public class EventsHandlerTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testDelayedEvents(Transport transport) throws Exception
+    public void testDelayedEvents(TransportType transportType) throws Exception
     {
         TestEventsRecordingHandler eventsHandler = new TestEventsRecordingHandler(new Handler.Abstract()
         {
@@ -295,11 +295,11 @@ public class EventsHandlerTest extends AbstractTest
                 }
             }
         });
-        startServer(transport, eventsHandler);
-        startClient(transport);
+        startServer(transportType, eventsHandler);
+        startClient(transportType);
 
         long delayMs = 500;
-        URI uri = URI.create(newURI(transport).toASCIIString() + "?handling=%d&succeeding=%d".formatted(delayMs, delayMs));
+        URI uri = URI.create(newURI(transportType).toASCIIString() + "?handling=%d&succeeding=%d".formatted(delayMs, delayMs));
 
         ContentResponse response = client.GET(uri);
         assertThat(response.getStatus(), is(200));

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/EventsHandlerTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/EventsHandlerTest.java
@@ -225,7 +225,7 @@ public class EventsHandlerTest extends AbstractTest
             // One read, maybe one null read, one write, one write complete.
             case H2:
             case H2C:
-            case H3:
+            case H3_QUICHE:
                 await().atMost(5, TimeUnit.SECONDS).until(() -> eventsHandler.exceptions.size() / 4, allOf(greaterThanOrEqualTo(7), lessThanOrEqualTo(8)));
                 break;
             default:

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpChannelAssociationTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpChannelAssociationTest.java
@@ -55,18 +55,18 @@ public class HttpChannelAssociationTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transports")
-    public void testAssociationFailedAbortsRequest(Transport transport) throws Exception
+    public void testAssociationFailedAbortsRequest(TransportType transportType) throws Exception
     {
-        startServer(transport, new EmptyServerHandler());
+        startServer(transportType, new EmptyServerHandler());
 
-        client = new HttpClient(newHttpClientTransport(transport, exchange -> false));
+        client = new HttpClient(newHttpClientTransport(transportType, exchange -> false));
         QueuedThreadPool clientThreads = new QueuedThreadPool();
         clientThreads.setName("client");
         client.setExecutor(clientThreads);
         client.start();
 
         CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .send(result ->
             {
                 if (result.isFailed())
@@ -78,12 +78,12 @@ public class HttpChannelAssociationTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testIdleTimeoutJustBeforeAssociation(Transport transport) throws Exception
+    public void testIdleTimeoutJustBeforeAssociation(TransportType transportType) throws Exception
     {
-        startServer(transport, new EmptyServerHandler());
+        startServer(transportType, new EmptyServerHandler());
 
         long idleTimeout = 1000;
-        client = new HttpClient(newHttpClientTransport(transport, exchange ->
+        client = new HttpClient(newHttpClientTransport(transportType, exchange ->
         {
             // We idle timeout just before the association,
             // we must be able to send the request successfully.
@@ -97,7 +97,7 @@ public class HttpChannelAssociationTest extends AbstractTest
         client.start();
 
         CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .send(result ->
             {
                 if (result.isSucceeded())
@@ -107,9 +107,9 @@ public class HttpChannelAssociationTest extends AbstractTest
         assertTrue(latch.await(5 * idleTimeout, TimeUnit.MILLISECONDS));
     }
 
-    private HttpClientTransport newHttpClientTransport(Transport transport, Predicate<HttpExchange> code) throws Exception
+    private HttpClientTransport newHttpClientTransport(TransportType transportType, Predicate<HttpExchange> code) throws Exception
     {
-        return switch (transport)
+        return switch (transportType)
         {
             case HTTP:
             case HTTPS:

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpChannelAssociationTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpChannelAssociationTest.java
@@ -170,7 +170,7 @@ public class HttpChannelAssociationTest extends AbstractTest
                     }
                 };
             }
-            case H3:
+            case H3_QUICHE:
             {
                 SslContextFactory.Client sslClient = newSslContextFactoryClient();
                 HTTP3Client http3Client = new HTTP3Client(new ClientQuicConfiguration(sslClient, null));

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientConnectTimeoutTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientConnectTimeoutTest.java
@@ -35,7 +35,7 @@ public class HttpClientConnectTimeoutTest extends AbstractTest
     @ParameterizedTest
     @MethodSource("transportsTCP")
     @Tag("external")
-    public void testConnectTimeout(Transport transport) throws Exception
+    public void testConnectTimeout(TransportType transportType) throws Exception
     {
         // Using IANA hosted example.com:81 to reliably produce a Connect Timeout.
         String host = "example.com";
@@ -43,7 +43,7 @@ public class HttpClientConnectTimeoutTest extends AbstractTest
         int connectTimeout = 1000;
         assumeTrue(connectTimeout(host, port, connectTimeout));
 
-        start(transport, new EmptyServerHandler());
+        start(transportType, new EmptyServerHandler());
         client.setConnectTimeout(connectTimeout);
 
         CountDownLatch latch = new CountDownLatch(1);
@@ -61,7 +61,7 @@ public class HttpClientConnectTimeoutTest extends AbstractTest
     @ParameterizedTest
     @MethodSource("transportsTCP")
     @Tag("external")
-    public void testConnectTimeoutIsCancelledByShorterRequestTimeout(Transport transport) throws Exception
+    public void testConnectTimeoutIsCancelledByShorterRequestTimeout(TransportType transportType) throws Exception
     {
         // Using IANA hosted example.com:81 to reliably produce a Connect Timeout.
         String host = "example.com";
@@ -69,7 +69,7 @@ public class HttpClientConnectTimeoutTest extends AbstractTest
         int connectTimeout = 2000;
         assumeTrue(connectTimeout(host, port, connectTimeout));
 
-        start(transport, new EmptyServerHandler());
+        start(transportType, new EmptyServerHandler());
         client.setConnectTimeout(connectTimeout);
 
         AtomicInteger completes = new AtomicInteger();
@@ -90,7 +90,7 @@ public class HttpClientConnectTimeoutTest extends AbstractTest
     @ParameterizedTest
     @MethodSource("transportsTCP")
     @Tag("external")
-    public void retryAfterConnectTimeout(Transport transport) throws Exception
+    public void retryAfterConnectTimeout(TransportType transportType) throws Exception
     {
         // Using IANA hosted example.com:81 to reliably produce a Connect Timeout.
         String host = "example.com";
@@ -98,7 +98,7 @@ public class HttpClientConnectTimeoutTest extends AbstractTest
         int connectTimeout = 1000;
         assumeTrue(connectTimeout(host, port, connectTimeout));
 
-        start(transport, new EmptyServerHandler());
+        start(transportType, new EmptyServerHandler());
         client.setConnectTimeout(connectTimeout);
 
         CountDownLatch latch = new CountDownLatch(1);

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientIdleTimeoutTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientIdleTimeoutTest.java
@@ -39,11 +39,11 @@ public class HttpClientIdleTimeoutTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testClientIdleTimeout(Transport transport) throws Exception
+    public void testClientIdleTimeout(TransportType transportType) throws Exception
     {
         long serverIdleTimeout = idleTimeout * 2;
         AtomicReference<Callback> serverCallbackRef = new AtomicReference<>();
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, Response response, Callback callback)
@@ -60,7 +60,7 @@ public class HttpClientIdleTimeoutTest extends AbstractTest
         client.setIdleTimeout(idleTimeout);
 
         CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .path("/timeout")
             .body(new StringRequestContent("some data"))
             .send(result ->
@@ -72,7 +72,7 @@ public class HttpClientIdleTimeoutTest extends AbstractTest
         assertTrue(latch.await(2 * idleTimeout, TimeUnit.MILLISECONDS));
 
         // Verify that after the timeout we can make another request.
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .timeout(5, TimeUnit.SECONDS)
             .body(new StringRequestContent("more data"))
             .send();
@@ -85,11 +85,11 @@ public class HttpClientIdleTimeoutTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testRequestIdleTimeout(Transport transport) throws Exception
+    public void testRequestIdleTimeout(TransportType transportType) throws Exception
     {
         long serverIdleTimeout = idleTimeout * 2;
         AtomicReference<Callback> serverCallbackRef = new AtomicReference<>();
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, Response response, Callback callback) throws Exception
@@ -105,7 +105,7 @@ public class HttpClientIdleTimeoutTest extends AbstractTest
         connector.setIdleTimeout(serverIdleTimeout);
 
         CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .path("/timeout")
             .body(new StringRequestContent("some data"))
             .idleTimeout(idleTimeout, TimeUnit.MILLISECONDS)
@@ -118,7 +118,7 @@ public class HttpClientIdleTimeoutTest extends AbstractTest
         assertTrue(latch.await(2 * idleTimeout, TimeUnit.MILLISECONDS));
 
         // Verify that after the timeout we can make another request.
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .body(new StringRequestContent("more data"))
             .timeout(5, TimeUnit.SECONDS)
             .send();
@@ -131,38 +131,38 @@ public class HttpClientIdleTimeoutTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testIdleClientIdleTimeout(Transport transport) throws Exception
+    public void testIdleClientIdleTimeout(TransportType transportType) throws Exception
     {
-        start(transport, new EmptyServerHandler());
+        start(transportType, new EmptyServerHandler());
         client.setIdleTimeout(idleTimeout);
 
         // Make a first request to open a connection.
-        ContentResponse response = client.newRequest(newURI(transport)).send();
+        ContentResponse response = client.newRequest(newURI(transportType)).send();
         assertEquals(HttpStatus.OK_200, response.getStatus());
 
         // Let the connection idle timeout.
         Thread.sleep(2 * idleTimeout);
 
         // Verify that after the timeout we can make another request.
-        response = client.newRequest(newURI(transport)).send();
+        response = client.newRequest(newURI(transportType)).send();
         assertEquals(HttpStatus.OK_200, response.getStatus());
     }
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testIdleServerIdleTimeout(Transport transport) throws Exception
+    public void testIdleServerIdleTimeout(TransportType transportType) throws Exception
     {
-        start(transport, new EmptyServerHandler());
+        start(transportType, new EmptyServerHandler());
         connector.setIdleTimeout(idleTimeout);
 
-        ContentResponse response1 = client.newRequest(newURI(transport)).send();
+        ContentResponse response1 = client.newRequest(newURI(transportType)).send();
         assertEquals(HttpStatus.OK_200, response1.getStatus());
 
         // Let the server idle timeout.
         Thread.sleep(2 * idleTimeout);
 
         // Make sure we can make another request successfully.
-        ContentResponse response2 = client.newRequest(newURI(transport))
+        ContentResponse response2 = client.newRequest(newURI(transportType))
             .timeout(5, TimeUnit.SECONDS)
             .send();
         assertEquals(HttpStatus.OK_200, response2.getStatus());

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientLoadTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientLoadTest.java
@@ -93,7 +93,7 @@ public class HttpClientLoadTest extends AbstractTest
     public void testConcurrent(TransportType transportType) throws Exception
     {
         // TODO: cannot run HTTP/3 (or UDP) in Jenkins.
-        Assumptions.assumeTrue(transportType != TransportType.H3);
+        Assumptions.assumeTrue(transportType != TransportType.H3_QUICHE);
 
         start(transportType, new LoadHandler());
         client.stop();
@@ -154,7 +154,7 @@ public class HttpClientLoadTest extends AbstractTest
         ThreadLocalRandom random = ThreadLocalRandom.current();
         // Choose a random destination
         String host;
-        if (transportType == TransportType.H3)
+        if (transportType == TransportType.H3_QUICHE)
             host = "localhost";
         else
             host = random.nextBoolean() ? "localhost" : "127.0.0.1";

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientLoadTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientLoadTest.java
@@ -57,10 +57,10 @@ public class HttpClientLoadTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testIterative(Transport transport) throws Exception
+    public void testIterative(TransportType transportType) throws Exception
     {
         server = newServer();
-        start(transport, new LoadHandler());
+        start(transportType, new LoadHandler());
         setStreamIdleTimeout(120000);
         client.stop();
         ArrayByteBufferPool.Tracking byteBufferPool = new ArrayByteBufferPool.Tracking();
@@ -75,14 +75,14 @@ public class HttpClientLoadTest extends AbstractTest
         int iterations = 100;
         for (int i = 0; i < runs; ++i)
         {
-            run(transport, iterations);
+            run(transportType, iterations);
         }
 
         // Re-run after warmup
         iterations = 250;
         for (int i = 0; i < runs; ++i)
         {
-            run(transport, iterations);
+            run(transportType, iterations);
         }
 
         assertThat("Leaks: " + byteBufferPool.dumpLeaks(), byteBufferPool.getLeaks().size(), Matchers.is(0));
@@ -90,12 +90,12 @@ public class HttpClientLoadTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testConcurrent(Transport transport) throws Exception
+    public void testConcurrent(TransportType transportType) throws Exception
     {
         // TODO: cannot run HTTP/3 (or UDP) in Jenkins.
-        Assumptions.assumeTrue(transport != Transport.H3);
+        Assumptions.assumeTrue(transportType != TransportType.H3);
 
-        start(transport, new LoadHandler());
+        start(transportType, new LoadHandler());
         client.stop();
         ArrayByteBufferPool.Tracking byteBufferPool = new ArrayByteBufferPool.Tracking();
         client.setByteBufferPool(byteBufferPool);
@@ -107,12 +107,12 @@ public class HttpClientLoadTest extends AbstractTest
         int iterations = 128;
         IntStream.range(0, 16).parallel().forEach(i ->
                 IntStream.range(0, runs).forEach(j ->
-                        run(transport, iterations)));
+                        run(transportType, iterations)));
 
         assertThat("Connection Leaks: " + byteBufferPool.getLeaks(), byteBufferPool.getLeaks().size(), Matchers.is(0));
     }
 
-    private void run(Transport transport, int iterations)
+    private void run(TransportType transportType, int iterations)
     {
         CountDownLatch latch = new CountDownLatch(iterations);
         List<String> failures = new ArrayList<>();
@@ -133,13 +133,13 @@ public class HttpClientLoadTest extends AbstractTest
         long begin = NanoTime.now();
         for (int i = 0; i < iterations; ++i)
         {
-            test(transport, latch, failures);
+            test(transportType, latch, failures);
 //            test("http", "localhost", "GET", false, false, 64 * 1024, false, latch, failures);
         }
         long end = NanoTime.now();
         task.cancel();
         long elapsed = NanoTime.millisElapsed(begin, end);
-        logger.info("{} {} requests in {} ms, {} req/s", iterations, transport, elapsed, elapsed > 0 ? iterations * 1000L / elapsed : -1);
+        logger.info("{} {} requests in {} ms, {} req/s", iterations, transportType, elapsed, elapsed > 0 ? iterations * 1000L / elapsed : -1);
 
         for (String failure : failures)
         {
@@ -149,19 +149,19 @@ public class HttpClientLoadTest extends AbstractTest
         assertTrue(failures.isEmpty(), failures.toString());
     }
 
-    private void test(Transport transport, CountDownLatch latch, List<String> failures)
+    private void test(TransportType transportType, CountDownLatch latch, List<String> failures)
     {
         ThreadLocalRandom random = ThreadLocalRandom.current();
         // Choose a random destination
         String host;
-        if (transport == Transport.H3)
+        if (transportType == TransportType.H3)
             host = "localhost";
         else
             host = random.nextBoolean() ? "localhost" : "127.0.0.1";
         // Choose a random method
         HttpMethod method = random.nextBoolean() ? HttpMethod.GET : HttpMethod.POST;
 
-        boolean ssl = transport.isSecure();
+        boolean ssl = transportType.isSecure();
 
         // Choose randomly whether to close the connection on the client or on the server
         boolean clientClose = !ssl && random.nextInt(100) < 5;

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientStreamTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientStreamTest.java
@@ -94,7 +94,7 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testFileUpload(Transport transport) throws Exception
+    public void testFileUpload(TransportType transportType) throws Exception
     {
         // Prepare a big file to upload
         Path targetTestsDir = MavenTestingUtils.getTargetTestingPath();
@@ -109,7 +109,7 @@ public class HttpClientStreamTest extends AbstractTest
             }
         }
 
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback) throws Exception
@@ -126,7 +126,7 @@ public class HttpClientStreamTest extends AbstractTest
         });
 
         AtomicLong requestTime = new AtomicLong();
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .file(upload)
             .onRequestSuccess(request -> requestTime.set(NanoTime.now()))
             .timeout(2, TimeUnit.MINUTES)
@@ -143,12 +143,12 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testDownload(Transport transport) throws Exception
+    public void testDownload(TransportType transportType) throws Exception
     {
         byte[] data = new byte[128 * 1024];
         byte value = 1;
         Arrays.fill(data, value);
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
@@ -159,7 +159,7 @@ public class HttpClientStreamTest extends AbstractTest
         });
 
         InputStreamResponseListener listener = new InputStreamResponseListener();
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .send(listener);
         Response response = listener.get(5, TimeUnit.SECONDS);
         assertNotNull(response);
@@ -186,10 +186,10 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testDownloadOfUTF8Content(Transport transport) throws Exception
+    public void testDownloadOfUTF8Content(TransportType transportType) throws Exception
     {
         byte[] data = new byte[]{(byte)0xC3, (byte)0xA8}; // UTF-8 representation of &egrave;
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
@@ -200,7 +200,7 @@ public class HttpClientStreamTest extends AbstractTest
         });
 
         InputStreamResponseListener listener = new InputStreamResponseListener();
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .send(listener);
         Response response = listener.get(5, TimeUnit.SECONDS);
         assertNotNull(response);
@@ -226,12 +226,12 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testDownloadWithFailure(Transport transport) throws Exception
+    public void testDownloadWithFailure(TransportType transportType) throws Exception
     {
         byte[] data = new byte[64 * 1024];
         byte value = 1;
         Arrays.fill(data, value);
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback) throws Exception
@@ -248,7 +248,7 @@ public class HttpClientStreamTest extends AbstractTest
         });
 
         InputStreamResponseListener listener = new InputStreamResponseListener();
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .send(listener);
         Response response = listener.get(5, TimeUnit.SECONDS);
         assertNotNull(response);
@@ -278,9 +278,9 @@ public class HttpClientStreamTest extends AbstractTest
     @ParameterizedTest
     @MethodSource("transports")
     @Tag("DisableLeakTracking:client:FCGI")
-    public void testInputStreamResponseListenerClosedBeforeReading(Transport transport) throws Exception
+    public void testInputStreamResponseListenerClosedBeforeReading(TransportType transportType) throws Exception
     {
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
@@ -295,7 +295,7 @@ public class HttpClientStreamTest extends AbstractTest
         // Close the stream immediately.
         stream.close();
 
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .body(new BytesRequestContent(new byte[]{0, 1, 2, 3}))
             .send(listener);
         Response response = listener.get(5, TimeUnit.SECONDS);
@@ -310,10 +310,10 @@ public class HttpClientStreamTest extends AbstractTest
     @Tag("DisableLeakTracking:client:HTTPS")
     @Tag("DisableLeakTracking:client:FCGI")
     @Tag("DisableLeakTracking:client:UNIX_DOMAIN")
-    public void testInputStreamResponseListenerClosedBeforeContent(Transport transport) throws Exception
+    public void testInputStreamResponseListenerClosedBeforeContent(TransportType transportType) throws Exception
     {
         AtomicReference<HandlerContext> contextRef = new AtomicReference<>();
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback) throws Exception
@@ -334,7 +334,7 @@ public class HttpClientStreamTest extends AbstractTest
                 latch.countDown();
             }
         };
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .send(listener);
 
         Response response = listener.get(5, TimeUnit.SECONDS);
@@ -354,11 +354,11 @@ public class HttpClientStreamTest extends AbstractTest
     @ParameterizedTest
     @MethodSource("transports")
     @Tag("DisableLeakTracking:client")
-    public void testInputStreamResponseListenerClosedWhileWaiting(Transport transport) throws Exception
+    public void testInputStreamResponseListenerClosedWhileWaiting(TransportType transportType) throws Exception
     {
         byte[] chunk1 = new byte[]{0, 1};
         byte[] chunk2 = new byte[]{2, 3};
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback) throws Exception
@@ -388,7 +388,7 @@ public class HttpClientStreamTest extends AbstractTest
                 failedLatch.countDown();
             }
         };
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .send(listener);
         Response response = listener.get(5, TimeUnit.SECONDS);
         assertEquals(HttpStatus.OK_200, response.getStatus());
@@ -410,9 +410,9 @@ public class HttpClientStreamTest extends AbstractTest
     @Tag("DisableLeakTracking:client:HTTPS")
     @Tag("DisableLeakTracking:client:FCGI")
     @Tag("DisableLeakTracking:client:UNIX_DOMAIN")
-    public void testInputStreamResponseListenerFailedWhileWaiting(Transport transport) throws Exception
+    public void testInputStreamResponseListenerFailedWhileWaiting(TransportType transportType) throws Exception
     {
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
@@ -442,7 +442,7 @@ public class HttpClientStreamTest extends AbstractTest
                 failedLatch.countDown();
             }
         };
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .send(listener);
         Response response = listener.get(5, TimeUnit.SECONDS);
         assertEquals(HttpStatus.OK_200, response.getStatus());
@@ -459,14 +459,14 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testInputStreamResponseListenerFailedBeforeResponse(Transport transport) throws Exception
+    public void testInputStreamResponseListenerFailedBeforeResponse(TransportType transportType) throws Exception
     {
         // Failure to connect is based on TCP connection refused
         // (as the server is stopped), which does not work for UDP.
-        Assumptions.assumeTrue(transport != Transport.H3);
+        Assumptions.assumeTrue(transportType != TransportType.H3);
 
-        start(transport, new EmptyServerHandler());
-        URI uri = newURI(transport);
+        start(transportType, new EmptyServerHandler());
+        URI uri = newURI(transportType);
         server.stop();
 
         InputStreamResponseListener listener = new InputStreamResponseListener();
@@ -480,9 +480,9 @@ public class HttpClientStreamTest extends AbstractTest
     @ParameterizedTest
     @MethodSource("transports")
     @Tag("DisableLeakTracking:client")
-    public void testInputStreamContentProviderThrowingWhileReading(Transport transport) throws Exception
+    public void testInputStreamContentProviderThrowingWhileReading(TransportType transportType) throws Exception
     {
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
@@ -494,7 +494,7 @@ public class HttpClientStreamTest extends AbstractTest
 
         byte[] data = new byte[]{0, 1, 2, 3};
         ExecutionException e = assertThrows(ExecutionException.class, () ->
-            client.newRequest(newURI(transport))
+            client.newRequest(newURI(transportType))
                 .body(new InputStreamRequestContent(new InputStream()
                 {
                     private int index = 0;
@@ -519,13 +519,13 @@ public class HttpClientStreamTest extends AbstractTest
     @Tag("DisableLeakTracking:client:FCGI")
     @Tag("DisableLeakTracking:client:UNIX_DOMAIN")
     @Tag("flaky")
-    public void testDownloadWithCloseBeforeContent(Transport transport) throws Exception
+    public void testDownloadWithCloseBeforeContent(TransportType transportType) throws Exception
     {
         byte[] data = new byte[128 * 1024];
         byte value = 3;
         Arrays.fill(data, value);
         CountDownLatch latch = new CountDownLatch(1);
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback) throws Exception
@@ -547,7 +547,7 @@ public class HttpClientStreamTest extends AbstractTest
         });
 
         InputStreamResponseListener listener = new InputStreamResponseListener();
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .send(listener);
         Response response = listener.get(5, TimeUnit.SECONDS);
         assertNotNull(response);
@@ -570,14 +570,14 @@ public class HttpClientStreamTest extends AbstractTest
     @Tag("DisableLeakTracking:client:FCGI")
     @Tag("DisableLeakTracking:client:UNIX_DOMAIN")
     @MethodSource("transports")
-    public void testDownloadWithCloseMiddleOfContent(Transport transport) throws Exception
+    public void testDownloadWithCloseMiddleOfContent(TransportType transportType) throws Exception
     {
         byte[] data1 = new byte[1024];
         Arrays.fill(data1, (byte)1);
         byte[] data2 = new byte[1024];
         Arrays.fill(data2, (byte)2);
         CountDownLatch latch = new CountDownLatch(1);
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback) throws Exception
@@ -599,7 +599,7 @@ public class HttpClientStreamTest extends AbstractTest
         });
 
         InputStreamResponseListener listener = new InputStreamResponseListener();
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .send(listener);
         Response response = listener.get(5, TimeUnit.SECONDS);
         assertNotNull(response);
@@ -622,10 +622,10 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testDownloadWithCloseEndOfContent(Transport transport) throws Exception
+    public void testDownloadWithCloseEndOfContent(TransportType transportType) throws Exception
     {
         byte[] data = new byte[1024];
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
@@ -636,7 +636,7 @@ public class HttpClientStreamTest extends AbstractTest
         });
 
         InputStreamResponseListener listener = new InputStreamResponseListener();
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .send(listener);
         Response response = listener.get(5, TimeUnit.SECONDS);
         assertNotNull(response);
@@ -661,9 +661,9 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testUploadWithDeferredContentProviderFromInputStream(Transport transport) throws Exception
+    public void testUploadWithDeferredContentProviderFromInputStream(TransportType transportType) throws Exception
     {
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
@@ -677,7 +677,7 @@ public class HttpClientStreamTest extends AbstractTest
         CountDownLatch responseLatch = new CountDownLatch(1);
         try (AsyncRequestContent content = new AsyncRequestContent())
         {
-            client.newRequest(newURI(transport))
+            client.newRequest(newURI(transportType))
                 .body(content)
                 .onRequestCommit((request) -> requestSentLatch.countDown())
                 .send(result ->
@@ -704,9 +704,9 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testUploadWithDeferredContentAvailableCallbacksNotifiedOnce(Transport transport) throws Exception
+    public void testUploadWithDeferredContentAvailableCallbacksNotifiedOnce(TransportType transportType) throws Exception
     {
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
@@ -730,7 +730,7 @@ public class HttpClientStreamTest extends AbstractTest
                 }
             });
 
-            client.newRequest(newURI(transport))
+            client.newRequest(newURI(transportType))
                 .body(content)
                 .send(result ->
                 {
@@ -744,9 +744,9 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testUploadWithDeferredContentProviderRacingWithSend(Transport transport) throws Exception
+    public void testUploadWithDeferredContentProviderRacingWithSend(TransportType transportType) throws Exception
     {
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
@@ -770,7 +770,7 @@ public class HttpClientStreamTest extends AbstractTest
             }
         };
 
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .body(content)
             .send(new BufferingResponseListener()
             {
@@ -789,9 +789,9 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testUploadWithOutputStream(Transport transport) throws Exception
+    public void testUploadWithOutputStream(TransportType transportType) throws Exception
     {
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
@@ -804,7 +804,7 @@ public class HttpClientStreamTest extends AbstractTest
         byte[] data = new byte[512];
         CountDownLatch latch = new CountDownLatch(1);
         OutputStreamRequestContent content = new OutputStreamRequestContent();
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .body(content)
             .send(new BufferingResponseListener()
             {
@@ -831,9 +831,9 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testBigUploadWithOutputStreamFromInputStream(Transport transport) throws Exception
+    public void testBigUploadWithOutputStreamFromInputStream(TransportType transportType) throws Exception
     {
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
@@ -847,7 +847,7 @@ public class HttpClientStreamTest extends AbstractTest
         new Random().nextBytes(data);
         CountDownLatch latch = new CountDownLatch(1);
         OutputStreamRequestContent content = new OutputStreamRequestContent();
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .body(content)
             .send(new BufferingResponseListener(data.length)
             {
@@ -874,10 +874,10 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testUploadWithOutputStreamFailureToConnect(Transport transport) throws Exception
+    public void testUploadWithOutputStreamFailureToConnect(TransportType transportType) throws Exception
     {
         long connectTimeout = 1000;
-        start(transport, new EmptyServerHandler());
+        start(transportType, new EmptyServerHandler());
         client.setConnectTimeout(connectTimeout);
 
         byte[] data = new byte[512];
@@ -905,9 +905,9 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testUploadWithDeferredContentProviderFailsMultipleOffers(Transport transport) throws Exception
+    public void testUploadWithDeferredContentProviderFailsMultipleOffers(TransportType transportType) throws Exception
     {
-        start(transport, new EmptyServerHandler());
+        start(transportType, new EmptyServerHandler());
 
         CountDownLatch failLatch = new CountDownLatch(2);
         Callback callback = new Callback()
@@ -921,7 +921,7 @@ public class HttpClientStreamTest extends AbstractTest
 
         CountDownLatch completeLatch = new CountDownLatch(1);
         AsyncRequestContent content = new AsyncRequestContent();
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .body(content)
             .onRequestBegin(request ->
             {
@@ -952,10 +952,10 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testUploadWithConnectFailureClosesStream(Transport transport) throws Exception
+    public void testUploadWithConnectFailureClosesStream(TransportType transportType) throws Exception
     {
         long connectTimeout = 1000;
-        start(transport, new EmptyServerHandler());
+        start(transportType, new EmptyServerHandler());
         client.setConnectTimeout(connectTimeout);
 
         CountDownLatch closeLatch = new CountDownLatch(1);
@@ -987,10 +987,10 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testUploadWithConcurrentServerCloseClosesStream(Transport transport) throws Exception
+    public void testUploadWithConcurrentServerCloseClosesStream(TransportType transportType) throws Exception
     {
         CountDownLatch serverLatch = new CountDownLatch(1);
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
@@ -1044,7 +1044,7 @@ public class HttpClientStreamTest extends AbstractTest
         InputStreamRequestContent content = new InputStreamRequestContent(stream, 1);
 
         CountDownLatch completeLatch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .body(content)
             .onRequestCommit(request -> commit.set(true))
             .send(result ->
@@ -1059,10 +1059,10 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testUploadWithPendingReadConcurrentServerCloseClosesStream(Transport transport) throws Exception
+    public void testUploadWithPendingReadConcurrentServerCloseClosesStream(TransportType transportType) throws Exception
     {
         CountDownLatch serverLatch = new CountDownLatch(1);
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
@@ -1132,7 +1132,7 @@ public class HttpClientStreamTest extends AbstractTest
         InputStreamRequestContent content = new InputStreamRequestContent(stream, 1);
 
         CountDownLatch completeLatch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .body(content)
             .onRequestCommit(request -> commit.set(true))
             .send(result ->
@@ -1147,11 +1147,11 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testInputStreamResponseListenerBufferedRead(Transport transport) throws Exception
+    public void testInputStreamResponseListenerBufferedRead(TransportType transportType) throws Exception
     {
         AtomicReference<HandlerContext> contextRef = new AtomicReference<>();
         CountDownLatch latch = new CountDownLatch(1);
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
@@ -1163,7 +1163,7 @@ public class HttpClientStreamTest extends AbstractTest
         });
 
         InputStreamResponseListener listener = new InputStreamResponseListener();
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .timeout(5, TimeUnit.SECONDS)
             .send(listener);
 
@@ -1198,9 +1198,9 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testInputStreamResponseListenerWithRedirect(Transport transport) throws Exception
+    public void testInputStreamResponseListenerWithRedirect(TransportType transportType) throws Exception
     {
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
@@ -1213,7 +1213,7 @@ public class HttpClientStreamTest extends AbstractTest
         });
 
         InputStreamResponseListener listener = new InputStreamResponseListener();
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .path("/303")
             .followRedirects(true)
             .send(listener);
@@ -1227,14 +1227,14 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testMultiplexedConnectionsForcibleStop(Transport transport) throws Exception
+    public void testMultiplexedConnectionsForcibleStop(TransportType transportType) throws Exception
     {
-        Assumptions.assumeTrue(transport.isMultiplexed());
+        Assumptions.assumeTrue(transportType.isMultiplexed());
 
         long timeoutInSeconds = 5;
         AtomicInteger processCount = new AtomicInteger();
         CountDownLatch processLatch = new CountDownLatch(1);
-        startServer(transport, new Handler.Abstract()
+        startServer(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback) throws Exception
@@ -1247,7 +1247,7 @@ public class HttpClientStreamTest extends AbstractTest
                 return true;
             }
         });
-        startClient(transport);
+        startClient(transportType);
         // Set up the client such as:
         // - only one connection can be created;
         // - the connection can be used by two concurrent requests;
@@ -1270,8 +1270,8 @@ public class HttpClientStreamTest extends AbstractTest
 
         // Send two parallel requests.
         CountDownLatch clientLatch = new CountDownLatch(2);
-        client.newRequest(newURI(transport)).send(result -> clientLatch.countDown());
-        client.newRequest(newURI(transport)).send(result -> clientLatch.countDown());
+        client.newRequest(newURI(transportType)).send(result -> clientLatch.countDown());
+        client.newRequest(newURI(transportType)).send(result -> clientLatch.countDown());
 
         // Wait until both requests are in-flight.
         await().atMost(timeoutInSeconds, TimeUnit.SECONDS).until(processCount::get, is(2));
@@ -1286,11 +1286,11 @@ public class HttpClientStreamTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testHttpStreamConsumeAvailableUponClientAbort(Transport transport) throws Exception
+    public void testHttpStreamConsumeAvailableUponClientAbort(TransportType transportType) throws Exception
     {
         AtomicReference<org.eclipse.jetty.client.Request> clientRequestRef = new AtomicReference<>();
 
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
@@ -1355,7 +1355,7 @@ public class HttpClientStreamTest extends AbstractTest
         new Random().nextBytes(data);
         ByteBufferRequestContent content = new ByteBufferRequestContent(ByteBuffer.wrap(data));
 
-        var request = client.newRequest(newURI(transport))
+        var request = client.newRequest(newURI(transportType))
             .body(content);
         clientRequestRef.set(request);
         Throwable throwable = new CompletableResponseListener(request)
@@ -1371,13 +1371,13 @@ public class HttpClientStreamTest extends AbstractTest
     @Tag("DisableLeakTracking:server:UNIX_DOMAIN")
     @Tag("DisableLeakTracking:server:HTTP")
     @Tag("DisableLeakTracking:server:HTTPS")
-    public void testUploadWithRetainedData(Transport transport) throws Exception
+    public void testUploadWithRetainedData(TransportType transportType) throws Exception
     {
         // TODO: broken for FCGI, investigate.
 
         List<Content.Chunk> chunks = new CopyOnWriteArrayList<>();
 
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
@@ -1437,7 +1437,7 @@ public class HttpClientStreamTest extends AbstractTest
         CountDownLatch latch = new CountDownLatch(1);
         ByteBufferRequestContent content = new ByteBufferRequestContent(ByteBuffer.wrap(data));
 
-        new CompletableResponseListener(client.newRequest(newURI(transport)).body(content))
+        new CompletableResponseListener(client.newRequest(newURI(transportType)).body(content))
             .send()
             .whenComplete((r, t) ->
             {

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientStreamTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientStreamTest.java
@@ -463,7 +463,7 @@ public class HttpClientStreamTest extends AbstractTest
     {
         // Failure to connect is based on TCP connection refused
         // (as the server is stopped), which does not work for UDP.
-        Assumptions.assumeTrue(transportType != TransportType.H3);
+        Assumptions.assumeTrue(transportType != TransportType.H3_QUICHE);
 
         start(transportType, new EmptyServerHandler());
         URI uri = newURI(transportType);

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
@@ -359,7 +359,7 @@ public class HttpClientTest extends AbstractTest
         client.start();
 
         // H3 times out b/c it is QUIC's way of figuring out a connection cannot be established.
-        Class<? extends Exception> expectedType = transportType == TransportType.H3 ? TimeoutException.class : ExecutionException.class;
+        Class<? extends Exception> expectedType = transportType == TransportType.H3_QUICHE ? TimeoutException.class : ExecutionException.class;
         assertThrows(expectedType, () ->
         {
             // Use an IP address not present in the certificate.
@@ -676,7 +676,7 @@ public class HttpClientTest extends AbstractTest
     public void testIPv6Host(TransportType transportType) throws Exception
     {
         assumeTrue(Net.isIpv6InterfaceAvailable());
-        assumeTrue(transportType != TransportType.H3);
+        assumeTrue(transportType != TransportType.H3_QUICHE);
 
         start(transportType, new Handler.Abstract()
         {
@@ -731,7 +731,7 @@ public class HttpClientTest extends AbstractTest
     public void testRequestWithDifferentDestination(TransportType transportType) throws Exception
     {
         // TODO fix for H3
-        Assumptions.assumeFalse(transportType == TransportType.H3);
+        Assumptions.assumeFalse(transportType == TransportType.H3_QUICHE);
         String requestScheme = newURI(transportType).getScheme();
         String requestHost = "otherHost.com";
         int requestPort = 8888;

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
@@ -82,10 +82,10 @@ public class HttpClientTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transports")
-    public void testRequestWithoutResponseContent(Transport transport) throws Exception
+    public void testRequestWithoutResponseContent(TransportType transportType) throws Exception
     {
         final int status = HttpStatus.NO_CONTENT_204;
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
@@ -96,7 +96,7 @@ public class HttpClientTest extends AbstractTest
             }
         });
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .timeout(5, TimeUnit.SECONDS)
             .send();
 
@@ -106,23 +106,23 @@ public class HttpClientTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testRequestWithSmallResponseContent(Transport transport) throws Exception
+    public void testRequestWithSmallResponseContent(TransportType transportType) throws Exception
     {
-        testRequestWithResponseContent(transport, 1024);
+        testRequestWithResponseContent(transportType, 1024);
     }
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testRequestWithLargeResponseContent(Transport transport) throws Exception
+    public void testRequestWithLargeResponseContent(TransportType transportType) throws Exception
     {
-        testRequestWithResponseContent(transport, 1024 * 1024);
+        testRequestWithResponseContent(transportType, 1024 * 1024);
     }
 
-    private void testRequestWithResponseContent(Transport transport, int length) throws Exception
+    private void testRequestWithResponseContent(TransportType transportType, int length) throws Exception
     {
         final byte[] bytes = new byte[length];
         new Random().nextBytes(bytes);
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
@@ -133,7 +133,7 @@ public class HttpClientTest extends AbstractTest
             }
         });
 
-        var request = client.newRequest(newURI(transport))
+        var request = client.newRequest(newURI(transportType))
             .timeout(10, TimeUnit.SECONDS);
         CompletableFuture<ContentResponse> completable = new CompletableResponseListener(request, length).send();
         ContentResponse response = completable.get();
@@ -144,19 +144,19 @@ public class HttpClientTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testRequestWithSmallResponseContentChunked(Transport transport) throws Exception
+    public void testRequestWithSmallResponseContentChunked(TransportType transportType) throws Exception
     {
-        testRequestWithResponseContentChunked(transport, 512);
+        testRequestWithResponseContentChunked(transportType, 512);
     }
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testRequestWithLargeResponseContentChunked(Transport transport) throws Exception
+    public void testRequestWithLargeResponseContentChunked(TransportType transportType) throws Exception
     {
-        testRequestWithResponseContentChunked(transport, 512 * 512);
+        testRequestWithResponseContentChunked(transportType, 512 * 512);
     }
 
-    private void testRequestWithResponseContentChunked(Transport transport, int length) throws Exception
+    private void testRequestWithResponseContentChunked(TransportType transportType, int length) throws Exception
     {
         final byte[] chunk1 = new byte[length];
         final byte[] chunk2 = new byte[length];
@@ -166,7 +166,7 @@ public class HttpClientTest extends AbstractTest
         byte[] bytes = new byte[chunk1.length + chunk2.length];
         System.arraycopy(chunk1, 0, bytes, 0, chunk1.length);
         System.arraycopy(chunk2, 0, bytes, chunk1.length, chunk2.length);
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback) throws Exception
@@ -177,7 +177,7 @@ public class HttpClientTest extends AbstractTest
             }
         });
 
-        var request = client.newRequest(newURI(transport))
+        var request = client.newRequest(newURI(transportType))
             .timeout(10, TimeUnit.SECONDS);
         CompletableFuture<ContentResponse> completable = new CompletableResponseListener(request, 2 * length).send();
         ContentResponse response = completable.get();
@@ -188,30 +188,30 @@ public class HttpClientTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testUploadZeroLengthWithoutResponseContent(Transport transport) throws Exception
+    public void testUploadZeroLengthWithoutResponseContent(TransportType transportType) throws Exception
     {
-        testUploadWithoutResponseContent(transport, 0);
+        testUploadWithoutResponseContent(transportType, 0);
     }
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testUploadSmallWithoutResponseContent(Transport transport) throws Exception
+    public void testUploadSmallWithoutResponseContent(TransportType transportType) throws Exception
     {
-        testUploadWithoutResponseContent(transport, 1024);
+        testUploadWithoutResponseContent(transportType, 1024);
     }
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testUploadLargeWithoutResponseContent(Transport transport) throws Exception
+    public void testUploadLargeWithoutResponseContent(TransportType transportType) throws Exception
     {
-        testUploadWithoutResponseContent(transport, 1024 * 1024);
+        testUploadWithoutResponseContent(transportType, 1024 * 1024);
     }
 
-    private void testUploadWithoutResponseContent(Transport transport, int length) throws Exception
+    private void testUploadWithoutResponseContent(TransportType transportType, int length) throws Exception
     {
         final byte[] bytes = new byte[length];
         new Random().nextBytes(bytes);
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback) throws Exception
@@ -227,7 +227,7 @@ public class HttpClientTest extends AbstractTest
             }
         });
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(new BytesRequestContent(bytes))
             .timeout(15, TimeUnit.SECONDS)
@@ -239,9 +239,9 @@ public class HttpClientTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testClientManyWritesSlowServer(Transport transport) throws Exception
+    public void testClientManyWritesSlowServer(TransportType transportType) throws Exception
     {
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback) throws Exception
@@ -282,7 +282,7 @@ public class HttpClientTest extends AbstractTest
         int chunkSize = 16;
         byte[][] bytes = IntStream.range(0, chunks).mapToObj(x -> new byte[chunkSize]).toArray(byte[][]::new);
         BytesRequestContent content = new BytesRequestContent("application/octet-stream", bytes);
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(content)
             .timeout(15, TimeUnit.SECONDS)
@@ -296,12 +296,12 @@ public class HttpClientTest extends AbstractTest
     @MethodSource("transports")
     @Tag("DisableLeakTracking:client:H3")
     @Tag("DisableLeakTracking:client:FCGI")
-    public void testRequestAfterFailedRequest(Transport transport) throws Exception
+    public void testRequestAfterFailedRequest(TransportType transportType) throws Exception
     {
         // TODO find and fix the leaks
 
         int length = FlowControlStrategy.DEFAULT_WINDOW_SIZE;
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
@@ -312,7 +312,7 @@ public class HttpClientTest extends AbstractTest
         });
 
         // Make a request with a large enough response buffer.
-        var request = client.newRequest(newURI(transport));
+        var request = client.newRequest(newURI(transportType));
         CompletableFuture<ContentResponse> completable = new CompletableResponseListener(request, length).send();
         ContentResponse response = completable.get(15, TimeUnit.SECONDS);
         assertEquals(response.getStatus(), 200);
@@ -320,7 +320,7 @@ public class HttpClientTest extends AbstractTest
         // Make a request with a small response buffer, should fail.
         try
         {
-            request = client.newRequest(newURI(transport));
+            request = client.newRequest(newURI(transportType));
             completable = new CompletableResponseListener(request, length / 10).send();
             completable.get(15, TimeUnit.SECONDS);
             fail("Expected ExecutionException");
@@ -331,7 +331,7 @@ public class HttpClientTest extends AbstractTest
         }
 
         // Verify that we can make another request.
-        request = client.newRequest(newURI(transport));
+        request = client.newRequest(newURI(transportType));
         completable = new CompletableResponseListener(request, length).send();
         response = completable.get(15, TimeUnit.SECONDS);
         assertEquals(response.getStatus(), 200);
@@ -339,12 +339,12 @@ public class HttpClientTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testClientCannotValidateServerCertificate(Transport transport) throws Exception
+    public void testClientCannotValidateServerCertificate(TransportType transportType) throws Exception
     {
         // Only run this test for transports over TLS.
-        assumeTrue(transport.isSecure());
+        assumeTrue(transportType.isSecure());
 
-        start(transport, new EmptyServerHandler());
+        start(transportType, new EmptyServerHandler());
         // Disable validations on the server to be sure
         // that the test failure happens during the
         // validation of the certificate on the client.
@@ -359,11 +359,11 @@ public class HttpClientTest extends AbstractTest
         client.start();
 
         // H3 times out b/c it is QUIC's way of figuring out a connection cannot be established.
-        Class<? extends Exception> expectedType = transport == Transport.H3 ? TimeoutException.class : ExecutionException.class;
+        Class<? extends Exception> expectedType = transportType == TransportType.H3 ? TimeoutException.class : ExecutionException.class;
         assertThrows(expectedType, () ->
         {
             // Use an IP address not present in the certificate.
-            int serverPort = newURI(transport).getPort();
+            int serverPort = newURI(transportType).getPort();
             client.newRequest("https://127.0.0.2:" + serverPort)
                 .timeout(5, TimeUnit.SECONDS)
                 .send();
@@ -372,9 +372,9 @@ public class HttpClientTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testOPTIONS(Transport transport) throws Exception
+    public void testOPTIONS(TransportType transportType) throws Exception
     {
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
@@ -386,7 +386,7 @@ public class HttpClientTest extends AbstractTest
             }
         });
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .method(HttpMethod.OPTIONS)
             .path("*")
             .timeout(5, TimeUnit.SECONDS)
@@ -397,9 +397,9 @@ public class HttpClientTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testOPTIONSWithRelativeRedirect(Transport transport) throws Exception
+    public void testOPTIONSWithRelativeRedirect(TransportType transportType) throws Exception
     {
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
@@ -416,7 +416,7 @@ public class HttpClientTest extends AbstractTest
             }
         });
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .method(HttpMethod.OPTIONS)
             .path("*")
             .timeout(5, TimeUnit.SECONDS)
@@ -427,10 +427,10 @@ public class HttpClientTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testDownloadWithInputStreamResponseListener(Transport transport) throws Exception
+    public void testDownloadWithInputStreamResponseListener(TransportType transportType) throws Exception
     {
         String content = "hello world";
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
@@ -442,7 +442,7 @@ public class HttpClientTest extends AbstractTest
 
         CountDownLatch latch = new CountDownLatch(1);
         InputStreamResponseListener listener = new InputStreamResponseListener();
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .onResponseSuccess(response -> latch.countDown())
             .send(listener);
         Response response = listener.get(5, TimeUnit.SECONDS);
@@ -459,9 +459,9 @@ public class HttpClientTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testConnectionListener(Transport transport) throws Exception
+    public void testConnectionListener(TransportType transportType) throws Exception
     {
-        start(transport, new EmptyServerHandler());
+        start(transportType, new EmptyServerHandler());
         long idleTimeout = 1000;
         client.setIdleTimeout(idleTimeout);
 
@@ -482,7 +482,7 @@ public class HttpClientTest extends AbstractTest
             }
         });
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .timeout(5, TimeUnit.SECONDS)
             .send();
 
@@ -495,9 +495,9 @@ public class HttpClientTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testAsyncResponseContentBackPressure(Transport transport) throws Exception
+    public void testAsyncResponseContentBackPressure(TransportType transportType) throws Exception
     {
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
@@ -512,7 +512,7 @@ public class HttpClientTest extends AbstractTest
         AtomicInteger counter = new AtomicInteger();
         AtomicReference<Runnable> demanderRef = new AtomicReference<>();
         AtomicReference<CountDownLatch> latchRef = new AtomicReference<>(new CountDownLatch(1));
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .onResponseContentAsync((response, chunk, demander) ->
             {
                 if (counter.incrementAndGet() == 1)
@@ -538,9 +538,9 @@ public class HttpClientTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testResponseWithContentCompleteListenerInvokedOnce(Transport transport) throws Exception
+    public void testResponseWithContentCompleteListenerInvokedOnce(TransportType transportType) throws Exception
     {
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
@@ -551,7 +551,7 @@ public class HttpClientTest extends AbstractTest
         });
 
         AtomicInteger completes = new AtomicInteger();
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .send(result -> completes.incrementAndGet());
 
         sleep(1000);
@@ -561,23 +561,23 @@ public class HttpClientTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testHEADResponds200(Transport transport) throws Exception
+    public void testHEADResponds200(TransportType transportType) throws Exception
     {
-        testHEAD(transport, "/", HttpStatus.OK_200);
+        testHEAD(transportType, "/", HttpStatus.OK_200);
     }
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testHEADResponds404(Transport transport) throws Exception
+    public void testHEADResponds404(TransportType transportType) throws Exception
     {
-        testHEAD(transport, "/notMapped", HttpStatus.NOT_FOUND_404);
+        testHEAD(transportType, "/notMapped", HttpStatus.NOT_FOUND_404);
     }
 
-    private void testHEAD(Transport transport, String path, int status) throws Exception
+    private void testHEAD(TransportType transportType, String path, int status) throws Exception
     {
         byte[] data = new byte[1024];
         new Random().nextBytes(data);
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
@@ -591,7 +591,7 @@ public class HttpClientTest extends AbstractTest
             }
         });
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .method(HttpMethod.HEAD)
             .path(path)
             .send();
@@ -602,10 +602,10 @@ public class HttpClientTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testHEADWithAcceptHeaderAndSendError(Transport transport) throws Exception
+    public void testHEADWithAcceptHeaderAndSendError(TransportType transportType) throws Exception
     {
         int status = HttpStatus.BAD_REQUEST_400;
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
@@ -615,7 +615,7 @@ public class HttpClientTest extends AbstractTest
             }
         });
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .method(HttpMethod.HEAD)
             .headers(headers -> headers.put(HttpHeader.ACCEPT, "*/*"))
             .send();
@@ -626,10 +626,10 @@ public class HttpClientTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testHEADWithContentLengthGreaterThanMaxBufferingCapacity(Transport transport) throws Exception
+    public void testHEADWithContentLengthGreaterThanMaxBufferingCapacity(TransportType transportType) throws Exception
     {
         int length = 1024;
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
@@ -640,7 +640,7 @@ public class HttpClientTest extends AbstractTest
             }
         });
 
-        var request = client.newRequest(newURI(transport))
+        var request = client.newRequest(newURI(transportType))
             .method(HttpMethod.HEAD);
         CompletableFuture<ContentResponse> completable = new CompletableResponseListener(request, length / 2).send();
         ContentResponse response = completable.get(5, TimeUnit.SECONDS);
@@ -651,16 +651,16 @@ public class HttpClientTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testOneDestinationPerUser(Transport transport) throws Exception
+    public void testOneDestinationPerUser(TransportType transportType) throws Exception
     {
-        start(transport, new EmptyServerHandler());
+        start(transportType, new EmptyServerHandler());
         int runs = 4;
         int users = 16;
         for (int i = 0; i < runs; ++i)
         {
             for (int j = 0; j < users; ++j)
             {
-                ContentResponse response = client.newRequest(newURI(transport))
+                ContentResponse response = client.newRequest(newURI(transportType))
                     .tag(j)
                     .send();
                 assertEquals(HttpStatus.OK_200, response.getStatus());
@@ -673,12 +673,12 @@ public class HttpClientTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testIPv6Host(Transport transport) throws Exception
+    public void testIPv6Host(TransportType transportType) throws Exception
     {
         assumeTrue(Net.isIpv6InterfaceAvailable());
-        assumeTrue(transport != Transport.H3);
+        assumeTrue(transportType != TransportType.H3);
 
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
@@ -692,7 +692,7 @@ public class HttpClientTest extends AbstractTest
         // Test with a full URI.
         String hostAddress = "::1";
         String host = "[" + hostAddress + "]";
-        URI serverURI = newURI(transport);
+        URI serverURI = newURI(transportType);
         String uri = serverURI.toString().replace("localhost", host) + "/path";
         ContentResponse response = client.newRequest(uri)
             .method(HttpMethod.PUT)
@@ -728,14 +728,14 @@ public class HttpClientTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testRequestWithDifferentDestination(Transport transport) throws Exception
+    public void testRequestWithDifferentDestination(TransportType transportType) throws Exception
     {
         // TODO fix for H3
-        Assumptions.assumeFalse(transport == Transport.H3);
-        String requestScheme = newURI(transport).getScheme();
+        Assumptions.assumeFalse(transportType == TransportType.H3);
+        String requestScheme = newURI(transportType).getScheme();
         String requestHost = "otherHost.com";
         int requestPort = 8888;
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
@@ -743,13 +743,13 @@ public class HttpClientTest extends AbstractTest
                 HttpURI uri = request.getHttpURI();
                 assertEquals(requestHost, uri.getHost());
                 assertEquals(requestPort, uri.getPort());
-                if (transport == Transport.H2C || transport == Transport.H2)
+                if (transportType == TransportType.H2C || transportType == TransportType.H2)
                     assertEquals(requestScheme, uri.getScheme());
                 callback.succeeded();
                 return true;
             }
         });
-        if (transport.isSecure())
+        if (transportType.isSecure())
             httpConfig.getCustomizer(SecureRequestCustomizer.class).setSniHostCheck(false);
 
         Origin origin = new Origin(requestScheme, "localhost", ((NetworkConnector)connector).getLocalPort());
@@ -774,11 +774,11 @@ public class HttpClientTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testRequestIdleTimeout(Transport transport) throws Exception
+    public void testRequestIdleTimeout(TransportType transportType) throws Exception
     {
         CountDownLatch latch = new CountDownLatch(1);
         long idleTimeout = 500;
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback) throws Exception
@@ -796,7 +796,7 @@ public class HttpClientTest extends AbstractTest
         });
 
         assertThrows(TimeoutException.class, () ->
-            client.newRequest(newURI(transport))
+            client.newRequest(newURI(transportType))
                 .path("/1")
                 .idleTimeout(idleTimeout, TimeUnit.MILLISECONDS)
                 .timeout(2 * idleTimeout, TimeUnit.MILLISECONDS)
@@ -804,7 +804,7 @@ public class HttpClientTest extends AbstractTest
         latch.countDown();
 
         // Make another request without specifying the idle timeout, should not fail
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .path("/2")
             .timeout(3 * idleTimeout, TimeUnit.MILLISECONDS)
             .send();
@@ -815,10 +815,10 @@ public class HttpClientTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testContentSourceListeners(Transport transport) throws Exception
+    public void testContentSourceListeners(TransportType transportType) throws Exception
     {
         int totalBytes = 1024;
-        start(transport, new TestHandler(totalBytes));
+        start(transportType, new TestHandler(totalBytes));
 
         List<Content.Chunk> chunks = new CopyOnWriteArrayList<>();
         CompleteContentSourceListener listener = new CompleteContentSourceListener()
@@ -829,7 +829,7 @@ public class HttpClientTest extends AbstractTest
                 accumulateChunks(contentSource, chunks);
             }
         };
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .path("/")
             .send(listener);
         listener.await(5, TimeUnit.SECONDS);
@@ -843,12 +843,12 @@ public class HttpClientTest extends AbstractTest
     @MethodSource("transports")
     @Tag("DisableLeakTracking:client:H3")
     @Tag("DisableLeakTracking:client:FCGI")
-    public void testContentSourceListenersFailure(Transport transport) throws Exception
+    public void testContentSourceListenersFailure(TransportType transportType) throws Exception
     {
         // TODO find and fix the leaks!
 
         int totalBytes = 1024;
-        start(transport, new TestHandler(totalBytes));
+        start(transportType, new TestHandler(totalBytes));
 
         CompleteContentSourceListener listener = new CompleteContentSourceListener()
         {
@@ -858,7 +858,7 @@ public class HttpClientTest extends AbstractTest
                 contentSource.fail(new Exception("Synthetic Failure"));
             }
         };
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .path("/")
             .send(listener);
         listener.await(5, TimeUnit.SECONDS);
@@ -869,10 +869,10 @@ public class HttpClientTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testContentSourceListenerDemandInSpawnedThread(Transport transport) throws Exception
+    public void testContentSourceListenerDemandInSpawnedThread(TransportType transportType) throws Exception
     {
         int totalBytes = 1024;
-        start(transport, new TestHandler(totalBytes));
+        start(transportType, new TestHandler(totalBytes));
 
         List<Content.Chunk> chunks = new CopyOnWriteArrayList<>();
         CompleteContentSourceListener listener = new CompleteContentSourceListener()
@@ -884,7 +884,7 @@ public class HttpClientTest extends AbstractTest
                     .start();
             }
         };
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .path("/")
             .send(listener);
         listener.await(5, TimeUnit.SECONDS);
@@ -896,16 +896,16 @@ public class HttpClientTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testParallelContentSourceListeners(Transport transport) throws Exception
+    public void testParallelContentSourceListeners(TransportType transportType) throws Exception
     {
         int totalBytes = 1024;
-        start(transport, new TestHandler(totalBytes));
+        start(transportType, new TestHandler(totalBytes));
 
         List<Content.Chunk> chunks1 = new CopyOnWriteArrayList<>();
         List<Content.Chunk> chunks2 = new CopyOnWriteArrayList<>();
         List<Content.Chunk> chunks3 = new CopyOnWriteArrayList<>();
 
-        ContentResponse resp = client.newRequest(newURI(transport))
+        ContentResponse resp = client.newRequest(newURI(transportType))
             .path("/")
             .onResponseContentSource((response, contentSource) -> accumulateChunks(contentSource, chunks1))
             .onResponseContentSource((response, contentSource) -> accumulateChunks(contentSource, chunks2))
@@ -925,15 +925,15 @@ public class HttpClientTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testParallelContentSourceListenersPartialFailure(Transport transport) throws Exception
+    public void testParallelContentSourceListenersPartialFailure(TransportType transportType) throws Exception
     {
         int totalBytes = 1024;
-        start(transport, new TestHandler(totalBytes));
+        start(transportType, new TestHandler(totalBytes));
 
         List<Content.Chunk> chunks1 = new CopyOnWriteArrayList<>();
         List<Content.Chunk> chunks2 = new CopyOnWriteArrayList<>();
         List<Content.Chunk> chunks3 = new CopyOnWriteArrayList<>();
-        ContentResponse contentResponse = client.newRequest(newURI(transport))
+        ContentResponse contentResponse = client.newRequest(newURI(transportType))
             .path("/")
             .onResponseContentSource((response, contentSource) -> accumulateChunks(contentSource, chunks1))
             .onResponseContentSource((response, contentSource) -> accumulateChunks(contentSource, chunks2))
@@ -959,16 +959,16 @@ public class HttpClientTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testParallelContentSourceListenersPartialFailureInSpawnedThread(Transport transport) throws Exception
+    public void testParallelContentSourceListenersPartialFailureInSpawnedThread(TransportType transportType) throws Exception
     {
         int totalBytes = 1024;
-        start(transport, new TestHandler(totalBytes));
+        start(transportType, new TestHandler(totalBytes));
 
         List<Content.Chunk> chunks1 = new CopyOnWriteArrayList<>();
         List<Content.Chunk> chunks2 = new CopyOnWriteArrayList<>();
         List<Content.Chunk> chunks3 = new CopyOnWriteArrayList<>();
         CountDownLatch chunks3Latch = new CountDownLatch(1);
-        ContentResponse contentResponse = client.newRequest(newURI(transport))
+        ContentResponse contentResponse = client.newRequest(newURI(transportType))
             .path("/")
             .onResponseContentSource((response, contentSource) -> accumulateChunks(contentSource, chunks1))
             .onResponseContentSource((response, contentSource) -> accumulateChunks(contentSource, chunks2))
@@ -1003,11 +1003,11 @@ public class HttpClientTest extends AbstractTest
     @MethodSource("transports")
     @Tag("DisableLeakTracking:client:H3")
     @Tag("DisableLeakTracking:client:FCGI")
-    public void testParallelContentSourceListenersTotalFailure(Transport transport) throws Exception
+    public void testParallelContentSourceListenersTotalFailure(TransportType transportType) throws Exception
     {
         // TODO find and fix the leaks!
 
-        start(transport, new TestHandler(1024));
+        start(transportType, new TestHandler(1024));
 
         CompleteContentSourceListener listener = new CompleteContentSourceListener()
         {
@@ -1017,7 +1017,7 @@ public class HttpClientTest extends AbstractTest
                 contentSource.fail(new Exception("Synthetic Failure"));
             }
         };
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .path("/")
             .onResponseContentSource((response, contentSource) -> contentSource.fail(new Exception("Synthetic Failure")))
             .onResponseContentSource((response, contentSource) -> contentSource.fail(new Exception("Synthetic Failure")))
@@ -1030,11 +1030,11 @@ public class HttpClientTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testRequestConnection(Transport transport) throws Exception
+    public void testRequestConnection(TransportType transportType) throws Exception
     {
-        start(transport, new EmptyServerHandler());
+        start(transportType, new EmptyServerHandler());
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .onRequestBegin(r ->
             {
                 Connection connection = r.getConnection();
@@ -1043,7 +1043,7 @@ public class HttpClientTest extends AbstractTest
             })
             .onRequestHeaders(r ->
             {
-                if (transport.isSecure())
+                if (transportType.isSecure())
                 {
                     EndPoint.SslSessionData sslSessionData = r.getConnection().getSslSessionData();
                     if (sslSessionData == null)

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpInterimResponseTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpInterimResponseTest.java
@@ -38,9 +38,9 @@ public class HttpInterimResponseTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testImplicit100Continue(Transport transport) throws Exception
+    public void testImplicit100Continue(TransportType transportType) throws Exception
     {
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, Response response, Callback callback) throws Exception
@@ -52,7 +52,7 @@ public class HttpInterimResponseTest extends AbstractTest
             }
         });
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
             .body(new StringRequestContent("request-content"))
             .timeout(5, TimeUnit.SECONDS)
@@ -63,9 +63,9 @@ public class HttpInterimResponseTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testMultipleDifferentInterimResponses(Transport transport) throws Exception
+    public void testMultipleDifferentInterimResponses(TransportType transportType) throws Exception
     {
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, Response response, Callback callback) throws Exception
@@ -114,7 +114,7 @@ public class HttpInterimResponseTest extends AbstractTest
             }
         });
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
             .body(new StringRequestContent("request-content"))
             .timeout(5, TimeUnit.SECONDS)

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/ReproducibleRequestContentTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/ReproducibleRequestContentTest.java
@@ -43,9 +43,9 @@ public class ReproducibleRequestContentTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testRedirectWithReproducibleRequestContent(Transport transport) throws Exception
+    public void testRedirectWithReproducibleRequestContent(TransportType transportType) throws Exception
     {
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, Response response, Callback callback)
@@ -59,7 +59,7 @@ public class ReproducibleRequestContentTest extends AbstractTest
         });
 
         String text = "hello world";
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(new StringRequestContent(text))
             .send();
@@ -70,10 +70,10 @@ public class ReproducibleRequestContentTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testBasicAuthenticationWithReproducibleRequestContent(Transport transport) throws Exception
+    public void testBasicAuthenticationWithReproducibleRequestContent(TransportType transportType) throws Exception
     {
         String realm = "test-realm";
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, Response response, Callback callback)
@@ -91,7 +91,7 @@ public class ReproducibleRequestContentTest extends AbstractTest
             }
         });
 
-        URI uri = newURI(transport);
+        URI uri = newURI(transportType);
         client.getAuthenticationStore().addAuthentication(new BasicAuthentication(uri, realm, "test", "secret"));
 
         String text = "hello world";
@@ -106,9 +106,9 @@ public class ReproducibleRequestContentTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testRedirectWithReproducibleRequestContentSplitAndDelayed(Transport transport) throws Exception
+    public void testRedirectWithReproducibleRequestContentSplitAndDelayed(TransportType transportType) throws Exception
     {
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, Response response, Callback callback)
@@ -126,7 +126,7 @@ public class ReproducibleRequestContentTest extends AbstractTest
         ReproducibleAsyncRequestContent body = new ReproducibleAsyncRequestContent();
         body.write(StandardCharsets.UTF_8.encode(text1));
         CompletableFuture<ContentResponse> completable = new CompletableResponseListener(
-            client.newRequest(newURI(transport))
+            client.newRequest(newURI(transportType))
                 .method(HttpMethod.POST)
                 .body(body)
         ).send();
@@ -146,10 +146,10 @@ public class ReproducibleRequestContentTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testBasicAuthenticationWithReproducibleRequestContentSplitAndDelayed(Transport transport) throws Exception
+    public void testBasicAuthenticationWithReproducibleRequestContentSplitAndDelayed(TransportType transportType) throws Exception
     {
         String realm = "test-realm";
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, Response response, Callback callback)
@@ -167,7 +167,7 @@ public class ReproducibleRequestContentTest extends AbstractTest
             }
         });
 
-        URI uri = newURI(transport);
+        URI uri = newURI(transportType);
         client.getAuthenticationStore().addAuthentication(new BasicAuthentication(uri, realm, "test", "secret"));
 
         String text1 = "hello";
@@ -175,7 +175,7 @@ public class ReproducibleRequestContentTest extends AbstractTest
         ReproducibleAsyncRequestContent body = new ReproducibleAsyncRequestContent();
         body.write(StandardCharsets.UTF_8.encode(text1));
         CompletableFuture<ContentResponse> completable = new CompletableResponseListener(
-            client.newRequest(newURI(transport))
+            client.newRequest(newURI(transportType))
                 .method(HttpMethod.POST)
                 .body(body)
         ).send();

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/RequestNanoTimesTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/RequestNanoTimesTest.java
@@ -34,9 +34,9 @@ public class RequestNanoTimesTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transports")
-    public void testRequestNanoTimes(Transport transport) throws Exception
+    public void testRequestNanoTimes(TransportType transportType) throws Exception
     {
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, Response response, Callback callback)
@@ -51,7 +51,7 @@ public class RequestNanoTimesTest extends AbstractTest
         for (int i = 0; i < 2; ++i)
         {
             long clientRequestNanoTime = NanoTime.now();
-            ContentResponse response = client.newRequest(newURI(transport))
+            ContentResponse response = client.newRequest(newURI(transportType))
                 .timeout(5, TimeUnit.SECONDS)
                 .send();
 

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/RoundRobinConnectionPoolTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/RoundRobinConnectionPoolTest.java
@@ -48,11 +48,11 @@ public class RoundRobinConnectionPoolTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transports")
-    public void testRoundRobin(Transport transport) throws Exception
+    public void testRoundRobin(TransportType transportType) throws Exception
     {
         AtomicBoolean record = new AtomicBoolean();
         List<Integer> remotePorts = new CopyOnWriteArrayList<>();
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, Response response, Callback callback)
@@ -77,7 +77,7 @@ public class RoundRobinConnectionPoolTest extends AbstractTest
         // Send one request to trigger destination creation
         // and connection pool pre-creation of connections,
         // so we can test reliably the round-robin behavior.
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .timeout(5, TimeUnit.SECONDS)
             .send();
         setup.get(5, TimeUnit.SECONDS);
@@ -86,7 +86,7 @@ public class RoundRobinConnectionPoolTest extends AbstractTest
         int requests = 2 * maxConnections - 1;
         for (int i = 0; i < requests; ++i)
         {
-            ContentResponse response = client.newRequest(newURI(transport))
+            ContentResponse response = client.newRequest(newURI(transportType))
                 .timeout(5, TimeUnit.SECONDS)
                 .send();
             assertEquals(HttpStatus.OK_200, response.getStatus());
@@ -106,10 +106,10 @@ public class RoundRobinConnectionPoolTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testMultiplex(Transport transport) throws Exception
+    public void testMultiplex(TransportType transportType) throws Exception
     {
         int multiplex = 1;
-        if (transport.isMultiplexed())
+        if (transportType.isMultiplexed())
             multiplex = 4;
         int maxMultiplex = multiplex;
 
@@ -121,7 +121,7 @@ public class RoundRobinConnectionPoolTest extends AbstractTest
         AtomicReference<CountDownLatch> requestLatch = new AtomicReference<>();
         CountDownLatch serverLatch = new CountDownLatch(count);
         CyclicBarrier barrier = new CyclicBarrier(count + 1);
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, Response response, Callback callback)
@@ -157,7 +157,7 @@ public class RoundRobinConnectionPoolTest extends AbstractTest
         // Send one request to trigger destination creation
         // and connection pool pre-creation of connections,
         // so we can test reliably the round-robin behavior.
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .timeout(5, TimeUnit.SECONDS)
             .send();
         setup.get(5, TimeUnit.SECONDS);
@@ -169,7 +169,7 @@ public class RoundRobinConnectionPoolTest extends AbstractTest
         {
             CountDownLatch latch = new CountDownLatch(1);
             requestLatch.set(latch);
-            client.newRequest(newURI(transport))
+            client.newRequest(newURI(transportType))
                 .path("/" + i)
                 .onRequestQueued(request -> requests.incrementAndGet())
                 .onRequestBegin(request -> requests.decrementAndGet())
@@ -202,10 +202,10 @@ public class RoundRobinConnectionPoolTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testMultiplexWithMaxUsage(Transport transport) throws Exception
+    public void testMultiplexWithMaxUsage(TransportType transportType) throws Exception
     {
         int multiplex = 1;
-        if (transport.isMultiplexed())
+        if (transportType.isMultiplexed())
             multiplex = 2;
         int maxMultiplex = multiplex;
 
@@ -214,7 +214,7 @@ public class RoundRobinConnectionPoolTest extends AbstractTest
         int count = 2 * maxConnections * maxMultiplex * maxUsage;
 
         List<Integer> remotePorts = new CopyOnWriteArrayList<>();
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, Response response, Callback callback)
@@ -224,7 +224,7 @@ public class RoundRobinConnectionPoolTest extends AbstractTest
                 return true;
             }
         });
-        if (transport == Transport.H3)
+        if (transportType == TransportType.H3)
             ((QuicServerConnector)connector).getQuicConfiguration().setMaxBidirectionalRemoteStreams(maxUsage);
         client.getHttpClientTransport().setConnectionPoolFactory(destination ->
         {
@@ -236,7 +236,7 @@ public class RoundRobinConnectionPoolTest extends AbstractTest
         CountDownLatch clientLatch = new CountDownLatch(count);
         for (int i = 0; i < count; ++i)
         {
-            client.newRequest(newURI(transport))
+            client.newRequest(newURI(transportType))
                 .path("/" + i)
                 .timeout(5, TimeUnit.SECONDS)
                 .send(result ->
@@ -249,7 +249,7 @@ public class RoundRobinConnectionPoolTest extends AbstractTest
         assertEquals(count, remotePorts.size());
 
         // UDP does not have TIME_WAIT so ports may be reused by different connections.
-        if (transport == Transport.H3)
+        if (transportType == TransportType.H3)
             return;
 
         // Maps {remote_port -> number_of_times_port_was_used}.

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/RoundRobinConnectionPoolTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/RoundRobinConnectionPoolTest.java
@@ -224,7 +224,7 @@ public class RoundRobinConnectionPoolTest extends AbstractTest
                 return true;
             }
         });
-        if (transportType == TransportType.H3)
+        if (transportType == TransportType.H3_QUICHE)
             ((QuicServerConnector)connector).getQuicConfiguration().setMaxBidirectionalRemoteStreams(maxUsage);
         client.getHttpClientTransport().setConnectionPoolFactory(destination ->
         {
@@ -249,7 +249,7 @@ public class RoundRobinConnectionPoolTest extends AbstractTest
         assertEquals(count, remotePorts.size());
 
         // UDP does not have TIME_WAIT so ports may be reused by different connections.
-        if (transportType == TransportType.H3)
+        if (transportType == TransportType.H3_QUICHE)
             return;
 
         // Maps {remote_port -> number_of_times_port_was_used}.

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/ServerRetainContentTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/ServerRetainContentTest.java
@@ -41,12 +41,12 @@ public class ServerRetainContentTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testRetainPOST(Transport transport) throws Exception
+    public void testRetainPOST(TransportType transportType) throws Exception
     {
         Queue<Content.Chunk> chunks = new ConcurrentLinkedQueue<>();
         CountDownLatch blocked = new CountDownLatch(1);
 
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, Response response, Callback callback)
@@ -87,7 +87,7 @@ public class ServerRetainContentTest extends AbstractTest
         long baseMemory = byteBufferPool.getDirectMemory() + byteBufferPool.getHeapMemory() + byteBufferPool.getReserved();
 
         CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method("POST")
             .body(content)
             .send(result ->
@@ -129,7 +129,7 @@ public class ServerRetainContentTest extends AbstractTest
                 totalData += chunk.remaining();
         }
 
-        assertThat(finalMemory - baseMemory, lessThanOrEqualTo((transport.isSecure() ? 100 : 32) * 1024L));
+        assertThat(finalMemory - baseMemory, lessThanOrEqualTo((transportType.isSecure() ? 100 : 32) * 1024L));
 
         client.close();
     }

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/TLSHandshakeFailureTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/TLSHandshakeFailureTest.java
@@ -62,30 +62,30 @@ public class TLSHandshakeFailureTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsTLS")
-    public void testTLSWrapAbruptSSLEngineClose(Transport transport) throws Exception
+    public void testTLSWrapAbruptSSLEngineClose(TransportType transportType) throws Exception
     {
         TLSHandshakeAction action = SSLEngine::closeOutbound;
-        testTLSWrapFailure(transport, action, 1);
+        testTLSWrapFailure(transportType, action, 1);
         stop();
-        testTLSWrapFailure(transport, action, 2);
+        testTLSWrapFailure(transportType, action, 2);
     }
 
     @ParameterizedTest
     @MethodSource("transportsTLS")
-    public void testTLSWrapAbruptSSLEngineFailure(Transport transport) throws Exception
+    public void testTLSWrapAbruptSSLEngineFailure(TransportType transportType) throws Exception
     {
         TLSHandshakeAction action = sslEngine ->
         {
             throw new SSLException("test");
         };
-        testTLSWrapFailure(transport, action, 1);
+        testTLSWrapFailure(transportType, action, 1);
         stop();
-        testTLSWrapFailure(transport, action, 2);
+        testTLSWrapFailure(transportType, action, 2);
     }
 
-    private void testTLSWrapFailure(Transport transport, TLSHandshakeAction action, int wrapCount) throws Exception
+    private void testTLSWrapFailure(TransportType transportType, TLSHandshakeAction action, int wrapCount) throws Exception
     {
-        start(transport, new EmptyServerHandler());
+        start(transportType, new EmptyServerHandler());
         client.stop();
         client = new HttpClient(client.getHttpClientTransport())
         {
@@ -123,7 +123,7 @@ public class TLSHandshakeFailureTest extends AbstractTest
         int count = 10;
         for (int i = 0; i < count; ++i)
         {
-            assertThrows(ExecutionException.class, () -> client.newRequest(newURI(transport))
+            assertThrows(ExecutionException.class, () -> client.newRequest(newURI(transportType))
                 .timeout(5, TimeUnit.SECONDS)
                 .send()
             );
@@ -138,30 +138,30 @@ public class TLSHandshakeFailureTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsTLS")
-    public void testTLSUnwrapAbruptSSLEngineClose(Transport transport) throws Exception
+    public void testTLSUnwrapAbruptSSLEngineClose(TransportType transportType) throws Exception
     {
         TLSHandshakeAction action = SSLEngine::closeInbound;
-        testTLSUnwrapFailure(transport, action, 1);
+        testTLSUnwrapFailure(transportType, action, 1);
         stop();
-        testTLSUnwrapFailure(transport, action, 2);
+        testTLSUnwrapFailure(transportType, action, 2);
     }
 
     @ParameterizedTest
     @MethodSource("transportsTLS")
-    public void testTLSUnwrapAbruptSSLEngineFailure(Transport transport) throws Exception
+    public void testTLSUnwrapAbruptSSLEngineFailure(TransportType transportType) throws Exception
     {
         TLSHandshakeAction action = sslEngine ->
         {
             throw new SSLException("test");
         };
-        testTLSUnwrapFailure(transport, action, 1);
+        testTLSUnwrapFailure(transportType, action, 1);
         stop();
-        testTLSUnwrapFailure(transport, action, 2);
+        testTLSUnwrapFailure(transportType, action, 2);
     }
 
-    private void testTLSUnwrapFailure(Transport transport, TLSHandshakeAction action, int unwrapCount) throws Exception
+    private void testTLSUnwrapFailure(TransportType transportType, TLSHandshakeAction action, int unwrapCount) throws Exception
     {
-        start(transport, new EmptyServerHandler());
+        start(transportType, new EmptyServerHandler());
         client.stop();
         client = new HttpClient(client.getHttpClientTransport())
         {
@@ -199,7 +199,7 @@ public class TLSHandshakeFailureTest extends AbstractTest
         int count = 10;
         for (int i = 0; i < count; ++i)
         {
-            assertThrows(ExecutionException.class, () -> client.newRequest(newURI(transport))
+            assertThrows(ExecutionException.class, () -> client.newRequest(newURI(transportType))
                 .timeout(5, TimeUnit.SECONDS)
                 .send()
             );

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/ThreadStarvationTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/ThreadStarvationTest.java
@@ -45,7 +45,7 @@ public class ThreadStarvationTest extends AbstractTest
     {
         // Leave only 1 thread available to handle requests.
         // 1 acceptor (0 for H3), 1 selector, 1 available.
-        int maxThreads = transportType == TransportType.H3 ? 2 : 3;
+        int maxThreads = transportType == TransportType.H3_QUICHE ? 2 : 3;
         AtomicReference<Thread> handlerThreadRef = new AtomicReference<>();
         prepareServer(transportType, new Handler.Abstract()
         {
@@ -144,7 +144,7 @@ public class ThreadStarvationTest extends AbstractTest
         });
         // Leave only 1 thread available to handle requests.
         // 1 acceptor (0 for H3), 1 selector, 1 available.
-        int maxThreads = transportType == TransportType.H3 ? 2 : 3;
+        int maxThreads = transportType == TransportType.H3_QUICHE ? 2 : 3;
         QueuedThreadPool serverThreads = (QueuedThreadPool)server.getThreadPool();
         serverThreads.setReservedThreads(0);
         serverThreads.setDetailedDump(true);

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/ThreadStarvationTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/ThreadStarvationTest.java
@@ -41,13 +41,13 @@ public class ThreadStarvationTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transports")
-    public void testReadStarvation(Transport transport) throws Exception
+    public void testReadStarvation(TransportType transportType) throws Exception
     {
         // Leave only 1 thread available to handle requests.
         // 1 acceptor (0 for H3), 1 selector, 1 available.
-        int maxThreads = transport == Transport.H3 ? 2 : 3;
+        int maxThreads = transportType == TransportType.H3 ? 2 : 3;
         AtomicReference<Thread> handlerThreadRef = new AtomicReference<>();
-        prepareServer(transport, new Handler.Abstract()
+        prepareServer(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, Response response, Callback callback) throws Exception
@@ -68,12 +68,12 @@ public class ThreadStarvationTest extends AbstractTest
 
         await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertEquals(1, serverThreads.getReadyThreads()));
 
-        startClient(transport);
+        startClient(transportType);
 
         // Send one request that will block the last thread on the server.
         CountDownLatch responseLatch = new CountDownLatch(1);
         AsyncRequestContent content = new AsyncRequestContent(UTF_8.encode("0"));
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(content)
             .timeout(5, TimeUnit.SECONDS)
@@ -101,12 +101,12 @@ public class ThreadStarvationTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testIdleTimeoutStarvation(Transport transport) throws Exception
+    public void testIdleTimeoutStarvation(TransportType transportType) throws Exception
     {
         long idleTimeout = 1000;
         AtomicReference<Thread> handlerThreadRef = new AtomicReference<>();
         CountDownLatch serverExceptionLatch = new CountDownLatch(1);
-        prepareServer(transport, new Handler.Abstract()
+        prepareServer(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, Response response, Callback callback) throws Exception
@@ -144,7 +144,7 @@ public class ThreadStarvationTest extends AbstractTest
         });
         // Leave only 1 thread available to handle requests.
         // 1 acceptor (0 for H3), 1 selector, 1 available.
-        int maxThreads = transport == Transport.H3 ? 2 : 3;
+        int maxThreads = transportType == TransportType.H3 ? 2 : 3;
         QueuedThreadPool serverThreads = (QueuedThreadPool)server.getThreadPool();
         serverThreads.setReservedThreads(0);
         serverThreads.setDetailedDump(true);
@@ -155,12 +155,12 @@ public class ThreadStarvationTest extends AbstractTest
 
         await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertEquals(1, serverThreads.getReadyThreads()));
 
-        startClient(transport);
+        startClient(transportType);
 
         // Send one request that will block the last thread on the server.
         CountDownLatch responseLatch = new CountDownLatch(1);
         AsyncRequestContent content = new AsyncRequestContent();
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(content)
             .timeout(2 * idleTimeout, TimeUnit.MILLISECONDS)

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/TrailersTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/TrailersTest.java
@@ -43,11 +43,11 @@ public class TrailersTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testTrailers(Transport transport) throws Exception
+    public void testTrailers(TransportType transportType) throws Exception
     {
         String trailerName = "Some-Trailer";
         String trailerValue = "0xC0FFEE";
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, Response response, Callback callback) throws Exception
@@ -89,7 +89,7 @@ public class TrailersTest extends AbstractTest
         InputStreamResponseListener listener = new InputStreamResponseListener();
         try (OutputStream output = body.getOutputStream())
         {
-            client.newRequest(newURI(transport))
+            client.newRequest(newURI(transportType))
                 .trailersSupplier(() -> requestTrailers)
                 .body(body)
                 .timeout(15, TimeUnit.SECONDS)
@@ -120,9 +120,9 @@ public class TrailersTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testTrailersWithDelayedRead(Transport transport) throws Exception
+    public void testTrailersWithDelayedRead(TransportType transportType) throws Exception
     {
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, Response response, Callback callback) throws Exception
@@ -142,7 +142,7 @@ public class TrailersTest extends AbstractTest
         String content = "Some-Content";
         String trailerName = "X-Trailer";
         String trailerValue = "0xC0FFEE";
-        var request = client.newRequest(newURI(transport))
+        var request = client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .headers(headers -> headers.put(HttpHeader.TRAILER, trailerName))
             .body(new StringRequestContent(content))

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/VirtualThreadsTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/VirtualThreadsTest.java
@@ -37,13 +37,13 @@ public class VirtualThreadsTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transports")
-    public void testHandlerInvokedOnVirtualThread(Transport transport) throws Exception
+    public void testHandlerInvokedOnVirtualThread(TransportType transportType) throws Exception
     {
         // No virtual thread support in FCGI server-side.
-        Assumptions.assumeTrue(transport != Transport.FCGI);
+        Assumptions.assumeTrue(transportType != TransportType.FCGI);
 
         String virtualThreadsName = "green-";
-        prepareServer(transport, new Handler.Abstract()
+        prepareServer(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, Response response, Callback callback)
@@ -63,12 +63,12 @@ public class VirtualThreadsTest extends AbstractTest
             ((VirtualThreads.Configurable)threadPool).setVirtualThreadsExecutor(virtualThreadsExecutor);
         }
         server.start();
-        startClient(transport);
+        startClient(transportType);
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .timeout(5, TimeUnit.SECONDS)
             .send();
 
-        assertEquals(HttpStatus.OK_200, response.getStatus(), " for transport " + transport);
+        assertEquals(HttpStatus.OK_200, response.getStatus(), " for transport " + transportType);
     }
 }

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/ZippedRequestContentTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/ZippedRequestContentTest.java
@@ -44,9 +44,9 @@ public class ZippedRequestContentTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testZippedRequestContent(Transport transport) throws Exception
+    public void testZippedRequestContent(TransportType transportType) throws Exception
     {
-        start(transport, new Handler.Abstract()
+        start(transportType, new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, Response response, Callback callback) throws Exception
@@ -74,7 +74,7 @@ public class ZippedRequestContentTest extends AbstractTest
 
         OutputStreamRequestContent content = new OutputStreamRequestContent();
         CompletableFuture<ContentResponse> completable = new CompletableResponseListener(
-            client.newRequest(newURI(transport))
+            client.newRequest(newURI(transportType))
                 .method(HttpMethod.POST)
                 .body(content)
         ).send();

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/AbstractTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/AbstractTest.java
@@ -84,7 +84,7 @@ public class AbstractTest
     {
         EnumSet<TransportType> transportTypes = EnumSet.allOf(TransportType.class);
         if ("ci".equals(System.getProperty("env")))
-            transportTypes.remove(TransportType.H3);
+            transportTypes.remove(TransportType.H3_QUICHE);
         return transportTypes;
     }
 
@@ -104,9 +104,9 @@ public class AbstractTest
 
     public static Collection<TransportType> transportsSecure()
     {
-        EnumSet<TransportType> transportTypes = EnumSet.of(TransportType.HTTPS, TransportType.H2, TransportType.H3);
+        EnumSet<TransportType> transportTypes = EnumSet.of(TransportType.HTTPS, TransportType.H2, TransportType.H3_QUICHE);
         if ("ci".equals(System.getProperty("env")))
-            transportTypes.remove(TransportType.H3);
+            transportTypes.remove(TransportType.H3_QUICHE);
         return transportTypes;
     }
 
@@ -203,7 +203,7 @@ public class AbstractTest
         {
             case HTTP, HTTPS, H2C, H2, FCGI ->
                 new ServerConnector(server, 1, 1, newServerConnectionFactory(transportType));
-            case H3 ->
+            case H3_QUICHE ->
                 new QuicServerConnector(server, serverQuicConfig, newServerConnectionFactory(transportType));
         };
     }
@@ -235,7 +235,7 @@ public class AbstractTest
                 SslConnectionFactory ssl = new SslConnectionFactory(sslContextFactoryServer, alpn.getProtocol());
                 yield List.of(ssl, alpn, h2);
             }
-            case H3 ->
+            case H3_QUICHE ->
             {
                 httpConfig.addCustomizer(new SecureRequestCustomizer());
                 httpConfig.addCustomizer(new HostHeaderCustomizer());
@@ -273,7 +273,7 @@ public class AbstractTest
                 HTTP2Client http2Client = new HTTP2Client(clientConnector);
                 yield new HttpClientTransportOverHTTP2(http2Client);
             }
-            case H3 ->
+            case H3_QUICHE ->
             {
                 ClientConnector clientConnector = new ClientConnector();
                 clientConnector.setSelectors(1);
@@ -315,14 +315,14 @@ public class AbstractTest
 
     public enum TransportType
     {
-        HTTP, HTTPS, H2C, H2, H3, FCGI;
+        HTTP, HTTPS, H2C, H2, H3_QUICHE, FCGI;
 
         public boolean isSecure()
         {
             return switch (this)
             {
                 case HTTP, H2C, FCGI -> false;
-                case HTTPS, H2, H3 -> true;
+                case HTTPS, H2, H3_QUICHE -> true;
             };
         }
 
@@ -331,7 +331,7 @@ public class AbstractTest
             return switch (this)
             {
                 case HTTP, HTTPS, FCGI -> false;
-                case H2C, H2, H3 -> true;
+                case H2C, H2, H3_QUICHE -> true;
             };
         }
     }

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/AsyncIOServletTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/AsyncIOServletTest.java
@@ -97,9 +97,9 @@ public class AsyncIOServletTest extends AbstractTest
     private static final ThreadLocal<RuntimeException> scope = new ThreadLocal<>();
 
     @Override
-    protected void prepareServer(Transport transport, HttpServlet servlet) throws Exception
+    protected void prepareServer(TransportType transportType, HttpServlet servlet) throws Exception
     {
-        super.prepareServer(transport, servlet);
+        super.prepareServer(transportType, servlet);
         // Add this listener before the context is started, so it's durable.
         servletContextHandler.addEventListener(new ContextHandler.ContextScopeListener()
         {
@@ -152,22 +152,22 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncReadThrowsException(Transport transport) throws Exception
+    public void testAsyncReadThrowsException(TransportType transportType) throws Exception
     {
-        testAsyncReadThrows(transport, new NullPointerException("explicitly_thrown_by_test"));
+        testAsyncReadThrows(transportType, new NullPointerException("explicitly_thrown_by_test"));
     }
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncReadThrowsError(Transport transport) throws Exception
+    public void testAsyncReadThrowsError(TransportType transportType) throws Exception
     {
-        testAsyncReadThrows(transport, new Error("explicitly_thrown_by_test"));
+        testAsyncReadThrows(transportType, new Error("explicitly_thrown_by_test"));
     }
 
-    private void testAsyncReadThrows(Transport transport, Throwable throwable) throws Exception
+    private void testAsyncReadThrows(TransportType transportType, Throwable throwable) throws Exception
     {
         CountDownLatch latch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -207,7 +207,7 @@ public class AsyncIOServletTest extends AbstractTest
             }
         });
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(new StringRequestContent("0123456789"))
             .timeout(5, TimeUnit.SECONDS)
@@ -219,10 +219,10 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncReadIdleTimeout(Transport transport) throws Exception
+    public void testAsyncReadIdleTimeout(TransportType transportType) throws Exception
     {
         int status = 567;
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -282,7 +282,7 @@ public class AsyncIOServletTest extends AbstractTest
         content.write(ByteBuffer.wrap(data.getBytes(StandardCharsets.UTF_8)), Callback.NOOP);
         CountDownLatch responseLatch = new CountDownLatch(1);
         CountDownLatch clientLatch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(content)
             .onResponseSuccess(r -> responseLatch.countDown())
@@ -294,7 +294,7 @@ public class AsyncIOServletTest extends AbstractTest
             });
 
         // HTTP/2 does not close a Connection when the request idle times out.
-        if (transport != Transport.H2C && transport != Transport.H2)
+        if (transportType != TransportType.H2C && transportType != TransportType.H2)
             assertTrue(closeLatch.await(5, TimeUnit.SECONDS), "close latch expired");
         assertTrue(responseLatch.await(5, TimeUnit.SECONDS), "response latch expired");
         content.close();
@@ -303,10 +303,10 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testOnErrorThrows(Transport transport) throws Exception
+    public void testOnErrorThrows(TransportType transportType) throws Exception
     {
         AtomicInteger errors = new AtomicInteger();
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -352,7 +352,7 @@ public class AsyncIOServletTest extends AbstractTest
 
         try (StacklessLogging ignore = new StacklessLogging(HttpChannelState.class))
         {
-            ContentResponse response = client.newRequest(newURI(transport))
+            ContentResponse response = client.newRequest(newURI(transportType))
                 .body(new StringRequestContent("0123456789"))
                 .timeout(5, TimeUnit.SECONDS)
                 .send();
@@ -364,22 +364,22 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncWriteThrowsException(Transport transport) throws Exception
+    public void testAsyncWriteThrowsException(TransportType transportType) throws Exception
     {
-        testAsyncWriteThrows(transport, new NullPointerException("explicitly_thrown_by_test"));
+        testAsyncWriteThrows(transportType, new NullPointerException("explicitly_thrown_by_test"));
     }
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncWriteThrowsError(Transport transport) throws Exception
+    public void testAsyncWriteThrowsError(TransportType transportType) throws Exception
     {
-        testAsyncWriteThrows(transport, new Error("explicitly_thrown_by_test"));
+        testAsyncWriteThrows(transportType, new Error("explicitly_thrown_by_test"));
     }
 
-    private void testAsyncWriteThrows(Transport transport, Throwable throwable) throws Exception
+    private void testAsyncWriteThrows(TransportType transportType, Throwable throwable) throws Exception
     {
         CountDownLatch latch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -412,7 +412,7 @@ public class AsyncIOServletTest extends AbstractTest
             }
         });
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .timeout(5, TimeUnit.SECONDS)
             .send();
 
@@ -422,12 +422,12 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncWriteClosed(Transport transport) throws Exception
+    public void testAsyncWriteClosed(TransportType transportType) throws Exception
     {
         byte[] data = new byte[1024];
 
         CountDownLatch errorLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -480,7 +480,7 @@ public class AsyncIOServletTest extends AbstractTest
         });
 
         CountDownLatch clientLatch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .onResponseHeaders(response ->
             {
                 if (response.getStatus() == HttpStatus.OK_200)
@@ -498,10 +498,10 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncWriteLessThanContentLengthFlushed(Transport transport) throws Exception
+    public void testAsyncWriteLessThanContentLengthFlushed(TransportType transportType) throws Exception
     {
         CountDownLatch complete = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -569,7 +569,7 @@ public class AsyncIOServletTest extends AbstractTest
 
         AtomicBoolean failed = new AtomicBoolean(false);
         CountDownLatch clientLatch = new CountDownLatch(3);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .onResponseHeaders(response ->
             {
                 if (response.getStatus() == HttpStatus.OK_200)
@@ -593,12 +593,12 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testIsReadyAtEOF(Transport transport) throws Exception
+    public void testIsReadyAtEOF(TransportType transportType) throws Exception
     {
         String text = "TEST\n";
         byte[] data = text.getBytes(StandardCharsets.UTF_8);
 
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -652,7 +652,7 @@ public class AsyncIOServletTest extends AbstractTest
             }
         });
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .headers(headers -> headers.put(HttpHeader.CONNECTION, HttpHeaderValue.CLOSE))
             .body(new StringRequestContent(text))
@@ -665,10 +665,10 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testOnAllDataRead(Transport transport) throws Exception
+    public void testOnAllDataRead(TransportType transportType) throws Exception
     {
         String success = "SUCCESS";
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -734,7 +734,7 @@ public class AsyncIOServletTest extends AbstractTest
                 return data.length;
             }
         };
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(content)
             .timeout(5, TimeUnit.SECONDS)
@@ -762,10 +762,10 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testOtherThreadOnAllDataRead(Transport transport) throws Exception
+    public void testOtherThreadOnAllDataRead(TransportType transportType) throws Exception
     {
         String success = "SUCCESS";
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -838,7 +838,7 @@ public class AsyncIOServletTest extends AbstractTest
         byte[] data = "X".getBytes(StandardCharsets.UTF_8);
         CountDownLatch clientLatch = new CountDownLatch(1);
         AsyncRequestContent content = new AsyncRequestContent();
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(content)
             .timeout(5, TimeUnit.SECONDS)
@@ -866,11 +866,11 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testCompleteBeforeOnAllDataRead(Transport transport) throws Exception
+    public void testCompleteBeforeOnAllDataRead(TransportType transportType) throws Exception
     {
         String success = "SUCCESS";
 
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -918,7 +918,7 @@ public class AsyncIOServletTest extends AbstractTest
             }
         });
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .headers(headers -> headers.put(HttpHeader.CONNECTION, HttpHeaderValue.CLOSE))
             .body(new StringRequestContent("XYZ"))
@@ -931,12 +931,12 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testEmptyAsyncRead(Transport transport) throws Exception
+    public void testEmptyAsyncRead(TransportType transportType) throws Exception
     {
         AtomicBoolean oda = new AtomicBoolean();
         CountDownLatch latch = new CountDownLatch(1);
 
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -973,7 +973,7 @@ public class AsyncIOServletTest extends AbstractTest
             }
         });
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.CONNECTION, HttpHeaderValue.CLOSE))
             .timeout(5, TimeUnit.SECONDS)
             .send();
@@ -986,11 +986,11 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testWriteFromOnDataAvailable(Transport transport) throws Exception
+    public void testWriteFromOnDataAvailable(TransportType transportType) throws Exception
     {
         Queue<Throwable> errors = new ConcurrentLinkedQueue<>();
         CountDownLatch writeLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -1052,7 +1052,7 @@ public class AsyncIOServletTest extends AbstractTest
         AsyncRequestContent requestContent = new AsyncRequestContent();
         requestContent.write(ByteBuffer.wrap(content.getBytes(StandardCharsets.UTF_8)), Callback.NOOP);
         CountDownLatch clientLatch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(requestContent)
             .send(new BufferingResponseListener()
@@ -1081,19 +1081,19 @@ public class AsyncIOServletTest extends AbstractTest
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
     @Disabled // TODO Cannot write response from onError as failure has occurred
-    public void testAsyncReadEarlyEOF(Transport transport) throws Exception
+    public void testAsyncReadEarlyEOF(TransportType transportType) throws Exception
     {
         // SSLEngine receives the close alert from the client, and when
         // the server passes the response to encrypt and write, SSLEngine
         // only generates the close alert back, without encrypting the
         // response, so we need to skip the transports over TLS.
-        Assumptions.assumeFalse(transport.isSecure());
+        Assumptions.assumeFalse(transportType.isSecure());
 
         String content = "jetty";
         int responseCode = HttpStatus.NO_CONTENT_204;
         CountDownLatch readLatch = new CountDownLatch(content.length());
         CountDownLatch errorLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -1131,17 +1131,17 @@ public class AsyncIOServletTest extends AbstractTest
         CountDownLatch responseLatch = new CountDownLatch(1);
         AsyncRequestContent requestContent = new AsyncRequestContent();
         requestContent.write(ByteBuffer.wrap(content.getBytes(StandardCharsets.UTF_8)), Callback.NOOP);
-        var request = client.newRequest(newURI(transport))
+        var request = client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(requestContent)
             .onResponseSuccess(response ->
             {
-                if (transport == Transport.HTTP)
+                if (transportType == TransportType.HTTP)
                     responseLatch.countDown();
             })
             .onResponseFailure((response, failure) ->
             {
-                if (transport == Transport.H2C)
+                if (transportType == TransportType.H2C)
                     responseLatch.countDown();
             });
 
@@ -1152,7 +1152,7 @@ public class AsyncIOServletTest extends AbstractTest
         CountDownLatch clientLatch = new CountDownLatch(1);
         connection.send(request, result ->
         {
-            switch (transport)
+            switch (transportType)
             {
                 case HTTP:
                     assertThat(result.getResponse().getStatus(), Matchers.equalTo(responseCode));
@@ -1162,14 +1162,14 @@ public class AsyncIOServletTest extends AbstractTest
                     assertTrue(result.isFailed());
                     break;
                 default:
-                    fail("Unhandled transport: " + transport);
+                    fail("Unhandled transport: " + transportType);
             }
             clientLatch.countDown();
         });
 
         assertTrue(readLatch.await(5, TimeUnit.SECONDS));
 
-        switch (transport)
+        switch (transportType)
         {
             case HTTP:
                 ((HttpConnectionOverHTTP)connection).getEndPoint().shutdownOutput();
@@ -1183,7 +1183,7 @@ public class AsyncIOServletTest extends AbstractTest
                 ((HTTP2Session)session).getEndPoint().shutdownOutput();
                 break;
             default:
-                fail("Unhandled transport: " + transport);
+                fail("Unhandled transport: " + transportType);
         }
 
         // Wait for the response to arrive before finishing the request.
@@ -1196,12 +1196,12 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testAsyncReadEcho(Transport transport) throws Exception
+    public void testAsyncReadEcho(TransportType transportType) throws Exception
     {
         // TODO: investigate why H3 does not work.
-        Assumptions.assumeTrue(transport != Transport.H3);
+        Assumptions.assumeTrue(transportType != TransportType.H3);
 
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -1243,7 +1243,7 @@ public class AsyncIOServletTest extends AbstractTest
         CountDownLatch clientLatch = new CountDownLatch(1);
 
         AtomicReference<Result> resultRef = new AtomicReference<>();
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(contentProvider)
             .send(new BufferingResponseListener(16 * 1024 * 1024)
@@ -1269,9 +1269,9 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testWriteListenerFromOtherThread(Transport transport) throws Exception
+    public void testWriteListenerFromOtherThread(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -1294,7 +1294,7 @@ public class AsyncIOServletTest extends AbstractTest
                 {
                     try
                     {
-                        ContentResponse response = client.newRequest(newURI(transport))
+                        ContentResponse response = client.newRequest(newURI(transportType))
                             .method(HttpMethod.POST)
                             .body(new InputStreamRequestContent(new ByteArrayInputStream(new byte[16 * 1024])
                             {
@@ -1326,11 +1326,11 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testClientDefersContentServerIdleTimeout(Transport transport) throws Exception
+    public void testClientDefersContentServerIdleTimeout(TransportType transportType) throws Exception
     {
         CountDownLatch dataLatch = new CountDownLatch(1);
         CountDownLatch errorLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -1374,7 +1374,7 @@ public class AsyncIOServletTest extends AbstractTest
                 return bytes.length;
             }
         };
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(content)
             .onResponseSuccess(response ->
@@ -1397,11 +1397,11 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testOnAllDataReadCalledOnceThenIdleTimeout(Transport transport) throws Exception
+    public void testOnAllDataReadCalledOnceThenIdleTimeout(TransportType transportType) throws Exception
     {
         AtomicInteger allDataReadCount = new AtomicInteger();
         AtomicReference<Throwable> errorRef = new AtomicReference<>();
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse resp) throws IOException
@@ -1447,7 +1447,7 @@ public class AsyncIOServletTest extends AbstractTest
         connector.setIdleTimeout(2 * idleTimeout);
         setStreamIdleTimeout(idleTimeout);
 
-        assertThrows(TimeoutException.class, () -> client.newRequest(newURI(transport))
+        assertThrows(TimeoutException.class, () -> client.newRequest(newURI(transportType))
             .timeout(2 * idleTimeout, TimeUnit.MILLISECONDS)
             .send()
         );
@@ -1458,11 +1458,11 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testIsReadyIdempotent(Transport transport) throws Exception
+    public void testIsReadyIdempotent(TransportType transportType) throws Exception
     {
         CountDownLatch bodyLatch = new CountDownLatch(1);
         CountDownLatch dataLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -1514,7 +1514,7 @@ public class AsyncIOServletTest extends AbstractTest
         });
 
         AsyncRequestContent body = new AsyncRequestContent();
-        var request = client.newRequest(newURI(transport))
+        var request = client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(body)
             .timeout(15, TimeUnit.SECONDS);

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/AsyncIOServletTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/AsyncIOServletTest.java
@@ -1199,7 +1199,7 @@ public class AsyncIOServletTest extends AbstractTest
     public void testAsyncReadEcho(TransportType transportType) throws Exception
     {
         // TODO: investigate why H3 does not work.
-        Assumptions.assumeTrue(transportType != TransportType.H3);
+        Assumptions.assumeTrue(transportType != TransportType.H3_QUICHE);
 
         start(transportType, new HttpServlet()
         {

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/BlockedIOTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/BlockedIOTest.java
@@ -48,14 +48,14 @@ public class BlockedIOTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transports")
-    public void testBlockingReadThenNormalComplete(Transport transport) throws Exception
+    public void testBlockingReadThenNormalComplete(TransportType transportType) throws Exception
     {
         CountDownLatch started = new CountDownLatch(1);
         CountDownLatch stopped = new CountDownLatch(1);
         AtomicReference<Throwable> readException = new AtomicReference<>();
         AtomicReference<Throwable> reReadException = new AtomicReference<>();
 
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
@@ -114,7 +114,7 @@ public class BlockedIOTest extends AbstractTest
 
         AsyncRequestContent requestContent = new AsyncRequestContent();
         CountDownLatch ok = new CountDownLatch(2);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method("POST")
             .body(requestContent)
             .onResponseContent((response, content) ->

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/HttpClientContinueTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/HttpClientContinueTest.java
@@ -71,21 +71,21 @@ public class HttpClientContinueTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithOneContentRespond100Continue(Transport transport) throws Exception
+    public void testExpect100ContinueWithOneContentRespond100Continue(TransportType transportType) throws Exception
     {
-        testExpect100ContinueRespond100Continue(transport, "data1".getBytes(StandardCharsets.UTF_8));
+        testExpect100ContinueRespond100Continue(transportType, "data1".getBytes(StandardCharsets.UTF_8));
     }
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithMultipleContentsRespond100Continue(Transport transport) throws Exception
+    public void testExpect100ContinueWithMultipleContentsRespond100Continue(TransportType transportType) throws Exception
     {
-        testExpect100ContinueRespond100Continue(transport, "data1".getBytes(StandardCharsets.UTF_8), "data2".getBytes(StandardCharsets.UTF_8), "data3".getBytes(StandardCharsets.UTF_8));
+        testExpect100ContinueRespond100Continue(transportType, "data1".getBytes(StandardCharsets.UTF_8), "data2".getBytes(StandardCharsets.UTF_8), "data3".getBytes(StandardCharsets.UTF_8));
     }
 
-    private void testExpect100ContinueRespond100Continue(Transport transport, byte[]... contents) throws Exception
+    private void testExpect100ContinueRespond100Continue(TransportType transportType, byte[]... contents) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -95,7 +95,7 @@ public class HttpClientContinueTest extends AbstractTest
             }
         });
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
             .body(new BytesRequestContent(contents))
             .timeout(5, TimeUnit.SECONDS)
@@ -117,13 +117,13 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithMultipleContentsRespond100ContinueBlocking(Transport transport) throws Exception
+    public void testExpect100ContinueWithMultipleContentsRespond100ContinueBlocking(TransportType transportType) throws Exception
     {
         byte[][] contents = new byte[][]{
             "data1".getBytes(StandardCharsets.UTF_8), "data2".getBytes(StandardCharsets.UTF_8), "data3".getBytes(StandardCharsets.UTF_8)
         };
         AtomicReference<Thread> readerThreadRef = new AtomicReference<>();
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -161,7 +161,7 @@ public class HttpClientContinueTest extends AbstractTest
                     }
                 }
             }).start();
-            response = client.newRequest(newURI(transport))
+            response = client.newRequest(newURI(transportType))
                 .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
                 .body(content)
                 .timeout(5, TimeUnit.SECONDS)
@@ -184,9 +184,9 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithChunkedContentRespond100Continue(Transport transport) throws Exception
+    public void testExpect100ContinueWithChunkedContentRespond100Continue(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -201,7 +201,7 @@ public class HttpClientContinueTest extends AbstractTest
 
         byte[] content1 = new byte[10240];
         byte[] content2 = new byte[16384];
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
             .body(new BytesRequestContent(content1, content2)
             {
@@ -216,7 +216,7 @@ public class HttpClientContinueTest extends AbstractTest
 
         assertNotNull(response);
         assertEquals(200, response.getStatus());
-        if (EnumSet.of(Transport.HTTP, Transport.HTTPS).contains(transport))
+        if (EnumSet.of(TransportType.HTTP, TransportType.HTTPS).contains(transportType))
             assertTrue(response.getHeaders().contains(HttpHeader.TRANSFER_ENCODING, "chunked"));
 
         int index = 0;
@@ -233,21 +233,21 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithContentRespond417ExpectationFailed(Transport transport) throws Exception
+    public void testExpect100ContinueWithContentRespond417ExpectationFailed(TransportType transportType) throws Exception
     {
-        testExpect100ContinueWithContentRespondError(transport, HttpStatus.EXPECTATION_FAILED_417);
+        testExpect100ContinueWithContentRespondError(transportType, HttpStatus.EXPECTATION_FAILED_417);
     }
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithContentRespond413RequestEntityTooLarge(Transport transport) throws Exception
+    public void testExpect100ContinueWithContentRespond413RequestEntityTooLarge(TransportType transportType) throws Exception
     {
-        testExpect100ContinueWithContentRespondError(transport, HttpStatus.PAYLOAD_TOO_LARGE_413);
+        testExpect100ContinueWithContentRespondError(transportType, HttpStatus.PAYLOAD_TOO_LARGE_413);
     }
 
-    private void testExpect100ContinueWithContentRespondError(Transport transport, int error) throws Exception
+    private void testExpect100ContinueWithContentRespondError(TransportType transportType, int error) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -259,7 +259,7 @@ public class HttpClientContinueTest extends AbstractTest
         byte[] content1 = new byte[10240];
         byte[] content2 = new byte[16384];
         CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
             .body(new BytesRequestContent(content1, content2))
             .send(new BufferingResponseListener()
@@ -290,10 +290,10 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithContentWithRedirect(Transport transport) throws Exception
+    public void testExpect100ContinueWithContentWithRedirect(TransportType transportType) throws Exception
     {
         String data = "success";
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -314,7 +314,7 @@ public class HttpClientContinueTest extends AbstractTest
 
         byte[] content = new byte[10240];
         CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .path("/continue")
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
@@ -336,12 +336,12 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testRedirectWithExpect100ContinueWithContent(Transport transport) throws Exception
+    public void testRedirectWithExpect100ContinueWithContent(TransportType transportType) throws Exception
     {
         // A request with Expect: 100-Continue cannot receive non-final responses like 3xx
 
         String data = "success";
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -362,7 +362,7 @@ public class HttpClientContinueTest extends AbstractTest
 
         byte[] content = new byte[10240];
         CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .path("/redirect")
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
@@ -385,13 +385,13 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithContentWithResponseFailureBefore100Continue(Transport transport) throws Exception
+    public void testExpect100ContinueWithContentWithResponseFailureBefore100Continue(TransportType transportType) throws Exception
     {
         AtomicReference<Request> clientRequestRef = new AtomicReference<>();
         CountDownLatch clientLatch = new CountDownLatch(1);
         CountDownLatch serverLatch = new CountDownLatch(1);
 
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException
@@ -411,7 +411,7 @@ public class HttpClientContinueTest extends AbstractTest
         });
 
         byte[] content = new byte[1024];
-        Request clientRequest = client.newRequest(newURI(transport));
+        Request clientRequest = client.newRequest(newURI(transportType));
         clientRequestRef.set(clientRequest);
         clientRequest
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
@@ -434,12 +434,12 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithContentWithResponseFailureAfter100Continue(Transport transport) throws Exception
+    public void testExpect100ContinueWithContentWithResponseFailureAfter100Continue(TransportType transportType) throws Exception
     {
         AtomicReference<Request> clientRequestRef = new AtomicReference<>();
         CountDownLatch clientLatch = new CountDownLatch(1);
         CountDownLatch serverLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
@@ -461,7 +461,7 @@ public class HttpClientContinueTest extends AbstractTest
         });
 
         byte[] content = new byte[1024];
-        Request clientRequest = client.newRequest(newURI(transport));
+        Request clientRequest = client.newRequest(newURI(transportType));
         clientRequestRef.set(clientRequest);
         clientRequest
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
@@ -484,9 +484,9 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithContentWithResponseFailureDuring100Continue(Transport transport) throws Exception
+    public void testExpect100ContinueWithContentWithResponseFailureDuring100Continue(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -522,7 +522,7 @@ public class HttpClientContinueTest extends AbstractTest
 
         byte[] content = new byte[1024];
         CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
             .body(new BytesRequestContent(content))
             .send(new BufferingResponseListener()
@@ -542,7 +542,7 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithDeferredContentRespond100Continue(Transport transport) throws Exception
+    public void testExpect100ContinueWithDeferredContentRespond100Continue(TransportType transportType) throws Exception
     {
         byte[] chunk1 = new byte[]{0, 1, 2, 3};
         byte[] chunk2 = new byte[]{4, 5, 6, 7};
@@ -552,7 +552,7 @@ public class HttpClientContinueTest extends AbstractTest
 
         CountDownLatch serverLatch = new CountDownLatch(1);
         AtomicReference<Thread> handlerThread = new AtomicReference<>();
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -574,7 +574,7 @@ public class HttpClientContinueTest extends AbstractTest
 
         CountDownLatch requestLatch = new CountDownLatch(1);
         AsyncRequestContent content = new AsyncRequestContent();
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
             .body(content)
             .send(new BufferingResponseListener()
@@ -612,10 +612,10 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithInitialAndDeferredContentRespond100Continue(Transport transport) throws Exception
+    public void testExpect100ContinueWithInitialAndDeferredContentRespond100Continue(TransportType transportType) throws Exception
     {
         AtomicReference<Thread> handlerThread = new AtomicReference<>();
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -634,7 +634,7 @@ public class HttpClientContinueTest extends AbstractTest
 
         CountDownLatch latch = new CountDownLatch(1);
         AsyncRequestContent content = new AsyncRequestContent(ByteBuffer.wrap(chunk1));
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
             .body(content)
             .send(new BufferingResponseListener()
@@ -662,9 +662,9 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithConcurrentDeferredContentRespond100Continue(Transport transport) throws Exception
+    public void testExpect100ContinueWithConcurrentDeferredContentRespond100Continue(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -678,7 +678,7 @@ public class HttpClientContinueTest extends AbstractTest
         AsyncRequestContent content = new AsyncRequestContent();
 
         CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
             .onRequestHeaders(request ->
             {
@@ -701,9 +701,9 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithInitialAndConcurrentDeferredContentRespond100Continue(Transport transport) throws Exception
+    public void testExpect100ContinueWithInitialAndConcurrentDeferredContentRespond100Continue(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -740,7 +740,7 @@ public class HttpClientContinueTest extends AbstractTest
         });
 
         CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
             .body(content)
             .send(new BufferingResponseListener()
@@ -758,12 +758,12 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void test100ContinueThenTimeoutThenSendError(Transport transport) throws Exception
+    public void test100ContinueThenTimeoutThenSendError(TransportType transportType) throws Exception
     {
         long idleTimeout = 1000;
 
         CountDownLatch serverLatch = new CountDownLatch(1);
-        startServer(transport, new HttpServlet()
+        startServer(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -784,12 +784,12 @@ public class HttpClientContinueTest extends AbstractTest
                 }
             }
         });
-        startClient(transport, httpClient -> httpClient.setIdleTimeout(idleTimeout));
+        startClient(transportType, httpClient -> httpClient.setIdleTimeout(idleTimeout));
 
         AsyncRequestContent requestContent = new AsyncRequestContent();
         requestContent.write(ByteBuffer.wrap(new byte[512]), Callback.NOOP);
         CountDownLatch clientLatch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE.asString()))
             .body(requestContent)
             .send(result ->
@@ -807,9 +807,9 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithContentLengthZeroExpectIsRemoved(Transport transport) throws Exception
+    public void testExpect100ContinueWithContentLengthZeroExpectIsRemoved(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response)
@@ -820,7 +820,7 @@ public class HttpClientContinueTest extends AbstractTest
             }
         });
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE.asString()))
             .body(new StringRequestContent(""))
             .timeout(5, TimeUnit.SECONDS)
@@ -832,7 +832,7 @@ public class HttpClientContinueTest extends AbstractTest
     @Test
     public void testExpect100ContinueWithContentLengthZero() throws Exception
     {
-        startServer(Transport.HTTP, new HttpServlet()
+        startServer(TransportType.HTTP, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -870,7 +870,7 @@ public class HttpClientContinueTest extends AbstractTest
         // and immediately after with the "normal" response, say a 200 OK.
         // These may be read by the client in a single read, and must be handled correctly.
 
-        startClient(Transport.HTTP);
+        startClient(TransportType.HTTP);
 
         try (ServerSocket server = new ServerSocket())
         {
@@ -924,7 +924,7 @@ public class HttpClientContinueTest extends AbstractTest
     @Test
     public void testNoExpectRespond100Continue() throws Exception
     {
-        startClient(Transport.HTTP);
+        startClient(TransportType.HTTP);
         client.setMaxConnectionsPerDestination(1);
 
         try (ServerSocket server = new ServerSocket())
@@ -968,7 +968,7 @@ public class HttpClientContinueTest extends AbstractTest
     @Test
     public void testNoExpect100ContinueThen100ContinueThenRedirectThen100ContinueThenResponse() throws Exception
     {
-        startClient(Transport.HTTP);
+        startClient(TransportType.HTTP);
         client.setMaxConnectionsPerDestination(1);
 
         try (ServerSocket server = new ServerSocket())

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/HttpTrailersTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/HttpTrailersTest.java
@@ -51,23 +51,23 @@ public class HttpTrailersTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testRequestTrailersNoContent(Transport transport) throws Exception
+    public void testRequestTrailersNoContent(TransportType transportType) throws Exception
     {
-        testRequestTrailers(transport, null);
+        testRequestTrailers(transportType, null);
     }
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testRequestTrailersWithContent(Transport transport) throws Exception
+    public void testRequestTrailersWithContent(TransportType transportType) throws Exception
     {
-        testRequestTrailers(transport, "abcdefghijklmnopqrstuvwxyz".getBytes(StandardCharsets.UTF_8));
+        testRequestTrailers(transportType, "abcdefghijklmnopqrstuvwxyz".getBytes(StandardCharsets.UTF_8));
     }
 
-    private void testRequestTrailers(Transport transport, byte[] content) throws Exception
+    private void testRequestTrailers(TransportType transportType, byte[] content) throws Exception
     {
         String trailerName = "Trailer";
         String trailerValue = "value";
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -92,7 +92,7 @@ public class HttpTrailersTest extends AbstractTest
 
         HttpFields trailers = HttpFields.build().put(trailerName, trailerValue).asImmutable();
 
-        Request request = client.newRequest(newURI(transport))
+        Request request = client.newRequest(newURI(transportType))
             .trailersSupplier(() -> trailers);
         if (content != null)
             request.method(HttpMethod.POST).body(new BytesRequestContent(content));
@@ -102,9 +102,9 @@ public class HttpTrailersTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testEmptyRequestTrailers(Transport transport) throws Exception
+    public void testEmptyRequestTrailers(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -128,7 +128,7 @@ public class HttpTrailersTest extends AbstractTest
         });
 
         HttpFields trailers = HttpFields.EMPTY;
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .trailersSupplier(() -> trailers)
             .timeout(5, TimeUnit.SECONDS)
             .send();
@@ -137,24 +137,24 @@ public class HttpTrailersTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testResponseTrailersNoContent(Transport transport) throws Exception
+    public void testResponseTrailersNoContent(TransportType transportType) throws Exception
     {
-        testResponseTrailers(transport, null);
+        testResponseTrailers(transportType, null);
     }
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testResponseTrailersWithContent(Transport transport) throws Exception
+    public void testResponseTrailersWithContent(TransportType transportType) throws Exception
     {
-        testResponseTrailers(transport, "abcdefghijklmnopqrstuvwxyz".getBytes(StandardCharsets.UTF_8));
+        testResponseTrailers(transportType, "abcdefghijklmnopqrstuvwxyz".getBytes(StandardCharsets.UTF_8));
     }
 
-    private void testResponseTrailers(Transport transport, byte[] content) throws Exception
+    private void testResponseTrailers(TransportType transportType, byte[] content) throws Exception
     {
         AtomicBoolean firstRequest = new AtomicBoolean();
         String trailerName = "Trailer";
         String trailerValue = "value";
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -172,7 +172,7 @@ public class HttpTrailersTest extends AbstractTest
         });
 
         AtomicReference<Throwable> failure = new AtomicReference<>(new Throwable("no_success"));
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .onResponseSuccess(r ->
             {
                 try
@@ -193,7 +193,7 @@ public class HttpTrailersTest extends AbstractTest
         assertNull(failure.get());
 
         // Subsequent requests should not have trailers.
-        response = client.newRequest(newURI(transport))
+        response = client.newRequest(newURI(transportType))
             .onResponseSuccess(r ->
             {
                 try
@@ -214,9 +214,9 @@ public class HttpTrailersTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testEmptyResponseTrailers(Transport transport) throws Exception
+    public void testEmptyResponseTrailers(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response)
@@ -226,7 +226,7 @@ public class HttpTrailersTest extends AbstractTest
         });
 
         AtomicReference<Throwable> failure = new AtomicReference<>(new Throwable("no_success"));
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .onResponseSuccess(r ->
             {
                 try
@@ -248,13 +248,13 @@ public class HttpTrailersTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testResponseTrailersWithLargeContent(Transport transport) throws Exception
+    public void testResponseTrailersWithLargeContent(TransportType transportType) throws Exception
     {
         byte[] content = new byte[1024 * 1024];
         new Random().nextBytes(content);
         String trailerName = "Digest";
         String trailerValue = "0xCAFEBABE";
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -269,7 +269,7 @@ public class HttpTrailersTest extends AbstractTest
         });
 
         InputStreamResponseListener listener = new InputStreamResponseListener();
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .timeout(15, TimeUnit.SECONDS)
             .send(listener);
         Response response = listener.get(5, TimeUnit.SECONDS);
@@ -299,9 +299,9 @@ public class HttpTrailersTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testResponseResetAlsoResetsTrailers(Transport transport) throws Exception
+    public void testResponseResetAlsoResetsTrailers(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -322,7 +322,7 @@ public class HttpTrailersTest extends AbstractTest
         });
 
         CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .timeout(5, TimeUnit.SECONDS)
             .send(result ->
             {

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/InformationalResponseTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/InformationalResponseTest.java
@@ -37,9 +37,9 @@ public class InformationalResponseTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void test102Processing(Transport transport) throws Exception
+    public void test102Processing(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -64,7 +64,7 @@ public class InformationalResponseTest extends AbstractTest
                 completeLatch.countDown();
             }
         };
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method("GET")
             .timeout(10, TimeUnit.SECONDS)
             .send(listener);
@@ -76,9 +76,9 @@ public class InformationalResponseTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void test103EarlyHint(Transport transport) throws Exception
+    public void test103EarlyHint(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -106,7 +106,7 @@ public class InformationalResponseTest extends AbstractTest
                 complete.countDown();
             }
         };
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method("GET")
             .timeout(5, TimeUnit.SECONDS)
             .send(listener);

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/NeedClientAuthTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/NeedClientAuthTest.java
@@ -30,9 +30,9 @@ public class NeedClientAuthTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transportsSecure")
-    public void testNeedClientAuth(Transport transport) throws Exception
+    public void testNeedClientAuth(TransportType transportType) throws Exception
     {
-        prepareServer(transport, new HttpServlet()
+        prepareServer(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response)
@@ -44,7 +44,7 @@ public class NeedClientAuthTest extends AbstractTest
         sslContextFactoryServer.setNeedClientAuth(true);
         server.start();
 
-        startClient(transport, httpClient ->
+        startClient(transportType, httpClient ->
         {
             // Configure the SslContextFactory to send a certificate to the server.
             SslContextFactory.Client clientSSL = httpClient.getSslContextFactory();
@@ -53,7 +53,7 @@ public class NeedClientAuthTest extends AbstractTest
             clientSSL.setCertAlias("mykey");
         });
 
-        ContentResponse response = client.newRequest(newURI(transport)).send();
+        ContentResponse response = client.newRequest(newURI(transportType)).send();
 
         assertEquals(HttpStatus.OK_200, response.getStatus());
     }

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/PushedResourcesTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/PushedResourcesTest.java
@@ -39,7 +39,7 @@ public class PushedResourcesTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transportsWithPushSupport")
-    public void testPushedResources(Transport transport) throws Exception
+    public void testPushedResources(TransportType transportType) throws Exception
     {
         Random random = new Random();
         byte[] bytes = new byte[512];
@@ -51,7 +51,7 @@ public class PushedResourcesTest extends AbstractTest
 
         String path1 = "/secondary1";
         String path2 = "/secondary2";
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -92,7 +92,7 @@ public class PushedResourcesTest extends AbstractTest
 
         CountDownLatch latch1 = new CountDownLatch(1);
         CountDownLatch latch2 = new CountDownLatch(1);
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .headers(h -> h.add("Cookie", "C0=toBeRemoved"))
             .onPush((mainRequest, pushedRequest) -> new BufferingResponseListener()
             {
@@ -123,7 +123,7 @@ public class PushedResourcesTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsWithPushSupport")
-    public void testPushedResourceRedirect(Transport transport) throws Exception
+    public void testPushedResourceRedirect(TransportType transportType) throws Exception
     {
         Random random = new Random();
         byte[] pushBytes = new byte[512];
@@ -131,7 +131,7 @@ public class PushedResourcesTest extends AbstractTest
 
         String oldPath = "/old";
         String newPath = "/new";
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -148,7 +148,7 @@ public class PushedResourcesTest extends AbstractTest
 
         CountDownLatch latch = new CountDownLatch(1);
         ;
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .onPush((mainRequest, pushedRequest) -> new BufferingResponseListener()
             {
                 @Override

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/RequestReaderTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/RequestReaderTest.java
@@ -55,10 +55,10 @@ public class RequestReaderTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transports")
-    public void testChannelStateSucceeded(Transport transport) throws Exception
+    public void testChannelStateSucceeded(TransportType transportType) throws Exception
     {
         CountDownLatch servletDoneLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -141,7 +141,7 @@ public class RequestReaderTest extends AbstractTest
         AtomicReference<Result> resultRef = new AtomicReference<>();
         try (AsyncRequestContent content = new AsyncRequestContent())
         {
-            Request request = client.newRequest(newURI(transport))
+            Request request = client.newRequest(newURI(transportType))
                 .method("POST")
                 .timeout(5, TimeUnit.SECONDS)
                 .body(content);
@@ -158,14 +158,14 @@ public class RequestReaderTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testResetArrivingOnServer(Transport transport) throws Exception
+    public void testResetArrivingOnServer(TransportType transportType) throws Exception
     {
-        assumeTrue(transport.isMultiplexed());
+        assumeTrue(transportType.isMultiplexed());
 
         CountDownLatch servletOnDataAvailableLatch = new CountDownLatch(1);
         AtomicReference<Throwable> serverError = new AtomicReference<>();
         CountDownLatch errorDoneLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -223,7 +223,7 @@ public class RequestReaderTest extends AbstractTest
         AtomicReference<Result> resultRef = new AtomicReference<>();
         try (AsyncRequestContent content = new AsyncRequestContent(ByteBuffer.allocate(16)))
         {
-            Request request = client.newRequest(newURI(transport))
+            Request request = client.newRequest(newURI(transportType))
                 .method("POST")
                 .timeout(5, TimeUnit.SECONDS)
                 .body(content);
@@ -244,9 +244,9 @@ public class RequestReaderTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testRecyclingWhenUsingReader(Transport transport) throws Exception
+    public void testRecyclingWhenUsingReader(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
@@ -264,7 +264,7 @@ public class RequestReaderTest extends AbstractTest
             }
         });
 
-        ContentResponse response1 = client.newRequest(newURI(transport))
+        ContentResponse response1 = client.newRequest(newURI(transportType))
             .method("POST")
             .timeout(5, TimeUnit.SECONDS)
             .body(new BytesRequestContent(new byte[512]))
@@ -272,7 +272,7 @@ public class RequestReaderTest extends AbstractTest
         assertThat(response1.getStatus(), is(HttpStatus.OK_200));
 
         // Send a 2nd request to make sure recycling works.
-        ContentResponse response2 = client.newRequest(newURI(transport))
+        ContentResponse response2 = client.newRequest(newURI(transportType))
             .method("POST")
             .timeout(5, TimeUnit.SECONDS)
             .body(new BytesRequestContent(new byte[512]))

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/ServerTimeoutsTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/ServerTimeoutsTest.java
@@ -62,7 +62,7 @@ public class ServerTimeoutsTest extends AbstractTest
     @MethodSource("transportsNoFCGI")
     public void testBlockingReadWithDelayedFirstContentWithUndelayedDispatchIdleTimeoutFires(TransportType transportType) throws Exception
     {
-        assumeTrue(transportType != TransportType.H3 && transportType != TransportType.H2C && transportType != TransportType.H2); // TODO Fix
+        assumeTrue(transportType != TransportType.H3_QUICHE && transportType != TransportType.H2C && transportType != TransportType.H2); // TODO Fix
         testBlockingReadWithDelayedFirstContentIdleTimeoutFires(transportType, false);
     }
 
@@ -70,7 +70,7 @@ public class ServerTimeoutsTest extends AbstractTest
     @MethodSource("transportsNoFCGI")
     public void testBlockingReadWithDelayedFirstContentWithDelayedDispatchIdleTimeoutFires(TransportType transportType) throws Exception
     {
-        assumeTrue(transportType != TransportType.H3 && transportType != TransportType.H2C && transportType != TransportType.H2); // TODO Fix
+        assumeTrue(transportType != TransportType.H3_QUICHE && transportType != TransportType.H2C && transportType != TransportType.H2); // TODO Fix
         testBlockingReadWithDelayedFirstContentIdleTimeoutFires(transportType, true);
     }
 
@@ -242,7 +242,7 @@ public class ServerTimeoutsTest extends AbstractTest
     public void testAsyncWriteIdleTimeoutFires(TransportType transportType) throws Exception
     {
         // TODO fix for h3
-        assumeTrue(transportType != TransportType.H3);
+        assumeTrue(transportType != TransportType.H3_QUICHE);
         CountDownLatch handlerLatch = new CountDownLatch(1);
         start(transportType, new HttpServlet()
         {
@@ -368,7 +368,7 @@ public class ServerTimeoutsTest extends AbstractTest
     @MethodSource("transportsNoFCGI")
     public void testBlockingReadWithMinimumDataRateAboveLimit(TransportType transportType) throws Exception
     {
-        assumeTrue(transportType != TransportType.H3 && transportType != TransportType.H2C && transportType != TransportType.H2); // TODO Fix
+        assumeTrue(transportType != TransportType.H3_QUICHE && transportType != TransportType.H2C && transportType != TransportType.H2); // TODO Fix
 
         int bytesPerSecond = 20;
         httpConfig.setMinRequestDataRate(bytesPerSecond);

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/ServerTimeoutsTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/ServerTimeoutsTest.java
@@ -60,37 +60,37 @@ public class ServerTimeoutsTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testBlockingReadWithDelayedFirstContentWithUndelayedDispatchIdleTimeoutFires(Transport transport) throws Exception
+    public void testBlockingReadWithDelayedFirstContentWithUndelayedDispatchIdleTimeoutFires(TransportType transportType) throws Exception
     {
-        assumeTrue(transport != Transport.H3 && transport != Transport.H2C && transport != Transport.H2); // TODO Fix
-        testBlockingReadWithDelayedFirstContentIdleTimeoutFires(transport, false);
+        assumeTrue(transportType != TransportType.H3 && transportType != TransportType.H2C && transportType != TransportType.H2); // TODO Fix
+        testBlockingReadWithDelayedFirstContentIdleTimeoutFires(transportType, false);
     }
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testBlockingReadWithDelayedFirstContentWithDelayedDispatchIdleTimeoutFires(Transport transport) throws Exception
+    public void testBlockingReadWithDelayedFirstContentWithDelayedDispatchIdleTimeoutFires(TransportType transportType) throws Exception
     {
-        assumeTrue(transport != Transport.H3 && transport != Transport.H2C && transport != Transport.H2); // TODO Fix
-        testBlockingReadWithDelayedFirstContentIdleTimeoutFires(transport, true);
+        assumeTrue(transportType != TransportType.H3 && transportType != TransportType.H2C && transportType != TransportType.H2); // TODO Fix
+        testBlockingReadWithDelayedFirstContentIdleTimeoutFires(transportType, true);
     }
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncReadWithDelayedFirstContentWithUndelayedDispatchIdleTimeoutFires(Transport transport) throws Exception
+    public void testAsyncReadWithDelayedFirstContentWithUndelayedDispatchIdleTimeoutFires(TransportType transportType) throws Exception
     {
-        testAsyncReadWithDelayedFirstContentIdleTimeoutFires(transport, false);
+        testAsyncReadWithDelayedFirstContentIdleTimeoutFires(transportType, false);
     }
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncReadWithDelayedFirstContentWithDelayedDispatchIdleTimeoutFires(Transport transport) throws Exception
+    public void testAsyncReadWithDelayedFirstContentWithDelayedDispatchIdleTimeoutFires(TransportType transportType) throws Exception
     {
-        testAsyncReadWithDelayedFirstContentIdleTimeoutFires(transport, true);
+        testAsyncReadWithDelayedFirstContentIdleTimeoutFires(transportType, true);
     }
 
-    private void testBlockingReadWithDelayedFirstContentIdleTimeoutFires(Transport transport, boolean delayDispatch) throws Exception
+    private void testBlockingReadWithDelayedFirstContentIdleTimeoutFires(TransportType transportType, boolean delayDispatch) throws Exception
     {
-        testReadWithDelayedFirstContentIdleTimeoutFires(transport, new HttpServlet()
+        testReadWithDelayedFirstContentIdleTimeoutFires(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -102,9 +102,9 @@ public class ServerTimeoutsTest extends AbstractTest
         }, delayDispatch);
     }
 
-    private void testAsyncReadWithDelayedFirstContentIdleTimeoutFires(Transport transport, boolean delayDispatch) throws Exception
+    private void testAsyncReadWithDelayedFirstContentIdleTimeoutFires(TransportType transportType, boolean delayDispatch) throws Exception
     {
-        testReadWithDelayedFirstContentIdleTimeoutFires(transport, new HttpServlet()
+        testReadWithDelayedFirstContentIdleTimeoutFires(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -136,11 +136,11 @@ public class ServerTimeoutsTest extends AbstractTest
         }, delayDispatch);
     }
 
-    private void testReadWithDelayedFirstContentIdleTimeoutFires(Transport transport, HttpServlet servlet, boolean delayDispatch) throws Exception
+    private void testReadWithDelayedFirstContentIdleTimeoutFires(TransportType transportType, HttpServlet servlet, boolean delayDispatch) throws Exception
     {
         httpConfig.setDelayDispatchUntilContent(delayDispatch);
         CountDownLatch handlerLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
@@ -160,7 +160,7 @@ public class ServerTimeoutsTest extends AbstractTest
 
         CountDownLatch resultLatch = new CountDownLatch(2);
         AsyncRequestContent content = new AsyncRequestContent();
-        client.POST(newURI(transport))
+        client.POST(newURI(transportType))
             .body(content)
             .onResponseSuccess(response ->
             {
@@ -178,10 +178,10 @@ public class ServerTimeoutsTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncReadIdleTimeoutFires(Transport transport) throws Exception
+    public void testAsyncReadIdleTimeoutFires(TransportType transportType) throws Exception
     {
         CountDownLatch handlerLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -222,7 +222,7 @@ public class ServerTimeoutsTest extends AbstractTest
 
         AsyncRequestContent content = new AsyncRequestContent(ByteBuffer.allocate(1));
         CountDownLatch resultLatch = new CountDownLatch(1);
-        client.POST(newURI(transport))
+        client.POST(newURI(transportType))
             .body(content)
             .send(result ->
             {
@@ -239,12 +239,12 @@ public class ServerTimeoutsTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncWriteIdleTimeoutFires(Transport transport) throws Exception
+    public void testAsyncWriteIdleTimeoutFires(TransportType transportType) throws Exception
     {
         // TODO fix for h3
-        assumeTrue(transport != Transport.H3);
+        assumeTrue(transportType != TransportType.H3);
         CountDownLatch handlerLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -277,7 +277,7 @@ public class ServerTimeoutsTest extends AbstractTest
 
         BlockingQueue<Runnable> demanders = new LinkedBlockingQueue<>();
         CountDownLatch resultLatch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .onResponseContentAsync((response, chunk, demander) ->
             {
                 // Do not succeed the callback so the server will block writing.
@@ -304,12 +304,12 @@ public class ServerTimeoutsTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testBlockingReadWithMinimumDataRateBelowLimit(Transport transport) throws Exception
+    public void testBlockingReadWithMinimumDataRateBelowLimit(TransportType transportType) throws Exception
     {
         int bytesPerSecond = 20;
         httpConfig.setMinRequestDataRate(bytesPerSecond);
         CountDownLatch handlerLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -337,7 +337,7 @@ public class ServerTimeoutsTest extends AbstractTest
         AtomicReference<Response> responseRef = new AtomicReference<>();
         CountDownLatch responseLatch = new CountDownLatch(1);
         CountDownLatch resultLatch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .body(content)
             .onResponseSuccess(response ->
             {
@@ -366,14 +366,14 @@ public class ServerTimeoutsTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testBlockingReadWithMinimumDataRateAboveLimit(Transport transport) throws Exception
+    public void testBlockingReadWithMinimumDataRateAboveLimit(TransportType transportType) throws Exception
     {
-        assumeTrue(transport != Transport.H3 && transport != Transport.H2C && transport != Transport.H2); // TODO Fix
+        assumeTrue(transportType != TransportType.H3 && transportType != TransportType.H2C && transportType != TransportType.H2); // TODO Fix
 
         int bytesPerSecond = 20;
         httpConfig.setMinRequestDataRate(bytesPerSecond);
         CountDownLatch handlerLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -391,7 +391,7 @@ public class ServerTimeoutsTest extends AbstractTest
 
         AsyncRequestContent content = new AsyncRequestContent();
         CountDownLatch resultLatch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .body(content)
             .send(result ->
             {
@@ -412,20 +412,20 @@ public class ServerTimeoutsTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testBlockingReadHttpIdleTimeoutOverridesIdleTimeout(Transport transport) throws Exception
+    public void testBlockingReadHttpIdleTimeoutOverridesIdleTimeout(TransportType transportType) throws Exception
     {
         long httpIdleTimeout = 2500;
         long idleTimeout = 3 * httpIdleTimeout;
         httpConfig.setIdleTimeout(httpIdleTimeout);
         CountDownLatch handlerLatch = new CountDownLatch(1);
-        start(transport, new BlockingReadServlet(handlerLatch));
+        start(transportType, new BlockingReadServlet(handlerLatch));
         setStreamIdleTimeout(idleTimeout);
 
         try (StacklessLogging ignore = new StacklessLogging(HttpChannelState.class))
         {
             AsyncRequestContent content = new AsyncRequestContent(ByteBuffer.allocate(1));
             CountDownLatch resultLatch = new CountDownLatch(1);
-            client.POST(newURI(transport))
+            client.POST(newURI(transportType))
                 .body(content)
                 .send(result ->
                 {
@@ -443,25 +443,25 @@ public class ServerTimeoutsTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncReadHttpIdleTimeoutOverridesIdleTimeoutIsReadyFirst(Transport transport) throws Exception
+    public void testAsyncReadHttpIdleTimeoutOverridesIdleTimeoutIsReadyFirst(TransportType transportType) throws Exception
     {
-        testAsyncReadHttpIdleTimeoutOverridesIdleTimeout(transport, true);
+        testAsyncReadHttpIdleTimeoutOverridesIdleTimeout(transportType, true);
     }
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncReadHttpIdleTimeoutOverridesIdleTimeoutReadFirst(Transport transport) throws Exception
+    public void testAsyncReadHttpIdleTimeoutOverridesIdleTimeoutReadFirst(TransportType transportType) throws Exception
     {
-        testAsyncReadHttpIdleTimeoutOverridesIdleTimeout(transport, false);
+        testAsyncReadHttpIdleTimeoutOverridesIdleTimeout(transportType, false);
     }
 
-    private void testAsyncReadHttpIdleTimeoutOverridesIdleTimeout(Transport transport, boolean isReadyFirst) throws Exception
+    private void testAsyncReadHttpIdleTimeoutOverridesIdleTimeout(TransportType transportType, boolean isReadyFirst) throws Exception
     {
         long httpIdleTimeout = 2000;
         long idleTimeout = 3 * httpIdleTimeout;
         httpConfig.setIdleTimeout(httpIdleTimeout);
         CountDownLatch handlerLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -503,7 +503,7 @@ public class ServerTimeoutsTest extends AbstractTest
 
         AsyncRequestContent content = new AsyncRequestContent(ByteBuffer.allocate(1));
         CountDownLatch resultLatch = new CountDownLatch(1);
-        client.POST(newURI(transport))
+        client.POST(newURI(transportType))
             .body(content)
             .send(result ->
             {
@@ -521,10 +521,10 @@ public class ServerTimeoutsTest extends AbstractTest
     @Disabled
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testIdleTimeoutBeforeReadIsIgnored(Transport transport) throws Exception
+    public void testIdleTimeoutBeforeReadIsIgnored(TransportType transportType) throws Exception
     {
         long idleTimeout = 1000;
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -550,7 +550,7 @@ public class ServerTimeoutsTest extends AbstractTest
         System.arraycopy(data, data1.length, data2, 0, data2.length);
         AsyncRequestContent content = new AsyncRequestContent(ByteBuffer.wrap(data1));
         CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .body(content)
             .send(new BufferingResponseListener()
             {
@@ -575,7 +575,7 @@ public class ServerTimeoutsTest extends AbstractTest
     @Disabled
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testBlockingWriteWithMinimumDataRateBelowLimit(Transport transport) throws Exception
+    public void testBlockingWriteWithMinimumDataRateBelowLimit(TransportType transportType) throws Exception
     {
         // This test needs a large write to stall the server, and a slow reading client.
         // In HTTP/1.1, when using the loopback interface, the buffers are so large that
@@ -588,12 +588,12 @@ public class ServerTimeoutsTest extends AbstractTest
         // In HTTP/2, we force the flow control window to be small, so that the server
         // stalls almost immediately without having written many bytes, so that the test
         // completes quickly.
-        assumeTrue(transport == Transport.H2C || transport == Transport.H2);
+        assumeTrue(transportType == TransportType.H2C || transportType == TransportType.H2);
 
         int bytesPerSecond = 16 * 1024;
         httpConfig.setMinResponseDataRate(bytesPerSecond);
         CountDownLatch serverLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response)
@@ -614,7 +614,7 @@ public class ServerTimeoutsTest extends AbstractTest
         // Setup the client to read slower than the min data rate.
         BlockingQueue<Object> objects = new LinkedBlockingQueue<>();
         CountDownLatch clientLatch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .onResponseContentAsync((response, chunk, demander) ->
             {
                 objects.offer(chunk.remaining());

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/VirtualThreadsTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/VirtualThreadsTest.java
@@ -47,13 +47,13 @@ public class VirtualThreadsTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transports")
-    public void testServletInvokedOnVirtualThread(Transport transport) throws Exception
+    public void testServletInvokedOnVirtualThread(TransportType transportType) throws Exception
     {
         // No virtual thread support in FCGI server-side.
-        Assumptions.assumeTrue(transport != Transport.FCGI);
+        Assumptions.assumeTrue(transportType != TransportType.FCGI);
 
         String virtualThreadsName = "green-";
-        prepareServer(transport, new HttpServlet()
+        prepareServer(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response)
@@ -71,24 +71,24 @@ public class VirtualThreadsTest extends AbstractTest
             ((VirtualThreads.Configurable)threadPool).setVirtualThreadsExecutor(virtualThreadsExecutor);
         }
         server.start();
-        startClient(transport);
+        startClient(transportType);
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .timeout(5, TimeUnit.SECONDS)
             .send();
 
-        assertEquals(HttpStatus.OK_200, response.getStatus(), " for transport " + transport);
+        assertEquals(HttpStatus.OK_200, response.getStatus(), " for transport " + transportType);
     }
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testServletCallbacksInvokedOnVirtualThread(Transport transport) throws Exception
+    public void testServletCallbacksInvokedOnVirtualThread(TransportType transportType) throws Exception
     {
         // No virtual thread support in FCGI server-side.
-        Assumptions.assumeTrue(transport != Transport.FCGI);
+        Assumptions.assumeTrue(transportType != TransportType.FCGI);
 
         byte[] data = new byte[2 * 1024 * 1024];
-        prepareServer(transport, new HttpServlet()
+        prepareServer(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -151,11 +151,11 @@ public class VirtualThreadsTest extends AbstractTest
         if (threadPool instanceof VirtualThreads.Configurable)
             ((VirtualThreads.Configurable)threadPool).setVirtualThreadsExecutor(VirtualThreads.getDefaultVirtualThreadsExecutor());
         server.start();
-        startClient(transport);
+        startClient(transportType);
 
         CountDownLatch latch = new CountDownLatch(1);
         AtomicInteger length = new AtomicInteger();
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(new StringRequestContent("hello"))
             .onResponseContent((response, content) -> length.addAndGet(content.remaining()))

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/ZippedRequestContentTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/ZippedRequestContentTest.java
@@ -43,9 +43,9 @@ public class ZippedRequestContentTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testZippedRequestContent(Transport transport) throws Exception
+    public void testZippedRequestContent(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest req, HttpServletResponse resp) throws IOException
@@ -71,7 +71,7 @@ public class ZippedRequestContentTest extends AbstractTest
 
         OutputStreamRequestContent content = new OutputStreamRequestContent();
         CompletableFuture<ContentResponse> completable = new CompletableResponseListener(
-            client.newRequest(newURI(transport))
+            client.newRequest(newURI(transportType))
                 .method(HttpMethod.POST)
                 .body(content)
         ).send();

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/AbstractTest.java
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/AbstractTest.java
@@ -84,7 +84,7 @@ public class AbstractTest
     {
         EnumSet<TransportType> transportTypes = EnumSet.allOf(TransportType.class);
         if ("ci".equals(System.getProperty("env")))
-            transportTypes.remove(TransportType.H3);
+            transportTypes.remove(TransportType.H3_QUICHE);
         return transportTypes;
     }
 
@@ -104,9 +104,9 @@ public class AbstractTest
 
     public static Collection<TransportType> transportsSecure()
     {
-        EnumSet<TransportType> transportTypes = EnumSet.of(TransportType.HTTPS, TransportType.H2, TransportType.H3);
+        EnumSet<TransportType> transportTypes = EnumSet.of(TransportType.HTTPS, TransportType.H2, TransportType.H3_QUICHE);
         if ("ci".equals(System.getProperty("env")))
-            transportTypes.remove(TransportType.H3);
+            transportTypes.remove(TransportType.H3_QUICHE);
         return transportTypes;
     }
 
@@ -203,7 +203,7 @@ public class AbstractTest
         {
             case HTTP, HTTPS, H2C, H2, FCGI ->
                 new ServerConnector(server, 1, 1, newServerConnectionFactory(transportType));
-            case H3 ->
+            case H3_QUICHE ->
                 new QuicServerConnector(server, serverQuicConfig, newServerConnectionFactory(transportType));
         };
     }
@@ -235,7 +235,7 @@ public class AbstractTest
                 SslConnectionFactory ssl = new SslConnectionFactory(sslContextFactoryServer, alpn.getProtocol());
                 yield List.of(ssl, alpn, h2);
             }
-            case H3 ->
+            case H3_QUICHE ->
             {
                 httpConfig.addCustomizer(new SecureRequestCustomizer());
                 httpConfig.addCustomizer(new HostHeaderCustomizer());
@@ -273,7 +273,7 @@ public class AbstractTest
                 HTTP2Client http2Client = new HTTP2Client(clientConnector);
                 yield new HttpClientTransportOverHTTP2(http2Client);
             }
-            case H3 ->
+            case H3_QUICHE ->
             {
                 ClientConnector clientConnector = new ClientConnector();
                 clientConnector.setSelectors(1);
@@ -315,14 +315,14 @@ public class AbstractTest
 
     public enum TransportType
     {
-        HTTP, HTTPS, H2C, H2, H3, FCGI;
+        HTTP, HTTPS, H2C, H2, H3_QUICHE, FCGI;
 
         public boolean isSecure()
         {
             return switch (this)
             {
                 case HTTP, H2C, FCGI -> false;
-                case HTTPS, H2, H3 -> true;
+                case HTTPS, H2, H3_QUICHE -> true;
             };
         }
 
@@ -331,7 +331,7 @@ public class AbstractTest
             return switch (this)
             {
                 case HTTP, HTTPS, FCGI -> false;
-                case H2C, H2, H3 -> true;
+                case H2C, H2, H3_QUICHE -> true;
             };
         }
     }

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/AsyncIOServletTest.java
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/AsyncIOServletTest.java
@@ -97,9 +97,9 @@ public class AsyncIOServletTest extends AbstractTest
     private static final ThreadLocal<RuntimeException> scope = new ThreadLocal<>();
 
     @Override
-    protected void prepareServer(Transport transport, HttpServlet servlet) throws Exception
+    protected void prepareServer(TransportType transportType, HttpServlet servlet) throws Exception
     {
-        super.prepareServer(transport, servlet);
+        super.prepareServer(transportType, servlet);
         // Add this listener before the context is started, so it's durable.
         servletContextHandler.addEventListener(new ContextHandler.ContextScopeListener()
         {
@@ -152,22 +152,22 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncReadThrowsException(Transport transport) throws Exception
+    public void testAsyncReadThrowsException(TransportType transportType) throws Exception
     {
-        testAsyncReadThrows(transport, new NullPointerException("explicitly_thrown_by_test"));
+        testAsyncReadThrows(transportType, new NullPointerException("explicitly_thrown_by_test"));
     }
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncReadThrowsError(Transport transport) throws Exception
+    public void testAsyncReadThrowsError(TransportType transportType) throws Exception
     {
-        testAsyncReadThrows(transport, new Error("explicitly_thrown_by_test"));
+        testAsyncReadThrows(transportType, new Error("explicitly_thrown_by_test"));
     }
 
-    private void testAsyncReadThrows(Transport transport, Throwable throwable) throws Exception
+    private void testAsyncReadThrows(TransportType transportType, Throwable throwable) throws Exception
     {
         CountDownLatch latch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -207,7 +207,7 @@ public class AsyncIOServletTest extends AbstractTest
             }
         });
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(new StringRequestContent("0123456789"))
             .timeout(5, TimeUnit.SECONDS)
@@ -219,10 +219,10 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncReadIdleTimeout(Transport transport) throws Exception
+    public void testAsyncReadIdleTimeout(TransportType transportType) throws Exception
     {
         int status = 567;
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -282,7 +282,7 @@ public class AsyncIOServletTest extends AbstractTest
         content.write(ByteBuffer.wrap(data.getBytes(StandardCharsets.UTF_8)), Callback.NOOP);
         CountDownLatch responseLatch = new CountDownLatch(1);
         CountDownLatch clientLatch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(content)
             .onResponseSuccess(r -> responseLatch.countDown())
@@ -294,7 +294,7 @@ public class AsyncIOServletTest extends AbstractTest
             });
 
         // HTTP/2 does not close a Connection when the request idle times out.
-        if (transport != Transport.H2C && transport != Transport.H2)
+        if (transportType != TransportType.H2C && transportType != TransportType.H2)
             assertTrue(closeLatch.await(5, TimeUnit.SECONDS), "close latch expired");
         assertTrue(responseLatch.await(5, TimeUnit.SECONDS), "response latch expired");
         content.close();
@@ -303,10 +303,10 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testOnErrorThrows(Transport transport) throws Exception
+    public void testOnErrorThrows(TransportType transportType) throws Exception
     {
         AtomicInteger errors = new AtomicInteger();
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -352,7 +352,7 @@ public class AsyncIOServletTest extends AbstractTest
 
         try (StacklessLogging ignore = new StacklessLogging(HttpChannelState.class))
         {
-            ContentResponse response = client.newRequest(newURI(transport))
+            ContentResponse response = client.newRequest(newURI(transportType))
                 .body(new StringRequestContent("0123456789"))
                 .timeout(5, TimeUnit.SECONDS)
                 .send();
@@ -364,22 +364,22 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncWriteThrowsException(Transport transport) throws Exception
+    public void testAsyncWriteThrowsException(TransportType transportType) throws Exception
     {
-        testAsyncWriteThrows(transport, new NullPointerException("explicitly_thrown_by_test"));
+        testAsyncWriteThrows(transportType, new NullPointerException("explicitly_thrown_by_test"));
     }
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncWriteThrowsError(Transport transport) throws Exception
+    public void testAsyncWriteThrowsError(TransportType transportType) throws Exception
     {
-        testAsyncWriteThrows(transport, new Error("explicitly_thrown_by_test"));
+        testAsyncWriteThrows(transportType, new Error("explicitly_thrown_by_test"));
     }
 
-    private void testAsyncWriteThrows(Transport transport, Throwable throwable) throws Exception
+    private void testAsyncWriteThrows(TransportType transportType, Throwable throwable) throws Exception
     {
         CountDownLatch latch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -412,7 +412,7 @@ public class AsyncIOServletTest extends AbstractTest
             }
         });
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .timeout(5, TimeUnit.SECONDS)
             .send();
 
@@ -422,12 +422,12 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncWriteClosed(Transport transport) throws Exception
+    public void testAsyncWriteClosed(TransportType transportType) throws Exception
     {
         byte[] data = new byte[1024];
 
         CountDownLatch errorLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -480,7 +480,7 @@ public class AsyncIOServletTest extends AbstractTest
         });
 
         CountDownLatch clientLatch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .onResponseHeaders(response ->
             {
                 if (response.getStatus() == HttpStatus.OK_200)
@@ -498,10 +498,10 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncWriteLessThanContentLengthFlushed(Transport transport) throws Exception
+    public void testAsyncWriteLessThanContentLengthFlushed(TransportType transportType) throws Exception
     {
         CountDownLatch complete = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -569,7 +569,7 @@ public class AsyncIOServletTest extends AbstractTest
 
         AtomicBoolean failed = new AtomicBoolean(false);
         CountDownLatch clientLatch = new CountDownLatch(3);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .onResponseHeaders(response ->
             {
                 if (response.getStatus() == HttpStatus.OK_200)
@@ -593,12 +593,12 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testIsReadyAtEOF(Transport transport) throws Exception
+    public void testIsReadyAtEOF(TransportType transportType) throws Exception
     {
         String text = "TEST\n";
         byte[] data = text.getBytes(StandardCharsets.UTF_8);
 
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -652,7 +652,7 @@ public class AsyncIOServletTest extends AbstractTest
             }
         });
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .headers(headers -> headers.put(HttpHeader.CONNECTION, HttpHeaderValue.CLOSE))
             .body(new StringRequestContent(text))
@@ -665,10 +665,10 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testOnAllDataRead(Transport transport) throws Exception
+    public void testOnAllDataRead(TransportType transportType) throws Exception
     {
         String success = "SUCCESS";
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -734,7 +734,7 @@ public class AsyncIOServletTest extends AbstractTest
                 return data.length;
             }
         };
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(content)
             .timeout(5, TimeUnit.SECONDS)
@@ -762,10 +762,10 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testOtherThreadOnAllDataRead(Transport transport) throws Exception
+    public void testOtherThreadOnAllDataRead(TransportType transportType) throws Exception
     {
         String success = "SUCCESS";
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -838,7 +838,7 @@ public class AsyncIOServletTest extends AbstractTest
         byte[] data = "X".getBytes(StandardCharsets.UTF_8);
         CountDownLatch clientLatch = new CountDownLatch(1);
         AsyncRequestContent content = new AsyncRequestContent();
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(content)
             .timeout(5, TimeUnit.SECONDS)
@@ -866,11 +866,11 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testCompleteBeforeOnAllDataRead(Transport transport) throws Exception
+    public void testCompleteBeforeOnAllDataRead(TransportType transportType) throws Exception
     {
         String success = "SUCCESS";
 
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -918,7 +918,7 @@ public class AsyncIOServletTest extends AbstractTest
             }
         });
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .headers(headers -> headers.put(HttpHeader.CONNECTION, HttpHeaderValue.CLOSE))
             .body(new StringRequestContent("XYZ"))
@@ -931,12 +931,12 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testEmptyAsyncRead(Transport transport) throws Exception
+    public void testEmptyAsyncRead(TransportType transportType) throws Exception
     {
         AtomicBoolean oda = new AtomicBoolean();
         CountDownLatch latch = new CountDownLatch(1);
 
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -973,7 +973,7 @@ public class AsyncIOServletTest extends AbstractTest
             }
         });
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.CONNECTION, HttpHeaderValue.CLOSE))
             .timeout(5, TimeUnit.SECONDS)
             .send();
@@ -986,11 +986,11 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testWriteFromOnDataAvailable(Transport transport) throws Exception
+    public void testWriteFromOnDataAvailable(TransportType transportType) throws Exception
     {
         Queue<Throwable> errors = new ConcurrentLinkedQueue<>();
         CountDownLatch writeLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -1052,7 +1052,7 @@ public class AsyncIOServletTest extends AbstractTest
         AsyncRequestContent requestContent = new AsyncRequestContent();
         requestContent.write(ByteBuffer.wrap(content.getBytes(StandardCharsets.UTF_8)), Callback.NOOP);
         CountDownLatch clientLatch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(requestContent)
             .send(new BufferingResponseListener()
@@ -1081,19 +1081,19 @@ public class AsyncIOServletTest extends AbstractTest
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
     @Disabled // TODO Cannot write response from onError as failure has occurred
-    public void testAsyncReadEarlyEOF(Transport transport) throws Exception
+    public void testAsyncReadEarlyEOF(TransportType transportType) throws Exception
     {
         // SSLEngine receives the close alert from the client, and when
         // the server passes the response to encrypt and write, SSLEngine
         // only generates the close alert back, without encrypting the
         // response, so we need to skip the transports over TLS.
-        Assumptions.assumeFalse(transport.isSecure());
+        Assumptions.assumeFalse(transportType.isSecure());
 
         String content = "jetty";
         int responseCode = HttpStatus.NO_CONTENT_204;
         CountDownLatch readLatch = new CountDownLatch(content.length());
         CountDownLatch errorLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -1131,17 +1131,17 @@ public class AsyncIOServletTest extends AbstractTest
         CountDownLatch responseLatch = new CountDownLatch(1);
         AsyncRequestContent requestContent = new AsyncRequestContent();
         requestContent.write(ByteBuffer.wrap(content.getBytes(StandardCharsets.UTF_8)), Callback.NOOP);
-        var request = client.newRequest(newURI(transport))
+        var request = client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(requestContent)
             .onResponseSuccess(response ->
             {
-                if (transport == Transport.HTTP)
+                if (transportType == TransportType.HTTP)
                     responseLatch.countDown();
             })
             .onResponseFailure((response, failure) ->
             {
-                if (transport == Transport.H2C)
+                if (transportType == TransportType.H2C)
                     responseLatch.countDown();
             });
 
@@ -1152,7 +1152,7 @@ public class AsyncIOServletTest extends AbstractTest
         CountDownLatch clientLatch = new CountDownLatch(1);
         connection.send(request, result ->
         {
-            switch (transport)
+            switch (transportType)
             {
                 case HTTP:
                     assertThat(result.getResponse().getStatus(), Matchers.equalTo(responseCode));
@@ -1162,14 +1162,14 @@ public class AsyncIOServletTest extends AbstractTest
                     assertTrue(result.isFailed());
                     break;
                 default:
-                    fail("Unhandled transport: " + transport);
+                    fail("Unhandled transport: " + transportType);
             }
             clientLatch.countDown();
         });
 
         assertTrue(readLatch.await(5, TimeUnit.SECONDS));
 
-        switch (transport)
+        switch (transportType)
         {
             case HTTP:
                 ((HttpConnectionOverHTTP)connection).getEndPoint().shutdownOutput();
@@ -1183,7 +1183,7 @@ public class AsyncIOServletTest extends AbstractTest
                 ((HTTP2Session)session).getEndPoint().shutdownOutput();
                 break;
             default:
-                fail("Unhandled transport: " + transport);
+                fail("Unhandled transport: " + transportType);
         }
 
         // Wait for the response to arrive before finishing the request.
@@ -1196,12 +1196,12 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testAsyncReadEcho(Transport transport) throws Exception
+    public void testAsyncReadEcho(TransportType transportType) throws Exception
     {
         // TODO: investigate why H3 does not work.
-        Assumptions.assumeTrue(transport != Transport.H3);
+        Assumptions.assumeTrue(transportType != TransportType.H3);
 
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -1243,7 +1243,7 @@ public class AsyncIOServletTest extends AbstractTest
         CountDownLatch clientLatch = new CountDownLatch(1);
 
         AtomicReference<Result> resultRef = new AtomicReference<>();
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(contentProvider)
             .send(new BufferingResponseListener(16 * 1024 * 1024)
@@ -1269,9 +1269,9 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testWriteListenerFromOtherThread(Transport transport) throws Exception
+    public void testWriteListenerFromOtherThread(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -1294,7 +1294,7 @@ public class AsyncIOServletTest extends AbstractTest
                 {
                     try
                     {
-                        ContentResponse response = client.newRequest(newURI(transport))
+                        ContentResponse response = client.newRequest(newURI(transportType))
                             .method(HttpMethod.POST)
                             .body(new InputStreamRequestContent(new ByteArrayInputStream(new byte[16 * 1024])
                             {
@@ -1326,11 +1326,11 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testClientDefersContentServerIdleTimeout(Transport transport) throws Exception
+    public void testClientDefersContentServerIdleTimeout(TransportType transportType) throws Exception
     {
         CountDownLatch dataLatch = new CountDownLatch(1);
         CountDownLatch errorLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -1374,7 +1374,7 @@ public class AsyncIOServletTest extends AbstractTest
                 return bytes.length;
             }
         };
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(content)
             .onResponseSuccess(response ->
@@ -1397,11 +1397,11 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testOnAllDataReadCalledOnceThenIdleTimeout(Transport transport) throws Exception
+    public void testOnAllDataReadCalledOnceThenIdleTimeout(TransportType transportType) throws Exception
     {
         AtomicInteger allDataReadCount = new AtomicInteger();
         AtomicReference<Throwable> errorRef = new AtomicReference<>();
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse resp) throws IOException
@@ -1447,7 +1447,7 @@ public class AsyncIOServletTest extends AbstractTest
         connector.setIdleTimeout(2 * idleTimeout);
         setStreamIdleTimeout(idleTimeout);
 
-        assertThrows(TimeoutException.class, () -> client.newRequest(newURI(transport))
+        assertThrows(TimeoutException.class, () -> client.newRequest(newURI(transportType))
             .timeout(2 * idleTimeout, TimeUnit.MILLISECONDS)
             .send()
         );
@@ -1458,11 +1458,11 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testIsReadyIdempotent(Transport transport) throws Exception
+    public void testIsReadyIdempotent(TransportType transportType) throws Exception
     {
         CountDownLatch bodyLatch = new CountDownLatch(1);
         CountDownLatch dataLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -1514,7 +1514,7 @@ public class AsyncIOServletTest extends AbstractTest
         });
 
         AsyncRequestContent body = new AsyncRequestContent();
-        var request = client.newRequest(newURI(transport))
+        var request = client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(body)
             .timeout(15, TimeUnit.SECONDS);

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/AsyncIOServletTest.java
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/AsyncIOServletTest.java
@@ -1199,7 +1199,7 @@ public class AsyncIOServletTest extends AbstractTest
     public void testAsyncReadEcho(TransportType transportType) throws Exception
     {
         // TODO: investigate why H3 does not work.
-        Assumptions.assumeTrue(transportType != TransportType.H3);
+        Assumptions.assumeTrue(transportType != TransportType.H3_QUICHE);
 
         start(transportType, new HttpServlet()
         {

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/BlockedIOTest.java
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/BlockedIOTest.java
@@ -48,14 +48,14 @@ public class BlockedIOTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transports")
-    public void testBlockingReadThenNormalComplete(Transport transport) throws Exception
+    public void testBlockingReadThenNormalComplete(TransportType transportType) throws Exception
     {
         CountDownLatch started = new CountDownLatch(1);
         CountDownLatch stopped = new CountDownLatch(1);
         AtomicReference<Throwable> readException = new AtomicReference<>();
         AtomicReference<Throwable> reReadException = new AtomicReference<>();
 
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
@@ -114,7 +114,7 @@ public class BlockedIOTest extends AbstractTest
 
         AsyncRequestContent requestContent = new AsyncRequestContent();
         CountDownLatch ok = new CountDownLatch(2);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method("POST")
             .body(requestContent)
             .onResponseContent((response, content) ->

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/HttpClientContinueTest.java
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/HttpClientContinueTest.java
@@ -71,21 +71,21 @@ public class HttpClientContinueTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithOneContentRespond100Continue(Transport transport) throws Exception
+    public void testExpect100ContinueWithOneContentRespond100Continue(TransportType transportType) throws Exception
     {
-        testExpect100ContinueRespond100Continue(transport, "data1".getBytes(StandardCharsets.UTF_8));
+        testExpect100ContinueRespond100Continue(transportType, "data1".getBytes(StandardCharsets.UTF_8));
     }
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithMultipleContentsRespond100Continue(Transport transport) throws Exception
+    public void testExpect100ContinueWithMultipleContentsRespond100Continue(TransportType transportType) throws Exception
     {
-        testExpect100ContinueRespond100Continue(transport, "data1".getBytes(StandardCharsets.UTF_8), "data2".getBytes(StandardCharsets.UTF_8), "data3".getBytes(StandardCharsets.UTF_8));
+        testExpect100ContinueRespond100Continue(transportType, "data1".getBytes(StandardCharsets.UTF_8), "data2".getBytes(StandardCharsets.UTF_8), "data3".getBytes(StandardCharsets.UTF_8));
     }
 
-    private void testExpect100ContinueRespond100Continue(Transport transport, byte[]... contents) throws Exception
+    private void testExpect100ContinueRespond100Continue(TransportType transportType, byte[]... contents) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -95,7 +95,7 @@ public class HttpClientContinueTest extends AbstractTest
             }
         });
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
             .body(new BytesRequestContent(contents))
             .timeout(5, TimeUnit.SECONDS)
@@ -117,13 +117,13 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithMultipleContentsRespond100ContinueBlocking(Transport transport) throws Exception
+    public void testExpect100ContinueWithMultipleContentsRespond100ContinueBlocking(TransportType transportType) throws Exception
     {
         byte[][] contents = new byte[][]{
             "data1".getBytes(StandardCharsets.UTF_8), "data2".getBytes(StandardCharsets.UTF_8), "data3".getBytes(StandardCharsets.UTF_8)
         };
         AtomicReference<Thread> readerThreadRef = new AtomicReference<>();
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -161,7 +161,7 @@ public class HttpClientContinueTest extends AbstractTest
                     }
                 }
             }).start();
-            response = client.newRequest(newURI(transport))
+            response = client.newRequest(newURI(transportType))
                 .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
                 .body(content)
                 .timeout(5, TimeUnit.SECONDS)
@@ -185,9 +185,9 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithChunkedContentRespond100Continue(Transport transport) throws Exception
+    public void testExpect100ContinueWithChunkedContentRespond100Continue(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -202,7 +202,7 @@ public class HttpClientContinueTest extends AbstractTest
 
         byte[] content1 = new byte[10240];
         byte[] content2 = new byte[16384];
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
             .body(new BytesRequestContent(content1, content2)
             {
@@ -217,7 +217,7 @@ public class HttpClientContinueTest extends AbstractTest
 
         assertNotNull(response);
         assertEquals(200, response.getStatus());
-        if (EnumSet.of(Transport.HTTP, Transport.HTTPS).contains(transport))
+        if (EnumSet.of(TransportType.HTTP, TransportType.HTTPS).contains(transportType))
             assertTrue(response.getHeaders().contains(HttpHeader.TRANSFER_ENCODING, "chunked"));
 
         int index = 0;
@@ -234,21 +234,21 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithContentRespond417ExpectationFailed(Transport transport) throws Exception
+    public void testExpect100ContinueWithContentRespond417ExpectationFailed(TransportType transportType) throws Exception
     {
-        testExpect100ContinueWithContentRespondError(transport, 417);
+        testExpect100ContinueWithContentRespondError(transportType, 417);
     }
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithContentRespond413RequestEntityTooLarge(Transport transport) throws Exception
+    public void testExpect100ContinueWithContentRespond413RequestEntityTooLarge(TransportType transportType) throws Exception
     {
-        testExpect100ContinueWithContentRespondError(transport, 413);
+        testExpect100ContinueWithContentRespondError(transportType, 413);
     }
 
-    private void testExpect100ContinueWithContentRespondError(Transport transport, int error) throws Exception
+    private void testExpect100ContinueWithContentRespondError(TransportType transportType, int error) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -260,7 +260,7 @@ public class HttpClientContinueTest extends AbstractTest
         byte[] content1 = new byte[10240];
         byte[] content2 = new byte[16384];
         CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
             .body(new BytesRequestContent(content1, content2))
             .send(new BufferingResponseListener()
@@ -291,10 +291,10 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithContentWithRedirect(Transport transport) throws Exception
+    public void testExpect100ContinueWithContentWithRedirect(TransportType transportType) throws Exception
     {
         String data = "success";
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -315,7 +315,7 @@ public class HttpClientContinueTest extends AbstractTest
 
         byte[] content = new byte[10240];
         CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .path("/continue")
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
@@ -337,12 +337,12 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testRedirectWithExpect100ContinueWithContent(Transport transport) throws Exception
+    public void testRedirectWithExpect100ContinueWithContent(TransportType transportType) throws Exception
     {
         // A request with Expect: 100-Continue cannot receive non-final responses like 3xx
 
         String data = "success";
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -363,7 +363,7 @@ public class HttpClientContinueTest extends AbstractTest
 
         byte[] content = new byte[10240];
         CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .path("/redirect")
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
@@ -386,13 +386,13 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithContentWithResponseFailureBefore100Continue(Transport transport) throws Exception
+    public void testExpect100ContinueWithContentWithResponseFailureBefore100Continue(TransportType transportType) throws Exception
     {
         AtomicReference<Request> clientRequestRef = new AtomicReference<>();
         CountDownLatch clientLatch = new CountDownLatch(1);
         CountDownLatch serverLatch = new CountDownLatch(1);
 
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException
@@ -412,7 +412,7 @@ public class HttpClientContinueTest extends AbstractTest
         });
 
         byte[] content = new byte[1024];
-        Request clientRequest = client.newRequest(newURI(transport));
+        Request clientRequest = client.newRequest(newURI(transportType));
         clientRequestRef.set(clientRequest);
         clientRequest
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
@@ -435,12 +435,12 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithContentWithResponseFailureAfter100Continue(Transport transport) throws Exception
+    public void testExpect100ContinueWithContentWithResponseFailureAfter100Continue(TransportType transportType) throws Exception
     {
         AtomicReference<Request> clientRequestRef = new AtomicReference<>();
         CountDownLatch clientLatch = new CountDownLatch(1);
         CountDownLatch serverLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
@@ -462,7 +462,7 @@ public class HttpClientContinueTest extends AbstractTest
         });
 
         byte[] content = new byte[1024];
-        Request clientRequest = client.newRequest(newURI(transport));
+        Request clientRequest = client.newRequest(newURI(transportType));
         clientRequestRef.set(clientRequest);
         clientRequest
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
@@ -485,9 +485,9 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithContentWithResponseFailureDuring100Continue(Transport transport) throws Exception
+    public void testExpect100ContinueWithContentWithResponseFailureDuring100Continue(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -523,7 +523,7 @@ public class HttpClientContinueTest extends AbstractTest
 
         byte[] content = new byte[1024];
         CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
             .body(new BytesRequestContent(content))
             .send(new BufferingResponseListener()
@@ -543,7 +543,7 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithDeferredContentRespond100Continue(Transport transport) throws Exception
+    public void testExpect100ContinueWithDeferredContentRespond100Continue(TransportType transportType) throws Exception
     {
         byte[] chunk1 = new byte[]{0, 1, 2, 3};
         byte[] chunk2 = new byte[]{4, 5, 6, 7};
@@ -553,7 +553,7 @@ public class HttpClientContinueTest extends AbstractTest
 
         CountDownLatch serverLatch = new CountDownLatch(1);
         AtomicReference<Thread> handlerThread = new AtomicReference<>();
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -575,7 +575,7 @@ public class HttpClientContinueTest extends AbstractTest
 
         CountDownLatch requestLatch = new CountDownLatch(1);
         AsyncRequestContent content = new AsyncRequestContent();
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
             .body(content)
             .send(new BufferingResponseListener()
@@ -613,10 +613,10 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithInitialAndDeferredContentRespond100Continue(Transport transport) throws Exception
+    public void testExpect100ContinueWithInitialAndDeferredContentRespond100Continue(TransportType transportType) throws Exception
     {
         AtomicReference<Thread> handlerThread = new AtomicReference<>();
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -635,7 +635,7 @@ public class HttpClientContinueTest extends AbstractTest
 
         CountDownLatch latch = new CountDownLatch(1);
         AsyncRequestContent content = new AsyncRequestContent(ByteBuffer.wrap(chunk1));
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
             .body(content)
             .send(new BufferingResponseListener()
@@ -663,9 +663,9 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithConcurrentDeferredContentRespond100Continue(Transport transport) throws Exception
+    public void testExpect100ContinueWithConcurrentDeferredContentRespond100Continue(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -679,7 +679,7 @@ public class HttpClientContinueTest extends AbstractTest
         AsyncRequestContent content = new AsyncRequestContent();
 
         CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
             .onRequestHeaders(request ->
             {
@@ -702,9 +702,9 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithInitialAndConcurrentDeferredContentRespond100Continue(Transport transport) throws Exception
+    public void testExpect100ContinueWithInitialAndConcurrentDeferredContentRespond100Continue(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -741,7 +741,7 @@ public class HttpClientContinueTest extends AbstractTest
         });
 
         CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
             .body(content)
             .send(new BufferingResponseListener()
@@ -759,12 +759,12 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void test100ContinueThenTimeoutThenSendError(Transport transport) throws Exception
+    public void test100ContinueThenTimeoutThenSendError(TransportType transportType) throws Exception
     {
         long idleTimeout = 1000;
 
         CountDownLatch serverLatch = new CountDownLatch(1);
-        startServer(transport, new HttpServlet()
+        startServer(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -785,12 +785,12 @@ public class HttpClientContinueTest extends AbstractTest
                 }
             }
         });
-        startClient(transport, httpClient -> httpClient.setIdleTimeout(idleTimeout));
+        startClient(transportType, httpClient -> httpClient.setIdleTimeout(idleTimeout));
 
         AsyncRequestContent requestContent = new AsyncRequestContent();
         requestContent.write(ByteBuffer.wrap(new byte[512]), Callback.NOOP);
         CountDownLatch clientLatch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE.asString()))
             .body(requestContent)
             .send(result ->
@@ -813,7 +813,7 @@ public class HttpClientContinueTest extends AbstractTest
         // and immediately after with the "normal" response, say a 200 OK.
         // These may be read by the client in a single read, and must be handled correctly.
 
-        startClient(Transport.HTTP);
+        startClient(TransportType.HTTP);
 
         try (ServerSocket server = new ServerSocket())
         {
@@ -866,9 +866,9 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithContentLengthZeroExpectIsRemoved(Transport transport) throws Exception
+    public void testExpect100ContinueWithContentLengthZeroExpectIsRemoved(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response)
@@ -879,7 +879,7 @@ public class HttpClientContinueTest extends AbstractTest
             }
         });
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE.asString()))
             .body(new StringRequestContent(""))
             .timeout(5, TimeUnit.SECONDS)
@@ -891,7 +891,7 @@ public class HttpClientContinueTest extends AbstractTest
     @Test
     public void testExpect100ContinueWithContentLengthZero() throws Exception
     {
-        startServer(Transport.HTTP, new HttpServlet()
+        startServer(TransportType.HTTP, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -925,7 +925,7 @@ public class HttpClientContinueTest extends AbstractTest
     @Test
     public void testNoExpectRespond100Continue() throws Exception
     {
-        startClient(Transport.HTTP);
+        startClient(TransportType.HTTP);
         client.setMaxConnectionsPerDestination(1);
 
         try (ServerSocket server = new ServerSocket())
@@ -969,7 +969,7 @@ public class HttpClientContinueTest extends AbstractTest
     @Test
     public void testNoExpect100ContinueThen100ContinueThenRedirectThen100ContinueThenResponse() throws Exception
     {
-        startClient(Transport.HTTP);
+        startClient(TransportType.HTTP);
         client.setMaxConnectionsPerDestination(1);
 
         try (ServerSocket server = new ServerSocket())

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/HttpTrailersTest.java
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/HttpTrailersTest.java
@@ -51,23 +51,23 @@ public class HttpTrailersTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testRequestTrailersNoContent(Transport transport) throws Exception
+    public void testRequestTrailersNoContent(TransportType transportType) throws Exception
     {
-        testRequestTrailers(transport, null);
+        testRequestTrailers(transportType, null);
     }
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testRequestTrailersWithContent(Transport transport) throws Exception
+    public void testRequestTrailersWithContent(TransportType transportType) throws Exception
     {
-        testRequestTrailers(transport, "abcdefghijklmnopqrstuvwxyz".getBytes(StandardCharsets.UTF_8));
+        testRequestTrailers(transportType, "abcdefghijklmnopqrstuvwxyz".getBytes(StandardCharsets.UTF_8));
     }
 
-    private void testRequestTrailers(Transport transport, byte[] content) throws Exception
+    private void testRequestTrailers(TransportType transportType, byte[] content) throws Exception
     {
         String trailerName = "Trailer";
         String trailerValue = "value";
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -92,7 +92,7 @@ public class HttpTrailersTest extends AbstractTest
 
         HttpFields trailers = HttpFields.build().put(trailerName, trailerValue).asImmutable();
 
-        Request request = client.newRequest(newURI(transport))
+        Request request = client.newRequest(newURI(transportType))
             .trailersSupplier(() -> trailers);
         if (content != null)
             request.method(HttpMethod.POST).body(new BytesRequestContent(content));
@@ -102,9 +102,9 @@ public class HttpTrailersTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testEmptyRequestTrailers(Transport transport) throws Exception
+    public void testEmptyRequestTrailers(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -128,7 +128,7 @@ public class HttpTrailersTest extends AbstractTest
         });
 
         HttpFields trailers = HttpFields.EMPTY;
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .trailersSupplier(() -> trailers)
             .timeout(5, TimeUnit.SECONDS)
             .send();
@@ -137,24 +137,24 @@ public class HttpTrailersTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testResponseTrailersNoContent(Transport transport) throws Exception
+    public void testResponseTrailersNoContent(TransportType transportType) throws Exception
     {
-        testResponseTrailers(transport, null);
+        testResponseTrailers(transportType, null);
     }
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testResponseTrailersWithContent(Transport transport) throws Exception
+    public void testResponseTrailersWithContent(TransportType transportType) throws Exception
     {
-        testResponseTrailers(transport, "abcdefghijklmnopqrstuvwxyz".getBytes(StandardCharsets.UTF_8));
+        testResponseTrailers(transportType, "abcdefghijklmnopqrstuvwxyz".getBytes(StandardCharsets.UTF_8));
     }
 
-    private void testResponseTrailers(Transport transport, byte[] content) throws Exception
+    private void testResponseTrailers(TransportType transportType, byte[] content) throws Exception
     {
         AtomicBoolean firstRequest = new AtomicBoolean();
         String trailerName = "Trailer";
         String trailerValue = "value";
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -172,7 +172,7 @@ public class HttpTrailersTest extends AbstractTest
         });
 
         AtomicReference<Throwable> failure = new AtomicReference<>(new Throwable("no_success"));
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .onResponseSuccess(r ->
             {
                 try
@@ -193,7 +193,7 @@ public class HttpTrailersTest extends AbstractTest
         assertNull(failure.get());
 
         // Subsequent requests should not have trailers.
-        response = client.newRequest(newURI(transport))
+        response = client.newRequest(newURI(transportType))
             .onResponseSuccess(r ->
             {
                 try
@@ -214,9 +214,9 @@ public class HttpTrailersTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testEmptyResponseTrailers(Transport transport) throws Exception
+    public void testEmptyResponseTrailers(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response)
@@ -226,7 +226,7 @@ public class HttpTrailersTest extends AbstractTest
         });
 
         AtomicReference<Throwable> failure = new AtomicReference<>(new Throwable("no_success"));
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .onResponseSuccess(r ->
             {
                 try
@@ -248,13 +248,13 @@ public class HttpTrailersTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testResponseTrailersWithLargeContent(Transport transport) throws Exception
+    public void testResponseTrailersWithLargeContent(TransportType transportType) throws Exception
     {
         byte[] content = new byte[1024 * 1024];
         new Random().nextBytes(content);
         String trailerName = "Digest";
         String trailerValue = "0xCAFEBABE";
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -269,7 +269,7 @@ public class HttpTrailersTest extends AbstractTest
         });
 
         InputStreamResponseListener listener = new InputStreamResponseListener();
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .timeout(15, TimeUnit.SECONDS)
             .send(listener);
         Response response = listener.get(5, TimeUnit.SECONDS);
@@ -299,9 +299,9 @@ public class HttpTrailersTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testResponseResetAlsoResetsTrailers(Transport transport) throws Exception
+    public void testResponseResetAlsoResetsTrailers(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -322,7 +322,7 @@ public class HttpTrailersTest extends AbstractTest
         });
 
         CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .timeout(5, TimeUnit.SECONDS)
             .send(result ->
             {

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/InformationalResponseTest.java
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/InformationalResponseTest.java
@@ -37,9 +37,9 @@ public class InformationalResponseTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void test102Processing(Transport transport) throws Exception
+    public void test102Processing(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -64,7 +64,7 @@ public class InformationalResponseTest extends AbstractTest
                 completeLatch.countDown();
             }
         };
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method("GET")
             .timeout(10, TimeUnit.SECONDS)
             .send(listener);
@@ -76,9 +76,9 @@ public class InformationalResponseTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void test103EarlyHint(Transport transport) throws Exception
+    public void test103EarlyHint(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -106,7 +106,7 @@ public class InformationalResponseTest extends AbstractTest
                 complete.countDown();
             }
         };
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method("GET")
             .timeout(5, TimeUnit.SECONDS)
             .send(listener);

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/NeedClientAuthTest.java
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/NeedClientAuthTest.java
@@ -30,9 +30,9 @@ public class NeedClientAuthTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transportsSecure")
-    public void testNeedClientAuth(Transport transport) throws Exception
+    public void testNeedClientAuth(TransportType transportType) throws Exception
     {
-        prepareServer(transport, new HttpServlet()
+        prepareServer(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response)
@@ -44,7 +44,7 @@ public class NeedClientAuthTest extends AbstractTest
         sslContextFactoryServer.setNeedClientAuth(true);
         server.start();
 
-        startClient(transport, httpClient ->
+        startClient(transportType, httpClient ->
         {
             // Configure the SslContextFactory to send a certificate to the server.
             SslContextFactory.Client clientSSL = httpClient.getSslContextFactory();
@@ -53,7 +53,7 @@ public class NeedClientAuthTest extends AbstractTest
             clientSSL.setCertAlias("mykey");
         });
 
-        ContentResponse response = client.newRequest(newURI(transport)).send();
+        ContentResponse response = client.newRequest(newURI(transportType)).send();
 
         assertEquals(HttpStatus.OK_200, response.getStatus());
     }

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/PushedResourcesTest.java
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/PushedResourcesTest.java
@@ -39,7 +39,7 @@ public class PushedResourcesTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transportsWithPushSupport")
-    public void testPushedResources(Transport transport) throws Exception
+    public void testPushedResources(TransportType transportType) throws Exception
     {
         Random random = new Random();
         byte[] bytes = new byte[512];
@@ -51,7 +51,7 @@ public class PushedResourcesTest extends AbstractTest
 
         String path1 = "/secondary1";
         String path2 = "/secondary2";
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -93,7 +93,7 @@ public class PushedResourcesTest extends AbstractTest
 
         CountDownLatch latch1 = new CountDownLatch(1);
         CountDownLatch latch2 = new CountDownLatch(1);
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .headers(h -> h.add("Cookie", "C0=toBeRemoved"))
             .onPush((mainRequest, pushedRequest) -> new BufferingResponseListener()
             {
@@ -124,7 +124,7 @@ public class PushedResourcesTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsWithPushSupport")
-    public void testPushedResourceRedirect(Transport transport) throws Exception
+    public void testPushedResourceRedirect(TransportType transportType) throws Exception
     {
         Random random = new Random();
         byte[] pushBytes = new byte[512];
@@ -132,7 +132,7 @@ public class PushedResourcesTest extends AbstractTest
 
         String oldPath = "/old";
         String newPath = "/new";
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -149,7 +149,7 @@ public class PushedResourcesTest extends AbstractTest
 
         CountDownLatch latch = new CountDownLatch(1);
         ;
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .onPush((mainRequest, pushedRequest) -> new BufferingResponseListener()
             {
                 @Override

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/RequestReaderTest.java
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/RequestReaderTest.java
@@ -55,10 +55,10 @@ public class RequestReaderTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transports")
-    public void testChannelStateSucceeded(Transport transport) throws Exception
+    public void testChannelStateSucceeded(TransportType transportType) throws Exception
     {
         CountDownLatch servletDoneLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -141,7 +141,7 @@ public class RequestReaderTest extends AbstractTest
         AtomicReference<Result> resultRef = new AtomicReference<>();
         try (AsyncRequestContent content = new AsyncRequestContent())
         {
-            Request request = client.newRequest(newURI(transport))
+            Request request = client.newRequest(newURI(transportType))
                 .method("POST")
                 .timeout(5, TimeUnit.SECONDS)
                 .body(content);
@@ -158,14 +158,14 @@ public class RequestReaderTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testResetArrivingOnServer(Transport transport) throws Exception
+    public void testResetArrivingOnServer(TransportType transportType) throws Exception
     {
-        assumeTrue(transport.isMultiplexed());
+        assumeTrue(transportType.isMultiplexed());
 
         CountDownLatch servletOnDataAvailableLatch = new CountDownLatch(1);
         AtomicReference<Throwable> serverError = new AtomicReference<>();
         CountDownLatch errorDoneLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -223,7 +223,7 @@ public class RequestReaderTest extends AbstractTest
         AtomicReference<Result> resultRef = new AtomicReference<>();
         try (AsyncRequestContent content = new AsyncRequestContent(ByteBuffer.allocate(16)))
         {
-            Request request = client.newRequest(newURI(transport))
+            Request request = client.newRequest(newURI(transportType))
                 .method("POST")
                 .timeout(5, TimeUnit.SECONDS)
                 .body(content);
@@ -244,9 +244,9 @@ public class RequestReaderTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testRecyclingWhenUsingReader(Transport transport) throws Exception
+    public void testRecyclingWhenUsingReader(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
@@ -264,7 +264,7 @@ public class RequestReaderTest extends AbstractTest
             }
         });
 
-        ContentResponse response1 = client.newRequest(newURI(transport))
+        ContentResponse response1 = client.newRequest(newURI(transportType))
             .method("POST")
             .timeout(5, TimeUnit.SECONDS)
             .body(new BytesRequestContent(new byte[512]))
@@ -272,7 +272,7 @@ public class RequestReaderTest extends AbstractTest
         assertThat(response1.getStatus(), is(HttpStatus.OK_200));
 
         // Send a 2nd request to make sure recycling works.
-        ContentResponse response2 = client.newRequest(newURI(transport))
+        ContentResponse response2 = client.newRequest(newURI(transportType))
             .method("POST")
             .timeout(5, TimeUnit.SECONDS)
             .body(new BytesRequestContent(new byte[512]))

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/ServerTimeoutsTest.java
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/ServerTimeoutsTest.java
@@ -62,7 +62,7 @@ public class ServerTimeoutsTest extends AbstractTest
     @MethodSource("transportsNoFCGI")
     public void testBlockingReadWithDelayedFirstContentWithUndelayedDispatchIdleTimeoutFires(TransportType transportType) throws Exception
     {
-        assumeTrue(transportType != TransportType.H3 && transportType != TransportType.H2C && transportType != TransportType.H2); // TODO Fix
+        assumeTrue(transportType != TransportType.H3_QUICHE && transportType != TransportType.H2C && transportType != TransportType.H2); // TODO Fix
         testBlockingReadWithDelayedFirstContentIdleTimeoutFires(transportType, false);
     }
 
@@ -70,7 +70,7 @@ public class ServerTimeoutsTest extends AbstractTest
     @MethodSource("transportsNoFCGI")
     public void testBlockingReadWithDelayedFirstContentWithDelayedDispatchIdleTimeoutFires(TransportType transportType) throws Exception
     {
-        assumeTrue(transportType != TransportType.H3 && transportType != TransportType.H2C && transportType != TransportType.H2); // TODO Fix
+        assumeTrue(transportType != TransportType.H3_QUICHE && transportType != TransportType.H2C && transportType != TransportType.H2); // TODO Fix
         testBlockingReadWithDelayedFirstContentIdleTimeoutFires(transportType, true);
     }
 
@@ -242,7 +242,7 @@ public class ServerTimeoutsTest extends AbstractTest
     public void testAsyncWriteIdleTimeoutFires(TransportType transportType) throws Exception
     {
         // TODO fix for h3
-        assumeTrue(transportType != TransportType.H3);
+        assumeTrue(transportType != TransportType.H3_QUICHE);
         CountDownLatch handlerLatch = new CountDownLatch(1);
         start(transportType, new HttpServlet()
         {
@@ -368,7 +368,7 @@ public class ServerTimeoutsTest extends AbstractTest
     @MethodSource("transportsNoFCGI")
     public void testBlockingReadWithMinimumDataRateAboveLimit(TransportType transportType) throws Exception
     {
-        assumeTrue(transportType != TransportType.H3 && transportType != TransportType.H2C && transportType != TransportType.H2); // TODO Fix
+        assumeTrue(transportType != TransportType.H3_QUICHE && transportType != TransportType.H2C && transportType != TransportType.H2); // TODO Fix
 
         int bytesPerSecond = 20;
         httpConfig.setMinRequestDataRate(bytesPerSecond);

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/ServerTimeoutsTest.java
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/ServerTimeoutsTest.java
@@ -60,37 +60,37 @@ public class ServerTimeoutsTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testBlockingReadWithDelayedFirstContentWithUndelayedDispatchIdleTimeoutFires(Transport transport) throws Exception
+    public void testBlockingReadWithDelayedFirstContentWithUndelayedDispatchIdleTimeoutFires(TransportType transportType) throws Exception
     {
-        assumeTrue(transport != Transport.H3 && transport != Transport.H2C && transport != Transport.H2); // TODO Fix
-        testBlockingReadWithDelayedFirstContentIdleTimeoutFires(transport, false);
+        assumeTrue(transportType != TransportType.H3 && transportType != TransportType.H2C && transportType != TransportType.H2); // TODO Fix
+        testBlockingReadWithDelayedFirstContentIdleTimeoutFires(transportType, false);
     }
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testBlockingReadWithDelayedFirstContentWithDelayedDispatchIdleTimeoutFires(Transport transport) throws Exception
+    public void testBlockingReadWithDelayedFirstContentWithDelayedDispatchIdleTimeoutFires(TransportType transportType) throws Exception
     {
-        assumeTrue(transport != Transport.H3 && transport != Transport.H2C && transport != Transport.H2); // TODO Fix
-        testBlockingReadWithDelayedFirstContentIdleTimeoutFires(transport, true);
+        assumeTrue(transportType != TransportType.H3 && transportType != TransportType.H2C && transportType != TransportType.H2); // TODO Fix
+        testBlockingReadWithDelayedFirstContentIdleTimeoutFires(transportType, true);
     }
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncReadWithDelayedFirstContentWithUndelayedDispatchIdleTimeoutFires(Transport transport) throws Exception
+    public void testAsyncReadWithDelayedFirstContentWithUndelayedDispatchIdleTimeoutFires(TransportType transportType) throws Exception
     {
-        testAsyncReadWithDelayedFirstContentIdleTimeoutFires(transport, false);
+        testAsyncReadWithDelayedFirstContentIdleTimeoutFires(transportType, false);
     }
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncReadWithDelayedFirstContentWithDelayedDispatchIdleTimeoutFires(Transport transport) throws Exception
+    public void testAsyncReadWithDelayedFirstContentWithDelayedDispatchIdleTimeoutFires(TransportType transportType) throws Exception
     {
-        testAsyncReadWithDelayedFirstContentIdleTimeoutFires(transport, true);
+        testAsyncReadWithDelayedFirstContentIdleTimeoutFires(transportType, true);
     }
 
-    private void testBlockingReadWithDelayedFirstContentIdleTimeoutFires(Transport transport, boolean delayDispatch) throws Exception
+    private void testBlockingReadWithDelayedFirstContentIdleTimeoutFires(TransportType transportType, boolean delayDispatch) throws Exception
     {
-        testReadWithDelayedFirstContentIdleTimeoutFires(transport, new HttpServlet()
+        testReadWithDelayedFirstContentIdleTimeoutFires(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -102,9 +102,9 @@ public class ServerTimeoutsTest extends AbstractTest
         }, delayDispatch);
     }
 
-    private void testAsyncReadWithDelayedFirstContentIdleTimeoutFires(Transport transport, boolean delayDispatch) throws Exception
+    private void testAsyncReadWithDelayedFirstContentIdleTimeoutFires(TransportType transportType, boolean delayDispatch) throws Exception
     {
-        testReadWithDelayedFirstContentIdleTimeoutFires(transport, new HttpServlet()
+        testReadWithDelayedFirstContentIdleTimeoutFires(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -136,11 +136,11 @@ public class ServerTimeoutsTest extends AbstractTest
         }, delayDispatch);
     }
 
-    private void testReadWithDelayedFirstContentIdleTimeoutFires(Transport transport, HttpServlet servlet, boolean delayDispatch) throws Exception
+    private void testReadWithDelayedFirstContentIdleTimeoutFires(TransportType transportType, HttpServlet servlet, boolean delayDispatch) throws Exception
     {
         httpConfig.setDelayDispatchUntilContent(delayDispatch);
         CountDownLatch handlerLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
@@ -160,7 +160,7 @@ public class ServerTimeoutsTest extends AbstractTest
 
         CountDownLatch resultLatch = new CountDownLatch(2);
         AsyncRequestContent content = new AsyncRequestContent();
-        client.POST(newURI(transport))
+        client.POST(newURI(transportType))
             .body(content)
             .onResponseSuccess(response ->
             {
@@ -178,10 +178,10 @@ public class ServerTimeoutsTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncReadIdleTimeoutFires(Transport transport) throws Exception
+    public void testAsyncReadIdleTimeoutFires(TransportType transportType) throws Exception
     {
         CountDownLatch handlerLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -222,7 +222,7 @@ public class ServerTimeoutsTest extends AbstractTest
 
         AsyncRequestContent content = new AsyncRequestContent(ByteBuffer.allocate(1));
         CountDownLatch resultLatch = new CountDownLatch(1);
-        client.POST(newURI(transport))
+        client.POST(newURI(transportType))
             .body(content)
             .send(result ->
             {
@@ -239,12 +239,12 @@ public class ServerTimeoutsTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncWriteIdleTimeoutFires(Transport transport) throws Exception
+    public void testAsyncWriteIdleTimeoutFires(TransportType transportType) throws Exception
     {
         // TODO fix for h3
-        assumeTrue(transport != Transport.H3);
+        assumeTrue(transportType != TransportType.H3);
         CountDownLatch handlerLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -277,7 +277,7 @@ public class ServerTimeoutsTest extends AbstractTest
 
         BlockingQueue<Runnable> demanders = new LinkedBlockingQueue<>();
         CountDownLatch resultLatch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .onResponseContentAsync((response, chunk, demander) ->
             {
                 // Do not succeed the callback so the server will block writing.
@@ -304,12 +304,12 @@ public class ServerTimeoutsTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testBlockingReadWithMinimumDataRateBelowLimit(Transport transport) throws Exception
+    public void testBlockingReadWithMinimumDataRateBelowLimit(TransportType transportType) throws Exception
     {
         int bytesPerSecond = 20;
         httpConfig.setMinRequestDataRate(bytesPerSecond);
         CountDownLatch handlerLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -337,7 +337,7 @@ public class ServerTimeoutsTest extends AbstractTest
         AtomicReference<Response> responseRef = new AtomicReference<>();
         CountDownLatch responseLatch = new CountDownLatch(1);
         CountDownLatch resultLatch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .body(content)
             .onResponseSuccess(response ->
             {
@@ -366,14 +366,14 @@ public class ServerTimeoutsTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testBlockingReadWithMinimumDataRateAboveLimit(Transport transport) throws Exception
+    public void testBlockingReadWithMinimumDataRateAboveLimit(TransportType transportType) throws Exception
     {
-        assumeTrue(transport != Transport.H3 && transport != Transport.H2C && transport != Transport.H2); // TODO Fix
+        assumeTrue(transportType != TransportType.H3 && transportType != TransportType.H2C && transportType != TransportType.H2); // TODO Fix
 
         int bytesPerSecond = 20;
         httpConfig.setMinRequestDataRate(bytesPerSecond);
         CountDownLatch handlerLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -391,7 +391,7 @@ public class ServerTimeoutsTest extends AbstractTest
 
         AsyncRequestContent content = new AsyncRequestContent();
         CountDownLatch resultLatch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .body(content)
             .send(result ->
             {
@@ -412,20 +412,20 @@ public class ServerTimeoutsTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testBlockingReadHttpIdleTimeoutOverridesIdleTimeout(Transport transport) throws Exception
+    public void testBlockingReadHttpIdleTimeoutOverridesIdleTimeout(TransportType transportType) throws Exception
     {
         long httpIdleTimeout = 2500;
         long idleTimeout = 3 * httpIdleTimeout;
         httpConfig.setIdleTimeout(httpIdleTimeout);
         CountDownLatch handlerLatch = new CountDownLatch(1);
-        start(transport, new BlockingReadServlet(handlerLatch));
+        start(transportType, new BlockingReadServlet(handlerLatch));
         setStreamIdleTimeout(idleTimeout);
 
         try (StacklessLogging ignore = new StacklessLogging(HttpChannelState.class))
         {
             AsyncRequestContent content = new AsyncRequestContent(ByteBuffer.allocate(1));
             CountDownLatch resultLatch = new CountDownLatch(1);
-            client.POST(newURI(transport))
+            client.POST(newURI(transportType))
                 .body(content)
                 .send(result ->
                 {
@@ -443,25 +443,25 @@ public class ServerTimeoutsTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncReadHttpIdleTimeoutOverridesIdleTimeoutIsReadyFirst(Transport transport) throws Exception
+    public void testAsyncReadHttpIdleTimeoutOverridesIdleTimeoutIsReadyFirst(TransportType transportType) throws Exception
     {
-        testAsyncReadHttpIdleTimeoutOverridesIdleTimeout(transport, true);
+        testAsyncReadHttpIdleTimeoutOverridesIdleTimeout(transportType, true);
     }
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncReadHttpIdleTimeoutOverridesIdleTimeoutReadFirst(Transport transport) throws Exception
+    public void testAsyncReadHttpIdleTimeoutOverridesIdleTimeoutReadFirst(TransportType transportType) throws Exception
     {
-        testAsyncReadHttpIdleTimeoutOverridesIdleTimeout(transport, false);
+        testAsyncReadHttpIdleTimeoutOverridesIdleTimeout(transportType, false);
     }
 
-    private void testAsyncReadHttpIdleTimeoutOverridesIdleTimeout(Transport transport, boolean isReadyFirst) throws Exception
+    private void testAsyncReadHttpIdleTimeoutOverridesIdleTimeout(TransportType transportType, boolean isReadyFirst) throws Exception
     {
         long httpIdleTimeout = 2000;
         long idleTimeout = 3 * httpIdleTimeout;
         httpConfig.setIdleTimeout(httpIdleTimeout);
         CountDownLatch handlerLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -503,7 +503,7 @@ public class ServerTimeoutsTest extends AbstractTest
 
         AsyncRequestContent content = new AsyncRequestContent(ByteBuffer.allocate(1));
         CountDownLatch resultLatch = new CountDownLatch(1);
-        client.POST(newURI(transport))
+        client.POST(newURI(transportType))
             .body(content)
             .send(result ->
             {
@@ -521,10 +521,10 @@ public class ServerTimeoutsTest extends AbstractTest
     @Disabled
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testIdleTimeoutBeforeReadIsIgnored(Transport transport) throws Exception
+    public void testIdleTimeoutBeforeReadIsIgnored(TransportType transportType) throws Exception
     {
         long idleTimeout = 1000;
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -550,7 +550,7 @@ public class ServerTimeoutsTest extends AbstractTest
         System.arraycopy(data, data1.length, data2, 0, data2.length);
         AsyncRequestContent content = new AsyncRequestContent(ByteBuffer.wrap(data1));
         CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .body(content)
             .send(new BufferingResponseListener()
             {
@@ -575,7 +575,7 @@ public class ServerTimeoutsTest extends AbstractTest
     @Disabled
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testBlockingWriteWithMinimumDataRateBelowLimit(Transport transport) throws Exception
+    public void testBlockingWriteWithMinimumDataRateBelowLimit(TransportType transportType) throws Exception
     {
         // This test needs a large write to stall the server, and a slow reading client.
         // In HTTP/1.1, when using the loopback interface, the buffers are so large that
@@ -588,12 +588,12 @@ public class ServerTimeoutsTest extends AbstractTest
         // In HTTP/2, we force the flow control window to be small, so that the server
         // stalls almost immediately without having written many bytes, so that the test
         // completes quickly.
-        assumeTrue(transport == Transport.H2C || transport == Transport.H2);
+        assumeTrue(transportType == TransportType.H2C || transportType == TransportType.H2);
 
         int bytesPerSecond = 16 * 1024;
         httpConfig.setMinResponseDataRate(bytesPerSecond);
         CountDownLatch serverLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response)
@@ -614,7 +614,7 @@ public class ServerTimeoutsTest extends AbstractTest
         // Setup the client to read slower than the min data rate.
         BlockingQueue<Object> objects = new LinkedBlockingQueue<>();
         CountDownLatch clientLatch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .onResponseContentAsync((response, chunk, demander) ->
             {
                 objects.offer(chunk.remaining());

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/VirtualThreadsTest.java
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/VirtualThreadsTest.java
@@ -47,13 +47,13 @@ public class VirtualThreadsTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transports")
-    public void testServletInvokedOnVirtualThread(Transport transport) throws Exception
+    public void testServletInvokedOnVirtualThread(TransportType transportType) throws Exception
     {
         // No virtual thread support in FCGI server-side.
-        Assumptions.assumeTrue(transport != Transport.FCGI);
+        Assumptions.assumeTrue(transportType != TransportType.FCGI);
 
         String virtualThreadsName = "green-";
-        prepareServer(transport, new HttpServlet()
+        prepareServer(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response)
@@ -71,24 +71,24 @@ public class VirtualThreadsTest extends AbstractTest
             ((VirtualThreads.Configurable)threadPool).setVirtualThreadsExecutor(virtualThreadsExecutor);
         }
         server.start();
-        startClient(transport);
+        startClient(transportType);
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .timeout(5, TimeUnit.SECONDS)
             .send();
 
-        assertEquals(HttpStatus.OK_200, response.getStatus(), " for transport " + transport);
+        assertEquals(HttpStatus.OK_200, response.getStatus(), " for transport " + transportType);
     }
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testServletCallbacksInvokedOnVirtualThread(Transport transport) throws Exception
+    public void testServletCallbacksInvokedOnVirtualThread(TransportType transportType) throws Exception
     {
         // No virtual thread support in FCGI server-side.
-        Assumptions.assumeTrue(transport != Transport.FCGI);
+        Assumptions.assumeTrue(transportType != TransportType.FCGI);
 
         byte[] data = new byte[2 * 1024 * 1024];
-        prepareServer(transport, new HttpServlet()
+        prepareServer(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -151,11 +151,11 @@ public class VirtualThreadsTest extends AbstractTest
         if (threadPool instanceof VirtualThreads.Configurable)
             ((VirtualThreads.Configurable)threadPool).setVirtualThreadsExecutor(VirtualThreads.getDefaultVirtualThreadsExecutor());
         server.start();
-        startClient(transport);
+        startClient(transportType);
 
         CountDownLatch latch = new CountDownLatch(1);
         AtomicInteger length = new AtomicInteger();
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(new StringRequestContent("hello"))
             .onResponseContent((response, content) -> length.addAndGet(content.remaining()))

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/ZippedRequestContentTest.java
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/ZippedRequestContentTest.java
@@ -43,9 +43,9 @@ public class ZippedRequestContentTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testZippedRequestContent(Transport transport) throws Exception
+    public void testZippedRequestContent(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest req, HttpServletResponse resp) throws IOException
@@ -71,7 +71,7 @@ public class ZippedRequestContentTest extends AbstractTest
 
         OutputStreamRequestContent content = new OutputStreamRequestContent();
         CompletableFuture<ContentResponse> completable = new CompletableResponseListener(
-            client.newRequest(newURI(transport))
+            client.newRequest(newURI(transportType))
                 .method(HttpMethod.POST)
                 .body(content)
         ).send();

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/AbstractTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/AbstractTest.java
@@ -88,7 +88,7 @@ public class AbstractTest
     {
         EnumSet<TransportType> transportTypes = EnumSet.allOf(TransportType.class);
         if ("ci".equals(System.getProperty("env")))
-            transportTypes.remove(TransportType.H3);
+            transportTypes.remove(TransportType.H3_QUICHE);
         return transportTypes;
     }
 
@@ -202,7 +202,7 @@ public class AbstractTest
         {
             case HTTP, HTTPS, H2C, H2, FCGI ->
                 new ServerConnector(server, 1, 1, newServerConnectionFactory(transportType));
-            case H3 ->
+            case H3_QUICHE ->
                 new QuicServerConnector(server, serverQuicConfig, newServerConnectionFactory(transportType));
         };
     }
@@ -233,7 +233,7 @@ public class AbstractTest
                 SslConnectionFactory ssl = new SslConnectionFactory(sslContextFactoryServer, alpn.getProtocol());
                 yield List.of(ssl, alpn, h2);
             }
-            case H3 ->
+            case H3_QUICHE ->
             {
                 httpConfig.addCustomizer(new SecureRequestCustomizer());
                 httpConfig.addCustomizer(new HostHeaderCustomizer());
@@ -271,7 +271,7 @@ public class AbstractTest
                 HTTP2Client http2Client = new HTTP2Client(clientConnector);
                 yield new HttpClientTransportOverHTTP2(http2Client);
             }
-            case H3 ->
+            case H3_QUICHE ->
             {
                 ClientConnector clientConnector = new ClientConnector();
                 clientConnector.setSelectors(1);
@@ -313,14 +313,14 @@ public class AbstractTest
 
     public enum TransportType
     {
-        HTTP, HTTPS, H2C, H2, H3, FCGI;
+        HTTP, HTTPS, H2C, H2, H3_QUICHE, FCGI;
 
         public boolean isSecure()
         {
             return switch (this)
             {
                 case HTTP, H2C, FCGI -> false;
-                case HTTPS, H2, H3 -> true;
+                case HTTPS, H2, H3_QUICHE -> true;
             };
         }
     }

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/AbstractTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/AbstractTest.java
@@ -84,26 +84,26 @@ public class AbstractTest
     protected ServletContextHandler servletContextHandler;
     protected HttpClient client;
 
-    public static Collection<Transport> transports()
+    public static Collection<TransportType> transports()
     {
-        EnumSet<Transport> transports = EnumSet.allOf(Transport.class);
+        EnumSet<TransportType> transportTypes = EnumSet.allOf(TransportType.class);
         if ("ci".equals(System.getProperty("env")))
-            transports.remove(Transport.H3);
-        return transports;
+            transportTypes.remove(TransportType.H3);
+        return transportTypes;
     }
 
-    public static Collection<Transport> transportsNoFCGI()
+    public static Collection<TransportType> transportsNoFCGI()
     {
-        Collection<Transport> transports = transports();
-        transports.remove(Transport.FCGI);
-        return transports;
+        Collection<TransportType> transportTypes = transports();
+        transportTypes.remove(TransportType.FCGI);
+        return transportTypes;
     }
 
-    public static Collection<Transport> transportsWithPushSupport()
+    public static Collection<TransportType> transportsWithPushSupport()
     {
-        Collection<Transport> transports = transports();
-        transports.retainAll(List.of(Transport.H2C, Transport.H2));
-        return transports;
+        Collection<TransportType> transportTypes = transports();
+        transportTypes.retainAll(List.of(TransportType.H2C, TransportType.H2));
+        return transportTypes;
     }
 
     @BeforeEach
@@ -119,31 +119,31 @@ public class AbstractTest
         LifeCycle.stop(server);
     }
 
-    protected void start(Transport transport, HttpServlet servlet) throws Exception
+    protected void start(TransportType transportType, HttpServlet servlet) throws Exception
     {
-        startServer(transport, servlet);
-        startClient(transport);
+        startServer(transportType, servlet);
+        startClient(transportType);
     }
 
-    protected void startServer(Transport transport, HttpServlet servlet) throws Exception
+    protected void startServer(TransportType transportType, HttpServlet servlet) throws Exception
     {
-        prepareServer(transport, servlet);
+        prepareServer(transportType, servlet);
         server.start();
     }
 
-    protected void prepareServer(Transport transport, HttpServlet servlet) throws Exception
+    protected void prepareServer(TransportType transportType, HttpServlet servlet) throws Exception
     {
-        prepareServer(transport, servlet, "/");
+        prepareServer(transportType, servlet, "/");
     }
 
-    protected void prepareServer(Transport transport, HttpServlet servlet, String path) throws Exception
+    protected void prepareServer(TransportType transportType, HttpServlet servlet, String path) throws Exception
     {
         sslContextFactoryServer = newSslContextFactoryServer();
         Path serverPemDirectory = Files.createDirectories(pemDir.resolve("server"));
         serverQuicConfig = new ServerQuicConfiguration(sslContextFactoryServer, serverPemDirectory);
         if (server == null)
             server = newServer();
-        connector = newConnector(transport, server);
+        connector = newConnector(transportType, server);
         server.addConnector(connector);
         servletContextHandler = new ServletContextHandler();
         addServlet(servlet, path);
@@ -186,30 +186,30 @@ public class AbstractTest
         sslContextFactory.setCipherComparator(HTTP2Cipher.COMPARATOR);
     }
 
-    protected void startClient(Transport transport) throws Exception
+    protected void startClient(TransportType transportType) throws Exception
     {
         QueuedThreadPool clientThreads = new QueuedThreadPool();
         clientThreads.setName("client");
-        client = new HttpClient(newHttpClientTransport(transport));
+        client = new HttpClient(newHttpClientTransport(transportType));
         client.setExecutor(clientThreads);
         client.setSocketAddressResolver(new SocketAddressResolver.Sync());
         client.start();
     }
 
-    public AbstractConnector newConnector(Transport transport, Server server)
+    public AbstractConnector newConnector(TransportType transportType, Server server)
     {
-        return switch (transport)
+        return switch (transportType)
         {
             case HTTP, HTTPS, H2C, H2, FCGI ->
-                new ServerConnector(server, 1, 1, newServerConnectionFactory(transport));
+                new ServerConnector(server, 1, 1, newServerConnectionFactory(transportType));
             case H3 ->
-                new QuicServerConnector(server, serverQuicConfig, newServerConnectionFactory(transport));
+                new QuicServerConnector(server, serverQuicConfig, newServerConnectionFactory(transportType));
         };
     }
 
-    protected ConnectionFactory[] newServerConnectionFactory(Transport transport)
+    protected ConnectionFactory[] newServerConnectionFactory(TransportType transportType)
     {
-        List<ConnectionFactory> list = switch (transport)
+        List<ConnectionFactory> list = switch (transportType)
         {
             case HTTP -> List.of(new HttpConnectionFactory(httpConfig));
             case HTTPS ->
@@ -252,9 +252,9 @@ public class AbstractTest
         return ssl;
     }
 
-    protected HttpClientTransport newHttpClientTransport(Transport transport) throws Exception
+    protected HttpClientTransport newHttpClientTransport(TransportType transportType) throws Exception
     {
-        return switch (transport)
+        return switch (transportType)
         {
             case HTTP, HTTPS ->
             {
@@ -285,9 +285,9 @@ public class AbstractTest
         };
     }
 
-    protected URI newURI(Transport transport)
+    protected URI newURI(TransportType transportType)
     {
-        String scheme = transport.isSecure() ? "https" : "http";
+        String scheme = transportType.isSecure() ? "https" : "http";
         String uri = scheme + "://localhost";
         if (connector instanceof NetworkConnector networkConnector)
             uri += ":" + networkConnector.getLocalPort();
@@ -311,7 +311,7 @@ public class AbstractTest
         }
     }
 
-    public enum Transport
+    public enum TransportType
     {
         HTTP, HTTPS, H2C, H2, H3, FCGI;
 

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/AsyncIOServletTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/AsyncIOServletTest.java
@@ -99,9 +99,9 @@ public class AsyncIOServletTest extends AbstractTest
     private static final ThreadLocal<RuntimeException> scope = new ThreadLocal<>();
 
     @Override
-    protected void prepareServer(Transport transport, HttpServlet servlet) throws Exception
+    protected void prepareServer(TransportType transportType, HttpServlet servlet) throws Exception
     {
-        super.prepareServer(transport, servlet);
+        super.prepareServer(transportType, servlet);
         // Add this listener before the context is started, so it's durable.
         servletContextHandler.addEventListener(new ContextHandler.ContextScopeListener()
         {
@@ -154,22 +154,22 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncReadThrowsException(Transport transport) throws Exception
+    public void testAsyncReadThrowsException(TransportType transportType) throws Exception
     {
-        testAsyncReadThrows(transport, new NullPointerException("explicitly_thrown_by_test"));
+        testAsyncReadThrows(transportType, new NullPointerException("explicitly_thrown_by_test"));
     }
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncReadThrowsError(Transport transport) throws Exception
+    public void testAsyncReadThrowsError(TransportType transportType) throws Exception
     {
-        testAsyncReadThrows(transport, new Error("explicitly_thrown_by_test"));
+        testAsyncReadThrows(transportType, new Error("explicitly_thrown_by_test"));
     }
 
-    private void testAsyncReadThrows(Transport transport, Throwable throwable) throws Exception
+    private void testAsyncReadThrows(TransportType transportType, Throwable throwable) throws Exception
     {
         CountDownLatch latch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -209,7 +209,7 @@ public class AsyncIOServletTest extends AbstractTest
             }
         });
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(new StringRequestContent("0123456789"))
             .timeout(5, TimeUnit.SECONDS)
@@ -221,10 +221,10 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncReadIdleTimeout(Transport transport) throws Exception
+    public void testAsyncReadIdleTimeout(TransportType transportType) throws Exception
     {
         int status = 567;
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -284,7 +284,7 @@ public class AsyncIOServletTest extends AbstractTest
         content.write(ByteBuffer.wrap(data.getBytes(StandardCharsets.UTF_8)), Callback.NOOP);
         CountDownLatch responseLatch = new CountDownLatch(1);
         CountDownLatch clientLatch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(content)
             .onResponseSuccess(r -> responseLatch.countDown())
@@ -296,7 +296,7 @@ public class AsyncIOServletTest extends AbstractTest
             });
 
         // HTTP/2 does not close a Connection when the request idle times out.
-        if (transport != Transport.H2C && transport != Transport.H2)
+        if (transportType != TransportType.H2C && transportType != TransportType.H2)
             assertTrue(closeLatch.await(5, TimeUnit.SECONDS), "close latch expired");
         assertTrue(responseLatch.await(5, TimeUnit.SECONDS), "response latch expired");
         content.close();
@@ -305,10 +305,10 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testOnErrorThrows(Transport transport) throws Exception
+    public void testOnErrorThrows(TransportType transportType) throws Exception
     {
         AtomicInteger errors = new AtomicInteger();
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -354,7 +354,7 @@ public class AsyncIOServletTest extends AbstractTest
 
         try (StacklessLogging ignore = new StacklessLogging(HttpChannelState.class))
         {
-            ContentResponse response = client.newRequest(newURI(transport))
+            ContentResponse response = client.newRequest(newURI(transportType))
                 .body(new StringRequestContent("0123456789"))
                 .timeout(5, TimeUnit.SECONDS)
                 .send();
@@ -366,22 +366,22 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncWriteThrowsException(Transport transport) throws Exception
+    public void testAsyncWriteThrowsException(TransportType transportType) throws Exception
     {
-        testAsyncWriteThrows(transport, new NullPointerException("explicitly_thrown_by_test"));
+        testAsyncWriteThrows(transportType, new NullPointerException("explicitly_thrown_by_test"));
     }
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncWriteThrowsError(Transport transport) throws Exception
+    public void testAsyncWriteThrowsError(TransportType transportType) throws Exception
     {
-        testAsyncWriteThrows(transport, new Error("explicitly_thrown_by_test"));
+        testAsyncWriteThrows(transportType, new Error("explicitly_thrown_by_test"));
     }
 
-    private void testAsyncWriteThrows(Transport transport, Throwable throwable) throws Exception
+    private void testAsyncWriteThrows(TransportType transportType, Throwable throwable) throws Exception
     {
         CountDownLatch latch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -414,7 +414,7 @@ public class AsyncIOServletTest extends AbstractTest
             }
         });
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .timeout(5, TimeUnit.SECONDS)
             .send();
 
@@ -424,12 +424,12 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncWriteClosed(Transport transport) throws Exception
+    public void testAsyncWriteClosed(TransportType transportType) throws Exception
     {
         byte[] data = new byte[1024];
 
         CountDownLatch errorLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -482,7 +482,7 @@ public class AsyncIOServletTest extends AbstractTest
         });
 
         CountDownLatch clientLatch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .onResponseHeaders(response ->
             {
                 if (response.getStatus() == HttpStatus.OK_200)
@@ -500,10 +500,10 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncWriteLessThanContentLengthFlushed(Transport transport) throws Exception
+    public void testAsyncWriteLessThanContentLengthFlushed(TransportType transportType) throws Exception
     {
         CountDownLatch complete = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -571,7 +571,7 @@ public class AsyncIOServletTest extends AbstractTest
 
         AtomicBoolean failed = new AtomicBoolean(false);
         CountDownLatch clientLatch = new CountDownLatch(3);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .onResponseHeaders(response ->
             {
                 if (response.getStatus() == HttpStatus.OK_200)
@@ -595,12 +595,12 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testIsReadyAtEOF(Transport transport) throws Exception
+    public void testIsReadyAtEOF(TransportType transportType) throws Exception
     {
         String text = "TEST\n";
         byte[] data = text.getBytes(StandardCharsets.UTF_8);
 
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -654,7 +654,7 @@ public class AsyncIOServletTest extends AbstractTest
             }
         });
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .headers(headers -> headers.put(HttpHeader.CONNECTION, HttpHeaderValue.CLOSE))
             .body(new StringRequestContent(text))
@@ -667,10 +667,10 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testOnAllDataRead(Transport transport) throws Exception
+    public void testOnAllDataRead(TransportType transportType) throws Exception
     {
         String success = "SUCCESS";
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -736,7 +736,7 @@ public class AsyncIOServletTest extends AbstractTest
                 return data.length;
             }
         };
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(content)
             .timeout(5, TimeUnit.SECONDS)
@@ -764,10 +764,10 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testOtherThreadOnAllDataRead(Transport transport) throws Exception
+    public void testOtherThreadOnAllDataRead(TransportType transportType) throws Exception
     {
         String success = "SUCCESS";
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -840,7 +840,7 @@ public class AsyncIOServletTest extends AbstractTest
         byte[] data = "X".getBytes(StandardCharsets.UTF_8);
         CountDownLatch clientLatch = new CountDownLatch(1);
         AsyncRequestContent content = new AsyncRequestContent();
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(content)
             .timeout(5, TimeUnit.SECONDS)
@@ -868,11 +868,11 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testCompleteBeforeOnAllDataRead(Transport transport) throws Exception
+    public void testCompleteBeforeOnAllDataRead(TransportType transportType) throws Exception
     {
         String success = "SUCCESS";
 
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -920,7 +920,7 @@ public class AsyncIOServletTest extends AbstractTest
             }
         });
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .headers(headers -> headers.put(HttpHeader.CONNECTION, HttpHeaderValue.CLOSE))
             .body(new StringRequestContent("XYZ"))
@@ -933,12 +933,12 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testEmptyAsyncRead(Transport transport) throws Exception
+    public void testEmptyAsyncRead(TransportType transportType) throws Exception
     {
         AtomicBoolean oda = new AtomicBoolean();
         CountDownLatch latch = new CountDownLatch(1);
 
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -975,7 +975,7 @@ public class AsyncIOServletTest extends AbstractTest
             }
         });
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.CONNECTION, HttpHeaderValue.CLOSE))
             .timeout(5, TimeUnit.SECONDS)
             .send();
@@ -988,11 +988,11 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testWriteFromOnDataAvailable(Transport transport) throws Exception
+    public void testWriteFromOnDataAvailable(TransportType transportType) throws Exception
     {
         Queue<Throwable> errors = new ConcurrentLinkedQueue<>();
         CountDownLatch writeLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -1054,7 +1054,7 @@ public class AsyncIOServletTest extends AbstractTest
         AsyncRequestContent requestContent = new AsyncRequestContent();
         requestContent.write(ByteBuffer.wrap(content.getBytes(StandardCharsets.UTF_8)), Callback.NOOP);
         CountDownLatch clientLatch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(requestContent)
             .send(new BufferingResponseListener()
@@ -1083,19 +1083,19 @@ public class AsyncIOServletTest extends AbstractTest
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
     @Disabled // TODO Cannot write response from onError as failure has occurred
-    public void testAsyncReadEarlyEOF(Transport transport) throws Exception
+    public void testAsyncReadEarlyEOF(TransportType transportType) throws Exception
     {
         // SSLEngine receives the close alert from the client, and when
         // the server passes the response to encrypt and write, SSLEngine
         // only generates the close alert back, without encrypting the
         // response, so we need to skip the transports over TLS.
-        Assumptions.assumeFalse(transport.isSecure());
+        Assumptions.assumeFalse(transportType.isSecure());
 
         String content = "jetty";
         int responseCode = HttpStatus.NO_CONTENT_204;
         CountDownLatch readLatch = new CountDownLatch(content.length());
         CountDownLatch errorLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -1133,17 +1133,17 @@ public class AsyncIOServletTest extends AbstractTest
         CountDownLatch responseLatch = new CountDownLatch(1);
         AsyncRequestContent requestContent = new AsyncRequestContent();
         requestContent.write(ByteBuffer.wrap(content.getBytes(StandardCharsets.UTF_8)), Callback.NOOP);
-        var request = client.newRequest(newURI(transport))
+        var request = client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(requestContent)
             .onResponseSuccess(response ->
             {
-                if (transport == Transport.HTTP)
+                if (transportType == TransportType.HTTP)
                     responseLatch.countDown();
             })
             .onResponseFailure((response, failure) ->
             {
-                if (transport == Transport.H2C)
+                if (transportType == TransportType.H2C)
                     responseLatch.countDown();
             });
 
@@ -1154,7 +1154,7 @@ public class AsyncIOServletTest extends AbstractTest
         CountDownLatch clientLatch = new CountDownLatch(1);
         connection.send(request, result ->
         {
-            switch (transport)
+            switch (transportType)
             {
                 case HTTP:
                     assertThat(result.getResponse().getStatus(), Matchers.equalTo(responseCode));
@@ -1164,14 +1164,14 @@ public class AsyncIOServletTest extends AbstractTest
                     assertTrue(result.isFailed());
                     break;
                 default:
-                    fail("Unhandled transport: " + transport);
+                    fail("Unhandled transport: " + transportType);
             }
             clientLatch.countDown();
         });
 
         assertTrue(readLatch.await(5, TimeUnit.SECONDS));
 
-        switch (transport)
+        switch (transportType)
         {
             case HTTP:
                 ((HttpConnectionOverHTTP)connection).getEndPoint().shutdownOutput();
@@ -1185,7 +1185,7 @@ public class AsyncIOServletTest extends AbstractTest
                 ((HTTP2Session)session).getEndPoint().shutdownOutput();
                 break;
             default:
-                fail("Unhandled transport: " + transport);
+                fail("Unhandled transport: " + transportType);
         }
 
         // Wait for the response to arrive before finishing the request.
@@ -1199,9 +1199,9 @@ public class AsyncIOServletTest extends AbstractTest
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
     @Disabled // TODO
-    public void testAsyncIntercepted(Transport transport) throws Exception
+    public void testAsyncIntercepted(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -1329,7 +1329,7 @@ public class AsyncIOServletTest extends AbstractTest
             "S5" +
             "S6";
 
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(content)
             .send(new BufferingResponseListener()
@@ -1367,12 +1367,12 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncEcho(Transport transport) throws Exception
+    public void testAsyncEcho(TransportType transportType) throws Exception
     {
         // TODO: investigate why H3 does not work.
-        Assumptions.assumeTrue(transport != Transport.H3);
+        Assumptions.assumeTrue(transportType != TransportType.H3);
 
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -1417,7 +1417,7 @@ public class AsyncIOServletTest extends AbstractTest
         CountDownLatch clientLatch = new CountDownLatch(1);
 
         AtomicReference<Result> resultRef = new AtomicReference<>();
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(contentProvider)
             .send(new BufferingResponseListener(16 * 1024 * 1024)
@@ -1550,9 +1550,9 @@ public class AsyncIOServletTest extends AbstractTest
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
     @Disabled // TODO
-    public void testAsyncInterceptedTwiceWithNulls(Transport transport) throws Exception
+    public void testAsyncInterceptedTwiceWithNulls(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -1636,7 +1636,7 @@ public class AsyncIOServletTest extends AbstractTest
             "4S" +
             "6S";
 
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(contentProvider)
             .send(new BufferingResponseListener()
@@ -1674,9 +1674,9 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testWriteListenerFromOtherThread(Transport transport) throws Exception
+    public void testWriteListenerFromOtherThread(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -1699,7 +1699,7 @@ public class AsyncIOServletTest extends AbstractTest
                 {
                     try
                     {
-                        ContentResponse response = client.newRequest(newURI(transport))
+                        ContentResponse response = client.newRequest(newURI(transportType))
                             .method(HttpMethod.POST)
                             .body(new InputStreamRequestContent(new ByteArrayInputStream(new byte[16 * 1024])
                             {
@@ -1731,11 +1731,11 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testClientDefersContentServerIdleTimeout(Transport transport) throws Exception
+    public void testClientDefersContentServerIdleTimeout(TransportType transportType) throws Exception
     {
         CountDownLatch dataLatch = new CountDownLatch(1);
         CountDownLatch errorLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -1779,7 +1779,7 @@ public class AsyncIOServletTest extends AbstractTest
                 return bytes.length;
             }
         };
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(content)
             .onResponseSuccess(response ->
@@ -1802,11 +1802,11 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testOnAllDataReadCalledOnceThenIdleTimeout(Transport transport) throws Exception
+    public void testOnAllDataReadCalledOnceThenIdleTimeout(TransportType transportType) throws Exception
     {
         AtomicInteger allDataReadCount = new AtomicInteger();
         AtomicReference<Throwable> errorRef = new AtomicReference<>();
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse resp) throws IOException
@@ -1852,7 +1852,7 @@ public class AsyncIOServletTest extends AbstractTest
         connector.setIdleTimeout(2 * idleTimeout);
         setStreamIdleTimeout(idleTimeout);
 
-        assertThrows(TimeoutException.class, () -> client.newRequest(newURI(transport))
+        assertThrows(TimeoutException.class, () -> client.newRequest(newURI(transportType))
             .timeout(2 * idleTimeout, TimeUnit.MILLISECONDS)
             .send()
         );

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/AsyncIOServletTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/AsyncIOServletTest.java
@@ -1370,7 +1370,7 @@ public class AsyncIOServletTest extends AbstractTest
     public void testAsyncEcho(TransportType transportType) throws Exception
     {
         // TODO: investigate why H3 does not work.
-        Assumptions.assumeTrue(transportType != TransportType.H3);
+        Assumptions.assumeTrue(transportType != TransportType.H3_QUICHE);
 
         start(transportType, new HttpServlet()
         {

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/BlockedIOTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/BlockedIOTest.java
@@ -48,14 +48,14 @@ public class BlockedIOTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transports")
-    public void testBlockingReadThenNormalComplete(Transport transport) throws Exception
+    public void testBlockingReadThenNormalComplete(TransportType transportType) throws Exception
     {
         CountDownLatch started = new CountDownLatch(1);
         CountDownLatch stopped = new CountDownLatch(1);
         AtomicReference<Throwable> readException = new AtomicReference<>();
         AtomicReference<Throwable> reReadException = new AtomicReference<>();
 
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
@@ -114,7 +114,7 @@ public class BlockedIOTest extends AbstractTest
 
         AsyncRequestContent requestContent = new AsyncRequestContent();
         CountDownLatch ok = new CountDownLatch(2);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method("POST")
             .body(requestContent)
             .onResponseContent((response, content) ->

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/HttpClientContinueTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/HttpClientContinueTest.java
@@ -67,21 +67,21 @@ public class HttpClientContinueTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithOneContentRespond100Continue(Transport transport) throws Exception
+    public void testExpect100ContinueWithOneContentRespond100Continue(TransportType transportType) throws Exception
     {
-        testExpect100ContinueRespond100Continue(transport, "data1".getBytes(StandardCharsets.UTF_8));
+        testExpect100ContinueRespond100Continue(transportType, "data1".getBytes(StandardCharsets.UTF_8));
     }
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithMultipleContentsRespond100Continue(Transport transport) throws Exception
+    public void testExpect100ContinueWithMultipleContentsRespond100Continue(TransportType transportType) throws Exception
     {
-        testExpect100ContinueRespond100Continue(transport, "data1".getBytes(StandardCharsets.UTF_8), "data2".getBytes(StandardCharsets.UTF_8), "data3".getBytes(StandardCharsets.UTF_8));
+        testExpect100ContinueRespond100Continue(transportType, "data1".getBytes(StandardCharsets.UTF_8), "data2".getBytes(StandardCharsets.UTF_8), "data3".getBytes(StandardCharsets.UTF_8));
     }
 
-    private void testExpect100ContinueRespond100Continue(Transport transport, byte[]... contents) throws Exception
+    private void testExpect100ContinueRespond100Continue(TransportType transportType, byte[]... contents) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -91,7 +91,7 @@ public class HttpClientContinueTest extends AbstractTest
             }
         });
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
             .body(new BytesRequestContent(contents))
             .timeout(5, TimeUnit.SECONDS)
@@ -113,9 +113,9 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithChunkedContentRespond100Continue(Transport transport) throws Exception
+    public void testExpect100ContinueWithChunkedContentRespond100Continue(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -130,7 +130,7 @@ public class HttpClientContinueTest extends AbstractTest
 
         byte[] content1 = new byte[10240];
         byte[] content2 = new byte[16384];
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
             .body(new BytesRequestContent(content1, content2)
             {
@@ -160,21 +160,21 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithContentRespond417ExpectationFailed(Transport transport) throws Exception
+    public void testExpect100ContinueWithContentRespond417ExpectationFailed(TransportType transportType) throws Exception
     {
-        testExpect100ContinueWithContentRespondError(transport, 417);
+        testExpect100ContinueWithContentRespondError(transportType, 417);
     }
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithContentRespond413RequestEntityTooLarge(Transport transport) throws Exception
+    public void testExpect100ContinueWithContentRespond413RequestEntityTooLarge(TransportType transportType) throws Exception
     {
-        testExpect100ContinueWithContentRespondError(transport, 413);
+        testExpect100ContinueWithContentRespondError(transportType, 413);
     }
 
-    private void testExpect100ContinueWithContentRespondError(Transport transport, int error) throws Exception
+    private void testExpect100ContinueWithContentRespondError(TransportType transportType, int error) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -186,7 +186,7 @@ public class HttpClientContinueTest extends AbstractTest
         byte[] content1 = new byte[10240];
         byte[] content2 = new byte[16384];
         CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
             .body(new BytesRequestContent(content1, content2))
             .send(new BufferingResponseListener()
@@ -217,10 +217,10 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithContentWithRedirect(Transport transport) throws Exception
+    public void testExpect100ContinueWithContentWithRedirect(TransportType transportType) throws Exception
     {
         String data = "success";
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -241,7 +241,7 @@ public class HttpClientContinueTest extends AbstractTest
 
         byte[] content = new byte[10240];
         CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .path("/continue")
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
@@ -263,12 +263,12 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testRedirectWithExpect100ContinueWithContent(Transport transport) throws Exception
+    public void testRedirectWithExpect100ContinueWithContent(TransportType transportType) throws Exception
     {
         // A request with Expect: 100-Continue cannot receive non-final responses like 3xx
 
         String data = "success";
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -289,7 +289,7 @@ public class HttpClientContinueTest extends AbstractTest
 
         byte[] content = new byte[10240];
         CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .path("/redirect")
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
@@ -312,13 +312,13 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithContentWithResponseFailureBefore100Continue(Transport transport) throws Exception
+    public void testExpect100ContinueWithContentWithResponseFailureBefore100Continue(TransportType transportType) throws Exception
     {
         AtomicReference<Request> clientRequestRef = new AtomicReference<>();
         CountDownLatch clientLatch = new CountDownLatch(1);
         CountDownLatch serverLatch = new CountDownLatch(1);
 
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException
@@ -338,7 +338,7 @@ public class HttpClientContinueTest extends AbstractTest
         });
 
         byte[] content = new byte[1024];
-        Request clientRequest = client.newRequest(newURI(transport));
+        Request clientRequest = client.newRequest(newURI(transportType));
         clientRequestRef.set(clientRequest);
         clientRequest
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
@@ -361,12 +361,12 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithContentWithResponseFailureAfter100Continue(Transport transport) throws Exception
+    public void testExpect100ContinueWithContentWithResponseFailureAfter100Continue(TransportType transportType) throws Exception
     {
         AtomicReference<Request> clientRequestRef = new AtomicReference<>();
         CountDownLatch clientLatch = new CountDownLatch(1);
         CountDownLatch serverLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
@@ -388,7 +388,7 @@ public class HttpClientContinueTest extends AbstractTest
         });
 
         byte[] content = new byte[1024];
-        Request clientRequest = client.newRequest(newURI(transport));
+        Request clientRequest = client.newRequest(newURI(transportType));
         clientRequestRef.set(clientRequest);
         clientRequest
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
@@ -411,9 +411,9 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithContentWithResponseFailureDuring100Continue(Transport transport) throws Exception
+    public void testExpect100ContinueWithContentWithResponseFailureDuring100Continue(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -449,7 +449,7 @@ public class HttpClientContinueTest extends AbstractTest
 
         byte[] content = new byte[1024];
         CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
             .body(new BytesRequestContent(content))
             .send(new BufferingResponseListener()
@@ -469,7 +469,7 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithDeferredContentRespond100Continue(Transport transport) throws Exception
+    public void testExpect100ContinueWithDeferredContentRespond100Continue(TransportType transportType) throws Exception
     {
         byte[] chunk1 = new byte[]{0, 1, 2, 3};
         byte[] chunk2 = new byte[]{4, 5, 6, 7};
@@ -479,7 +479,7 @@ public class HttpClientContinueTest extends AbstractTest
 
         CountDownLatch serverLatch = new CountDownLatch(1);
         AtomicReference<Thread> handlerThread = new AtomicReference<>();
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -501,7 +501,7 @@ public class HttpClientContinueTest extends AbstractTest
 
         CountDownLatch requestLatch = new CountDownLatch(1);
         AsyncRequestContent content = new AsyncRequestContent();
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
             .body(content)
             .send(new BufferingResponseListener()
@@ -539,10 +539,10 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithInitialAndDeferredContentRespond100Continue(Transport transport) throws Exception
+    public void testExpect100ContinueWithInitialAndDeferredContentRespond100Continue(TransportType transportType) throws Exception
     {
         AtomicReference<Thread> handlerThread = new AtomicReference<>();
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -561,7 +561,7 @@ public class HttpClientContinueTest extends AbstractTest
 
         CountDownLatch latch = new CountDownLatch(1);
         AsyncRequestContent content = new AsyncRequestContent(ByteBuffer.wrap(chunk1));
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
             .body(content)
             .send(new BufferingResponseListener()
@@ -589,9 +589,9 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithConcurrentDeferredContentRespond100Continue(Transport transport) throws Exception
+    public void testExpect100ContinueWithConcurrentDeferredContentRespond100Continue(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -605,7 +605,7 @@ public class HttpClientContinueTest extends AbstractTest
         AsyncRequestContent content = new AsyncRequestContent();
 
         CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
             .onRequestHeaders(request ->
             {
@@ -628,9 +628,9 @@ public class HttpClientContinueTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testExpect100ContinueWithInitialAndConcurrentDeferredContentRespond100Continue(Transport transport) throws Exception
+    public void testExpect100ContinueWithInitialAndConcurrentDeferredContentRespond100Continue(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -667,7 +667,7 @@ public class HttpClientContinueTest extends AbstractTest
         });
 
         CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .headers(headers -> headers.put(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE))
             .body(content)
             .send(new BufferingResponseListener()
@@ -690,7 +690,7 @@ public class HttpClientContinueTest extends AbstractTest
         // and immediately after with the "normal" response, say a 200 OK.
         // These may be read by the client in a single read, and must be handled correctly.
 
-        startClient(Transport.HTTP);
+        startClient(TransportType.HTTP);
 
         try (ServerSocket server = new ServerSocket())
         {
@@ -744,7 +744,7 @@ public class HttpClientContinueTest extends AbstractTest
     @Test
     public void testNoExpectRespond100Continue() throws Exception
     {
-        startClient(Transport.HTTP);
+        startClient(TransportType.HTTP);
         client.setMaxConnectionsPerDestination(1);
 
         try (ServerSocket server = new ServerSocket())
@@ -789,7 +789,7 @@ public class HttpClientContinueTest extends AbstractTest
     @Test
     public void testNoExpect100ContinueThen100ContinueThenRedirectThen100ContinueThenResponse() throws Exception
     {
-        startClient(Transport.HTTP);
+        startClient(TransportType.HTTP);
         client.setMaxConnectionsPerDestination(1);
 
         try (ServerSocket server = new ServerSocket())

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/HttpTrailersTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/HttpTrailersTest.java
@@ -51,23 +51,23 @@ public class HttpTrailersTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testRequestTrailersNoContent(Transport transport) throws Exception
+    public void testRequestTrailersNoContent(TransportType transportType) throws Exception
     {
-        testRequestTrailers(transport, null);
+        testRequestTrailers(transportType, null);
     }
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testRequestTrailersWithContent(Transport transport) throws Exception
+    public void testRequestTrailersWithContent(TransportType transportType) throws Exception
     {
-        testRequestTrailers(transport, "abcdefghijklmnopqrstuvwxyz".getBytes(StandardCharsets.UTF_8));
+        testRequestTrailers(transportType, "abcdefghijklmnopqrstuvwxyz".getBytes(StandardCharsets.UTF_8));
     }
 
-    private void testRequestTrailers(Transport transport, byte[] content) throws Exception
+    private void testRequestTrailers(TransportType transportType, byte[] content) throws Exception
     {
         String trailerName = "Trailer";
         String trailerValue = "value";
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -91,7 +91,7 @@ public class HttpTrailersTest extends AbstractTest
         });
 
         HttpFields trailers = HttpFields.build().put(trailerName, trailerValue).asImmutable();
-        Request request = client.newRequest(newURI(transport))
+        Request request = client.newRequest(newURI(transportType))
             .trailersSupplier(() -> trailers);
         if (content != null)
             request.method(HttpMethod.POST).body(new BytesRequestContent(content));
@@ -101,9 +101,9 @@ public class HttpTrailersTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testEmptyRequestTrailers(Transport transport) throws Exception
+    public void testEmptyRequestTrailers(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -127,7 +127,7 @@ public class HttpTrailersTest extends AbstractTest
         });
 
         HttpFields trailers = HttpFields.EMPTY;
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .trailersSupplier(() -> trailers)
             .timeout(5, TimeUnit.SECONDS)
             .send();
@@ -136,24 +136,24 @@ public class HttpTrailersTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testResponseTrailersNoContent(Transport transport) throws Exception
+    public void testResponseTrailersNoContent(TransportType transportType) throws Exception
     {
-        testResponseTrailers(transport, null);
+        testResponseTrailers(transportType, null);
     }
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testResponseTrailersWithContent(Transport transport) throws Exception
+    public void testResponseTrailersWithContent(TransportType transportType) throws Exception
     {
-        testResponseTrailers(transport, "abcdefghijklmnopqrstuvwxyz".getBytes(StandardCharsets.UTF_8));
+        testResponseTrailers(transportType, "abcdefghijklmnopqrstuvwxyz".getBytes(StandardCharsets.UTF_8));
     }
 
-    private void testResponseTrailers(Transport transport, byte[] content) throws Exception
+    private void testResponseTrailers(TransportType transportType, byte[] content) throws Exception
     {
         AtomicBoolean firstRequest = new AtomicBoolean();
         String trailerName = "Trailer";
         String trailerValue = "value";
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -171,7 +171,7 @@ public class HttpTrailersTest extends AbstractTest
         });
 
         AtomicReference<Throwable> failure = new AtomicReference<>(new Throwable("no_success"));
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .onResponseSuccess(r ->
             {
                 try
@@ -192,7 +192,7 @@ public class HttpTrailersTest extends AbstractTest
         assertNull(failure.get());
 
         // Subsequent requests should not have trailers.
-        response = client.newRequest(newURI(transport))
+        response = client.newRequest(newURI(transportType))
             .onResponseSuccess(r ->
             {
                 try
@@ -213,9 +213,9 @@ public class HttpTrailersTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testEmptyResponseTrailers(Transport transport) throws Exception
+    public void testEmptyResponseTrailers(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response)
@@ -225,7 +225,7 @@ public class HttpTrailersTest extends AbstractTest
         });
 
         AtomicReference<Throwable> failure = new AtomicReference<>(new Throwable("no_success"));
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .onResponseSuccess(r ->
             {
                 try
@@ -247,13 +247,13 @@ public class HttpTrailersTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testResponseTrailersWithLargeContent(Transport transport) throws Exception
+    public void testResponseTrailersWithLargeContent(TransportType transportType) throws Exception
     {
         byte[] content = new byte[1024 * 1024];
         new Random().nextBytes(content);
         String trailerName = "Digest";
         String trailerValue = "0xCAFEBABE";
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -268,7 +268,7 @@ public class HttpTrailersTest extends AbstractTest
         });
 
         InputStreamResponseListener listener = new InputStreamResponseListener();
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .timeout(15, TimeUnit.SECONDS)
             .send(listener);
         Response response = listener.get(5, TimeUnit.SECONDS);
@@ -298,9 +298,9 @@ public class HttpTrailersTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testResponseResetAlsoResetsTrailers(Transport transport) throws Exception
+    public void testResponseResetAlsoResetsTrailers(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -320,7 +320,7 @@ public class HttpTrailersTest extends AbstractTest
         });
 
         CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .timeout(5, TimeUnit.SECONDS)
             .send(result ->
             {

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/InformationalResponseTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/InformationalResponseTest.java
@@ -37,9 +37,9 @@ public class InformationalResponseTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void test102Processing(Transport transport) throws Exception
+    public void test102Processing(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -64,7 +64,7 @@ public class InformationalResponseTest extends AbstractTest
                 completeLatch.countDown();
             }
         };
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method("GET")
             .timeout(10, TimeUnit.SECONDS)
             .send(listener);
@@ -76,9 +76,9 @@ public class InformationalResponseTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void test103EarlyHint(Transport transport) throws Exception
+    public void test103EarlyHint(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -106,7 +106,7 @@ public class InformationalResponseTest extends AbstractTest
                 complete.countDown();
             }
         };
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method("GET")
             .timeout(5, TimeUnit.SECONDS)
             .send(listener);

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/PushedResourcesTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/PushedResourcesTest.java
@@ -43,7 +43,7 @@ public class PushedResourcesTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transportsWithPushSupport")
-    public void testPushedResources(Transport transport) throws Exception
+    public void testPushedResources(TransportType transportType) throws Exception
     {
         Random random = new Random();
         byte[] bytes = new byte[512];
@@ -55,7 +55,7 @@ public class PushedResourcesTest extends AbstractTest
 
         String path1 = "/secondary1";
         String path2 = "/secondary2";
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -84,7 +84,7 @@ public class PushedResourcesTest extends AbstractTest
 
         CountDownLatch latch1 = new CountDownLatch(1);
         CountDownLatch latch2 = new CountDownLatch(1);
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .onPush((mainRequest, pushedRequest) -> new BufferingResponseListener()
             {
                 @Override
@@ -114,7 +114,7 @@ public class PushedResourcesTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsWithPushSupport")
-    public void testPushedResourcesSomewhatLikeTCK(Transport transport) throws Exception
+    public void testPushedResourcesSomewhatLikeTCK(TransportType transportType) throws Exception
     {
         Random random = new Random();
         byte[] bytes = new byte[512];
@@ -126,7 +126,7 @@ public class PushedResourcesTest extends AbstractTest
 
         String path1 = "/secondary1";
         String path2 = "/secondary2";
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -202,7 +202,7 @@ public class PushedResourcesTest extends AbstractTest
 
         CountDownLatch latch1 = new CountDownLatch(1);
         CountDownLatch latch2 = new CountDownLatch(1);
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .onPush((mainRequest, pushedRequest) -> new BufferingResponseListener()
             {
                 @Override
@@ -232,11 +232,11 @@ public class PushedResourcesTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsWithPushSupport")
-    public void testPushedResourcesLikeTCK(Transport transport) throws Exception
+    public void testPushedResourcesLikeTCK(TransportType transportType) throws Exception
     {
         String path1 = "/secondary1.html";
 
-        prepareServer(transport, new DefaultServlet());
+        prepareServer(transportType, new DefaultServlet());
         Path staticDir = MavenTestingUtils.getTestResourcePath("serverpushtck");
         assertNotNull(staticDir);
         servletContextHandler.setBaseResourceAsPath(staticDir);
@@ -302,10 +302,10 @@ public class PushedResourcesTest extends AbstractTest
             "/serverpushtck/*");
 
         server.start();
-        startClient(transport);
+        startClient(transportType);
         CountDownLatch latch1 = new CountDownLatch(1);
 
-        String scheme = transport.isSecure() ? "https" : "http";
+        String scheme = transportType.isSecure() ? "https" : "http";
         String uri = scheme + "://localhost";
         if (connector instanceof NetworkConnector networkConnector)
             uri += ":" + networkConnector.getLocalPort();
@@ -335,7 +335,7 @@ public class PushedResourcesTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsWithPushSupport")
-    public void testPushedResourceRedirect(Transport transport) throws Exception
+    public void testPushedResourceRedirect(TransportType transportType) throws Exception
     {
         Random random = new Random();
         byte[] pushBytes = new byte[512];
@@ -343,7 +343,7 @@ public class PushedResourcesTest extends AbstractTest
 
         String oldPath = "/old";
         String newPath = "/new";
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -360,7 +360,7 @@ public class PushedResourcesTest extends AbstractTest
 
         CountDownLatch latch = new CountDownLatch(1);
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .onPush((mainRequest, pushedRequest) -> new BufferingResponseListener()
             {
                 @Override

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/RequestReaderTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/RequestReaderTest.java
@@ -34,9 +34,9 @@ public class RequestReaderTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transports")
-    public void testRecyclingWhenUsingReader(Transport transport) throws Exception
+    public void testRecyclingWhenUsingReader(TransportType transportType) throws Exception
     {
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
@@ -54,7 +54,7 @@ public class RequestReaderTest extends AbstractTest
             }
         });
 
-        ContentResponse response1 = client.newRequest(newURI(transport))
+        ContentResponse response1 = client.newRequest(newURI(transportType))
             .method("POST")
             .timeout(5, TimeUnit.SECONDS)
             .body(new BytesRequestContent(new byte[512]))
@@ -62,7 +62,7 @@ public class RequestReaderTest extends AbstractTest
         assertThat(response1.getStatus(), is(HttpStatus.OK_200));
 
         // Send a 2nd request to make sure recycling works.
-        ContentResponse response2 = client.newRequest(newURI(transport))
+        ContentResponse response2 = client.newRequest(newURI(transportType))
             .method("POST")
             .timeout(5, TimeUnit.SECONDS)
             .body(new BytesRequestContent(new byte[512]))

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/ServerTimeoutsTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/ServerTimeoutsTest.java
@@ -65,35 +65,35 @@ public class ServerTimeoutsTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testBlockingReadWithDelayedFirstContentWithUndelayedDispatchIdleTimeoutFires(Transport transport) throws Exception
+    public void testBlockingReadWithDelayedFirstContentWithUndelayedDispatchIdleTimeoutFires(TransportType transportType) throws Exception
     {
-        testBlockingReadWithDelayedFirstContentIdleTimeoutFires(transport, false);
+        testBlockingReadWithDelayedFirstContentIdleTimeoutFires(transportType, false);
     }
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testBlockingReadWithDelayedFirstContentWithDelayedDispatchIdleTimeoutFires(Transport transport) throws Exception
+    public void testBlockingReadWithDelayedFirstContentWithDelayedDispatchIdleTimeoutFires(TransportType transportType) throws Exception
     {
-        testBlockingReadWithDelayedFirstContentIdleTimeoutFires(transport, true);
+        testBlockingReadWithDelayedFirstContentIdleTimeoutFires(transportType, true);
     }
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncReadWithDelayedFirstContentWithUndelayedDispatchIdleTimeoutFires(Transport transport) throws Exception
+    public void testAsyncReadWithDelayedFirstContentWithUndelayedDispatchIdleTimeoutFires(TransportType transportType) throws Exception
     {
-        testAsyncReadWithDelayedFirstContentIdleTimeoutFires(transport, false);
+        testAsyncReadWithDelayedFirstContentIdleTimeoutFires(transportType, false);
     }
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncReadWithDelayedFirstContentWithDelayedDispatchIdleTimeoutFires(Transport transport) throws Exception
+    public void testAsyncReadWithDelayedFirstContentWithDelayedDispatchIdleTimeoutFires(TransportType transportType) throws Exception
     {
-        testAsyncReadWithDelayedFirstContentIdleTimeoutFires(transport, true);
+        testAsyncReadWithDelayedFirstContentIdleTimeoutFires(transportType, true);
     }
 
-    private void testBlockingReadWithDelayedFirstContentIdleTimeoutFires(Transport transport, boolean delayDispatch) throws Exception
+    private void testBlockingReadWithDelayedFirstContentIdleTimeoutFires(TransportType transportType, boolean delayDispatch) throws Exception
     {
-        testReadWithDelayedFirstContentIdleTimeoutFires(transport, new HttpServlet()
+        testReadWithDelayedFirstContentIdleTimeoutFires(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -105,9 +105,9 @@ public class ServerTimeoutsTest extends AbstractTest
         }, delayDispatch);
     }
 
-    private void testAsyncReadWithDelayedFirstContentIdleTimeoutFires(Transport transport, boolean delayDispatch) throws Exception
+    private void testAsyncReadWithDelayedFirstContentIdleTimeoutFires(TransportType transportType, boolean delayDispatch) throws Exception
     {
-        testReadWithDelayedFirstContentIdleTimeoutFires(transport, new HttpServlet()
+        testReadWithDelayedFirstContentIdleTimeoutFires(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -139,11 +139,11 @@ public class ServerTimeoutsTest extends AbstractTest
         }, delayDispatch);
     }
 
-    private void testReadWithDelayedFirstContentIdleTimeoutFires(Transport transport, HttpServlet servlet, boolean delayDispatch) throws Exception
+    private void testReadWithDelayedFirstContentIdleTimeoutFires(TransportType transportType, HttpServlet servlet, boolean delayDispatch) throws Exception
     {
         httpConfig.setDelayDispatchUntilContent(delayDispatch);
         CountDownLatch handlerLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
@@ -163,7 +163,7 @@ public class ServerTimeoutsTest extends AbstractTest
 
         CountDownLatch resultLatch = new CountDownLatch(2);
         AsyncRequestContent content = new AsyncRequestContent();
-        client.POST(newURI(transport))
+        client.POST(newURI(transportType))
             .body(content)
             .onResponseSuccess(response ->
             {
@@ -181,10 +181,10 @@ public class ServerTimeoutsTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncReadIdleTimeoutFires(Transport transport) throws Exception
+    public void testAsyncReadIdleTimeoutFires(TransportType transportType) throws Exception
     {
         CountDownLatch handlerLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -225,7 +225,7 @@ public class ServerTimeoutsTest extends AbstractTest
 
         AsyncRequestContent content = new AsyncRequestContent(ByteBuffer.allocate(1));
         CountDownLatch resultLatch = new CountDownLatch(1);
-        client.POST(newURI(transport))
+        client.POST(newURI(transportType))
             .body(content)
             .send(result ->
             {
@@ -242,10 +242,10 @@ public class ServerTimeoutsTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncWriteIdleTimeoutFires(Transport transport) throws Exception
+    public void testAsyncWriteIdleTimeoutFires(TransportType transportType) throws Exception
     {
         CountDownLatch handlerLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -278,7 +278,7 @@ public class ServerTimeoutsTest extends AbstractTest
 
         BlockingQueue<Runnable> demanders = new LinkedBlockingQueue<>();
         CountDownLatch resultLatch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .onResponseContentAsync((response, chunk, demander) ->
             {
                 // Do not succeed the callback so the server will block writing.
@@ -305,12 +305,12 @@ public class ServerTimeoutsTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testBlockingReadWithMinimumDataRateBelowLimit(Transport transport) throws Exception
+    public void testBlockingReadWithMinimumDataRateBelowLimit(TransportType transportType) throws Exception
     {
         int bytesPerSecond = 20;
         httpConfig.setMinRequestDataRate(bytesPerSecond);
         CountDownLatch handlerLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -338,7 +338,7 @@ public class ServerTimeoutsTest extends AbstractTest
         AtomicReference<Response> responseRef = new AtomicReference<>();
         CountDownLatch responseLatch = new CountDownLatch(1);
         CountDownLatch resultLatch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .body(content)
             .onResponseSuccess(response ->
             {
@@ -367,12 +367,12 @@ public class ServerTimeoutsTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testBlockingReadWithMinimumDataRateAboveLimit(Transport transport) throws Exception
+    public void testBlockingReadWithMinimumDataRateAboveLimit(TransportType transportType) throws Exception
     {
         int bytesPerSecond = 20;
         httpConfig.setMinRequestDataRate(bytesPerSecond);
         CountDownLatch handlerLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -390,7 +390,7 @@ public class ServerTimeoutsTest extends AbstractTest
 
         AsyncRequestContent content = new AsyncRequestContent();
         CountDownLatch resultLatch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .body(content)
             .send(result ->
             {
@@ -411,20 +411,20 @@ public class ServerTimeoutsTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testBlockingReadHttpIdleTimeoutOverridesIdleTimeout(Transport transport) throws Exception
+    public void testBlockingReadHttpIdleTimeoutOverridesIdleTimeout(TransportType transportType) throws Exception
     {
         long httpIdleTimeout = 2500;
         long idleTimeout = 3 * httpIdleTimeout;
         httpConfig.setIdleTimeout(httpIdleTimeout);
         CountDownLatch handlerLatch = new CountDownLatch(1);
-        start(transport, new BlockingReadServlet(handlerLatch));
+        start(transportType, new BlockingReadServlet(handlerLatch));
         setStreamIdleTimeout(idleTimeout);
 
         try (StacklessLogging ignore = new StacklessLogging(HttpChannelState.class))
         {
             AsyncRequestContent content = new AsyncRequestContent(ByteBuffer.allocate(1));
             CountDownLatch resultLatch = new CountDownLatch(1);
-            client.POST(newURI(transport))
+            client.POST(newURI(transportType))
                 .body(content)
                 .send(result ->
                 {
@@ -442,13 +442,13 @@ public class ServerTimeoutsTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testAsyncReadHttpIdleTimeoutOverridesIdleTimeout(Transport transport) throws Exception
+    public void testAsyncReadHttpIdleTimeoutOverridesIdleTimeout(TransportType transportType) throws Exception
     {
         long httpIdleTimeout = 2500;
         long idleTimeout = 3 * httpIdleTimeout;
         httpConfig.setIdleTimeout(httpIdleTimeout);
         CountDownLatch handlerLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -488,7 +488,7 @@ public class ServerTimeoutsTest extends AbstractTest
 
         AsyncRequestContent content = new AsyncRequestContent(ByteBuffer.allocate(1));
         CountDownLatch resultLatch = new CountDownLatch(1);
-        client.POST(newURI(transport))
+        client.POST(newURI(transportType))
             .body(content)
             .send(result ->
             {
@@ -505,10 +505,10 @@ public class ServerTimeoutsTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testIdleTimeoutBeforeReadIsIgnored(Transport transport) throws Exception
+    public void testIdleTimeoutBeforeReadIsIgnored(TransportType transportType) throws Exception
     {
         long idleTimeout = 1000;
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -534,7 +534,7 @@ public class ServerTimeoutsTest extends AbstractTest
         System.arraycopy(data, data1.length, data2, 0, data2.length);
         AsyncRequestContent content = new AsyncRequestContent(ByteBuffer.wrap(data1));
         CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .body(content)
             .send(new BufferingResponseListener()
             {
@@ -558,7 +558,7 @@ public class ServerTimeoutsTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testBlockingWriteWithMinimumDataRateBelowLimit(Transport transport) throws Exception
+    public void testBlockingWriteWithMinimumDataRateBelowLimit(TransportType transportType) throws Exception
     {
         // This test needs a large write to stall the server, and a slow reading client.
         // In HTTP/1.1, when using the loopback interface, the buffers are so large that
@@ -571,12 +571,12 @@ public class ServerTimeoutsTest extends AbstractTest
         // In HTTP/2, we force the flow control window to be small, so that the server
         // stalls almost immediately without having written many bytes, so that the test
         // completes quickly.
-        assumeTrue(transport == Transport.H2C || transport == Transport.H2);
+        assumeTrue(transportType == TransportType.H2C || transportType == TransportType.H2);
 
         int bytesPerSecond = 16 * 1024;
         httpConfig.setMinResponseDataRate(bytesPerSecond);
         CountDownLatch serverLatch = new CountDownLatch(1);
-        start(transport, new HttpServlet()
+        start(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response)
@@ -597,7 +597,7 @@ public class ServerTimeoutsTest extends AbstractTest
         // Setup the client to read slower than the min data rate.
         BlockingQueue<Object> objects = new LinkedBlockingQueue<>();
         CountDownLatch clientLatch = new CountDownLatch(1);
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .onResponseContentAsync((response, chunk, demander) ->
             {
                 objects.offer(chunk.remaining());

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/VirtualThreadsTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/VirtualThreadsTest.java
@@ -47,13 +47,13 @@ public class VirtualThreadsTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transports")
-    public void testServletInvokedOnVirtualThread(Transport transport) throws Exception
+    public void testServletInvokedOnVirtualThread(TransportType transportType) throws Exception
     {
         // No virtual thread support in FCGI server-side.
-        Assumptions.assumeTrue(transport != Transport.FCGI);
+        Assumptions.assumeTrue(transportType != TransportType.FCGI);
 
         String virtualThreadsName = "green-";
-        prepareServer(transport, new HttpServlet()
+        prepareServer(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response)
@@ -71,24 +71,24 @@ public class VirtualThreadsTest extends AbstractTest
             ((VirtualThreads.Configurable)threadPool).setVirtualThreadsExecutor(virtualThreadsExecutor);
         }
         server.start();
-        startClient(transport);
+        startClient(transportType);
 
-        ContentResponse response = client.newRequest(newURI(transport))
+        ContentResponse response = client.newRequest(newURI(transportType))
             .timeout(5, TimeUnit.SECONDS)
             .send();
 
-        assertEquals(HttpStatus.OK_200, response.getStatus(), " for transport " + transport);
+        assertEquals(HttpStatus.OK_200, response.getStatus(), " for transport " + transportType);
     }
 
     @ParameterizedTest
     @MethodSource("transports")
-    public void testServletCallbacksInvokedOnVirtualThread(Transport transport) throws Exception
+    public void testServletCallbacksInvokedOnVirtualThread(TransportType transportType) throws Exception
     {
         // No virtual thread support in FCGI server-side.
-        Assumptions.assumeTrue(transport != Transport.FCGI);
+        Assumptions.assumeTrue(transportType != TransportType.FCGI);
 
         byte[] data = new byte[2 * 1024 * 1024];
-        prepareServer(transport, new HttpServlet()
+        prepareServer(transportType, new HttpServlet()
         {
             @Override
             protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
@@ -151,11 +151,11 @@ public class VirtualThreadsTest extends AbstractTest
         if (threadPool instanceof VirtualThreads.Configurable)
             ((VirtualThreads.Configurable)threadPool).setVirtualThreadsExecutor(VirtualThreads.getDefaultVirtualThreadsExecutor());
         server.start();
-        startClient(transport);
+        startClient(transportType);
 
         CountDownLatch latch = new CountDownLatch(1);
         AtomicInteger length = new AtomicInteger();
-        client.newRequest(newURI(transport))
+        client.newRequest(newURI(transportType))
             .method(HttpMethod.POST)
             .body(new StringRequestContent("hello"))
             .onResponseContent((response, content) -> length.addAndGet(content.remaining()))


### PR DESCRIPTION
This is to avoid confusion with oej.io.Transport, and facilitate refactoring (as the word "transport" appears in package names, documentation, etc.).

Also renamed the constant `H3` to `H3_QUICHE`, to facilitate merging of the QuicStreams work.