### PR TITLE
Fixes #12639 - Request.Content.getContentType()'s Javadoc contradicts HttpConnection.normalizeRequest()

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/Request.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/Request.java
@@ -676,7 +676,7 @@ public interface Request
     {
         /**
          * @return the value of the {@code Content-Type} header for the request
-         * content, such as {@code application/octet-stream} or {@code application/json},
+         * content, such as {@code text/html;charset=utf-8} or {@code application/json},
          * or {@code null} to use the value from
          * {@link HttpClient#getDefaultRequestContentType()}
          */

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/Request.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/Request.java
@@ -675,9 +675,10 @@ public interface Request
     public interface Content extends org.eclipse.jetty.io.Content.Source
     {
         /**
-         * @return the content type string such as "application/octet-stream" or
-         * "application/json;charset=UTF8", or null if the {@code Content-Type}
-         * header must not be set
+         * @return the value of the {@code Content-Type} header for the request
+         * content, such as {@code application/octet-stream} or {@code application/json},
+         * or {@code null} to use the value from
+         * {@link HttpClient#getDefaultRequestContentType()}
          */
         public default String getContentType()
         {


### PR DESCRIPTION
Fixed javadocs.