### PR TITLE
Issue #12725 reset match indexes for FilterMappings on setFilterMappings

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletHandler.java
@@ -1395,6 +1395,8 @@ public class ServletHandler extends Handler.Wrapper
             if (isRunning())
                 updateMappings();
             invalidateChainsCache();
+            _matchBeforeIndex = -1;
+            _matchAfterIndex = -1;
         }
     }
 


### PR DESCRIPTION
This is an alternative fix for PR #12725.

When a user calls `ServletHandler.setFilterMappings(FilterMapping[])` this is like a reset of any `FilterMappings` that may have existed previously, either by a previous call to the same method, or importantly via a call to `addFilterMapping(FilterMapping)`. When `addFilterMapping(FilterMapping)` is called, we need to calculate where it should be added, as the servlet spec allows for pre or postpending to existing `FilterMappings`. We maintain 2 indexes `_matchBeforeIndex` and `_matchAfterIndex` to help us determine where to insert the added `FilterMapping`.

As `setFilterMappings([FilterMapping[])` is essentially a reset, these 2 indexes need to be reset too.
