### PR TITLE
Improve consistency in API of FormFields maxFields and maxLength

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/FormFields.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/FormFields.java
@@ -127,7 +127,7 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
      * Calls to {@code onFields} and {@code getFields} methods are idempotent, and
      * can be called multiple times, with subsequent calls returning the results of the first call.
      * @param request The request to get or read the Fields from
-     * @param maxFields The maximum number of fields to accept or -1 for a default
+     * @param maxFields The maximum number of fields to accept or -1 for a default.
      * @param maxLength The maximum length of fields or -1 for a default.
      * @return the Fields
      * @see #onFields(Request, Promise.Invocable)
@@ -213,8 +213,8 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
      *
      * @param request The request to get or read the Fields from
      * @param charset The {@link Charset} of the request content, if previously extracted.
-     * @param maxFields The maximum number of fields to accept; or -1 for a default
-     * @param maxLength The maximum length of fields; or -1 for a default
+     * @param maxFields The maximum number of fields to accept; or -1 for a default.
+     * @param maxLength The maximum length of fields; or -1 for a default.
      * @param promise The action to take when the FormFields are available.
      */
     public static void onFields(Request request, Charset charset, int maxFields, int maxLength, Promise.Invocable<Fields> promise)
@@ -254,9 +254,7 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
     @Deprecated(forRemoval = true, since = "12.0.15")
     public static CompletableFuture<Fields> from(Request request)
     {
-        int maxFields = getContextAttribute(request.getContext(), FormFields.MAX_FIELDS_ATTRIBUTE, FormFields.MAX_FIELDS_DEFAULT);
-        int maxLength = getContextAttribute(request.getContext(), FormFields.MAX_LENGTH_ATTRIBUTE, FormFields.MAX_LENGTH_DEFAULT);
-        return from(request, maxFields, maxLength);
+        return from(request, -1, -1);
     }
 
     /**
@@ -271,9 +269,7 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
     @Deprecated(forRemoval = true, since = "12.0.15")
     public static CompletableFuture<Fields> from(Request request, Charset charset)
     {
-        int maxFields = getContextAttribute(request.getContext(), FormFields.MAX_FIELDS_ATTRIBUTE, FormFields.MAX_FIELDS_DEFAULT);
-        int maxLength = getContextAttribute(request.getContext(), FormFields.MAX_LENGTH_ATTRIBUTE, FormFields.MAX_LENGTH_DEFAULT);
-        return from(request, charset, maxFields, maxLength);
+        return from(request, charset, -1, -1);
     }
 
     /**
@@ -281,8 +277,8 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
      * @param request The {@link Request} in which to look for an existing {@link FormFields} attribute,
      *                using the classname as the attribute name, else the request is used
      *                as a {@link Content.Source} from which to read the fields and set the attribute.
-     * @param maxFields The maximum number of fields to be parsed or -1 for unlimited
-     * @param maxLength The maximum total size of the fields or -1 for unlimited
+     * @param maxFields The maximum number of fields to be parsed or -1 for a default.
+     * @param maxLength The maximum total size of the fields or -1 for a default.
      * @return A {@link CompletableFuture} that will provide the {@link Fields} or a failure.
      * @deprecated use {@link #onFields(Request, Charset, int, int, Promise.Invocable)} instead.
      */
@@ -298,14 +294,18 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
      *                using the classname as the attribute name, else the request is used
      *                as a {@link Content.Source} from which to read the fields and set the attribute.
      * @param charset the {@link Charset} to use for byte to string conversion.
-     * @param maxFields The maximum number of fields to be parsed or -1 for unlimited
-     * @param maxLength The maximum total size of the fields or -1 for unlimited
+     * @param maxFields The maximum number of fields to be parsed or -1 for a default.
+     * @param maxLength The maximum total size of the fields or -1 for a default.
      * @return A {@link CompletableFuture} that will provide the {@link Fields} or a failure.
      * @deprecated use {@link #onFields(Request, Charset, int, int, Promise.Invocable)} instead.
      */
     @Deprecated(forRemoval = true, since = "12.0.15")
     public static CompletableFuture<Fields> from(Request request, Charset charset, int maxFields, int maxLength)
     {
+        if (maxFields < 0)
+            maxFields = getContextAttribute(request.getContext(), FormFields.MAX_FIELDS_ATTRIBUTE, FormFields.MAX_FIELDS_DEFAULT);
+        if (maxLength < 0)
+            maxLength = getContextAttribute(request.getContext(), FormFields.MAX_LENGTH_ATTRIBUTE, FormFields.MAX_LENGTH_DEFAULT);
         return from(request, InvocationType.NON_BLOCKING, request, charset, maxFields, maxLength);
     }
 
@@ -317,8 +317,8 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
      *                   {@link FormFields}, using the classname as the attribute name.  If not found the attribute
      *                   is set with the created {@link CompletableFuture} of {@link FormFields}.
      * @param charset the {@link Charset} to use for byte to string conversion.
-     * @param maxFields The maximum number of fields to be parsed
-     * @param maxLength The maximum total size of the fields
+     * @param maxFields The maximum number of fields to be parsed or -1 for unlimited.
+     * @param maxLength The maximum total size of the fields or -1 for unlimited.
      * @return A {@link CompletableFuture} that will provide the {@link Fields} or a failure.
      */
     static CompletableFuture<Fields> from(Content.Source source, InvocationType invocationType, Attributes attributes, Charset charset, int maxFields, int maxLength)

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/FormFields.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/FormFields.java
@@ -129,8 +129,8 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
      * Calls to {@code onFields} and {@code getFields} methods are idempotent, and
      * can be called multiple times, with subsequent calls returning the results of the first call.
      * @param request The request to get or read the Fields from
-     * @param maxFields The maximum number of fields to accept or -1 for unlimited
-     * @param maxLength The maximum length of fields or -1 for unlimited.
+     * @param maxFields The maximum number of fields to accept or -1 for a default
+     * @param maxLength The maximum length of fields or -1 for a default.
      * @return the Fields
      * @see #onFields(Request, Promise.Invocable)
      * @see #onFields(Request, Charset, Promise.Invocable)
@@ -138,6 +138,10 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
      */
     public static Fields getFields(Request request, int maxFields, int maxLength)
     {
+        if (maxFields < 0)
+            maxFields = getContextAttribute(request.getContext(), FormFields.MAX_FIELDS_ATTRIBUTE, FormFields.MAX_FIELDS_DEFAULT);
+        if (maxLength < 0)
+            maxLength = getContextAttribute(request.getContext(), FormFields.MAX_LENGTH_ATTRIBUTE, FormFields.MAX_LENGTH_DEFAULT);
         Charset charset = getFormEncodedCharset(request);
         return from(request, InvocationType.NON_BLOCKING, request, charset, maxFields, maxLength).join();
     }
@@ -154,8 +158,9 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
      * @param attributes The {@link Attributes} in which to look for an existing {@link CompletableFuture} of
      *                   {@link FormFields}, using the classname as the attribute name.  If not found the attribute
      *                   is set with the created {@link CompletableFuture} of {@link FormFields}.
-     * @param charset the {@link Charset} to use for byte to string conversion.     * @param maxFields The maximum number of fields to accept
-     * @param maxLength The maximum length of fields
+     * @param charset the {@link Charset} to use for byte to string conversion.
+     * @param maxFields The maximum number of fields to accept or -1 for a default.
+     * @param maxLength The maximum length of fields or -1 for a default.
      * @return the Fields
      * @see #onFields(Request, Promise.Invocable)
      * @see #onFields(Request, Charset, Promise.Invocable)
@@ -163,6 +168,10 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
      */
     public static Fields getFields(Content.Source source, Attributes attributes, Charset charset, int maxFields, int maxLength)
     {
+        if (maxFields < 0)
+            maxFields = FormFields.MAX_FIELDS_DEFAULT;
+        if (maxLength < 0)
+            maxLength = FormFields.MAX_FIELDS_DEFAULT;
         return from(source, InvocationType.NON_BLOCKING, attributes, charset, maxFields, maxLength).join();
     }
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/FormFields.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/FormFields.java
@@ -115,9 +115,7 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
      */
     public static Fields getFields(Request request)
     {
-        int maxFields = getContextAttribute(request.getContext(), FormFields.MAX_FIELDS_ATTRIBUTE, FormFields.MAX_FIELDS_DEFAULT);
-        int maxLength = getContextAttribute(request.getContext(), FormFields.MAX_LENGTH_ATTRIBUTE, FormFields.MAX_LENGTH_DEFAULT);
-        return getFields(request, maxFields, maxLength);
+        return getFields(request, -1, -1);
     }
 
     /**

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
@@ -666,6 +666,9 @@ public class ServletContextHandler extends ContextHandler
         return _welcomeFiles;
     }
 
+    /**
+     * @return the maximum size of the form content (in bytes).
+     */
     @ManagedAttribute("The maximum content size")
     public int getMaxFormContentSize()
     {
@@ -675,13 +678,19 @@ public class ServletContextHandler extends ContextHandler
     /**
      * Set the maximum size of a form post, to protect against DOS attacks from large forms.
      *
-     * @param maxSize the maximum size of the form content (in bytes)
+     * @param maxSize the maximum size of the form content (in bytes) or -1 for a default value.
      */
     public void setMaxFormContentSize(int maxSize)
     {
+        if (maxSize < 0)
+            maxSize = Integer.getInteger(MAX_FORM_CONTENT_SIZE_KEY, DEFAULT_MAX_FORM_CONTENT_SIZE);
         _maxFormContentSize = maxSize;
     }
 
+    /**
+     * @return the maximum number of form Keys.
+     */
+    @ManagedAttribute("The maximum number of form keys")
     public int getMaxFormKeys()
     {
         return _maxFormKeys;
@@ -690,10 +699,12 @@ public class ServletContextHandler extends ContextHandler
     /**
      * Set the maximum number of form Keys to protect against DOS attack from crafted hash keys.
      *
-     * @param max the maximum number of form keys
+     * @param max the maximum number of form keys or -1 for a default value.
      */
     public void setMaxFormKeys(int max)
     {
+        if (max < 0)
+            max = Integer.getInteger(MAX_FORM_KEYS_KEY, DEFAULT_MAX_FORM_KEYS);
         _maxFormKeys = max;
     }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/FormTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/FormTest.java
@@ -148,10 +148,7 @@ public class FormTest
             })
             .send();
 
-        int expected = (maxFormContentSize != null && maxFormContentSize < 0)
-            ? HttpStatus.OK_200
-            : HttpStatus.BAD_REQUEST_400;
-        assertEquals(expected, response.getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST_400, response.getStatus());
     }
 
     public static Stream<Integer> formKeysScenarios()
@@ -193,10 +190,7 @@ public class FormTest
             .body(new FormRequestContent(formParams))
             .send();
 
-        int expected = (maxFormKeys != null && maxFormKeys < 0)
-            ? HttpStatus.OK_200
-            : HttpStatus.BAD_REQUEST_400;
-        assertEquals(expected, response.getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST_400, response.getStatus());
     }
 
     @Test

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextHandler.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextHandler.java
@@ -688,7 +688,7 @@ public class ServletContextHandler extends ContextHandler
     /**
      * Set the maximum number of form Keys to protect against DOS attack from crafted hash keys.
      *
-     * @param max the maximum number of form keys
+     * @param max the maximum number of form keys or -1 for a default value.
      */
     public void setMaxFormKeys(int max)
     {

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextHandler.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextHandler.java
@@ -664,6 +664,9 @@ public class ServletContextHandler extends ContextHandler
         return _welcomeFiles;
     }
 
+    /**
+     * @return the maximum size of the form content (in bytes).
+     */
     @ManagedAttribute("The maximum content size")
     public int getMaxFormContentSize()
     {
@@ -673,13 +676,19 @@ public class ServletContextHandler extends ContextHandler
     /**
      * Set the maximum size of a form post, to protect against DOS attacks from large forms.
      *
-     * @param maxSize the maximum size of the form content (in bytes)
+     * @param maxSize the maximum size of the form content (in bytes) or -1 for a default value.
      */
     public void setMaxFormContentSize(int maxSize)
     {
+        if (maxSize < 0)
+            maxSize = Integer.getInteger(MAX_FORM_CONTENT_SIZE_KEY, DEFAULT_MAX_FORM_CONTENT_SIZE);
         _maxFormContentSize = maxSize;
     }
 
+    /**
+     * @return the maximum number of form Keys.
+     */
+    @ManagedAttribute("The maximum number of form keys")
     public int getMaxFormKeys()
     {
         return _maxFormKeys;
@@ -692,6 +701,8 @@ public class ServletContextHandler extends ContextHandler
      */
     public void setMaxFormKeys(int max)
     {
+        if (max < 0)
+            max = Integer.getInteger(MAX_FORM_KEYS_KEY, DEFAULT_MAX_FORM_KEYS);
         _maxFormKeys = max;
     }
 

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/FormTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/FormTest.java
@@ -148,10 +148,7 @@ public class FormTest
             })
             .send();
 
-        int expected = (maxFormContentSize != null && maxFormContentSize < 0)
-            ? HttpStatus.OK_200
-            : HttpStatus.BAD_REQUEST_400;
-        assertEquals(expected, response.getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST_400, response.getStatus());
     }
 
     public static Stream<Integer> formKeysScenarios()
@@ -193,10 +190,7 @@ public class FormTest
             .body(new FormRequestContent(formParams))
             .send();
 
-        int expected = (maxFormKeys != null && maxFormKeys < 0)
-            ? HttpStatus.OK_200
-            : HttpStatus.BAD_REQUEST_400;
-        assertEquals(expected, response.getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST_400, response.getStatus());
     }
 
     @Test

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
@@ -1377,6 +1377,9 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
         _errorHandler = errorHandler;
     }
 
+    /**
+     * @return the maximum size of the form content (in bytes).
+     */
     @ManagedAttribute("The maximum content size")
     public int getMaxFormContentSize()
     {
@@ -1386,13 +1389,19 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
     /**
      * Set the maximum size of a form post, to protect against DOS attacks from large forms.
      *
-     * @param maxSize the maximum size of the form content (in bytes)
+     * @param maxSize the maximum size of the form content (in bytes) or -1 for a default value.
      */
     public void setMaxFormContentSize(int maxSize)
     {
+        if (maxSize < 0)
+            maxSize = Integer.getInteger(MAX_FORM_CONTENT_SIZE_KEY, DEFAULT_MAX_FORM_CONTENT_SIZE);
         _maxFormContentSize = maxSize;
     }
 
+    /**
+     * @return the maximum number of form Keys.
+     */
+    @ManagedAttribute("The maximum number of form keys")
     public int getMaxFormKeys()
     {
         return _maxFormKeys;
@@ -1401,10 +1410,12 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
     /**
      * Set the maximum number of form Keys to protect against DOS attack from crafted hash keys.
      *
-     * @param max the maximum number of form keys
+     * @param max the maximum number of form keys or -1 for a default value.
      */
     public void setMaxFormKeys(int max)
     {
+        if (max < 0)
+            max = Integer.getInteger(MAX_FORM_KEYS_KEY, DEFAULT_MAX_FORM_KEYS);
         _maxFormKeys = max;
     }
 

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
@@ -2052,7 +2052,12 @@ public class Request implements HttpServletRequest
             else
             {
                 maxFormContentSize = lookupServerAttribute(ContextHandler.MAX_FORM_CONTENT_SIZE_KEY, maxFormContentSize);
+                if (maxFormContentSize < 0)
+                    maxFormContentSize = ContextHandler.DEFAULT_MAX_FORM_CONTENT_SIZE;
+
                 maxFormKeys = lookupServerAttribute(ContextHandler.MAX_FORM_KEYS_KEY, maxFormKeys);
+                if (maxFormKeys < 0)
+                    maxFormKeys = ContextHandler.DEFAULT_MAX_FORM_KEYS;
             }
 
             MultiPartCompliance multiPartCompliance = getHttpChannel().getHttpConfiguration().getMultiPartCompliance();

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/FormTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/FormTest.java
@@ -154,10 +154,7 @@ public class FormTest
             })
             .send();
 
-        int expected = (maxFormContentSize != null && maxFormContentSize < 0)
-            ? HttpStatus.OK_200
-            : HttpStatus.BAD_REQUEST_400;
-        assertEquals(expected, response.getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST_400, response.getStatus());
     }
 
     public static Stream<Integer> formKeysScenarios()
@@ -199,10 +196,7 @@ public class FormTest
             .body(new FormRequestContent(formParams))
             .send();
 
-        int expected = (maxFormKeys != null && maxFormKeys < 0)
-            ? HttpStatus.OK_200
-            : HttpStatus.BAD_REQUEST_400;
-        assertEquals(expected, response.getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST_400, response.getStatus());
     }
 
     @Test


### PR DESCRIPTION
I don't like the usage of `-1` for a default `maxFields` and `maxLength` value as we already have methods which don't take these `maxFields` and `maxLength` parameters which will give you a default value anyway.

But if we decide to use `-1` for a default value we should make it consistent across the other non-deprecated methods.

Methods like `CompletableFuture<Fields> from(Request request, Charset charset, int maxFields, int maxLength)` are still using -1 for unlimited, but these are deprecated. 