### PR TITLE
Issue #12760 force running flatten goal to really have boms generated and not cached one

### DIFF
--- a/.mvn/maven-build-cache-config.xml
+++ b/.mvn/maven-build-cache-config.xml
@@ -75,6 +75,11 @@
             <goal>deploy</goal>
           </goals>
         </goalsList>
+        <goalsList groupId="org.codehaus.mojo" artifactId="flatten-maven-plugin">
+          <goals>
+            <goal>flatten</goal>
+          </goals>
+        </goalsList>
       </goalsLists>
     </runAlways>
     <reconcile>


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>
