### PR TITLE
Issue #12739 Fix NPE if WEB-INF is CombinedResource

### DIFF
--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/JettyWebXmlConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/JettyWebXmlConfiguration.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.ee10.webapp;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.Map;
 
 import org.eclipse.jetty.util.resource.Resource;
@@ -132,7 +133,11 @@ public class JettyWebXmlConfiguration extends AbstractConfiguration
     {
         jettyConfig.setJettyStandardIdsAndProperties(context.getServer(), null);
         Map<String, String> props = jettyConfig.getProperties();
-        props.put(PROPERTY_WEB_INF_URI, XmlConfiguration.normalizeURI(webInf.getURI().toString()));
-        props.put(PROPERTY_WEB_INF, webInf.toString());
+        URI uri = webInf.getURI();
+        if (uri != null)
+        {
+            props.put(PROPERTY_WEB_INF_URI, XmlConfiguration.normalizeURI(uri.toString()));
+            props.put(PROPERTY_WEB_INF, webInf.toString());
+        }
     }
 }

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/JettyWebXmlConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/JettyWebXmlConfiguration.java
@@ -134,10 +134,13 @@ public class JettyWebXmlConfiguration extends AbstractConfiguration
         jettyConfig.setJettyStandardIdsAndProperties(context.getServer(), null);
         Map<String, String> props = jettyConfig.getProperties();
         URI uri = webInf.getURI();
-        if (uri != null)
+        if (uri == null)
         {
-            props.put(PROPERTY_WEB_INF_URI, XmlConfiguration.normalizeURI(uri.toString()));
-            props.put(PROPERTY_WEB_INF, webInf.toString());
+            if (LOG.isDebugEnabled())
+                LOG.debug("Unable to obtain unique URI for location of WEB-INF from {}", webInf.toString());
+            return;
         }
+        props.put(PROPERTY_WEB_INF_URI, XmlConfiguration.normalizeURI(uri.toString()));
+        props.put(PROPERTY_WEB_INF, webInf.toString());
     }
 }

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/JettyWebXmlConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/JettyWebXmlConfiguration.java
@@ -133,10 +133,14 @@ public class JettyWebXmlConfiguration extends AbstractConfiguration
         jettyConfig.setJettyStandardIdsAndProperties(context.getServer(), null);
         Map<String, String> props = jettyConfig.getProperties();
         URI uri = webInf.getURI();
-        if (uri != null)
+        if (uri == null)
         {
-            props.put(PROPERTY_WEB_INF_URI, XmlConfiguration.normalizeURI(uri.toString()));
-            props.put(PROPERTY_WEB_INF, webInf.toString());
+            if (LOG.isDebugEnabled())
+                LOG.debug("Unable to obtain unique URI for location of WEB-INF from {}", webInf.toString());
+            return;
         }
+
+        props.put(PROPERTY_WEB_INF_URI, XmlConfiguration.normalizeURI(uri.toString()));
+        props.put(PROPERTY_WEB_INF, webInf.toString());
     }
 }

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/JettyWebXmlConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/JettyWebXmlConfiguration.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.ee9.webapp;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.Map;
 
 import org.eclipse.jetty.util.resource.Resource;
@@ -131,7 +132,11 @@ public class JettyWebXmlConfiguration extends AbstractConfiguration
     {
         jettyConfig.setJettyStandardIdsAndProperties(context.getServer(), null);
         Map<String, String> props = jettyConfig.getProperties();
-        props.put(PROPERTY_WEB_INF_URI, XmlConfiguration.normalizeURI(webInf.getURI().toString()));
-        props.put(PROPERTY_WEB_INF, webInf.toString());
+        URI uri = webInf.getURI();
+        if (uri != null)
+        {
+            props.put(PROPERTY_WEB_INF_URI, XmlConfiguration.normalizeURI(uri.toString()));
+            props.put(PROPERTY_WEB_INF, webInf.toString());
+        }
     }
 }


### PR DESCRIPTION
Closes #12739 

If `WEB-INF` is represented by a `CombinedResource` we throw an `NPE` in `JettyWebXmlConfiguration` when we try to obtain it's `URI`.

 This is because `CombinedResource` will return `null` for a call to `getURI()` if it has more than one component `Resource` that exists and has a `URI`. This is a behaviour change from earlier versions of jetty, where `ResourceCollection` would always just return the `URI` of the first component `Resource`.