### PR TITLE
Fixes #12646 - CompleteListener may be invoked twice.

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpExchange.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpExchange.java
@@ -157,11 +157,11 @@ public class HttpExchange implements CyclicTimeouts.Expirable
     {
         try (AutoLock ignored = lock.lock())
         {
-            return completeRequest(failure);
+            return lockedCompleteRequest(failure);
         }
     }
 
-    private boolean completeRequest(Throwable failure)
+    private boolean lockedCompleteRequest(Throwable failure)
     {
         assert lock.isHeldByCurrentThread();
         if (requestState == State.PENDING)
@@ -185,11 +185,11 @@ public class HttpExchange implements CyclicTimeouts.Expirable
     {
         try (AutoLock ignored = lock.lock())
         {
-            return completeResponse(failure);
+            return lockedCompleteResponse(failure);
         }
     }
 
-    private boolean completeResponse(Throwable failure)
+    private boolean lockedCompleteResponse(Throwable failure)
     {
         assert lock.isHeldByCurrentThread();
         if (responseState == State.PENDING)
@@ -251,8 +251,8 @@ public class HttpExchange implements CyclicTimeouts.Expirable
         boolean abortResponse;
         try (AutoLock ignored = lock.lock())
         {
-            abortRequest = completeRequest(failure);
-            abortResponse = completeResponse(failure);
+            abortRequest = lockedCompleteRequest(failure);
+            abortResponse = lockedCompleteResponse(failure);
         }
 
         if (!abortRequest && !abortResponse)

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpExchange.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpExchange.java
@@ -247,10 +247,12 @@ public class HttpExchange implements CyclicTimeouts.Expirable
     {
         // Atomically change the state of this exchange to be completed.
         // This will avoid that this exchange can be associated to a channel.
+        HttpChannel channel;
         boolean abortRequest;
         boolean abortResponse;
         try (AutoLock ignored = lock.lock())
         {
+            channel = _channel;
             abortRequest = lockedCompleteRequest(failure);
             abortResponse = lockedCompleteResponse(failure);
         }
@@ -265,11 +267,6 @@ public class HttpExchange implements CyclicTimeouts.Expirable
             LOG.debug("Failed {}: req={}/rsp={}", this, abortRequest, abortResponse, failure);
 
         // We failed this exchange, deal with it.
-
-        // Retrieve the channel before other code
-        // may cause disassociation, so we can tell
-        // whether this exchange was ever associated.
-        HttpChannel channel = getHttpChannel();
 
         // Applications could be blocked providing
         // request content, notify them of the failure.

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientFailureTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientFailureTest.java
@@ -19,20 +19,29 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.jetty.client.transport.HttpClientTransportOverHTTP;
 import org.eclipse.jetty.client.transport.HttpDestination;
 import org.eclipse.jetty.client.transport.internal.HttpConnectionOverHTTP;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -41,7 +50,6 @@ public class HttpClientFailureTest
 {
     private Server server;
     private ServerConnector connector;
-    private HttpClient client;
 
     private void startServer(Handler handler) throws Exception
     {
@@ -57,10 +65,7 @@ public class HttpClientFailureTest
     @AfterEach
     public void dispose() throws Exception
     {
-        if (server != null)
-            server.stop();
-        if (client != null)
-            client.stop();
+        LifeCycle.stop(server);
     }
 
     @Test
@@ -68,19 +73,21 @@ public class HttpClientFailureTest
     {
         startServer(new EmptyServerHandler());
 
-        client = new HttpClient(new HttpClientTransportOverHTTP(1));
-        client.start();
+        try (HttpClient client = new HttpClient(new HttpClientTransportOverHTTP(1)))
+        {
+            client.start();
 
-        Request request = client.newRequest("localhost", connector.getLocalPort())
-            .onRequestHeaders(r -> r.getConnection().close())
-            .timeout(5, TimeUnit.SECONDS);
-        assertThrows(ExecutionException.class, request::send);
+            Request request = client.newRequest("localhost", connector.getLocalPort())
+                .onRequestHeaders(r -> r.getConnection().close())
+                .timeout(5, TimeUnit.SECONDS);
+            assertThrows(ExecutionException.class, request::send);
 
-        HttpDestination destination = (HttpDestination)client.resolveDestination(request);
-        DuplexConnectionPool connectionPool = (DuplexConnectionPool)destination.getConnectionPool();
-        assertEquals(0, connectionPool.getConnectionCount());
-        assertEquals(0, connectionPool.getActiveConnections().size());
-        assertEquals(0, connectionPool.getIdleConnections().size());
+            HttpDestination destination = (HttpDestination)client.resolveDestination(request);
+            DuplexConnectionPool connectionPool = (DuplexConnectionPool)destination.getConnectionPool();
+            assertEquals(0, connectionPool.getConnectionCount());
+            assertEquals(0, connectionPool.getActiveConnections().size());
+            assertEquals(0, connectionPool.getIdleConnections().size());
+        }
     }
 
     @Test
@@ -89,7 +96,7 @@ public class HttpClientFailureTest
         startServer(new EmptyServerHandler());
 
         AtomicReference<HttpConnectionOverHTTP> connectionRef = new AtomicReference<>();
-        client = new HttpClient(new HttpClientTransportOverHTTP(1)
+        try (HttpClient client = new HttpClient(new HttpClientTransportOverHTTP(1)
         {
             @Override
             public org.eclipse.jetty.io.Connection newConnection(EndPoint endPoint, Map<String, Object> context) throws IOException
@@ -98,48 +105,83 @@ public class HttpClientFailureTest
                 connectionRef.set(connection);
                 return connection;
             }
-        });
-        client.start();
+        }))
+        {
+            client.start();
 
-        CountDownLatch commitLatch = new CountDownLatch(1);
-        CountDownLatch completeLatch = new CountDownLatch(1);
-        AsyncRequestContent content = new AsyncRequestContent();
-        client.newRequest("localhost", connector.getLocalPort())
-            .onRequestCommit(request ->
+            CountDownLatch commitLatch = new CountDownLatch(1);
+            CountDownLatch completeLatch = new CountDownLatch(1);
+            AsyncRequestContent content = new AsyncRequestContent();
+            client.newRequest("localhost", connector.getLocalPort())
+                .onRequestCommit(request ->
+                {
+                    connectionRef.get().getEndPoint().close();
+                    commitLatch.countDown();
+                })
+                .body(content)
+                .idleTimeout(2, TimeUnit.SECONDS)
+                .send(result ->
+                {
+                    if (result.isFailed())
+                        completeLatch.countDown();
+                });
+
+            assertTrue(commitLatch.await(5, TimeUnit.SECONDS));
+
+            // The first chunk will be read but its write will fail.
+            content.write(ByteBuffer.allocate(1024), Callback.NOOP);
+
+            // The second chunk is failed because the content is failed.
+            CountDownLatch contentLatch = new CountDownLatch(1);
+            content.write(ByteBuffer.allocate(1024), new Callback()
             {
-                connectionRef.get().getEndPoint().close();
-                commitLatch.countDown();
-            })
-            .body(content)
-            .idleTimeout(2, TimeUnit.SECONDS)
-            .send(result ->
-            {
-                if (result.isFailed())
-                    completeLatch.countDown();
+                @Override
+                public void failed(Throwable x)
+                {
+                    contentLatch.countDown();
+                }
             });
 
-        assertTrue(commitLatch.await(5, TimeUnit.SECONDS));
+            assertTrue(contentLatch.await(5, TimeUnit.SECONDS));
+            assertTrue(completeLatch.await(5, TimeUnit.SECONDS));
 
-        // The first chunk will be read but its write will fail.
-        content.write(ByteBuffer.allocate(1024), Callback.NOOP);
+            DuplexConnectionPool connectionPool = (DuplexConnectionPool)connectionRef.get().getHttpDestination().getConnectionPool();
+            assertEquals(0, connectionPool.getConnectionCount());
+            assertEquals(0, connectionPool.getActiveConnections().size());
+            assertEquals(0, connectionPool.getIdleConnections().size());
+        }
+    }
 
-        // The second chunk is failed because the content is failed.
-        CountDownLatch contentLatch = new CountDownLatch(1);
-        content.write(ByteBuffer.allocate(1024), new Callback()
+    @Test
+    public void testPendingRequestContentThenTotalTimeout() throws Exception
+    {
+        startServer(new EmptyServerHandler());
+
+        try (HttpClient client = new HttpClient(new HttpClientTransportOverHTTP(1)))
         {
-            @Override
-            public void failed(Throwable x)
-            {
-                contentLatch.countDown();
-            }
-        });
+            client.start();
 
-        assertTrue(contentLatch.await(5, TimeUnit.SECONDS));
-        assertTrue(completeLatch.await(5, TimeUnit.SECONDS));
+            long timeout = 1000;
+            AsyncRequestContent content = new AsyncRequestContent();
+            AtomicInteger completed = new AtomicInteger();
+            CountDownLatch resultLatch = new CountDownLatch(1);
+            client.newRequest("localhost", connector.getLocalPort())
+                .method(HttpMethod.POST)
+                .body(content)
+                .timeout(timeout, TimeUnit.MILLISECONDS)
+                .send(result ->
+                {
+                    // This is invoked only when the total timeout elapses.
+                    completed.incrementAndGet();
+                    assertThat(result.getRequestFailure(), notNullValue());
+                    assertThat(result.getResponseFailure(), nullValue());
+                    assertThat(result.getResponse().getStatus(), is(HttpStatus.OK_200));
+                    resultLatch.countDown();
+                });
 
-        DuplexConnectionPool connectionPool = (DuplexConnectionPool)connectionRef.get().getHttpDestination().getConnectionPool();
-        assertEquals(0, connectionPool.getConnectionCount());
-        assertEquals(0, connectionPool.getActiveConnections().size());
-        assertEquals(0, connectionPool.getIdleConnections().size());
+            assertTrue(resultLatch.await(2 * timeout, TimeUnit.MILLISECONDS));
+            // Verify that the CompleteListener is invoked only once.
+            await().during(1, TimeUnit.SECONDS).atMost(5, TimeUnit.SECONDS).until(completed::get, is(1));
+        }
     }
 }


### PR DESCRIPTION
Fixed by capturing the HttpChannel before other code could disassociate it from the HttpExchange.