### PR TITLE
Update the _matchAfterIndex variable after setting new filter mappings

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletHandler.java
@@ -1392,6 +1392,7 @@ public class ServletHandler extends Handler.Wrapper
         {
             List<FilterMapping> mappings = filterMappings == null ? Collections.emptyList() : Arrays.asList(filterMappings);
             updateAndSet(_filterMappings, mappings);
+            _matchAfterIndex = mappings.size() - 1;
             if (isRunning())
                 updateMappings();
             invalidateChainsCache();


### PR DESCRIPTION
Updates the _matchAfterIndex to the correct value based on how many filter mappings the user added to the ServletHandler. Failing to do so produces an IndexOutOfBoundsException when adding subsequent filter mappings.