### PR TITLE
Fix rounding error in `MultiBufferFileMappedHttpContent` that truncates the contents of files over 2 GB in size

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/FileMappingHttpContentFactory.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/FileMappingHttpContentFactory.java
@@ -163,6 +163,12 @@ public class FileMappingHttpContentFactory implements HttpContent.Factory
 
             long contentLength = content.getContentLengthValue();
             int bufferCount = Math.toIntExact(contentLength / maxBufferSize);
+            if (contentLength % maxBufferSize != 0)
+            {
+                if (bufferCount == Integer.MAX_VALUE)
+                    throw new IOException("Cannot memory map Content as that would require over Integer.MAX_VALUE buffers: " + content);
+                bufferCount++;
+            }
             _buffers = new ByteBuffer[bufferCount];
             long currentPos = 0L;
             long total = 0L;

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ResourceHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ResourceHandlerTest.java
@@ -778,8 +778,6 @@ public class ResourceHandlerTest
                 \r
                 """));
 
-        System.err.println(response);
-
         assertThat(response.getStatus(), is(HttpStatus.OK_200));
         long responseContentLength = response.getLongField(CONTENT_LENGTH);
         assertThat(responseContentLength, is(hugeLength));
@@ -3973,11 +3971,9 @@ public class ResourceHandlerTest
         if (Files.exists(staticFile) && Files.size(staticFile) == size)
         {
             // all done, nothing left to do.
-            System.err.printf("File Exists Already: %s (%,d bytes)%n", staticFile, Files.size(staticFile));
             return;
         }
 
-        System.err.printf("Creating %,d byte file: %s ...%n", size, staticFile);
         try (SeekableByteChannel channel = Files.newByteChannel(staticFile, StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING))
         {
             long remaining = size;
@@ -3995,7 +3991,6 @@ public class ResourceHandlerTest
                 remaining -= len;
             }
         }
-        System.err.println(" Done");
     }
 
     private void setupQuestionMarkDir(Path base) throws IOException

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ResourceHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ResourceHandlerTest.java
@@ -18,6 +18,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
@@ -25,6 +27,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
@@ -758,6 +761,28 @@ public class ResourceHandlerTest
         assertThat(response.getStatus(), is(HttpStatus.OK_200));
         assertThat(response.getContent(), containsString("   400\tThis is a big file\n     1\tThis is a big file"));
         assertThat(response.getContent(), containsString("   400\tThis is a big file\n"));
+    }
+
+    @Test
+    public void testOver2GBFile() throws Exception
+    {
+        long hugeLength = (long)Integer.MAX_VALUE + 10L;
+
+        generateFile(docRoot.resolve("huge.mkv"), hugeLength);
+
+        HttpTester.Response response = HttpTester.parseResponse(
+            _local.getResponse("""
+                GET /context/huge.mkv HTTP/1.1\r
+                Host: local\r
+                Connection: close\r
+                \r
+                """));
+
+        System.err.println(response);
+
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        long responseContentLength = response.getLongField(CONTENT_LENGTH);
+        assertThat(responseContentLength, is(hugeLength));
     }
 
     @Test
@@ -3937,6 +3962,40 @@ public class ResourceHandlerTest
                 IO.copy(in, zipOut);
             }
         }
+    }
+
+    private void generateFile(Path staticFile, long size) throws Exception
+    {
+        byte[] buf = new byte[(int)(1024 * 1024)]; // about 1 MB
+        Arrays.fill(buf, (byte)'x');
+        ByteBuffer src = ByteBuffer.wrap(buf);
+
+        if (Files.exists(staticFile) && Files.size(staticFile) == size)
+        {
+            // all done, nothing left to do.
+            System.err.printf("File Exists Already: %s (%,d bytes)%n", staticFile, Files.size(staticFile));
+            return;
+        }
+
+        System.err.printf("Creating %,d byte file: %s ...%n", size, staticFile);
+        try (SeekableByteChannel channel = Files.newByteChannel(staticFile, StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING))
+        {
+            long remaining = size;
+            while (remaining > 0)
+            {
+                ByteBuffer slice = src.slice();
+                int len = buf.length;
+                if (remaining < Integer.MAX_VALUE)
+                {
+                    len = Math.min(buf.length, (int)remaining);
+                    slice.limit(len);
+                }
+
+                channel.write(slice);
+                remaining -= len;
+            }
+        }
+        System.err.println(" Done");
     }
 
     private void setupQuestionMarkDir(Path base) throws IOException


### PR DESCRIPTION
Fixes #12680