### PR TITLE
Issue #12752 make `jetty-server` compile scoped on `jetty-http-spi`

### DIFF
--- a/jetty-core/jetty-http-spi/pom.xml
+++ b/jetty-core/jetty-http-spi/pom.xml
@@ -19,7 +19,6 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Fixes #12752 by removing the provided scope