### PR TITLE
Issue #12768 - Cleanup references to old Jetty versions

### DIFF
--- a/jetty-core/jetty-slf4j-impl/src/main/java/org/eclipse/jetty/logging/StdErrAppender.java
+++ b/jetty-core/jetty-slf4j-impl/src/main/java/org/eclipse/jetty/logging/StdErrAppender.java
@@ -185,21 +185,15 @@ public class StdErrAppender implements JettyAppender
 
     private String renderedLevel(Level level)
     {
-        switch (level)
+        return switch (level)
         {
-            case ERROR:  // New for Jetty 10+
-                return "ERROR";
-            case WARN:
-                return "WARN ";
-            case INFO:
-                return "INFO ";
-            case DEBUG:
-                return "DEBUG";
-            case TRACE: // New for Jetty 10+
-                return "TRACE";
-            default:
-                return "UNKNOWN";
-        }
+            case ERROR -> "ERROR";
+            case WARN -> "WARN ";
+            case INFO -> "INFO ";
+            case DEBUG -> "DEBUG";
+            case TRACE -> "TRACE";
+            default -> "UNKNOWN";
+        };
     }
 
     private void appendCause(StringBuilder builder, Throwable cause, String indent, Set<Throwable> visited)

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
@@ -1468,11 +1468,6 @@ public class StartArgs
                 JavaVersion ver = JavaVersion.parse(value);
                 properties.setProperty("java.version.platform", Integer.toString(ver.getPlatform()), source);
 
-                // @deprecated - below will be removed in Jetty 10.x
-                properties.setProperty("java.version.major", Integer.toString(ver.getMajor()), "Deprecated");
-                properties.setProperty("java.version.minor", Integer.toString(ver.getMinor()), "Deprecated");
-                properties.setProperty("java.version.micro", Integer.toString(ver.getMicro()), "Deprecated");
-
                 // ALPN feature exists
                 properties.setProperty("runtime.feature.alpn", Boolean.toString(isMethodAvailable(javax.net.ssl.SSLParameters.class, "getApplicationProtocols", null)), source);
             }

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/CommandLineBuilderTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/CommandLineBuilderTest.java
@@ -49,8 +49,8 @@ public class CommandLineBuilderTest
     {
         CommandLineBuilder cmd = new CommandLineBuilder();
         cmd.addArg("java");
-        cmd.addArg("-Djetty.home", "/opt/jetty 10/home");
-        assertThat(cmd.toCommandLine(), is("java -Djetty.home='/opt/jetty 10/home'"));
+        cmd.addArg("-Djetty.home", "/opt/jetty 12/home");
+        assertThat(cmd.toCommandLine(), is("java -Djetty.home='/opt/jetty 12/home'"));
     }
 
     @Test

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/test/java/org/eclipse/jetty/websocket/client/WebSocketClientInitTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/test/java/org/eclipse/jetty/websocket/client/WebSocketClientInitTest.java
@@ -27,7 +27,7 @@ import static org.hamcrest.Matchers.nullValue;
 public class WebSocketClientInitTest
 {
     /**
-     * This is the new Jetty 9.4 advanced usage mode of WebSocketClient,
+     * Advanced usage mode of WebSocketClient,
      * that allows for more robust HTTP configurations (such as authentication,
      * cookies, and proxies)
      *

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/LikeJettyXml.java
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/LikeJettyXml.java
@@ -57,8 +57,9 @@ import org.eclipse.jetty.xml.EnvironmentBuilder;
 import org.slf4j.LoggerFactory;
 
 /**
- * Starts the Jetty Distribution's demo-base directory using entirely
- * embedded jetty techniques.
+ * Starts a new Jetty Base in the target/embedded/ directory using entirely
+ * embedded jetty techniques, in ways similar to the various Jetty XML files
+ * from {@code jetty-home}
  */
 public class LikeJettyXml
 {

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/test/java/org/eclipse/jetty/ee10/demos/LikeJettyXmlTest.java
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/test/java/org/eclipse/jetty/ee10/demos/LikeJettyXmlTest.java
@@ -44,7 +44,7 @@ public class LikeJettyXmlTest extends AbstractEmbeddedTest
         Map<String, Integer> ports = ServerUtil.fixDynamicPortConfigurations(server);
 
         // Establish base URI's that use "localhost" to prevent tripping over
-        // the "REMOTE ACCESS" warnings in demo-base
+        // the "REMOTE ACCESS" warnings in webapps/ee#-demo-jetty.d/ee#-demo-jetty-override-web.xml
         serverPlainUri = URI.create("http://localhost:" + ports.get("plain") + "/");
         serverSslUri = URI.create("https://localhost:" + ports.get("secure") + "/");
     }

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/test/java/org/eclipse/jetty/ee10/demos/ManyConnectorsTest.java
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/test/java/org/eclipse/jetty/ee10/demos/ManyConnectorsTest.java
@@ -43,7 +43,7 @@ public class ManyConnectorsTest extends AbstractEmbeddedTest
         Map<String, Integer> ports = ServerUtil.fixDynamicPortConfigurations(server);
 
         // Establish base URI's that use "localhost" to prevent tripping over
-        // the "REMOTE ACCESS" warnings in demo-base
+        // the "REMOTE ACCESS" warnings in webapps/ee#-demo-jetty.d/ee#-demo-jetty-override-web.xml
         serverPlainUri = URI.create("http://localhost:" + ports.get("plain") + "/");
         serverSslUri = URI.create("https://localhost:" + ports.get("secure") + "/");
     }

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-jetty-webapp/src/main/webapp/remote.html
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-jetty-webapp/src/main/webapp/remote.html
@@ -15,15 +15,18 @@
     </div>
 
     <div class="content">
-      <h1>Welcome to Jetty 11 - REMOTE ACCESS!!</h1>
+      <h1>Welcome to Jetty 12 (ee10) - REMOTE ACCESS!!</h1>
       <p>
        This is a demo webapp for the Eclipse Jetty HTTP Server and Servlet Container.
       </p>
       <p>
-       This test context serves several demo filters and servlets that are not safe for deployment on the internet, since (by design) they contain cross domain scripting vulnerabilities and reveal private information.  This page is displayed because you have accessed this context from a non local IP address.
+       This test context serves several demo filters and servlets that are not safe for deployment on the internet,
+       since (by design) they contain cross domain scripting vulnerabilities and reveal private information.
+       This page is displayed because you have accessed this context from a non local IP address.
       </p>
       <p>
-       You can disable the remote address checking by editing demo-base/webapps/demo-jetty.d/demo-jetty-override-web.xml, uncommenting the declaration of the TestFilter, and changing the "remote" init parameter to "true".
+       You can disable the remote address checking by editing webapps/ee10-demo-jetty.d/ee10-demo-jetty-override-web.xml,
+       uncommenting the declaration of the TestFilter, and changing the "remote" init parameter to "true".
       </p>
     </div>
 

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-proxy-webapp/src/test/java/org/eclipse/jetty/ee10/demos/ProxyWebAppTest.java
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-proxy-webapp/src/test/java/org/eclipse/jetty/ee10/demos/ProxyWebAppTest.java
@@ -34,7 +34,7 @@ import static org.hamcrest.Matchers.containsStringIgnoringCase;
 import static org.hamcrest.Matchers.is;
 
 /**
- * Test the configuration found in WEB-INF/web.xml for purposes of the demo-base
+ * Test the configuration found in WEB-INF/web.xml of ee10-demo-proxy.war
  */
 public class ProxyWebAppTest
 {

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/main/java/org/eclipse/jetty/ee9/demos/LikeJettyXml.java
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/main/java/org/eclipse/jetty/ee9/demos/LikeJettyXml.java
@@ -14,8 +14,9 @@
 package org.eclipse.jetty.ee9.demos;
 
 /**
- * Starts the Jetty Distribution's demo-base directory using entirely
- * embedded jetty techniques.
+ * Starts a new Jetty Base in the target/embedded/ directory using entirely
+ * embedded jetty techniques, in ways similar to the various Jetty XML files
+ * from {@code jetty-home}
  */
 public class LikeJettyXml
 {

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/test/java/org/eclipse/jetty/ee9/demos/LikeJettyXmlTest.java
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/test/java/org/eclipse/jetty/ee9/demos/LikeJettyXmlTest.java
@@ -45,7 +45,7 @@ public class LikeJettyXmlTest extends AbstractEmbeddedTest
         Map<String, Integer> ports = ServerUtil.fixDynamicPortConfigurations(server);
 
         // Establish base URI's that use "localhost" to prevent tripping over
-        // the "REMOTE ACCESS" warnings in demo-base
+        // the "REMOTE ACCESS" warnings in webapps/ee#-demo-jetty.d/ee#-demo-jetty-override-web.xml
         serverPlainUri = URI.create("http://localhost:" + ports.get("plain") + "/");
         serverSslUri = URI.create("https://localhost:" + ports.get("secure") + "/");
     }

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/test/java/org/eclipse/jetty/ee9/demos/ManyConnectorsTest.java
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-embedded/src/test/java/org/eclipse/jetty/ee9/demos/ManyConnectorsTest.java
@@ -43,7 +43,7 @@ public class ManyConnectorsTest extends AbstractEmbeddedTest
         Map<String, Integer> ports = ServerUtil.fixDynamicPortConfigurations(server);
 
         // Establish base URI's that use "localhost" to prevent tripping over
-        // the "REMOTE ACCESS" warnings in demo-base
+        // the "REMOTE ACCESS" warnings in webapps/ee#-demo-jetty.d/ee#-demo-jetty-override-web.xml
         serverPlainUri = URI.create("http://localhost:" + ports.get("plain") + "/");
         serverSslUri = URI.create("https://localhost:" + ports.get("secure") + "/");
     }

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-jetty-webapp/src/main/webapp/remote.html
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-jetty-webapp/src/main/webapp/remote.html
@@ -15,15 +15,18 @@
     </div>
 
     <div class="content">
-      <h1>Welcome to Jetty 11 - REMOTE ACCESS!!</h1>
+      <h1>Welcome to Jetty 12 (ee9) - REMOTE ACCESS!!</h1>
       <p>
        This is a demo webapp for the Eclipse Jetty HTTP Server and Servlet Container.
       </p>
       <p>
-       This test context serves several demo filters and servlets that are not safe for deployment on the internet, since (by design) they contain cross domain scripting vulnerabilities and reveal private information.  This page is displayed because you have accessed this context from a non local IP address.
+       This test context serves several demo filters and servlets that are not safe for deployment on the internet,
+       since (by design) they contain cross domain scripting vulnerabilities and reveal private information.
+       This page is displayed because you have accessed this context from a non local IP address.
       </p>
       <p>
-       You can disable the remote address checking by editing demo-base/webapps/demo-jetty.d/demo-jetty-override-web.xml, uncommenting the declaration of the TestFilter, and changing the "remote" init parameter to "true".
+       You can disable the remote address checking by editing webapps/ee9-demo-jetty.d/ee9-demo-jetty-override-web.xml,
+       uncommenting the declaration of the TestFilter, and changing the "remote" init parameter to "true".
       </p>
     </div>
 

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-proxy-webapp/src/test/java/org/eclipse/jetty/ee9/demos/ProxyWebAppTest.java
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-proxy-webapp/src/test/java/org/eclipse/jetty/ee9/demos/ProxyWebAppTest.java
@@ -37,7 +37,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Test the configuration found in WEB-INF/web.xml for purposes of the demo-base
+ * Test the configuration found in WEB-INF/web.xml of ee9-demo-proxy.war
  */
 public class ProxyWebAppTest
 {

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/java/org/eclipse/jetty/ee9/osgi/test/TestOSGiUtil.java
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/java/org/eclipse/jetty/ee9/osgi/test/TestOSGiUtil.java
@@ -142,7 +142,7 @@ public class TestOSGiUtil
         res.add(mavenBundle().groupId("org.slf4j").artifactId("slf4j-api").version("1.7.36").startLevel(START_LEVEL_SYSTEM_BUNDLES)); //.versionAsInProject().noStart());
 
         /*
-         * Jetty 11 uses slf4j 2.0.0 by default, however we want to test with slf4j 1.7.30 for backwards compatibility.
+         * Jetty 12 uses slf4j 2.0.0 by default, however we want to test with slf4j 1.7.30 for backwards compatibility.
          * To do that, we need to use slf4j-simple as the logging implementation. We make a simplelogger.properties
          * file available so that jetty logging can be configured
          */

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-client/src/test/java/org/eclipse/jetty/ee9/websocket/client/WebSocketClientInitTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-client/src/test/java/org/eclipse/jetty/ee9/websocket/client/WebSocketClientInitTest.java
@@ -27,7 +27,7 @@ import static org.hamcrest.Matchers.nullValue;
 public class WebSocketClientInitTest
 {
     /**
-     * This is the new Jetty 9.4 advanced usage mode of WebSocketClient,
+     * Advanced usage mode of WebSocketClient,
      * that allows for more robust HTTP configurations (such as authentication,
      * cookies, and proxies)
      *

--- a/jetty-home/src/main/resources/bin/jetty.sh
+++ b/jetty-home/src/main/resources/bin/jetty.sh
@@ -22,7 +22,7 @@ NAME=$(echo $(basename $0) | sed -e 's/^[SK][0-9]*//' -e 's/\.sh$//')
 # To get the service to restart correctly on reboot, uncomment below (3 lines):
 # ========================
 # chkconfig: 3 99 99
-# description: Jetty 9 webserver
+# description: Eclipse Jetty webserver
 # processname: jetty
 # ========================
 


### PR DESCRIPTION
Cleanup of static HTML, XML, and Java source for references to old Jetty versions or Jetty concepts (eg: "demo-base").
Did not change old references found in Documentation.

Fixes #12768