### PR TITLE
Issue #12714 verify workername for Mongo usage

### DIFF
--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-mongodb/src/test/java/org/eclipse/jetty/ee10/session/nosql/mongodb/MongoSessionDataStoreTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-mongodb/src/test/java/org/eclipse/jetty/ee10/session/nosql/mongodb/MongoSessionDataStoreTest.java
@@ -164,7 +164,7 @@ public class MongoSessionDataStoreTest extends AbstractSessionDataStoreTest
     {
         Server server = new Server();
         DefaultSessionIdManager idMgr = new DefaultSessionIdManager(server);
-        idMgr.setWorkerName("NODE99");
+        idMgr.setWorkerName("NODE_99");
         server.addBean(idMgr);
 
         //create the SessionDataStore

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-mongodb/src/test/java/org/eclipse/jetty/ee10/session/nosql/mongodb/MongoSessionDataStoreTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-mongodb/src/test/java/org/eclipse/jetty/ee10/session/nosql/mongodb/MongoSessionDataStoreTest.java
@@ -17,16 +17,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Consumer;
 
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.session.AbstractSessionDataStoreFactory;
 import org.eclipse.jetty.session.AbstractSessionDataStoreTest;
-import org.eclipse.jetty.session.DefaultSessionCache;
 import org.eclipse.jetty.session.DefaultSessionCacheFactory;
 import org.eclipse.jetty.session.DefaultSessionIdManager;
-import org.eclipse.jetty.session.ManagedSession;
 import org.eclipse.jetty.session.SessionContext;
 import org.eclipse.jetty.session.SessionData;
 import org.eclipse.jetty.session.SessionDataStore;
@@ -39,10 +36,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.testcontainers.shaded.org.hamcrest.Matchers.not;
 
 /**
  * MongoSessionDataStoreTest
@@ -184,10 +181,8 @@ public class MongoSessionDataStoreTest extends AbstractSessionDataStoreTest
         SessionDataStoreFactory factory = createSessionDataStoreFactory();
         server.addBean(factory);
 
-        not(assertThrows(IllegalStateException.class, () ->
-        {
-            server.start();
-        }));
+        assertDoesNotThrow(() ->
+            server.start());
     }
 
     @Test
@@ -211,10 +206,8 @@ public class MongoSessionDataStoreTest extends AbstractSessionDataStoreTest
         SessionDataStoreFactory factory = createSessionDataStoreFactory();
         server.addBean(factory);
 
-        not(assertThrows(IllegalStateException.class, () ->
-        {
-            server.start();
-        }));
+        assertDoesNotThrow(() ->
+            server.start());
     }
 
     /**

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-mongodb/src/test/java/org/eclipse/jetty/ee9/session/nosql/mongodb/MongoSessionDataStoreTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-mongodb/src/test/java/org/eclipse/jetty/ee9/session/nosql/mongodb/MongoSessionDataStoreTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -150,7 +150,7 @@ public class MongoSessionDataStoreTest extends AbstractSessionDataStoreTest
     {
         Server server = new Server();
         DefaultSessionIdManager idMgr = new DefaultSessionIdManager(server);
-        idMgr.setWorkerName("NODE99");
+        idMgr.setWorkerName("NODE_99");
         server.addBean(idMgr);
 
         //create the SessionDataStore
@@ -167,10 +167,8 @@ public class MongoSessionDataStoreTest extends AbstractSessionDataStoreTest
         SessionDataStoreFactory factory = createSessionDataStoreFactory();
         server.addBean(factory);
 
-        not(assertThrows(IllegalStateException.class, () ->
-        {
-            server.start();
-        }));
+        assertDoesNotThrow(() ->
+            server.start());
     }
 
     @Test
@@ -194,10 +192,8 @@ public class MongoSessionDataStoreTest extends AbstractSessionDataStoreTest
         SessionDataStoreFactory factory = createSessionDataStoreFactory();
         server.addBean(factory);
 
-        not(assertThrows(IllegalStateException.class, () ->
-        {
-            server.start();
-        }));
+        assertDoesNotThrow(() ->
+            server.start());
     }
 
     /**

--- a/jetty-integrations/jetty-nosql/src/main/java/org/eclipse/jetty/nosql/mongodb/MongoSessionDataStore.java
+++ b/jetty-integrations/jetty-nosql/src/main/java/org/eclipse/jetty/nosql/mongodb/MongoSessionDataStore.java
@@ -188,7 +188,7 @@ public class MongoSessionDataStore extends NoSqlSessionDataStore
             return;
 
         if (!_workerNamePattern.matcher(_context.getWorkerName()).matches())
-            throw new IllegalStateException("Invalid worker name: " + _context.getWorkerName());
+            throw new IllegalStateException("Worker name " + _context.getWorkerName() + " does not match pattern " + _workerNamePattern.pattern());
     }
 
     @Override

--- a/jetty-integrations/jetty-nosql/src/main/java/org/eclipse/jetty/nosql/mongodb/MongoSessionDataStore.java
+++ b/jetty-integrations/jetty-nosql/src/main/java/org/eclipse/jetty/nosql/mongodb/MongoSessionDataStore.java
@@ -16,20 +16,18 @@ package org.eclipse.jetty.nosql.mongodb;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import com.mongodb.BasicDBObject;
-import com.mongodb.BasicDBObjectBuilder;
 import com.mongodb.DBObject;
 import com.mongodb.MongoException;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Filters;
-import com.mongodb.client.model.IndexModel;
 import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.Indexes;
 import com.mongodb.client.model.Projections;
@@ -42,7 +40,6 @@ import org.eclipse.jetty.nosql.NoSqlSessionDataStore;
 import org.eclipse.jetty.session.SessionContext;
 import org.eclipse.jetty.session.SessionData;
 import org.eclipse.jetty.session.UnreadableSessionDataException;
-import org.eclipse.jetty.util.SearchPattern;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.annotation.ManagedObject;
@@ -160,7 +157,7 @@ public class MongoSessionDataStore extends NoSqlSessionDataStore
      */
     private DBObject _version1;
 
-    private SearchPattern _workerNamePattern = SearchPattern.compile("[0-9][a-zA-Z]*");
+    private Pattern _workerNamePattern = Pattern.compile("[0-9a-zA-Z]*");
 
     /**
      * Access to MongoDB
@@ -190,8 +187,7 @@ public class MongoSessionDataStore extends NoSqlSessionDataStore
         if (_context == null || StringUtil.isEmpty(_context.getWorkerName()))
             return;
 
-        byte[] bytes = _context.getWorkerName().getBytes();
-        if (_workerNamePattern.match(bytes, 0, bytes.length) < 0)
+        if (!_workerNamePattern.matcher(_context.getWorkerName()).matches())
             throw new IllegalStateException("Invalid worker name: " + _context.getWorkerName());
     }
 

--- a/jetty-integrations/jetty-nosql/src/main/java/org/eclipse/jetty/nosql/mongodb/MongoSessionDataStore.java
+++ b/jetty-integrations/jetty-nosql/src/main/java/org/eclipse/jetty/nosql/mongodb/MongoSessionDataStore.java
@@ -157,7 +157,7 @@ public class MongoSessionDataStore extends NoSqlSessionDataStore
      */
     private DBObject _version1;
 
-    private final Pattern _workerNamePattern = Pattern.compile("[0-9a-zA-Z]*");
+    private static final Pattern _workerNamePattern = Pattern.compile("[_0-9a-zA-Z]*");
 
     /**
      * Access to MongoDB

--- a/jetty-integrations/jetty-nosql/src/main/java/org/eclipse/jetty/nosql/mongodb/MongoSessionDataStore.java
+++ b/jetty-integrations/jetty-nosql/src/main/java/org/eclipse/jetty/nosql/mongodb/MongoSessionDataStore.java
@@ -157,7 +157,7 @@ public class MongoSessionDataStore extends NoSqlSessionDataStore
      */
     private DBObject _version1;
 
-    private Pattern _workerNamePattern = Pattern.compile("[0-9a-zA-Z]*");
+    private final Pattern _workerNamePattern = Pattern.compile("[0-9a-zA-Z]*");
 
     /**
      * Access to MongoDB


### PR DESCRIPTION
Fixes #12714

The `workerName` configured on the `DefaultSessionIdManager` can be unacceptable to `MongoDB`.  The `DefaultSessionIdManager` prepends the `workerName` onto the generated random id to form a session id. If this `workerName` contains punctuation or other delimiter type characters, this messes with the `MongoDB` index over the session ids. 

This PR allows `MongoSessionDataStore` to check the `workerName` at startup and fail the startup if it isn't admissible.