### PR TITLE
Fixes #12706 - Export ArrayByteBufferPool statistics via JMX.

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -130,7 +130,7 @@ public class HttpClient extends ContainerLifeCycle implements AutoCloseable
     private long addressResolutionTimeout = 15000;
     private boolean strictEventOrdering = false;
     private long destinationIdleTimeout;
-    private String name = getClass().getSimpleName() + "@" + Integer.toHexString(hashCode());
+    private String name = "%s@%x".formatted(getClass().getSimpleName(), hashCode());
     private HttpCompliance httpCompliance = HttpCompliance.RFC7230;
     private String defaultRequestContentType = "application/octet-stream";
     private boolean useInputDirectByteBuffers = true;

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -629,13 +629,11 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
 
         private Statistics getStatistics()
         {
-            List<Pool.Entry<RetainableByteBuffer>> entries = getPool().stream().toList();
-            int inUse = (int)entries.stream().filter(Pool.Entry::isInUse).count();
             long pooled = _pooled.longValue();
             long acquires = _acquires.longValue();
             float hitRatio = acquires == 0 ? Float.NaN : pooled * 100F / acquires;
-            return new Statistics(getCapacity(), inUse, entries.size(), pooled, acquires, _releases.longValue(),
-                hitRatio, _nonPooled.longValue(), _evicts.longValue(), _removes.longValue());
+            return new Statistics(getCapacity(), getPool().getInUseCount(), getPool().size(), pooled, acquires,
+                _releases.longValue(), hitRatio, _nonPooled.longValue(), _evicts.longValue(), _removes.longValue());
         }
 
         public void clear()

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/jmx/ServerMBean.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/jmx/ServerMBean.java
@@ -39,6 +39,13 @@ public class ServerMBean extends Handler.AbstractMBean
         return (Server)super.getManagedObject();
     }
 
+    @Override
+    public String getObjectContextBasis()
+    {
+        Server server = getManagedObject();
+        return "%s@%x".formatted(server.getClass().getSimpleName(), server.hashCode());
+    }
+
     @ManagedAttribute("The contexts on this server")
     public List<ContextHandler> getContexts()
     {


### PR DESCRIPTION
* Exposed bucket statistics as a list of maps.
* Exposed non-bucket statistic map.
* Fixed get[Direct|Heap]Memory() and exposed getAvailable[Direct|Heap]Memory().