### PR TITLE
Check UriCompliance.Violation.ALLOW_BAD_UTF8 in query parameter extraction

### DIFF
--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
@@ -33,6 +33,7 @@ import org.eclipse.jetty.server.LocalConnector.LocalEndPoint;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.DumpHandler;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.Fields;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,6 +41,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -49,6 +51,7 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RequestTest
 {
@@ -540,5 +543,57 @@ public class RequestTest
                 assertThat(response, not(containsString(notContainsCookie)));
             }
         }
+    }
+
+    /**
+     * Test to ensure that response.write() will add Content-Length on HTTP/1.1 responses.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = { "true", "false"})
+    public void testBadUtf8Query(boolean allowBadUtf8) throws Exception
+    {
+        server.stop();
+
+        if (allowBadUtf8)
+        {
+            for (Connector connector : server.getConnectors())
+            {
+                HttpConnectionFactory httpConnectionFactory = connector.getConnectionFactory(HttpConnectionFactory.class);
+                if (httpConnectionFactory != null)
+                {
+                    HttpConfiguration httpConfiguration = httpConnectionFactory.getHttpConfiguration();
+                    httpConfiguration.setUriCompliance(UriCompliance.DEFAULT.with("test", UriCompliance.Violation.BAD_UTF8_ENCODING));
+                }
+            }
+        }
+
+        server.setHandler(new Handler.Abstract.NonBlocking()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                if (allowBadUtf8)
+                {
+                    Fields fields = Request.extractQueryParameters(request);
+                    assertThat(fields.getValue("param"), is("bad_�"));
+                    assertThat(fields.getValue("other"), is("short�"));
+                }
+                else
+                {
+                    assertThrows(IllegalArgumentException.class, () -> Request.extractQueryParameters(request));
+                }
+                callback.succeeded();
+                return true;
+            }
+        });
+        server.start();
+
+        String request = """
+            GET /foo?param=bad_%e0%b8&other=short%a HTTP/1.1\r
+            Host: local\r
+            \r
+            """;
+        HttpTester.Response response = HttpTester.parseResponse(connector.getResponse(request));
+        assertEquals(HttpStatus.OK_200, response.getStatus());
     }
 }

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/RequestTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/RequestTest.java
@@ -213,6 +213,34 @@ public class RequestTest
     }
 
     @Test
+    public void testBadUtf8Query() throws Exception
+    {
+        _server.stop();
+        _connector.getConnectionFactory(HttpConnectionFactory.class)
+            .getHttpConfiguration().setUriCompliance(UriCompliance.DEFAULT.with("test", UriCompliance.Violation.BAD_UTF8_ENCODING));
+        _server.start();
+
+        _handler._checker = (request, response) ->
+        {
+            String param = request.getParameter("param");
+            String other = request.getParameter("other");
+            return param != null && param.equals("bad_�") && other != null && other.equals("short�");
+        };
+
+        //Send a request with query string with illegal hex code to cause
+        //an exception parsing the params
+        String request = """
+            GET /?param=bad_%e0%b8&other=short%a HTTP/1.1\r
+            Host: whatever\r
+            Connection: close
+            
+            """;
+
+        String responses = _connector.getResponse(request);
+        assertThat(responses, startsWith("HTTP/1.1 200"));
+    }
+
+    @Test
     public void testParamExtraction() throws Exception
     {
         _handler._checker = (request, response) ->


### PR DESCRIPTION
Restore legacy behaviour of using replacement characters for bad UTF8 in query parameters.