### PR TITLE
Jetty 10.0.x: avoid buffer use after repooling

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpOutput.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpOutput.java
@@ -32,6 +32,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.WriteListener;
 
 import org.eclipse.jetty.http.HttpContent;
+import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.EofException;
 import org.eclipse.jetty.util.BufferUtil;
@@ -652,8 +653,9 @@ public class HttpOutput extends ServletOutputStream implements Runnable
     {
         if (_aggregate != null)
         {
+            boolean asyncCancelPossible = _channel.getRequest().getMetaData().getHttpVersion().getVersion() >= HttpVersion.HTTP_2.getVersion();
             ByteBufferPool bufferPool = _channel.getConnector().getByteBufferPool();
-            if (failure == null)
+            if (failure == null || !asyncCancelPossible)
                 bufferPool.release(_aggregate);
             else
                 bufferPool.remove(_aggregate);

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpOutput.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpOutput.java
@@ -287,7 +287,7 @@ public class HttpOutput extends ServletOutputStream implements Runnable
                 _state = State.CLOSED;
                 closedCallback = _closedCallback;
                 _closedCallback = null;
-                releaseBuffer();
+                releaseBuffer(failure);
                 wake = updateApiState(failure);
             }
             else if (_state == State.CLOSE)
@@ -508,7 +508,7 @@ public class HttpOutput extends ServletOutputStream implements Runnable
         try (AutoLock l = _channelState.lock())
         {
             _state = State.CLOSED;
-            releaseBuffer();
+            releaseBuffer(failure);
         }
     }
 
@@ -648,12 +648,15 @@ public class HttpOutput extends ServletOutputStream implements Runnable
         return _aggregate;
     }
 
-    private void releaseBuffer()
+    private void releaseBuffer(Throwable failure)
     {
         if (_aggregate != null)
         {
             ByteBufferPool bufferPool = _channel.getConnector().getByteBufferPool();
-            bufferPool.release(_aggregate);
+            if (failure == null)
+                bufferPool.release(_aggregate);
+            else
+                bufferPool.remove(_aggregate);
             _aggregate = null;
         }
     }
@@ -1400,7 +1403,7 @@ public class HttpOutput extends ServletOutputStream implements Runnable
             _commitSize = config.getOutputAggregationSize();
             if (_commitSize > _bufferSize)
                 _commitSize = _bufferSize;
-            releaseBuffer();
+            releaseBuffer(null);
             _written = 0;
             _writeListener = null;
             _onError = null;

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpOutput.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpOutput.java
@@ -653,9 +653,8 @@ public class HttpOutput extends ServletOutputStream implements Runnable
     {
         if (_aggregate != null)
         {
-            boolean asyncCancelPossible = _channel.getRequest().getMetaData().getHttpVersion().getVersion() >= HttpVersion.HTTP_2.getVersion();
             ByteBufferPool bufferPool = _channel.getConnector().getByteBufferPool();
-            if (failure == null || !asyncCancelPossible)
+            if (failure == null || _channel.getRequest().getMetaData().getHttpVersion().getVersion() < HttpVersion.HTTP_2.getVersion())
                 bufferPool.release(_aggregate);
             else
                 bufferPool.remove(_aggregate);


### PR DESCRIPTION
Fixes the Jetty 11 problem reported at #12776: the change made in #11527 is safe for H1 but not for H2.