### PR TITLE
Issue #11494 - PathMappingsHandler exposes PathSpec and Context based on PathSpec.

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Context.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Context.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.server;
 
 import java.io.File;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Executor;
 
 import org.eclipse.jetty.http.MimeTypes;
@@ -164,5 +165,111 @@ public interface Context extends Attributes, Decorator, Executor
         if (encodedPath.charAt(encodedContextPath.length()) != '/')
             return null;
         return encodedPath.substring(encodedContextPath.length());
+    }
+
+    class Wrapper implements Context
+    {
+        private final Context _wrapped;
+
+        public Wrapper(Context context)
+        {
+            _wrapped = context;
+        }
+
+        @Override
+        public <T> T decorate(T o)
+        {
+            return _wrapped.decorate(o);
+        }
+
+        @Override
+        public void destroy(Object o)
+        {
+            _wrapped.destroy(o);
+        }
+
+        @Override
+        public String getContextPath()
+        {
+            return _wrapped.getContextPath();
+        }
+
+        @Override
+        public ClassLoader getClassLoader()
+        {
+            return _wrapped.getClassLoader();
+        }
+
+        @Override
+        public Resource getBaseResource()
+        {
+            return _wrapped.getBaseResource();
+        }
+
+        @Override
+        public Request.Handler getErrorHandler()
+        {
+            return _wrapped.getErrorHandler();
+        }
+
+        @Override
+        public List<String> getVirtualHosts()
+        {
+            return _wrapped.getVirtualHosts();
+        }
+
+        @Override
+        public MimeTypes getMimeTypes()
+        {
+            return _wrapped.getMimeTypes();
+        }
+
+        @Override
+        public void execute(Runnable task)
+        {
+            _wrapped.execute(task);
+        }
+
+        @Override
+        public Object removeAttribute(String name)
+        {
+            return _wrapped.removeAttribute(name);
+        }
+
+        @Override
+        public Object setAttribute(String name, Object attribute)
+        {
+            return _wrapped.setAttribute(name, attribute);
+        }
+
+        @Override
+        public Object getAttribute(String name)
+        {
+            return _wrapped.getAttribute(name);
+        }
+
+        @Override
+        public Set<String> getAttributeNameSet()
+        {
+            return _wrapped.getAttributeNameSet();
+        }
+
+        @Override
+        public void run(Runnable task)
+        {
+            _wrapped.run(task);
+        }
+
+        @Override
+        public void run(Runnable task, Request request)
+        {
+            _wrapped.run(task, request);
+        }
+
+        @Override
+        public File getTempDirectory()
+        {
+            return _wrapped.getTempDirectory();
+        }
     }
 }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/PathMappingsHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/PathMappingsHandler.java
@@ -24,12 +24,14 @@ import org.eclipse.jetty.http.pathmap.MatchedPath;
 import org.eclipse.jetty.http.pathmap.MatchedResource;
 import org.eclipse.jetty.http.pathmap.PathMappings;
 import org.eclipse.jetty.http.pathmap.PathSpec;
+import org.eclipse.jetty.http.pathmap.ServletPathSpec;
 import org.eclipse.jetty.server.Context;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.component.Dumpable;
 import org.eclipse.jetty.util.thread.Invocable;
 import org.slf4j.Logger;
@@ -180,13 +182,52 @@ public class PathMappingsHandler extends Handler.AbstractContainer
                 @Override
                 public String getContextPath()
                 {
-                    return matchedPath.getPathMatch();
+                    // Start with wrapper context path, and add onto it.
+                    String contextPath = getWrapped().getContext().getContextPath();
+
+                    if (pathSpec instanceof ServletPathSpec servletPathSpec)
+                    {
+                        return appendContextPath(contextPath, servletPathSpec.getPrefix());
+                    }
+                    else
+                    {
+                        return appendContextPath(contextPath, matchedPath.getPathMatch());
+                    }
+                }
+
+                private String appendContextPath(String contextPath1, String contextPath2)
+                {
+                    if (StringUtil.isBlank(contextPath2))
+                        return contextPath1;
+
+                    if (contextPath2.charAt(0) != '/')
+                    {
+                        if (contextPath1.endsWith("/"))
+                            return contextPath1 + contextPath2;
+                        else
+                            return contextPath1 + "/" + contextPath2;
+                    }
+                    else
+                    {
+                        if (contextPath1.equals("/"))
+                            return contextPath2;
+                        if (contextPath1.endsWith("/"))
+                            return contextPath1.substring(contextPath1.length() - 1) + contextPath2;
+                        else
+                            return contextPath1 + contextPath2;
+                    }
                 }
 
                 @Override
                 public String getPathInContext(String canonicallyEncodedPath)
                 {
-                    return matchedPath.getPathInfo();
+                    if (pathSpec instanceof ServletPathSpec)
+                    {
+                        return Context.getPathInContext(getContextPath(), canonicallyEncodedPath);
+                    }
+
+                    String pathInfo = matchedPath.getPathInfo();
+                    return pathInfo == null ? "" : pathInfo;
                 }
             };
         }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/PathMappingsHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/PathMappingsHandler.java
@@ -14,8 +14,10 @@
 package org.eclipse.jetty.server.handler;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import org.eclipse.jetty.http.pathmap.MappedResource;
 import org.eclipse.jetty.http.pathmap.MatchedPath;
@@ -34,11 +36,26 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A Handler that delegates to other handlers through a configured {@link PathMappings}.
+ * <p>A Handler that delegates to other handlers through a configured {@link PathMappings}.</p>
+ *
+ * {@code
+ * PathMappingHandler pathMappingsHandler = new PathMappingsHandler();
+ * pathMappingsHandler.addMapping(new ServletPathSpec("/"), new MyRootHandler());
+ * pathMappingsHandler.addMapping(new ServletPathSpec("/index.html"), new MyIndexHandler());
+ * pathMappingsHandler.addMapping(new ServletPathSpec("/static/*"), new ResourceHandler());
+ * pathMappingsHandler.addMapping(new RegexPathSpec("/rest/.*\\.api$"), new RestHandler());
+ * pathMappingsHandler.addMapping(new UriTemplatePathSpec("/chat/{channel}/{mode}"), new ChatHandler());
+ * }
+ *
+ * <p>
+ * Request handling can access the {@link PathSpec} used via the {@code Request#getAttribute} on
+ * the name {@link #PATHSPEC_ATTR}
+ * </p>
  */
 public class PathMappingsHandler extends Handler.AbstractContainer
 {
     private static final Logger LOG = LoggerFactory.getLogger(PathMappingsHandler.class);
+    public static final String PATHSPEC_ATTR = PathMappingsHandler.class.getName() + ".pathSpec";
 
     private final PathMappings<Handler> mappings = new PathMappings<>();
 
@@ -58,6 +75,12 @@ public class PathMappingsHandler extends Handler.AbstractContainer
         return mappings.streamResources().map(MappedResource::getResource).toList();
     }
 
+    /**
+     * Add a mapping of a {@link PathSpec} to a {@link Handler}.
+     *
+     * @param pathSpec the PathSpec to match against incoming Requests.
+     * @param handler the handler for requests that match the incoming PathSpec.
+     */
     public void addMapping(PathSpec pathSpec, Handler handler)
     {
         Objects.requireNonNull(pathSpec, "PathSpec cannot be null");
@@ -117,14 +140,30 @@ public class PathMappingsHandler extends Handler.AbstractContainer
         if (LOG.isDebugEnabled())
             LOG.debug("Matched {} to {} -> {}", pathInContext, matchedResource.getPathSpec(), handler);
 
-        PathSpecRequest pathSpecRequest = new PathSpecRequest(request, pathSpec);
+        Request pathSpecRequest = newPathSpecRequest(request, pathSpec);
         boolean handled = handler.handle(pathSpecRequest, response, callback);
         if (LOG.isDebugEnabled())
             LOG.debug("Handled {} {} by {}", handled, pathInContext, handler);
         return handled;
     }
 
-    private static class PathSpecRequest extends Request.Wrapper
+    protected Request newPathSpecRequest(Request request, PathSpec pathSpec)
+    {
+        return new PathSpecRequest(request, pathSpec);
+    }
+
+    /**
+     * <p>
+     * A custom {@link Request.Wrapper} that provides a {@link Context} based on the results
+     * of a {@link PathSpec}.
+     * </p>
+     *
+     * <p>
+     * Also provides the {@link PathSpec} used for this Request in the Attribute with
+     * the name {@link PathMappingsHandler#PATHSPEC_ATTR}
+     * </p>
+     */
+    public static class PathSpecRequest extends Request.Wrapper
     {
         private final PathSpec pathSpec;
         private final Context context;
@@ -150,6 +189,22 @@ public class PathMappingsHandler extends Handler.AbstractContainer
                     return matchedPath.getPathInfo();
                 }
             };
+        }
+
+        @Override
+        public Object getAttribute(String name)
+        {
+            if (name.equals(PATHSPEC_ATTR))
+                return pathSpec;
+            return super.getAttribute(name);
+        }
+
+        @Override
+        public Set<String> getAttributeNameSet()
+        {
+            Set<String> names = new HashSet<>(super.getAttributeNameSet());
+            names.add(PATHSPEC_ATTR);
+            return names;
         }
 
         @Override

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/PathMappingsHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/PathMappingsHandlerTest.java
@@ -185,14 +185,14 @@ public class PathMappingsHandlerTest
     public static Stream<Arguments> pathInContextInput()
     {
         return Stream.of(
-            Arguments.of("/", "/", "null", ServletPathSpec.class.getSimpleName(), "/"),
+            Arguments.of("/", "/", "/", ServletPathSpec.class.getSimpleName(), "/"),
             Arguments.of("/foo/test", "/foo", "/test", ServletPathSpec.class.getSimpleName(), "/foo/*"),
-            Arguments.of("/index.html", "/index.html", "null", ServletPathSpec.class.getSimpleName(), "/index.html"),
-            Arguments.of("/does-not-exist", "/does-not-exist", "null", ServletPathSpec.class.getSimpleName(), "/"),
-            Arguments.of("/deep/path/foo.php", "/deep/path/foo.php", "null", ServletPathSpec.class.getSimpleName(), "*.php"),
-            Arguments.of("/re/1234/baz", "/re/1234/baz", "null", ServletPathSpec.class.getSimpleName(), "/"),
-            Arguments.of("/re/ABC/baz", "/re/ABC/baz", "null", RegexPathSpec.class.getSimpleName(), "/re/[A-Z]*/.*"),
-            Arguments.of("/rest/api/users/ver-1/groupfoo/baruser", "api/users", "groupfoo/baruser", RegexPathSpec.class.getSimpleName(), "^/rest/(?<name>.*)/ver-[0-9]+/(?<info>.*)$"),
+            Arguments.of("/index.html", "/index.html", "", ServletPathSpec.class.getSimpleName(), "/index.html"),
+            Arguments.of("/does-not-exist", "/", "/does-not-exist", ServletPathSpec.class.getSimpleName(), "/"),
+            Arguments.of("/deep/path/foo.php", "/", "/deep/path/foo.php", ServletPathSpec.class.getSimpleName(), "*.php"),
+            Arguments.of("/re/1234/baz", "/", "/re/1234/baz", ServletPathSpec.class.getSimpleName(), "/"),
+            Arguments.of("/re/ABC/baz", "/re/ABC/baz", "", RegexPathSpec.class.getSimpleName(), "/re/[A-Z]*/.*"),
+            Arguments.of("/rest/api/users/ver-1/groupfoo/baruser", "/api/users", "groupfoo/baruser", RegexPathSpec.class.getSimpleName(), "^/rest/(?<name>.*)/ver-[0-9]+/(?<info>.*)$"),
             Arguments.of("/zed/test.txt", "/zed", "/test.txt", null, null)
         );
     }

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/PathMappingsHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/PathMappingsHandlerTest.java
@@ -13,7 +13,9 @@
 
 package org.eclipse.jetty.server.handler;
 
-import java.nio.charset.StandardCharsets;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -22,13 +24,15 @@ import java.util.stream.Stream;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.http.pathmap.PathSpec;
+import org.eclipse.jetty.http.pathmap.RegexPathSpec;
 import org.eclipse.jetty.http.pathmap.ServletPathSpec;
+import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.junit.jupiter.api.AfterEach;
@@ -178,6 +182,58 @@ public class PathMappingsHandlerTest
         assertEquals(expectedResponseBody, response.getContent());
     }
 
+    public static Stream<Arguments> pathInContextInput()
+    {
+        return Stream.of(
+            Arguments.of("/", "/", "null", ServletPathSpec.class.getSimpleName(), "/"),
+            Arguments.of("/foo/test", "/foo", "/test", ServletPathSpec.class.getSimpleName(), "/foo/*"),
+            Arguments.of("/index.html", "/index.html", "null", ServletPathSpec.class.getSimpleName(), "/index.html"),
+            Arguments.of("/does-not-exist", "/does-not-exist", "null", ServletPathSpec.class.getSimpleName(), "/"),
+            Arguments.of("/deep/path/foo.php", "/deep/path/foo.php", "null", ServletPathSpec.class.getSimpleName(), "*.php"),
+            Arguments.of("/re/1234/baz", "/re/1234/baz", "null", ServletPathSpec.class.getSimpleName(), "/"),
+            Arguments.of("/re/ABC/baz", "/re/ABC/baz", "null", RegexPathSpec.class.getSimpleName(), "/re/[A-Z]*/.*"),
+            Arguments.of("/rest/api/users/ver-1/groupfoo/baruser", "api/users", "groupfoo/baruser", RegexPathSpec.class.getSimpleName(), "^/rest/(?<name>.*)/ver-[0-9]+/(?<info>.*)$"),
+            Arguments.of("/zed/test.txt", "/zed", "/test.txt", null, null)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("pathInContextInput")
+    public void testPathContextResolution(String requestPath, String expectedContextPath, String expectedPathInContext,
+                                          String expectedPathSpecImpl, String expectedPathSpecDeclaration) throws Exception
+    {
+        ContextHandler contextHandler = new ContextHandler();
+        contextHandler.setContextPath("/");
+
+        PathMappingsHandler pathMappingsHandler = new PathMappingsHandler();
+        pathMappingsHandler.addMapping(new ServletPathSpec("/"), new ContextDumpHandler());
+        pathMappingsHandler.addMapping(new ServletPathSpec("/index.html"), new ContextDumpHandler());
+        pathMappingsHandler.addMapping(new ServletPathSpec("/foo/*"), new ContextDumpHandler());
+        pathMappingsHandler.addMapping(new ServletPathSpec("*.php"), new ContextDumpHandler());
+        pathMappingsHandler.addMapping(new RegexPathSpec("/re/[A-Z]*/.*"), new ContextDumpHandler());
+        pathMappingsHandler.addMapping(new RegexPathSpec("^/rest/(?<name>.*)/ver-[0-9]+/(?<info>.*)$"), new ContextDumpHandler());
+        ContextHandler zedContext = new ContextHandler("/zed");
+        zedContext.setHandler(new ContextDumpHandler());
+        pathMappingsHandler.addMapping(new ServletPathSpec("/zed/*"), zedContext);
+        contextHandler.setHandler(pathMappingsHandler);
+
+        startServer(contextHandler);
+
+        HttpTester.Response response = executeRequest("""
+            GET %s HTTP/1.1\r
+            Host: local\r
+            Connection: close\r
+            
+            """.formatted(requestPath));
+        assertEquals(200, response.getStatus());
+        assertThat(response.getContent(), containsString("contextPath=[" + expectedContextPath + "]"));
+        assertThat(response.getContent(), containsString("pathInContext=[" + expectedPathInContext + "]"));
+        if (expectedPathSpecImpl != null)
+            assertThat(response.getContent(), containsString("pathSpec=[" + expectedPathSpecImpl + "]"));
+        if (expectedPathSpecDeclaration != null)
+            assertThat(response.getContent(), containsString("pathSpec.declaration=[" + expectedPathSpecDeclaration + "]"));
+    }
+
     @Test
     public void testDump() throws Exception
     {
@@ -306,7 +362,7 @@ public class PathMappingsHandlerTest
             assertTrue(isStarted());
             response.setStatus(HttpStatus.OK_200);
             response.getHeaders().put(HttpHeader.CONTENT_TYPE, "text/plain; charset=utf-8");
-            response.write(true, BufferUtil.toBuffer(message, StandardCharsets.UTF_8), callback);
+            Content.Sink.write(response, true, message, callback);
             return true;
         }
 
@@ -314,6 +370,43 @@ public class PathMappingsHandlerTest
         public String toString()
         {
             return String.format("%s[msg=\"%s\"]", SimpleHandler.class.getSimpleName(), message);
+        }
+    }
+
+    private static class ContextDumpHandler extends Handler.Abstract
+    {
+        @Override
+        public boolean handle(Request request, Response response, Callback callback)
+        {
+            String message = null;
+            PathSpec pathSpec = (PathSpec)request.getAttribute(PathSpec.class.getName());
+            try (StringWriter stringWriter = new StringWriter();
+                 PrintWriter out = new PrintWriter(stringWriter))
+            {
+                out.printf("contextPath=[%s]\n", Request.getContextPath(request));
+                out.printf("pathInContext=[%s]\n", Request.getPathInContext(request));
+                if (pathSpec != null)
+                {
+                    out.printf("pathSpec=[%s]\n", pathSpec.getClass().getSimpleName());
+                    out.printf("pathSpec.declaration=[%s]\n", pathSpec.getDeclaration());
+                }
+                message = stringWriter.toString();
+            }
+            catch (IOException e)
+            {
+                callback.failed(e);
+                return true;
+            }
+            response.setStatus(HttpStatus.OK_200);
+            response.getHeaders().put(HttpHeader.CONTENT_TYPE, "text/plain; charset=utf-8");
+            Content.Sink.write(response, true, message, callback);
+            return true;
+        }
+
+        @Override
+        public String toString()
+        {
+            return ContextDumpHandler.class.getSimpleName();
         }
     }
 }

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/TryPathsHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/TryPathsHandlerTest.java
@@ -199,7 +199,7 @@ public class TryPathsHandlerTest
             @Override
             public boolean handle(Request request, Response response, Callback callback)
             {
-                assertThat(Request.getPathInContext(request), equalTo("/forward"));
+                assertThat(Request.getPathInContext(request), equalTo(""));
                 assertThat(request.getHttpURI().getQuery(), equalTo("p=/last"));
                 response.setStatus(HttpStatus.NO_CONTENT_204);
                 callback.succeeded();


### PR DESCRIPTION
Replacement of PR #11497, but for `jetty-12.1.x` instead.

* Introduces `Context.Wrapper`
* Introduces `PathMappingsHandler.PathSpecRequest` (wrapper, with custom Context)

Fixes: #11494