### PR TITLE
Upgrade to quiche 0.23.2

### DIFF
--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/main/java/org/eclipse/jetty/quic/quiche/foreign/NativeHelper.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/main/java/org/eclipse/jetty/quic/quiche/foreign/NativeHelper.java
@@ -35,7 +35,8 @@ import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 
 public class NativeHelper
 {
-    public static final ValueLayout.OfBoolean C_BOOL = ValueLayout.JAVA_BOOLEAN;
+    // In Rust, the size of bool is 1 byte, see https://github.com/rust-lang/rust/pull/46176#issuecomment-359593446
+    public static final ValueLayout.OfByte C_BOOL = ValueLayout.JAVA_BYTE;
     public static final ValueLayout.OfByte C_CHAR = ValueLayout.JAVA_BYTE;
     public static final ValueLayout.OfShort C_SHORT = ValueLayout.JAVA_SHORT;
     public static final ValueLayout.OfInt C_INT = ValueLayout.JAVA_INT;

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/main/java/org/eclipse/jetty/quic/quiche/foreign/quiche_h.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/main/java/org/eclipse/jetty/quic/quiche/foreign/quiche_h.java
@@ -30,7 +30,7 @@ import static org.eclipse.jetty.quic.quiche.foreign.NativeHelper.C_POINTER;
 
 public class quiche_h
 {
-    private static final String EXPECTED_QUICHE_VERSION = "0.22.0";
+    private static final String EXPECTED_QUICHE_VERSION = "0.23.2";
     private static final Logger LOG = LoggerFactory.getLogger(quiche_h.class);
 
     private static class LoggingCallback
@@ -1092,7 +1092,7 @@ public class quiche_h
     {
         try
         {
-            DowncallHandles.quiche_config_verify_peer.invokeExact(config, v);
+            DowncallHandles.quiche_config_verify_peer.invokeExact(config, (byte)(v ? 1 : 0));
         }
         catch (Throwable x)
         {
@@ -1104,7 +1104,7 @@ public class quiche_h
     {
         try
         {
-            DowncallHandles.quiche_config_grease.invokeExact(config, v);
+            DowncallHandles.quiche_config_grease.invokeExact(config, (byte)(v ? 1 : 0));
         }
         catch (Throwable x)
         {
@@ -1284,7 +1284,7 @@ public class quiche_h
     {
         try
         {
-            DowncallHandles.quiche_config_set_disable_active_migration.invokeExact(config, v);
+            DowncallHandles.quiche_config_set_disable_active_migration.invokeExact(config, (byte)(v ? 1 : 0));
         }
         catch (Throwable x)
         {
@@ -1332,7 +1332,7 @@ public class quiche_h
     {
         try
         {
-            DowncallHandles.quiche_config_enable_hystart.invokeExact(config, v);
+            DowncallHandles.quiche_config_enable_hystart.invokeExact(config, (byte)(v ? 1 : 0));
         }
         catch (Throwable x)
         {
@@ -1344,7 +1344,7 @@ public class quiche_h
     {
         try
         {
-            DowncallHandles.quiche_config_enable_pacing.invokeExact(config, v);
+            DowncallHandles.quiche_config_enable_pacing.invokeExact(config, (byte)(v ? 1 : 0));
         }
         catch (Throwable x)
         {
@@ -1368,7 +1368,7 @@ public class quiche_h
     {
         try
         {
-            DowncallHandles.quiche_config_enable_dgram.invokeExact(config, enabled, recv_queue_len, send_queue_len);
+            DowncallHandles.quiche_config_enable_dgram.invokeExact(config, (byte)(enabled ? 1 : 0), recv_queue_len, send_queue_len);
         }
         catch (Throwable x)
         {
@@ -1428,7 +1428,7 @@ public class quiche_h
     {
         try
         {
-            DowncallHandles.quiche_config_set_disable_dcid_reuse.invokeExact(config, v);
+            DowncallHandles.quiche_config_set_disable_dcid_reuse.invokeExact(config, (byte)(v ? 1 : 0));
         }
         catch (Throwable x)
         {
@@ -1524,7 +1524,7 @@ public class quiche_h
     {
         try
         {
-            return (boolean)DowncallHandles.quiche_version_is_supported.invokeExact(version);
+            return (byte)DowncallHandles.quiche_version_is_supported.invokeExact(version) != 0;
         }
         catch (Throwable x)
         {
@@ -1536,7 +1536,7 @@ public class quiche_h
     {
         try
         {
-            return (MemorySegment)DowncallHandles.quiche_conn_new_with_tls.invokeExact(scid, scid_len, odcid, odcid_len, local, local_len, peer, peer_len, config, ssl, is_server);
+            return (MemorySegment)DowncallHandles.quiche_conn_new_with_tls.invokeExact(scid, scid_len, odcid, odcid_len, local, local_len, peer, peer_len, config, ssl, (byte)(is_server ? 1 : 0));
         }
         catch (Throwable x)
         {
@@ -1548,7 +1548,7 @@ public class quiche_h
     {
         try
         {
-            return (boolean)DowncallHandles.quiche_conn_set_keylog_path.invokeExact(conn, path);
+            return (byte)DowncallHandles.quiche_conn_set_keylog_path.invokeExact(conn, path) != 0;
         }
         catch (Throwable x)
         {
@@ -1572,7 +1572,7 @@ public class quiche_h
     {
         try
         {
-            return (boolean)DowncallHandles.quiche_conn_set_qlog_path.invokeExact(conn, path, log_title, log_desc);
+            return (byte)DowncallHandles.quiche_conn_set_qlog_path.invokeExact(conn, path, log_title, log_desc) != 0;
         }
         catch (Throwable x)
         {
@@ -1680,7 +1680,7 @@ public class quiche_h
     {
         try
         {
-            return (long)DowncallHandles.quiche_conn_stream_send.invokeExact(conn, stream_id, buf, buf_len, fin, out_error_code);
+            return (long)DowncallHandles.quiche_conn_stream_send.invokeExact(conn, stream_id, buf, buf_len, (byte)(fin ? 1 : 0), out_error_code);
         }
         catch (Throwable x)
         {
@@ -1692,7 +1692,7 @@ public class quiche_h
     {
         try
         {
-            return (int)DowncallHandles.quiche_conn_stream_priority.invokeExact(conn, stream_id, urgency, incremental);
+            return (int)DowncallHandles.quiche_conn_stream_priority.invokeExact(conn, stream_id, urgency, (byte)(incremental ? 1 : 0));
         }
         catch (Throwable x)
         {
@@ -1734,7 +1734,7 @@ public class quiche_h
     {
         try
         {
-            return (boolean)DowncallHandles.quiche_conn_stream_readable.invokeExact(conn, stream_id);
+            return (byte)DowncallHandles.quiche_conn_stream_readable.invokeExact(conn, stream_id) != 0;
         }
         catch (Throwable x)
         {
@@ -1782,7 +1782,7 @@ public class quiche_h
     {
         try
         {
-            return (boolean)DowncallHandles.quiche_conn_stream_finished.invokeExact(conn, stream_id);
+            return (byte)DowncallHandles.quiche_conn_stream_finished.invokeExact(conn, stream_id) != 0;
         }
         catch (Throwable x)
         {
@@ -1866,7 +1866,7 @@ public class quiche_h
     {
         try
         {
-            return (int)DowncallHandles.quiche_conn_close.invokeExact(conn, app, err, reason, reason_len);
+            return (int)DowncallHandles.quiche_conn_close.invokeExact(conn, (byte)(app ? 1 : 0), err, reason, reason_len);
         }
         catch (Throwable x)
         {
@@ -1914,7 +1914,7 @@ public class quiche_h
     {
         try
         {
-            return (boolean)DowncallHandles.quiche_connection_id_iter_next.invokeExact(iter, out, out_len);
+            return (byte)DowncallHandles.quiche_connection_id_iter_next.invokeExact(iter, out, out_len) != 0;
         }
         catch (Throwable x)
         {
@@ -1986,7 +1986,7 @@ public class quiche_h
     {
         try
         {
-            return (boolean)DowncallHandles.quiche_conn_is_established.invokeExact(conn);
+            return (byte)DowncallHandles.quiche_conn_is_established.invokeExact(conn) != 0;
         }
         catch (Throwable x)
         {
@@ -1998,7 +1998,7 @@ public class quiche_h
     {
         try
         {
-            return (boolean)DowncallHandles.quiche_conn_is_resumed.invokeExact(conn);
+            return (byte)DowncallHandles.quiche_conn_is_resumed.invokeExact(conn) != 0;
         }
         catch (Throwable x)
         {
@@ -2010,7 +2010,7 @@ public class quiche_h
     {
         try
         {
-            return (boolean)DowncallHandles.quiche_conn_is_in_early_data.invokeExact(conn);
+            return (byte)DowncallHandles.quiche_conn_is_in_early_data.invokeExact(conn) != 0;
         }
         catch (Throwable x)
         {
@@ -2022,7 +2022,7 @@ public class quiche_h
     {
         try
         {
-            return (boolean)DowncallHandles.quiche_conn_is_readable.invokeExact(conn);
+            return (byte)DowncallHandles.quiche_conn_is_readable.invokeExact(conn) != 0;
         }
         catch (Throwable x)
         {
@@ -2034,7 +2034,7 @@ public class quiche_h
     {
         try
         {
-            return (boolean)DowncallHandles.quiche_conn_is_draining.invokeExact(conn);
+            return (byte)DowncallHandles.quiche_conn_is_draining.invokeExact(conn) != 0;
         }
         catch (Throwable x)
         {
@@ -2070,7 +2070,7 @@ public class quiche_h
     {
         try
         {
-            return (boolean)DowncallHandles.quiche_conn_is_closed.invokeExact(conn);
+            return (byte)DowncallHandles.quiche_conn_is_closed.invokeExact(conn) != 0;
         }
         catch (Throwable x)
         {
@@ -2082,7 +2082,7 @@ public class quiche_h
     {
         try
         {
-            return (boolean)DowncallHandles.quiche_conn_is_timed_out.invokeExact(conn);
+            return (byte)DowncallHandles.quiche_conn_is_timed_out.invokeExact(conn) != 0;
         }
         catch (Throwable x)
         {
@@ -2094,7 +2094,7 @@ public class quiche_h
     {
         try
         {
-            return (boolean)DowncallHandles.quiche_conn_peer_error.invokeExact(conn, is_app, error_code, reason, reason_len);
+            return (byte)DowncallHandles.quiche_conn_peer_error.invokeExact(conn, is_app, error_code, reason, reason_len) != 0;
         }
         catch (Throwable x)
         {
@@ -2106,7 +2106,7 @@ public class quiche_h
     {
         try
         {
-            return (boolean)DowncallHandles.quiche_conn_local_error.invokeExact(conn, is_app, error_code, reason, reason_len);
+            return (byte)DowncallHandles.quiche_conn_local_error.invokeExact(conn, is_app, error_code, reason, reason_len) != 0;
         }
         catch (Throwable x)
         {
@@ -2118,7 +2118,7 @@ public class quiche_h
     {
         try
         {
-            return (boolean)DowncallHandles.quiche_stream_iter_next.invokeExact(iter, stream_id);
+            return (byte)DowncallHandles.quiche_stream_iter_next.invokeExact(iter, stream_id) != 0;
         }
         catch (Throwable x)
         {
@@ -2154,7 +2154,7 @@ public class quiche_h
     {
         try
         {
-            return (boolean)DowncallHandles.quiche_conn_peer_transport_params.invokeExact(conn, out);
+            return (byte)DowncallHandles.quiche_conn_peer_transport_params.invokeExact(conn, out) != 0;
         }
         catch (Throwable x)
         {
@@ -2178,7 +2178,7 @@ public class quiche_h
     {
         try
         {
-            return (boolean)DowncallHandles.quiche_conn_is_server.invokeExact(conn);
+            return (byte)DowncallHandles.quiche_conn_is_server.invokeExact(conn) != 0;
         }
         catch (Throwable x)
         {
@@ -2214,7 +2214,7 @@ public class quiche_h
     {
         try
         {
-            return (boolean)DowncallHandles.quiche_conn_retired_scid_next.invokeExact(conn, out, out_len);
+            return (byte)DowncallHandles.quiche_conn_retired_scid_next.invokeExact(conn, out, out_len) != 0;
         }
         catch (Throwable x)
         {
@@ -2274,7 +2274,7 @@ public class quiche_h
     {
         try
         {
-            return (int)DowncallHandles.quiche_conn_new_scid.invokeExact(conn, scid, scid_len, reset_token, retire_if_needed, scid_seq);
+            return (int)DowncallHandles.quiche_conn_new_scid.invokeExact(conn, scid, scid_len, reset_token, (byte)(retire_if_needed ? 1 : 0), scid_seq);
         }
         catch (Throwable x)
         {
@@ -2454,7 +2454,7 @@ public class quiche_h
     {
         try
         {
-            return (boolean)DowncallHandles.quiche_socket_addr_iter_next.invokeExact(iter, peer, peer_len);
+            return (byte)DowncallHandles.quiche_socket_addr_iter_next.invokeExact(iter, peer, peer_len) != 0;
         }
         catch (Throwable x)
         {

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/main/java/org/eclipse/jetty/quic/quiche/foreign/quiche_path_stats.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/main/java/org/eclipse/jetty/quic/quiche/foreign/quiche_path_stats.java
@@ -39,6 +39,8 @@ public class quiche_path_stats
         C_LONG.withName("lost"),
         C_LONG.withName("retrans"),
         C_LONG.withName("rtt"),
+        C_LONG.withName("min_rtt"),
+        C_LONG.withName("rttvar"),
         C_LONG.withName("cwnd"),
         C_LONG.withName("sent_bytes"),
         C_LONG.withName("recv_bytes"),

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/JnaQuicheConnection.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/JnaQuicheConnection.java
@@ -129,7 +129,7 @@ public class JnaQuicheConnection extends QuicheConnection
 
         Boolean verifyPeer = config.getVerifyPeer();
         if (verifyPeer != null)
-            LibQuiche.INSTANCE.quiche_config_verify_peer(quicheConfig, verifyPeer);
+            LibQuiche.INSTANCE.quiche_config_verify_peer(quicheConfig, new bool(verifyPeer));
 
         String trustedCertsPemPath = config.getTrustedCertsPemPath();
         if (trustedCertsPemPath != null)
@@ -203,7 +203,7 @@ public class JnaQuicheConnection extends QuicheConnection
 
         Boolean disableActiveMigration = config.getDisableActiveMigration();
         if (disableActiveMigration != null)
-            LibQuiche.INSTANCE.quiche_config_set_disable_active_migration(quicheConfig, disableActiveMigration);
+            LibQuiche.INSTANCE.quiche_config_set_disable_active_migration(quicheConfig, new bool(disableActiveMigration));
 
         Long maxConnectionWindow = config.getMaxConnectionWindow();
         if (maxConnectionWindow != null)
@@ -289,7 +289,7 @@ public class JnaQuicheConnection extends QuicheConnection
         LOG.debug("dcid len: {}", dcid_len);
         LOG.debug("token len: {}", token_len);
 
-        if (!LibQuiche.INSTANCE.quiche_version_is_supported(version.getPointee()))
+        if (LibQuiche.INSTANCE.quiche_version_is_supported(version.getPointee()).isFalse())
         {
             LOG.debug("version negotiation");
 
@@ -360,7 +360,7 @@ public class JnaQuicheConnection extends QuicheConnection
         LOG.debug("dcid len: {}", dcid_len);
         LOG.debug("token len: {}", token_len);
 
-        if (!LibQuiche.INSTANCE.quiche_version_is_supported(version.getPointee()))
+        if (LibQuiche.INSTANCE.quiche_version_is_supported(version.getPointee()).isFalse())
         {
             LOG.debug("need version negotiation");
             return null;
@@ -409,7 +409,7 @@ public class JnaQuicheConnection extends QuicheConnection
             if (quicheConn == null)
                 throw new IllegalStateException("connection was released");
 
-            if (!LibQuiche.INSTANCE.quiche_conn_set_qlog_path(quicheConn, filename, title, desc))
+            if (LibQuiche.INSTANCE.quiche_conn_set_qlog_path(quicheConn, filename, title, desc).isFalse())
                 throw new IOException("unable to set qlog path to " + filename);
         }
     }
@@ -448,7 +448,7 @@ public class JnaQuicheConnection extends QuicheConnection
 
             List<Long> result = new ArrayList<>();
             uint64_t_pointer streamId = new uint64_t_pointer();
-            while (LibQuiche.INSTANCE.quiche_stream_iter_next(quiche_stream_iter, streamId))
+            while (LibQuiche.INSTANCE.quiche_stream_iter_next(quiche_stream_iter, streamId).isTrue())
             {
                 result.add(streamId.getValue());
             }
@@ -519,7 +519,7 @@ public class JnaQuicheConnection extends QuicheConnection
         {
             if (quicheConn == null)
                 throw new IllegalStateException("connection was released");
-            return LibQuiche.INSTANCE.quiche_conn_is_closed(quicheConn);
+            return LibQuiche.INSTANCE.quiche_conn_is_closed(quicheConn).isTrue();
         }
     }
 
@@ -530,7 +530,7 @@ public class JnaQuicheConnection extends QuicheConnection
         {
             if (quicheConn == null)
                 throw new IllegalStateException("connection was released");
-            return LibQuiche.INSTANCE.quiche_conn_is_established(quicheConn);
+            return LibQuiche.INSTANCE.quiche_conn_is_established(quicheConn).isTrue();
         }
     }
 
@@ -540,7 +540,7 @@ public class JnaQuicheConnection extends QuicheConnection
         {
             if (quicheConn == null)
                 throw new IllegalStateException("connection was released");
-            return LibQuiche.INSTANCE.quiche_conn_is_in_early_data(quicheConn);
+            return LibQuiche.INSTANCE.quiche_conn_is_in_early_data(quicheConn).isTrue();
         }
     }
 
@@ -592,7 +592,7 @@ public class JnaQuicheConnection extends QuicheConnection
                 return false;
             }
             int length = reason == null ? 0 : reason.getBytes(LibQuiche.CHARSET).length;
-            int rc = LibQuiche.INSTANCE.quiche_conn_close(quicheConn, true, new uint64_t(error), reason, new size_t(length));
+            int rc = LibQuiche.INSTANCE.quiche_conn_close(quicheConn, new bool(true), new uint64_t(error), reason, new size_t(length));
             if (rc == 0)
                 return true;
             if (rc == quiche_error.QUICHE_ERR_DONE)
@@ -624,7 +624,7 @@ public class JnaQuicheConnection extends QuicheConnection
         {
             if (quicheConn == null)
                 throw new IllegalStateException("connection was released");
-            return LibQuiche.INSTANCE.quiche_conn_is_draining(quicheConn);
+            return LibQuiche.INSTANCE.quiche_conn_is_draining(quicheConn).isTrue();
         }
     }
 
@@ -694,7 +694,7 @@ public class JnaQuicheConnection extends QuicheConnection
             if (quicheConn == null)
                 throw new IOException("connection was released");
             uint64_t_pointer outErrorCode = new uint64_t_pointer();
-            int written = LibQuiche.INSTANCE.quiche_conn_stream_send(quicheConn, new uint64_t(streamId), jnaBuffer(buffer), new size_t(buffer.remaining()), last, outErrorCode).intValue();
+            int written = LibQuiche.INSTANCE.quiche_conn_stream_send(quicheConn, new uint64_t(streamId), jnaBuffer(buffer), new size_t(buffer.remaining()), new bool(last), outErrorCode).intValue();
             if (written == quiche_error.QUICHE_ERR_DONE)
             {
                 int rc = LibQuiche.INSTANCE.quiche_conn_stream_writable(quicheConn, new uint64_t(streamId), new size_t(buffer.remaining()));
@@ -766,7 +766,7 @@ public class JnaQuicheConnection extends QuicheConnection
         {
             if (quicheConn == null)
                 throw new IllegalStateException("connection was released");
-            return LibQuiche.INSTANCE.quiche_conn_stream_finished(quicheConn, new uint64_t(streamId));
+            return LibQuiche.INSTANCE.quiche_conn_stream_finished(quicheConn, new uint64_t(streamId)).isTrue();
         }
     }
 
@@ -781,7 +781,7 @@ public class JnaQuicheConnection extends QuicheConnection
             uint64_t_pointer error = new uint64_t_pointer();
             char_pointer reason = new char_pointer();
             size_t_pointer reasonLength = new size_t_pointer();
-            if (LibQuiche.INSTANCE.quiche_conn_peer_error(quicheConn, app, error, reason, reasonLength))
+            if (LibQuiche.INSTANCE.quiche_conn_peer_error(quicheConn, app, error, reason, reasonLength).isTrue())
                 return new CloseInfo(error.getValue(), reason.getValueAsString((int)reasonLength.getValue(), LibQuiche.CHARSET));
             return null;
         }
@@ -798,7 +798,7 @@ public class JnaQuicheConnection extends QuicheConnection
             uint64_t_pointer error = new uint64_t_pointer();
             char_pointer reason = new char_pointer();
             size_t_pointer reasonLength = new size_t_pointer();
-            if (LibQuiche.INSTANCE.quiche_conn_local_error(quicheConn, app, error, reason, reasonLength))
+            if (LibQuiche.INSTANCE.quiche_conn_local_error(quicheConn, app, error, reason, reasonLength).isTrue())
                 return new CloseInfo(error.getValue(), reason.getValueAsString((int)reasonLength.getValue(), LibQuiche.CHARSET));
             return null;
         }

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/bool.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/bool.java
@@ -1,0 +1,40 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.quic.quiche.jna;
+
+import com.sun.jna.IntegerType;
+
+public class bool extends IntegerType
+{
+    public bool()
+    {
+        this(false);
+    }
+
+    public bool(boolean v)
+    {
+        // In Rust, the size of bool is 1 byte, see https://github.com/rust-lang/rust/pull/46176#issuecomment-359593446
+        super(1, v ? 1 : 0, true);
+    }
+
+    public boolean isTrue()
+    {
+        return this.byteValue() != 0;
+    }
+
+    public boolean isFalse()
+    {
+        return !isTrue();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
     <jboss.logging.processor.version>2.2.1.Final</jboss.logging.processor.version>
     <jboss.logging.version>3.6.1.Final</jboss.logging.version>
     <jetty-assembly-descriptors.version>1.1</jetty-assembly-descriptors.version>
-    <jetty-quiche-native.version>0.22.0</jetty-quiche-native.version>
+    <jetty-quiche-native.version>0.23.2</jetty-quiche-native.version>
     <jetty-test-policy.version>1.2</jetty-test-policy.version>
     <jetty-version.maven.plugin.version>2.7</jetty-version.maven.plugin.version>
     <jetty.perf-helper.version>1.0.7</jetty.perf-helper.version>


### PR DESCRIPTION
This also requires changing the binding of C `bool` to java `byte` (instead of java `boolean`) as quiche's FFI implementation now specifies the more strict ```extern "C"``` modifier.