### PR TITLE
Bump mina-core from 2.2.3 to 2.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -276,7 +276,7 @@
     <maven.surefire.plugin.version>3.3.0</maven.surefire.plugin.version>
     <maven.version>3.9.9</maven.version>
     <maven.war.plugin.version>3.4.0</maven.war.plugin.version>
-    <mina.core.version>2.2.3</mina.core.version>
+    <mina.core.version>2.2.4</mina.core.version>
     <mongo.docker.version>5.0.26</mongo.docker.version>
     <mongodb.version>5.1.3</mongodb.version>
     <netty.version>4.1.115.Final</netty.version>


### PR DESCRIPTION
Bump to a newer version of mina-core due CVE-2024-52046
