### PR TITLE
Fixes #12670 - Improve buffer management of HTTP/1 response headers.

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -125,7 +125,9 @@ public class HttpClient extends ContainerLifeCycle implements AutoCloseable
     private int maxConnectionsPerDestination = 64;
     private int maxRequestsQueuedPerDestination = 1024;
     private int requestBufferSize = 4096;
+    private int maxRequestHeadersSize = 8192;
     private int responseBufferSize = 16384;
+    private int maxResponseHeadersSize = -1;
     private int maxRedirects = 8;
     private long addressResolutionTimeout = 15000;
     private boolean strictEventOrdering = false;
@@ -135,7 +137,6 @@ public class HttpClient extends ContainerLifeCycle implements AutoCloseable
     private String defaultRequestContentType = "application/octet-stream";
     private boolean useInputDirectByteBuffers = true;
     private boolean useOutputDirectByteBuffers = true;
-    private int maxResponseHeadersSize = -1;
     private Sweeper destinationSweeper;
 
     /**
@@ -1075,6 +1076,24 @@ public class HttpClient extends ContainerLifeCycle implements AutoCloseable
     public void setUseInputDirectByteBuffers(boolean useInputDirectByteBuffers)
     {
         this.useInputDirectByteBuffers = useInputDirectByteBuffers;
+    }
+
+    /**
+     * @return the max size in bytes of the request headers
+     */
+    @ManagedAttribute("The max size in bytes of the request headers")
+    public int getMaxRequestHeadersSize()
+    {
+        return maxRequestHeadersSize;
+    }
+
+    /**
+     * Set the max size in bytes of the request headers.
+     * @param maxRequestHeadersSize the max size in bytes of the request headers
+     */
+    public void setMaxRequestHeadersSize(int maxRequestHeadersSize)
+    {
+        this.maxRequestHeadersSize = maxRequestHeadersSize;
     }
 
     /**

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/HttpClientTransportOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/HttpClientTransportOverHTTP2.java
@@ -103,7 +103,7 @@ public class HttpClientTransportOverHTTP2 extends AbstractHttpClientTransport
         http2Client.setUseOutputDirectByteBuffers(httpClient.isUseOutputDirectByteBuffers());
         http2Client.setConnectBlocking(httpClient.isConnectBlocking());
         http2Client.setBindAddress(httpClient.getBindAddress());
-        http2Client.setMaxRequestHeadersSize(httpClient.getRequestBufferSize());
+        http2Client.setMaxRequestHeadersSize(httpClient.getMaxRequestHeadersSize());
         http2Client.setMaxResponseHeadersSize(httpClient.getMaxResponseHeadersSize());
     }
 

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/AbstractHTTP2ServerConnectionFactory.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/AbstractHTTP2ServerConnectionFactory.java
@@ -306,7 +306,7 @@ public abstract class AbstractHTTP2ServerConnectionFactory extends AbstractConne
         ServerSessionListener listener = newSessionListener(connector, endPoint);
 
         Generator generator = new Generator(connector.getByteBufferPool(), isUseOutputDirectByteBuffers(), getMaxHeaderBlockFragment());
-        generator.getHpackEncoder().setMaxHeaderListSize(getHttpConfiguration().getResponseHeaderSize());
+        generator.getHpackEncoder().setMaxHeaderListSize(getHttpConfiguration().getMaxResponseHeaderSize());
 
         FlowControlStrategy flowControl = getFlowControlStrategyFactory().newFlowControlStrategy();
 

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
@@ -144,7 +144,7 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
             assertEquals(httpClient.getIdleTimeout(), http2Client.getIdleTimeout());
             assertEquals(httpClient.isUseInputDirectByteBuffers(), http2Client.isUseInputDirectByteBuffers());
             assertEquals(httpClient.isUseOutputDirectByteBuffers(), http2Client.isUseOutputDirectByteBuffers());
-            assertEquals(httpClient.getRequestBufferSize(), http2Client.getMaxRequestHeadersSize());
+            assertEquals(httpClient.getMaxRequestHeadersSize(), http2Client.getMaxRequestHeadersSize());
             assertEquals(httpClient.getMaxResponseHeadersSize(), http2Client.getMaxResponseHeadersSize());
         }
         assertTrue(http2Client.isStopped());

--- a/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/HttpClientTransportOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/HttpClientTransportOverHTTP3.java
@@ -84,6 +84,7 @@ public class HttpClientTransportOverHTTP3 extends AbstractHttpClientTransport im
         configuration.setInputBufferSize(httpClient.getResponseBufferSize());
         configuration.setUseInputDirectByteBuffers(httpClient.isUseInputDirectByteBuffers());
         configuration.setUseOutputDirectByteBuffers(httpClient.isUseOutputDirectByteBuffers());
+        configuration.setMaxRequestHeadersSize(httpClient.getMaxRequestHeadersSize());
         configuration.setMaxResponseHeadersSize(httpClient.getMaxResponseHeadersSize());
     }
 

--- a/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/AbstractHTTP3ServerConnectionFactory.java
+++ b/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/AbstractHTTP3ServerConnectionFactory.java
@@ -53,7 +53,7 @@ public abstract class AbstractHTTP3ServerConnectionFactory extends AbstractConne
         http3Configuration.setUseInputDirectByteBuffers(httpConfiguration.isUseInputDirectByteBuffers());
         http3Configuration.setUseOutputDirectByteBuffers(httpConfiguration.isUseOutputDirectByteBuffers());
         http3Configuration.setMaxRequestHeadersSize(httpConfiguration.getRequestHeaderSize());
-        http3Configuration.setMaxResponseHeadersSize(httpConfiguration.getResponseHeaderSize());
+        http3Configuration.setMaxResponseHeadersSize(httpConfiguration.getMaxResponseHeaderSize());
     }
 
     public ServerQuicConfiguration getQuicConfiguration()

--- a/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/HttpClientTransportOverHTTP3Test.java
+++ b/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/HttpClientTransportOverHTTP3Test.java
@@ -92,6 +92,7 @@ public class HttpClientTransportOverHTTP3Test extends AbstractClientServerTest
             HTTP3Configuration http3Configuration = http3Client.getHTTP3Configuration();
             assertEquals(httpClient.isUseInputDirectByteBuffers(), http3Configuration.isUseInputDirectByteBuffers());
             assertEquals(httpClient.isUseOutputDirectByteBuffers(), http3Configuration.isUseOutputDirectByteBuffers());
+            assertEquals(httpClient.getMaxRequestHeadersSize(), http3Configuration.getMaxRequestHeadersSize());
             assertEquals(httpClient.getMaxResponseHeadersSize(), http3Configuration.getMaxResponseHeadersSize());
         }
         assertTrue(http3Client.isStopped());

--- a/jetty-core/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ReverseProxyTest.java
+++ b/jetty-core/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ReverseProxyTest.java
@@ -147,6 +147,7 @@ public class ReverseProxyTest extends AbstractProxyTest
 
         int maxResponseHeadersSize = 256;
         serverHttpConfig.setResponseHeaderSize(maxResponseHeadersSize);
+        serverHttpConfig.setMaxResponseHeaderSize(maxResponseHeadersSize);
         startServer(new Handler.Abstract()
         {
             @Override
@@ -283,6 +284,7 @@ public class ReverseProxyTest extends AbstractProxyTest
 
         CountDownLatch proxyToClientFailureLatch = new CountDownLatch(1);
         proxyHttpConfig.setResponseHeaderSize(maxResponseHeadersSize);
+        proxyHttpConfig.setMaxResponseHeaderSize(maxResponseHeadersSize);
         startProxy(new ProxyHandler.Reverse(clientToProxyRequest ->
             HttpURI.build(clientToProxyRequest.getHttpURI()).port(serverConnector.getLocalPort()))
         {

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java
@@ -62,6 +62,7 @@ public class HttpConfiguration implements Dumpable
     private int _outputAggregationSize = _outputBufferSize / 4;
     private int _requestHeaderSize = 8 * 1024;
     private int _responseHeaderSize = 8 * 1024;
+    private int _maxResponseHeaderSize = 16 * 1024;
     private int _headerCacheSize = 1024;
     private boolean _headerCacheCaseSensitive = false;
     private int _securePort;
@@ -137,6 +138,7 @@ public class HttpConfiguration implements Dumpable
         _outputAggregationSize = config._outputAggregationSize;
         _requestHeaderSize = config._requestHeaderSize;
         _responseHeaderSize = config._responseHeaderSize;
+        _maxResponseHeaderSize = config._maxResponseHeaderSize;
         _headerCacheSize = config._headerCacheSize;
         _headerCacheCaseSensitive = config._headerCacheCaseSensitive;
         _secureScheme = config._secureScheme;
@@ -217,10 +219,16 @@ public class HttpConfiguration implements Dumpable
         return _requestHeaderSize;
     }
 
-    @ManagedAttribute("The maximum allowed size in bytes for an HTTP response header")
+    @ManagedAttribute("The default size in bytes for the HTTP response headers buffer")
     public int getResponseHeaderSize()
     {
         return _responseHeaderSize;
+    }
+
+    @ManagedAttribute("The maximum size in bytes for the HTTP response headers buffer")
+    public int getMaxResponseHeaderSize()
+    {
+        return _maxResponseHeaderSize;
     }
 
     @ManagedAttribute("The maximum allowed size in Trie nodes for an HTTP header field cache")
@@ -442,11 +450,22 @@ public class HttpConfiguration implements Dumpable
      * <p>Larger headers will allow for more and/or larger cookies and longer HTTP headers (eg for redirection).
      * However, larger headers will also consume more memory.</p>
      *
-     * @param responseHeaderSize the maximum size in bytes of the response header
+     * @param responseHeaderSize the default size in bytes of the response headers buffer
      */
     public void setResponseHeaderSize(int responseHeaderSize)
     {
         _responseHeaderSize = responseHeaderSize;
+    }
+
+    /**
+     * <p>Larger headers will allow for more and/or larger cookies and longer HTTP headers (eg for redirection).
+     * However, larger headers will also consume more memory.</p>
+     *
+     * @param maxResponseHeaderSize the maximum size in bytes of the response headers buffer
+     */
+    public void setMaxResponseHeaderSize(int maxResponseHeaderSize)
+    {
+        _maxResponseHeaderSize = maxResponseHeaderSize;
     }
 
     /**
@@ -839,6 +858,7 @@ public class HttpConfiguration implements Dumpable
             "outputAggregationSize=" + _outputAggregationSize,
             "requestHeaderSize=" + _requestHeaderSize,
             "responseHeaderSize=" + _responseHeaderSize,
+            "maxResponseHeaderSize=" + _maxResponseHeaderSize,
             "headerCacheSize=" + _headerCacheSize,
             "headerCacheCaseSensitive=" + _headerCacheCaseSensitive,
             "secureScheme=" + _secureScheme,

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConnectionTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConnectionTest.java
@@ -75,6 +75,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class HttpConnectionTest
 {
     private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(HttpConnectionTest.class);
+
+    private final HttpConfiguration httpConfig = new HttpConfiguration();
     private Server _server;
     private LocalConnector _connector;
 
@@ -83,11 +85,10 @@ public class HttpConnectionTest
     {
         _server = new Server();
 
-        HttpConfiguration config = new HttpConfiguration();
-        config.setRequestHeaderSize(1024);
-        config.setResponseHeaderSize(1024);
-        config.setSendDateHeader(true);
-        HttpConnectionFactory http = new HttpConnectionFactory(config);
+        httpConfig.setRequestHeaderSize(1024);
+        httpConfig.setResponseHeaderSize(1024);
+        httpConfig.setSendDateHeader(true);
+        HttpConnectionFactory http = new HttpConnectionFactory(httpConfig);
 
         _connector = new LocalConnector(_server, http, null);
         _connector.setIdleTimeout(5000);
@@ -1187,6 +1188,8 @@ public class HttpConnectionTest
     @Test
     public void testOversizedResponse() throws Exception
     {
+        httpConfig.setMaxResponseHeaderSize(httpConfig.getResponseHeaderSize());
+
         String str = "thisisastringthatshouldreachover1kbytes-";
         for (int i = 0; i < 500; i++)
         {

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/LargeHeaderTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/LargeHeaderTest.java
@@ -62,6 +62,7 @@ public class LargeHeaderTest
         server = new Server();
 
         HttpConfiguration config = new HttpConfiguration();
+        config.setMaxResponseHeaderSize(config.getResponseHeaderSize());
         HttpConnectionFactory http = new HttpConnectionFactory(config);
 
         ServerConnector connector = new ServerConnector(server, http);

--- a/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/ProxyServletTest.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/ProxyServletTest.java
@@ -1789,6 +1789,7 @@ public class ProxyServletTest
     {
         int maxResponseHeadersSize = 256;
         httpConfig.setResponseHeaderSize(maxResponseHeadersSize);
+        httpConfig.setMaxResponseHeaderSize(maxResponseHeadersSize);
         startServer(new HttpServlet()
         {
             @Override

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/HttpOutputTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/HttpOutputTest.java
@@ -55,9 +55,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/**
- *
- */
 public class HttpOutputTest
 {
     public static final int OUTPUT_AGGREGATION_SIZE = 1024;


### PR DESCRIPTION
* Backported #12544 (client-side handling of request header overflow).
* Introduced HttpConfiguration.maxResponseHeaderSize
* Implemented server-side handling of response header overflow, similar to the client.