### PR TITLE
[jetty-http-spi] add filter support

### DIFF
--- a/jetty-core/jetty-http-spi/src/main/java/org/eclipse/jetty/http/spi/HttpSpiContextHandler.java
+++ b/jetty-core/jetty-http-spi/src/main/java/org/eclipse/jetty/http/spi/HttpSpiContextHandler.java
@@ -18,6 +18,7 @@ import java.util.Map;
 
 import com.sun.net.httpserver.Authenticator;
 import com.sun.net.httpserver.Authenticator.Result;
+import com.sun.net.httpserver.Filter.Chain;
 import com.sun.net.httpserver.HttpContext;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
@@ -61,7 +62,7 @@ public class HttpSpiContextHandler extends ContextHandler
                     if (auth != null && handleAuthentication(request, response, callback, jettyHttpExchange, auth))
                         return true;
 
-                    _httpHandler.handle(jettyHttpExchange);
+                    new Chain(_httpContext.getFilters(), _httpHandler).doFilter(jettyHttpExchange);
                     callback.succeeded();
                 }
                 catch (Exception ex)

--- a/jetty-core/jetty-http-spi/src/main/java/org/eclipse/jetty/http/spi/JettyHttpContext.java
+++ b/jetty-core/jetty-http-spi/src/main/java/org/eclipse/jetty/http/spi/JettyHttpContext.java
@@ -33,9 +33,9 @@ public class JettyHttpContext extends com.sun.net.httpserver.HttpContext
 
     private final HttpServer _server;
 
-    private final Map<String, Object> _attributes = new HashMap<>();
+    private final Map<String, Object> _attributes = new HashMap<String, Object>();
 
-    private final List<Filter> _filters = new ArrayList<>();
+    private final List<Filter> _filters = new ArrayList<Filter>();
 
     private Authenticator _authenticator;
 

--- a/jetty-core/jetty-http-spi/src/main/java/org/eclipse/jetty/http/spi/JettyHttpContext.java
+++ b/jetty-core/jetty-http-spi/src/main/java/org/eclipse/jetty/http/spi/JettyHttpContext.java
@@ -33,9 +33,9 @@ public class JettyHttpContext extends com.sun.net.httpserver.HttpContext
 
     private final HttpServer _server;
 
-    private final Map<String, Object> _attributes = new HashMap<String, Object>();
+    private final Map<String, Object> _attributes = new HashMap<>();
 
-    private final List<Filter> _filters = new ArrayList<Filter>();
+    private final List<Filter> _filters = new ArrayList<>();
 
     private Authenticator _authenticator;
 


### PR DESCRIPTION
Now calls filters before executing the HTTP handler

Fixes #9125