### PR TITLE
Issue #12650 Fix multipart attribute for forwards.

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/Dispatcher.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/Dispatcher.java
@@ -380,6 +380,10 @@ public class Dispatcher implements RequestDispatcher
         public Enumeration<String> getAttributeNames()
         {
             ArrayList<String> names = new ArrayList<>(Collections.list(super.getAttributeNames()));
+
+            //only return the multipart attribute name if this servlet mapping has multipart config
+            if (names.contains(ServletContextRequest.MULTIPART_CONFIG_ELEMENT) && _mappedServlet.getServletHolder().getMultipartConfigElement() == null)
+                names.remove(ServletContextRequest.MULTIPART_CONFIG_ELEMENT);
             
             //Servlet Spec 9.4.2 no forward attributes if a named dispatcher
             if (_named != null)

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/DispatcherTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/DispatcherTest.java
@@ -20,6 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -30,6 +31,7 @@ import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.FilterConfig;
 import jakarta.servlet.GenericServlet;
+import jakarta.servlet.MultipartConfigElement;
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.Servlet;
 import jakarta.servlet.ServletContext;
@@ -140,6 +142,34 @@ public class DispatcherTest
             Connection: close\r
             \r
             FORWARD""";
+
+        assertEquals(expected, rawResponse);
+    }
+
+
+    @Test
+    public void testMultiPartForwardAttribute() throws Exception
+    {
+        ServletHolder forwardServlet = new ServletHolder(new ForwardServlet());
+        forwardServlet.getRegistration().setMultipartConfig(new MultipartConfigElement("/tmp"));
+        _contextHandler.addServlet(forwardServlet, "/ForwardServlet/*");
+        _contextHandler.addServlet(AssertMultiPartForwardServlet.class, "/AssertMultiPartForwardServlet/*");
+
+        String rawResponse = _connector.getResponse("""
+            GET /context/ForwardServlet?do=assertmultipart&do=more&test=1 HTTP/1.1\r
+            Host: local\r
+            Connection: close\r
+            \r
+            """);
+
+        String expected = """
+            HTTP/1.1 200 OK\r
+            Content-Type: text/html\r
+            Content-Length: 42\r
+            Connection: close\r
+            \r
+            org.eclipse.jetty.multipartConfig = null\r
+            """;
 
         assertEquals(expected, rawResponse);
     }
@@ -993,6 +1023,8 @@ public class DispatcherTest
                 dispatcher = request.getRequestDispatcher(request.getParameter("uri"));
             else if (request.getParameter("do").equals("always"))
                 dispatcher = request.getRequestDispatcher("/AlwaysForwardServlet");
+            else if (request.getParameter("do").equals("assertmultipart"))
+                dispatcher = getServletContext().getRequestDispatcher("/AssertMultiPartForwardServlet?do=end&do=the");
             assert dispatcher != null;
             dispatcher.forward(request, response);
         }
@@ -1500,6 +1532,17 @@ public class DispatcherTest
             response.setContentType("text/html");
             response.setStatus(HttpServletResponse.SC_OK);
             response.getOutputStream().print(request.getDispatcherType().toString());
+        }
+    }
+
+    public static class AssertMultiPartForwardServlet extends HttpServlet
+    {
+        @Override
+        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+        {
+            response.setContentType("text/html");
+            response.setStatus(HttpServletResponse.SC_OK);
+            response.getOutputStream().println("org.eclipse.jetty.multipartConfig = " + request.getAttribute("org.eclipse.jetty.multipartConfig"));
         }
     }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/DispatcherTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/DispatcherTest.java
@@ -145,8 +145,7 @@ public class DispatcherTest
 
         assertEquals(expected, rawResponse);
     }
-
-
+    
     @Test
     public void testMultiPartForwardAttribute() throws Exception
     {


### PR DESCRIPTION
Fixes #12650


During a forward, the `getAttributeNames` method returns the attribute `org.eclipse.jetty.multipartConfig`  if the servlet that is the origin of the forward supports multipart, whereas it should only return it if the servlet that is the target of the forward supports it.