### PR TITLE
Issue #12750 - handle query double-pct-encoded BAD_UTF8_ENCODING

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/UriCompliance.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/UriCompliance.java
@@ -196,6 +196,7 @@ public final class UriCompliance implements ComplianceViolation.Mode
             Violation.AMBIGUOUS_PATH_SEPARATOR,
             Violation.AMBIGUOUS_PATH_ENCODING,
             Violation.AMBIGUOUS_EMPTY_SEGMENT,
+            Violation.BAD_UTF8_ENCODING,
             Violation.UTF16_ENCODINGS,
             Violation.USER_INFO));
 

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/FormFieldsTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/FormFieldsTest.java
@@ -111,7 +111,6 @@ public class FormFieldsTest
             Arguments.of(List.of("name%"), UTF_8, -1, -1, IllegalStateException.class),
             Arguments.of(List.of("name%A"), UTF_8, -1, -1, IllegalStateException.class),
 
-            // TODO: these 2 should throw the same exception.
             Arguments.of(List.of("name%A="), UTF_8, -1, -1, CharacterCodingException.class),
             Arguments.of(List.of("name%A&"), UTF_8, -1, -1, IllegalArgumentException.class),
 
@@ -125,6 +124,7 @@ public class FormFieldsTest
             Arguments.of(List.of("n=v&X=Y"), UTF_8, -1, 3, IllegalStateException.class),
             Arguments.of(List.of("n%AH=v"), UTF_8, -1, -1, IllegalArgumentException.class),
             Arguments.of(List.of("n=v%AH"), UTF_8, -1, -1, IllegalArgumentException.class),
+            Arguments.of(List.of("n=%%TOK%%"), UTF_8, -1, -1, IllegalArgumentException.class),
             Arguments.of(List.of("n=v%FF"), UTF_8, -1, -1, CharacterCodingException.class)
         );
     }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/UrlEncodedUtf8Test.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/UrlEncodedUtf8Test.java
@@ -32,9 +32,12 @@ public class UrlEncodedUtf8Test
         textBlock = """
         # query         | expectedName | expectedValue
         a=bad_%e0%b     | a            | bad_��
-        a=bad_%e0%ba    | a            | bad_�
-        b=short%a       | b            | short�
-        c=%%TOK%%       | c            | �OK�
+        b=bad_%e0%ba    | b            | bad_�
+        c=short%a       | c            | short�
+        d=b%aam         | d            | b�m
+        e=%%TOK%%       | e            | �OK�
+        f=%aardvark     | f            | �rdvark
+        g=b%ar          | g            | b�
         """)
     public void testDecodeAllowBadSequence(String query, String expectedName, String expectedValue)
     {

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/UrlEncodedUtf8Test.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/UrlEncodedUtf8Test.java
@@ -39,7 +39,8 @@ public class UrlEncodedUtf8Test
         f=%aardvark     | f            | �rdvark
         g=b%ar          | g            | b�
         h=end%          | h            | end�
-        i=%&z=2         | i            | �
+        # This shows how the '&' symbol gets swallowed by a pct-encoding effort.
+        i=%&z=2         | i            | �=2
         """)
     public void testDecodeAllowBadSequence(String query, String expectedName, String expectedValue)
     {

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/UrlEncodedUtf8Test.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/UrlEncodedUtf8Test.java
@@ -38,6 +38,7 @@ public class UrlEncodedUtf8Test
         e=%%TOK%%       | e            | �OK�
         f=%aardvark     | f            | �rdvark
         g=b%ar          | g            | b�
+        h=end%          | h            | end�
         """)
     public void testDecodeAllowBadSequence(String query, String expectedName, String expectedValue)
     {

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/UrlEncodedUtf8Test.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/UrlEncodedUtf8Test.java
@@ -18,16 +18,32 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.hamcrest.Matchers.notNullValue;
 
 public class UrlEncodedUtf8Test
 {
-    private static final Logger LOG = LoggerFactory.getLogger(UrlEncodedUtf8Test.class);
+    @ParameterizedTest
+    @CsvSource(delimiter = '|', useHeadersInDisplayName = false,
+        textBlock = """
+        # query         | expectedName | expectedValue
+        a=bad_%e0%b     | a            | bad_��
+        a=bad_%e0%ba    | a            | bad_�
+        b=short%a       | b            | short�
+        c=%%TOK%%       | c            | �OK�
+        """)
+    public void testDecodeAllowBadSequence(String query, String expectedName, String expectedValue)
+    {
+        Fields fields = new Fields();
+        UrlEncoded.decodeUtf8To(query, 0, query.length(), fields::add, true);
+        Fields.Field field = fields.get(expectedName);
+        assertThat("Name exists", field, notNullValue());
+        assertThat("Value", field.getValue(), is(expectedValue));
+    }
 
     @Test
     public void testIncompleteSequestAtTheEnd() throws Exception
@@ -36,8 +52,8 @@ public class UrlEncodedUtf8Test
         String test = new String(bytes, StandardCharsets.UTF_8);
         String expected = "c" + Utf8StringBuilder.REPLACEMENT;
 
-        fromString(test, test, "ab", expected, false);
-        fromInputStream(test, bytes, "ab", expected, false);
+        fromString(test, test, "ab", expected);
+        fromInputStream(test, bytes, "ab", expected);
     }
 
     @Test
@@ -47,8 +63,8 @@ public class UrlEncodedUtf8Test
         String test = new String(bytes, StandardCharsets.UTF_8);
         String expected = "" + Utf8StringBuilder.REPLACEMENT;
 
-        fromString(test, test, "ab", expected, false);
-        fromInputStream(test, bytes, "ab", expected, false);
+        fromString(test, test, "ab", expected);
+        fromInputStream(test, bytes, "ab", expected);
     }
 
     @Test
@@ -59,8 +75,8 @@ public class UrlEncodedUtf8Test
         String name = "e" + Utf8StringBuilder.REPLACEMENT;
         String value = "fg";
 
-        fromString(test, test, name, value, false);
-        fromInputStream(test, bytes, name, value, false);
+        fromString(test, test, name, value);
+        fromInputStream(test, bytes, name, value);
     }
 
     @Test
@@ -71,46 +87,24 @@ public class UrlEncodedUtf8Test
         String name = "ef";
         String value = "g" + Utf8StringBuilder.REPLACEMENT;
 
-        fromString(test, test, name, value, false);
-        fromInputStream(test, bytes, name, value, false);
+        fromString(test, test, name, value);
+        fromInputStream(test, bytes, name, value);
     }
 
-    // TODO: Split thrown/not-thrown
-    static void fromString(String test, String s, String field, String expected, boolean thrown) throws Exception
+    static void fromString(String test, String s, String field, String expected)
     {
-        MultiMap<String> values = new MultiMap<>();
-        try
-        {
-            UrlEncoded.decodeUtf8To(s, 0, s.length(), values);
-            if (thrown)
-                fail("Expected an exception");
-            assertThat(test, values.getString(field), is(expected));
-        }
-        catch (Exception e)
-        {
-            if (!thrown)
-                throw e;
-            LOG.trace("IGNORED", e);
-        }
+        Fields values = new Fields();
+        UrlEncoded.decodeUtf8To(s, 0, s.length(), values);
+        assertThat(test, values.getValue(field), is(expected));
     }
 
-    // TODO: Split thrown/not-thrown
-    static void fromInputStream(String test, byte[] b, String field, String expected, boolean thrown) throws Exception
+    static void fromInputStream(String test, byte[] b, String field, String expected) throws Exception
     {
-        InputStream is = new ByteArrayInputStream(b);
-        MultiMap<String> values = new MultiMap<>();
-        try
+        try (InputStream is = new ByteArrayInputStream(b))
         {
+            Fields values = new Fields();
             UrlEncoded.decodeUtf8To(is, values, 1000000, -1);
-            if (thrown)
-                fail("Expected an exception");
-            assertThat(test, values.getString(field), is(expected));
-        }
-        catch (Exception e)
-        {
-            if (!thrown)
-                throw e;
-            LOG.trace("IGNORED", e);
+            assertThat(test, values.getValue(field), is(expected));
         }
     }
 }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/UrlEncodedUtf8Test.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/UrlEncodedUtf8Test.java
@@ -39,6 +39,7 @@ public class UrlEncodedUtf8Test
         f=%aardvark     | f            | �rdvark
         g=b%ar          | g            | b�
         h=end%          | h            | end�
+        i=%&z=2         | i            | �
         """)
     public void testDecodeAllowBadSequence(String query, String expectedName, String expectedValue)
     {


### PR DESCRIPTION
Handle double-pct symbol in query for BAD_UTF8_ENCODING UriCompliance mode.

Fixes #12750