### PR TITLE
Issue #12674 - Exclude Xalan from ee8 dependencies

### DIFF
--- a/jetty-ee8/jetty-ee8-glassfish-jstl/pom.xml
+++ b/jetty-ee8/jetty-ee8-glassfish-jstl/pom.xml
@@ -32,20 +32,6 @@
     <dependency>
       <groupId>org.glassfish.web</groupId>
       <artifactId>javax.servlet.jsp.jstl</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.servlet</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>javax.servlet.jsp</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>javax.servlet.jsp.jstl</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/jetty-ee8/jetty-ee8-home/pom.xml
+++ b/jetty-ee8/jetty-ee8-home/pom.xml
@@ -17,11 +17,6 @@
   </properties>
 
   <dependencies>
-    <!--    <dependency>-->
-    <!--      <groupId>org.eclipse.jetty.ee8</groupId>-->
-    <!--      <artifactId>jetty-ee8-cdi</artifactId>-->
-    <!--      <optional>true</optional>-->
-    <!--    </dependency>-->
     <dependency>
       <groupId>org.eclipse.jetty.ee8</groupId>
       <artifactId>jetty-ee8-annotations</artifactId>
@@ -48,11 +43,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <!--    <dependency>-->
-    <!--      <groupId>org.eclipse.jetty.ee8</groupId>-->
-    <!--      <artifactId>jetty-ee8-jaspi</artifactId>-->
-    <!--      <optional>true</optional>-->
-    <!--    </dependency>-->
     <dependency>
       <groupId>org.eclipse.jetty.ee8</groupId>
       <artifactId>jetty-ee8-jndi</artifactId>
@@ -71,7 +61,6 @@
       <groupId>org.eclipse.jetty.ee8</groupId>
       <artifactId>jetty-ee8-proxy</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.eclipse.jetty.ee8</groupId>
       <artifactId>jetty-ee8-quickstart</artifactId>
@@ -198,10 +187,6 @@
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-tree</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>xalan</groupId>
-      <artifactId>xalan</artifactId>
     </dependency>
   </dependencies>
 

--- a/jetty-ee8/jetty-ee8-osgi/test-jetty-ee8-osgi/pom.xml
+++ b/jetty-ee8/jetty-ee8-osgi/test-jetty-ee8-osgi/pom.xml
@@ -84,16 +84,6 @@
     <dependency>
       <groupId>org.glassfish.web</groupId>
       <artifactId>javax.servlet.jsp.jstl</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.servlet</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>javax.servlet.jsp</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.mortbay.jasper</groupId>

--- a/jetty-ee8/pom.xml
+++ b/jetty-ee8/pom.xml
@@ -244,6 +244,24 @@
         <groupId>org.glassfish.web</groupId>
         <artifactId>javax.servlet.jsp.jstl</artifactId>
         <version>${javax.servlet.jsp.jstl.impl.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.servlet.jsp</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.servlet.jsp.jstl</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>xalan</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.mortbay.jasper</groupId>
@@ -254,11 +272,6 @@
         <groupId>org.mortbay.jasper</groupId>
         <artifactId>apache-jsp</artifactId>
         <version>${jsp.impl.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>xalan</groupId>
-        <artifactId>xalan</artifactId>
-        <version>2.7.3</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
The xalan jars are no longer needed on JDK 17+

Standardizing exclusions for xalan jars across all of jetty-ee8.