### PR TITLE
Fixes #12652 - Jetty Reactive client hangs for HTTP 401 responses.

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/ContentDecoder.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/ContentDecoder.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.client;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -21,6 +22,7 @@ import java.util.Map;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.io.RetainableByteBuffer;
+import org.eclipse.jetty.util.component.Dumpable;
 
 /**
  * {@link ContentDecoder} decodes content bytes of a response.
@@ -109,7 +111,7 @@ public interface ContentDecoder
         public abstract ContentDecoder newContentDecoder();
     }
 
-    public static class Factories implements Iterable<ContentDecoder.Factory>
+    public static class Factories implements Iterable<ContentDecoder.Factory>, Dumpable
     {
         private final Map<String, Factory> factories = new LinkedHashMap<>();
         private HttpField acceptEncodingField;
@@ -137,6 +139,18 @@ public interface ContentDecoder
             String value = String.join(",", factories.keySet());
             acceptEncodingField = new HttpField(HttpHeader.ACCEPT_ENCODING, value);
             return result;
+        }
+
+        @Override
+        public String dump()
+        {
+            return Dumpable.dump(this);
+        }
+
+        @Override
+        public void dump(Appendable out, String indent) throws IOException
+        {
+            Dumpable.dumpObjects(out, indent, this, factories);
         }
     }
 }

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/ResponseListeners.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/ResponseListeners.java
@@ -27,6 +27,7 @@ import org.eclipse.jetty.client.Result;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.content.ByteBufferContentSource;
+import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.ExceptionUtil;
 import org.eclipse.jetty.util.thread.AutoLock;
 import org.eclipse.jetty.util.thread.Invocable;
@@ -392,15 +393,14 @@ public class ResponseListeners
                 iterator.remove();
         }
         notifyHeaders(headersListener, response);
+        ByteBuffer content = BufferUtil.EMPTY_BUFFER;
         if (response instanceof ContentResponse contentResponse)
         {
-            byte[] content = contentResponse.getContent();
-            if (content != null && content.length > 0)
-            {
-                ByteBufferContentSource byteBufferContentSource = new ByteBufferContentSource(ByteBuffer.wrap(content));
-                notifyContentSource(contentSourceListener, response, byteBufferContentSource);
-            }
+            byte[] bytes = contentResponse.getContent();
+            if (bytes != null && bytes.length > 0)
+                content = ByteBuffer.wrap(bytes);
         }
+        notifyContentSource(contentSourceListener, response, new ByteBufferContentSource(content));
     }
 
     public void emitSuccess(Response response)


### PR DESCRIPTION
Fixed ResponseListeners.emitEvents() to emit the "contentSource" event in all cases.