### PR TITLE
Review `UriCompliance.LEGACY` behavior with bad UTF-8 in query

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/UriCompliance.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/UriCompliance.java
@@ -101,6 +101,11 @@ public final class UriCompliance implements ComplianceViolation.Mode
         BAD_UTF8_ENCODING("https://datatracker.ietf.org/doc/html/rfc5987#section-3.2.1", "Bad UTF-8 encoding"),
 
         /**
+         * Allow truncated UTF-8 encodings to be substituted by the replacement character.
+         */
+        TRUNCATED_UTF8_ENCODING("https://datatracker.ietf.org/doc/html/rfc5987#section-3.2.1", "Truncated UTF-8 encoding"),
+
+        /**
          * Allow encoded path characters not allowed by the Servlet spec rules.
          */
         SUSPICIOUS_PATH_CHARACTERS("https://jakarta.ee/specifications/servlet/6.0/jakarta-servlet-spec-6.0.html#uri-path-canonicalization", "Suspicious Path Character"),
@@ -210,7 +215,7 @@ public final class UriCompliance implements ComplianceViolation.Mode
             Violation.AMBIGUOUS_PATH_SEPARATOR,
             Violation.AMBIGUOUS_PATH_ENCODING,
             Violation.AMBIGUOUS_EMPTY_SEGMENT,
-            Violation.BAD_UTF8_ENCODING,
+            Violation.TRUNCATED_UTF8_ENCODING,
             Violation.UTF16_ENCODINGS,
             Violation.USER_INFO));
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -588,8 +588,8 @@ public interface Request extends Attributes, Content.Source
         }
         catch (Throwable t)
         {
-            if (uriCompliance == UriCompliance.LEGACY)
-                throw t;
+//            if (uriCompliance == UriCompliance.LEGACY)
+//                throw t;
             throw new BadMessageException("Bad query", t);
         }
     }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -570,8 +570,9 @@ public interface Request extends Attributes, Content.Source
             if (charset == null || StandardCharsets.UTF_8.equals(charset))
             {
                 UriCompliance uriCompliance = request.getConnectionMetaData().getHttpConfiguration().getUriCompliance();
+                boolean allowTruncatedUtf8 = uriCompliance.allows(UriCompliance.Violation.TRUNCATED_UTF8_ENCODING);
                 boolean allowBadUtf8 = uriCompliance.allows(UriCompliance.Violation.BAD_UTF8_ENCODING);
-                if (!UrlEncoded.decodeUtf8To(query, 0, query.length(), fields::add, allowBadUtf8))
+                if (!UrlEncoded.decodeUtf8To(query, 0, query.length(), fields::add, allowTruncatedUtf8, allowBadUtf8))
                 {
                     HttpChannel httpChannel = HttpChannel.from(request);
                     if (httpChannel != null && httpChannel.getComplianceViolationListener() != null)

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -36,6 +36,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.ComplianceViolation;
 import org.eclipse.jetty.http.HttpCookie;
 import org.eclipse.jetty.http.HttpFields;
@@ -559,27 +560,34 @@ public interface Request extends Attributes, Content.Source
 
     static Fields extractQueryParameters(Request request, Charset charset)
     {
-        String query = request.getHttpURI().getQuery();
-        if (StringUtil.isBlank(query))
-            return Fields.EMPTY;
-        Fields fields = new Fields(true);
+        try
+        {
+            String query = request.getHttpURI().getQuery();
+            if (StringUtil.isBlank(query))
+                return Fields.EMPTY;
+            Fields fields = new Fields(true);
 
-        if (charset == null || StandardCharsets.UTF_8.equals(charset))
-        {
-            UriCompliance uriCompliance = request.getConnectionMetaData().getHttpConfiguration().getUriCompliance();
-            boolean allowBadUtf8 = uriCompliance.allows(UriCompliance.Violation.BAD_UTF8_ENCODING);
-            if (!UrlEncoded.decodeUtf8To(query, 0, query.length(), fields::add, allowBadUtf8))
+            if (charset == null || StandardCharsets.UTF_8.equals(charset))
             {
-                HttpChannel httpChannel = HttpChannel.from(request);
-                if (httpChannel != null && httpChannel.getComplianceViolationListener() != null)
-                    httpChannel.getComplianceViolationListener().onComplianceViolation(new ComplianceViolation.Event(uriCompliance, UriCompliance.Violation.BAD_UTF8_ENCODING, "query=" + query));
+                UriCompliance uriCompliance = request.getConnectionMetaData().getHttpConfiguration().getUriCompliance();
+                boolean allowBadUtf8 = uriCompliance.allows(UriCompliance.Violation.BAD_UTF8_ENCODING);
+                if (!UrlEncoded.decodeUtf8To(query, 0, query.length(), fields::add, allowBadUtf8))
+                {
+                    HttpChannel httpChannel = HttpChannel.from(request);
+                    if (httpChannel != null && httpChannel.getComplianceViolationListener() != null)
+                        httpChannel.getComplianceViolationListener().onComplianceViolation(new ComplianceViolation.Event(uriCompliance, UriCompliance.Violation.BAD_UTF8_ENCODING, "query=" + query));
+                }
             }
+            else
+            {
+                UrlEncoded.decodeTo(query, fields::add, charset);
+            }
+            return fields;
         }
-        else
+        catch (Throwable t)
         {
-            UrlEncoded.decodeTo(query, fields::add, charset);
+            throw new BadMessageException("Bad query", t);
         }
-        return fields;
     }
 
     static Fields getParameters(Request request) throws Exception

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -560,6 +560,7 @@ public interface Request extends Attributes, Content.Source
 
     static Fields extractQueryParameters(Request request, Charset charset)
     {
+        UriCompliance uriCompliance = null;
         try
         {
             String query = request.getHttpURI().getQuery();
@@ -569,7 +570,7 @@ public interface Request extends Attributes, Content.Source
 
             if (charset == null || StandardCharsets.UTF_8.equals(charset))
             {
-                UriCompliance uriCompliance = request.getConnectionMetaData().getHttpConfiguration().getUriCompliance();
+                uriCompliance = request.getConnectionMetaData().getHttpConfiguration().getUriCompliance();
                 boolean allowTruncatedUtf8 = uriCompliance.allows(UriCompliance.Violation.TRUNCATED_UTF8_ENCODING);
                 boolean allowBadUtf8 = uriCompliance.allows(UriCompliance.Violation.BAD_UTF8_ENCODING);
                 if (!UrlEncoded.decodeUtf8To(query, 0, query.length(), fields::add, allowTruncatedUtf8, allowBadUtf8))
@@ -587,6 +588,8 @@ public interface Request extends Attributes, Content.Source
         }
         catch (Throwable t)
         {
+            if (uriCompliance == UriCompliance.LEGACY)
+                throw t;
             throw new BadMessageException("Bad query", t);
         }
     }

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/FormFieldsTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/FormFieldsTest.java
@@ -111,7 +111,7 @@ public class FormFieldsTest
             Arguments.of(List.of("name%"), UTF_8, -1, -1, IllegalStateException.class),
             Arguments.of(List.of("name%A"), UTF_8, -1, -1, IllegalStateException.class),
 
-            Arguments.of(List.of("name%A="), UTF_8, -1, -1, CharacterCodingException.class),
+            Arguments.of(List.of("name%A="), UTF_8, -1, -1, IllegalArgumentException.class),
             Arguments.of(List.of("name%A&"), UTF_8, -1, -1, IllegalArgumentException.class),
 
             Arguments.of(List.of("name=%"), UTF_8, -1, -1, IllegalStateException.class),

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
@@ -632,10 +632,10 @@ public class RequestTest
         cases.add(Arguments.of("other=foo&%E5%B8%BD%E5%AD%90=Beret", 200, "帽子", "Beret"));
 
         // truncated pct-encoded parameter names
-        cases.add(Arguments.of("%E5%B8%BD%E5%AD%9=Beret", 200, "帽孝Beret", ""));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%9=Beret", 400, "�", "")); // different from 11
         cases.add(Arguments.of("%E5%B8%BD%E5%AD%=Beret", 400, "帽子", ""));
         cases.add(Arguments.of("%E5%B8%BD%E5%AD=Beret", 200, "帽�", "Beret"));
-        cases.add(Arguments.of("%E5%B8%BD%E5%AD%9=Beret&other=foo", 200, "帽孝Beret", ""));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%9=Beret&other=foo", 400, "", "")); // different from 11
         cases.add(Arguments.of("%E5%B8%BD%E5%AD%=Beret&other=foo", 400, "帽子", ""));
         cases.add(Arguments.of("%E5%B8%BD%E5%AD=Beret&other=foo", 200, "帽�", "Beret"));
 

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
@@ -561,54 +561,54 @@ public class RequestTest
         cases.add(Arguments.of("param=%E2%9C%94&other=foo", 200, "param", "✔"));
 
         // Truncated / Insufficient Hex cases
-        cases.add(Arguments.of("param=%E2%9C%9", 500, "param", ""));
-        cases.add(Arguments.of("param=%E2%9C%9&other=foo", 500, "param", ""));
-        cases.add(Arguments.of("param=%E2%9C%", 500, "param", ""));
-        cases.add(Arguments.of("param=%E2%9C%&other=foo", 500, "param", ""));
+        cases.add(Arguments.of("param=%E2%9C%9", 400, "param", ""));
+        cases.add(Arguments.of("param=%E2%9C%9&other=foo", 400, "param", ""));
+        cases.add(Arguments.of("param=%E2%9C%", 400, "param", ""));
+        cases.add(Arguments.of("param=%E2%9C%&other=foo", 400, "param", ""));
         cases.add(Arguments.of("param=%E2%9C", 200, "param", "�"));
         cases.add(Arguments.of("param=%E2%9C&other=foo", 200, "param", "�"));
-        cases.add(Arguments.of("param=%E2%9", 500, "param", ""));
-        cases.add(Arguments.of("param=%E2%9&other=foo", 500, "param", ""));
-        cases.add(Arguments.of("param=%E2%", 500, "param", ""));
-        cases.add(Arguments.of("param=%E2%&other=foo", 500, "param", ""));
-        cases.add(Arguments.of("param=%E2", 500, "param", "")); // Yes, this failed in Jetty 11
-        cases.add(Arguments.of("param=%E2&other=foo", 200, "param", "�")); // Yes, this worked in Jetty 11
+        cases.add(Arguments.of("param=%E2%9", 400, "param", ""));
+        cases.add(Arguments.of("param=%E2%9&other=foo", 400, "param", ""));
+        cases.add(Arguments.of("param=%E2%", 400, "param", ""));
+        cases.add(Arguments.of("param=%E2%&other=foo", 400, "param", ""));
+        cases.add(Arguments.of("param=%E2", 200, "param", "�"));
+        cases.add(Arguments.of("param=%E2&other=foo", 200, "param", "�"));
 
         // Tokenized cases
-        cases.add(Arguments.of("param=%%TOK%%", 500, "param", ""));
-        cases.add(Arguments.of("param=%%TOK%%&other=foo", 500, "param", ""));
+        cases.add(Arguments.of("param=%%TOK%%", 400, "param", ""));
+        cases.add(Arguments.of("param=%%TOK%%&other=foo", 400, "param", ""));
 
         // Bad Hex
-        cases.add(Arguments.of("param=%xx", 500, "param", ""));
-        cases.add(Arguments.of("param=%xx&other=foo", 500, "param", ""));
+        cases.add(Arguments.of("param=%xx", 400, "param", ""));
+        cases.add(Arguments.of("param=%xx&other=foo", 400, "param", ""));
 
         // Overlong UTF-8 Encoding
-        cases.add(Arguments.of("param=%C0%AF", 500, "param", ""));
-        cases.add(Arguments.of("param=%C0%AF&other=foo", 500, "param", ""));
+        cases.add(Arguments.of("param=%C0%AF", 400, "param", ""));
+        cases.add(Arguments.of("param=%C0%AF&other=foo", 400, "param", ""));
 
         // Out of range
-        cases.add(Arguments.of("param=%F4%90%80%80", 500, "param", ""));
-        cases.add(Arguments.of("param=%F4%90%80%80&other=foo", 500, "param", ""));
+        cases.add(Arguments.of("param=%F4%90%80%80", 400, "param", ""));
+        cases.add(Arguments.of("param=%F4%90%80%80&other=foo", 400, "param", ""));
 
         // Long surrogate
-        cases.add(Arguments.of("param=%ED%A0%80", 500, "param", ""));
-        cases.add(Arguments.of("param=%ED%A0%80&other=foo", 500, "param", ""));
+        cases.add(Arguments.of("param=%ED%A0%80", 400, "param", ""));
+        cases.add(Arguments.of("param=%ED%A0%80&other=foo", 400, "param", ""));
 
         // Standalone continuations
-        cases.add(Arguments.of("param=%80", 500, "param", ""));
-        cases.add(Arguments.of("param=%80&other=foo", 500, "param", ""));
+        cases.add(Arguments.of("param=%80", 400, "param", ""));
+        cases.add(Arguments.of("param=%80&other=foo", 400, "param", ""));
 
         // Truncated sequence
         cases.add(Arguments.of("param=%E2%82", 200, "param", "�"));
         cases.add(Arguments.of("param=%E2%82&other=foo", 200, "param", "�"));
 
         // C1 never starts UTF-8
-        cases.add(Arguments.of("param=%C1%BF", 500, "param", ""));
-        cases.add(Arguments.of("param=%C1%BF&other=foo", 500, "param", ""));
+        cases.add(Arguments.of("param=%C1%BF", 400, "param", ""));
+        cases.add(Arguments.of("param=%C1%BF&other=foo", 400, "param", ""));
 
         // E0 must be followed by A0-BF
-        cases.add(Arguments.of("param=%E0%9F%80", 500, "param", ""));
-        cases.add(Arguments.of("param=%E0%9F%80&other=foo", 500, "param", ""));
+        cases.add(Arguments.of("param=%E0%9F%80", 400, "param", ""));
+        cases.add(Arguments.of("param=%E0%9F%80&other=foo", 400, "param", ""));
 
         // Community Examples
         cases.add(Arguments.of("param=f_%e0%b8", 200, "param", "f_�"));
@@ -631,13 +631,28 @@ public class RequestTest
         cases.add(Arguments.of("%E5%B8%BD%E5%AD%90=Beret&other=foo", 200, "帽子", "Beret"));
         cases.add(Arguments.of("other=foo&%E5%B8%BD%E5%AD%90=Beret", 200, "帽子", "Beret"));
 
-        // bad pct-encoded parameter names
-        cases.add(Arguments.of("%E5%B8%BD%E5%AD%9=Beret", 200, "帽子", null));
-        cases.add(Arguments.of("%E5%B8%BD%E5%AD%=Beret", 500, "帽子", null));
-        cases.add(Arguments.of("%E5%B8%BD%E5%AD=Beret", 200, "帽子", null));
-        cases.add(Arguments.of("%E5%B8%BD%E5%AD%9=Beret&other=foo", 200, "帽子", null));
-        cases.add(Arguments.of("%E5%B8%BD%E5%AD%=Beret&other=foo", 500, "帽子", null));
-        cases.add(Arguments.of("%E5%B8%BD%E5%AD=Beret&other=foo", 200, "帽子", null));
+        // truncated pct-encoded parameter names
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%9=Beret", 200, "帽孝Beret", ""));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%=Beret", 400, "帽子", ""));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD=Beret", 200, "帽�", "Beret"));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%9=Beret&other=foo", 200, "帽孝Beret", ""));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%=Beret&other=foo", 400, "帽子", ""));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD=Beret&other=foo", 200, "帽�", "Beret"));
+
+        // raw unicode parameter names (strange replacement logic here)
+        cases.add(Arguments.of("€=currency", 200, "?", "currency"));
+        cases.add(Arguments.of("帽子=Beret", 200, "??", "Beret"));
+
+        // invalid pct-encoded parameter name
+        cases.add(Arguments.of("foo%xx=abc", 400, "foo�", ""));
+        cases.add(Arguments.of("foo%x=abc", 400, "foo�", ""));
+        cases.add(Arguments.of("foo%=abc", 400, "foo�", ""));
+
+        // utf-16 values (LEGACY has UTF16_ENCODINGS enabled, but it doesn't work for query apparently)
+        cases.add(Arguments.of("foo=a%u2192z", 400, "foo", ""));
+
+        // truncated utf-16 values (LEGACY has UTF16_ENCODINGS enabled, but it doesn't work for query apparently)
+        cases.add(Arguments.of("foo=a%u219z", 400, "foo", ""));
 
         return cases.stream();
     }

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
@@ -41,7 +41,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -49,7 +48,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -670,60 +668,60 @@ public class RequestTest
         cases.add(Arguments.of("param=%E2%9C%94&other=foo", 200, "param", "✔"));
 
         // Truncated / Insufficient Hex cases
-        cases.add(Arguments.of("param=%E2%9C%9", 500, "param", ""));
-        cases.add(Arguments.of("param=%E2%9C%9&other=foo", 500, "param", ""));
-        cases.add(Arguments.of("param=%E2%9C%", 500, "param", ""));
-        cases.add(Arguments.of("param=%E2%9C%&other=foo", 500, "param", ""));
-        cases.add(Arguments.of("param=%E2%9C", 500, "param", ""));
-        cases.add(Arguments.of("param=%E2%9C&other=foo", 500, "param", "�"));
-        cases.add(Arguments.of("param=%E2%9", 500, "param", ""));
-        cases.add(Arguments.of("param=%E2%9&other=foo", 500, "param", ""));
-        cases.add(Arguments.of("param=%E2%", 500, "param", ""));
-        cases.add(Arguments.of("param=%E2%&other=foo", 500, "param", ""));
-        cases.add(Arguments.of("param=%E2", 500, "param", ""));
-        cases.add(Arguments.of("param=%E2&other=foo", 500, "param", ""));
+        cases.add(Arguments.of("param=%E2%9C%9", 400, "param", ""));
+        cases.add(Arguments.of("param=%E2%9C%9&other=foo", 400, "param", ""));
+        cases.add(Arguments.of("param=%E2%9C%", 400, "param", ""));
+        cases.add(Arguments.of("param=%E2%9C%&other=foo", 400, "param", ""));
+        cases.add(Arguments.of("param=%E2%9C", 400, "param", ""));
+        cases.add(Arguments.of("param=%E2%9C&other=foo", 400, "param", "�"));
+        cases.add(Arguments.of("param=%E2%9", 400, "param", ""));
+        cases.add(Arguments.of("param=%E2%9&other=foo", 400, "param", ""));
+        cases.add(Arguments.of("param=%E2%", 400, "param", ""));
+        cases.add(Arguments.of("param=%E2%&other=foo", 400, "param", ""));
+        cases.add(Arguments.of("param=%E2", 400, "param", ""));
+        cases.add(Arguments.of("param=%E2&other=foo", 400, "param", ""));
 
         // Tokenized cases
-        cases.add(Arguments.of("param=%%TOK%%", 500, "param", ""));
-        cases.add(Arguments.of("param=%%TOK%%&other=foo", 500, "param", ""));
+        cases.add(Arguments.of("param=%%TOK%%", 400, "param", ""));
+        cases.add(Arguments.of("param=%%TOK%%&other=foo", 400, "param", ""));
 
         // Bad Hex
-        cases.add(Arguments.of("param=%xx", 500, "param", ""));
-        cases.add(Arguments.of("param=%xx&other=foo", 500, "param", ""));
+        cases.add(Arguments.of("param=%xx", 400, "param", ""));
+        cases.add(Arguments.of("param=%xx&other=foo", 400, "param", ""));
 
         // Overlong UTF-8 Encoding
-        cases.add(Arguments.of("param=%C0%AF", 500, "param", ""));
-        cases.add(Arguments.of("param=%C0%AF&other=foo", 500, "param", ""));
+        cases.add(Arguments.of("param=%C0%AF", 400, "param", ""));
+        cases.add(Arguments.of("param=%C0%AF&other=foo", 400, "param", ""));
 
         // Out of range
-        cases.add(Arguments.of("param=%F4%90%80%80", 500, "param", ""));
-        cases.add(Arguments.of("param=%F4%90%80%80&other=foo", 500, "param", ""));
+        cases.add(Arguments.of("param=%F4%90%80%80", 400, "param", ""));
+        cases.add(Arguments.of("param=%F4%90%80%80&other=foo", 400, "param", ""));
 
         // Long surrogate
-        cases.add(Arguments.of("param=%ED%A0%80", 500, "param", ""));
-        cases.add(Arguments.of("param=%ED%A0%80&other=foo", 500, "param", ""));
+        cases.add(Arguments.of("param=%ED%A0%80", 400, "param", ""));
+        cases.add(Arguments.of("param=%ED%A0%80&other=foo", 400, "param", ""));
 
         // Standalone continuations
-        cases.add(Arguments.of("param=%80", 500, "param", ""));
-        cases.add(Arguments.of("param=%80&other=foo", 500, "param", ""));
+        cases.add(Arguments.of("param=%80", 400, "param", ""));
+        cases.add(Arguments.of("param=%80&other=foo", 400, "param", ""));
 
         // Truncated sequence
-        cases.add(Arguments.of("param=%E2%82", 500, "param", ""));
-        cases.add(Arguments.of("param=%E2%82&other=foo", 500, "param", ""));
+        cases.add(Arguments.of("param=%E2%82", 400, "param", ""));
+        cases.add(Arguments.of("param=%E2%82&other=foo", 400, "param", ""));
 
         // C1 never starts UTF-8
-        cases.add(Arguments.of("param=%C1%BF", 500, "param", ""));
-        cases.add(Arguments.of("param=%C1%BF&other=foo", 500, "param", ""));
+        cases.add(Arguments.of("param=%C1%BF", 400, "param", ""));
+        cases.add(Arguments.of("param=%C1%BF&other=foo", 400, "param", ""));
 
         // E0 must be followed by A0-BF
-        cases.add(Arguments.of("param=%E0%9F%80", 500, "param", ""));
-        cases.add(Arguments.of("param=%E0%9F%80&other=foo", 500, "param", ""));
+        cases.add(Arguments.of("param=%E0%9F%80", 400, "param", ""));
+        cases.add(Arguments.of("param=%E0%9F%80&other=foo", 400, "param", ""));
 
         // Community Examples
-        cases.add(Arguments.of("param=f_%e0%b8", 500, "param", ""));
-        cases.add(Arguments.of("param=f_%e0%b8&other=foo", 500, "param", ""));
-        cases.add(Arguments.of("param=%£", 500, "param", ""));
-        cases.add(Arguments.of("param=%£&other=foo", 500, "param", ""));
+        cases.add(Arguments.of("param=f_%e0%b8", 400, "param", ""));
+        cases.add(Arguments.of("param=f_%e0%b8&other=foo", 400, "param", ""));
+        cases.add(Arguments.of("param=%£", 400, "param", ""));
+        cases.add(Arguments.of("param=%£&other=foo", 400, "param", ""));
 
         // Extra ampersands
         cases.add(Arguments.of("param=aaa&&&", 200, "param", "aaa"));
@@ -741,12 +739,12 @@ public class RequestTest
         cases.add(Arguments.of("other=foo&%E5%B8%BD%E5%AD%90=Beret", 200, "帽子", "Beret"));
 
         // bad pct-encoded parameter names
-        cases.add(Arguments.of("%E5%B8%BD%E5%AD%9=Beret", 500, "帽子", null));
-        cases.add(Arguments.of("%E5%B8%BD%E5%AD%=Beret", 500, "帽子", null));
-        cases.add(Arguments.of("%E5%B8%BD%E5%AD=Beret", 500, "帽子", null));
-        cases.add(Arguments.of("%E5%B8%BD%E5%AD%9=Beret&other=foo", 500, "帽子", null));
-        cases.add(Arguments.of("%E5%B8%BD%E5%AD%=Beret&other=foo", 500, "帽子", null));
-        cases.add(Arguments.of("%E5%B8%BD%E5%AD=Beret&other=foo", 500, "帽子", null));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%9=Beret", 400, "帽子", null));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%=Beret", 400, "帽子", null));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD=Beret", 400, "帽子", null));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%9=Beret&other=foo", 400, "帽子", null));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%=Beret&other=foo", 400, "帽子", null));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD=Beret&other=foo", 400, "帽子", null));
 
         return cases.stream();
     }
@@ -772,16 +770,16 @@ public class RequestTest
         cases.add(Arguments.of("param=%E2%9C%94&other=foo", 200, "param", "✔"));
 
         // Truncated / Insufficient Hex cases
-        cases.add(Arguments.of("param=%E2%9C%9", 200, "param", "��"));
-        cases.add(Arguments.of("param=%E2%9C%9&other=foo", 200, "param", "��"));
-        cases.add(Arguments.of("param=%E2%9C%", 200, "param", "��"));
-        cases.add(Arguments.of("param=%E2%9C%&other=foo", 200, "param", "��"));
+        cases.add(Arguments.of("param=%E2%9C%9", 200, "param", "�"));
+        cases.add(Arguments.of("param=%E2%9C%9&other=foo", 200, "param", "�"));
+        cases.add(Arguments.of("param=%E2%9C%", 200, "param", "�"));
+        cases.add(Arguments.of("param=%E2%9C%&other=foo", 200, "param", "�"));
         cases.add(Arguments.of("param=%E2%9C", 200, "param", "�"));
         cases.add(Arguments.of("param=%E2%9C&other=foo", 200, "param", "�"));
-        cases.add(Arguments.of("param=%E2%9", 200, "param", "��"));
-        cases.add(Arguments.of("param=%E2%9&other=foo", 200, "param", "��"));
-        cases.add(Arguments.of("param=%E2%", 200, "param", "��"));
-        cases.add(Arguments.of("param=%E2%&other=foo", 200, "param", "��"));
+        cases.add(Arguments.of("param=%E2%9", 200, "param", "�"));
+        cases.add(Arguments.of("param=%E2%9&other=foo", 200, "param", "�"));
+        cases.add(Arguments.of("param=%E2%", 200, "param", "�"));
+        cases.add(Arguments.of("param=%E2%&other=foo", 200, "param", "�"));
         cases.add(Arguments.of("param=%E2", 200, "param", "�"));
         cases.add(Arguments.of("param=%E2&other=foo", 200, "param", "�"));
 
@@ -843,11 +841,11 @@ public class RequestTest
         cases.add(Arguments.of("other=foo&%E5%B8%BD%E5%AD%90=Beret", 200, "帽子", "Beret"));
 
         // bad pct-encoded parameter names
-        cases.add(Arguments.of("%E5%B8%BD%E5%AD%9=Beret", 200, "帽孝Beret", null));
-        cases.add(Arguments.of("%E5%B8%BD%E5%AD%=Beret", 200, "帽��eret", null));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%9=Beret", 200, "帽�", "Beret"));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%=Beret", 200, "帽�", "Beret"));
         cases.add(Arguments.of("%E5%B8%BD%E5%AD=Beret", 200, "帽�", "Beret"));
-        cases.add(Arguments.of("%E5%B8%BD%E5%AD%9=Beret&other=foo", 200, "帽孝Beret", null));
-        cases.add(Arguments.of("%E5%B8%BD%E5%AD%=Beret&other=foo", 200, "帽��eret", null));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%9=Beret&other=foo", 200, "帽�", "Beret"));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%=Beret&other=foo", 200, "帽�", "Beret"));
         cases.add(Arguments.of("%E5%B8%BD%E5%AD=Beret&other=foo", 200, "帽�", "Beret"));
 
         return cases.stream();
@@ -857,14 +855,8 @@ public class RequestTest
     @MethodSource("queryBehaviorsBadUtf8Allowed")
     public void testQueryExtractionBehaviorBadUtf8Allowed(String inputQuery, int expectedStatus, String expectedKey, String expectedValue) throws Exception
     {
-        /*
         UriCompliance uriCompliance = UriCompliance.DEFAULT.with("test",
-            UriCompliance.Violation.BAD_UTF8_ENCODING,
-            UriCompliance.Violation.TRUNCATED_UTF8_ENCODING);
-         */
-
-        UriCompliance uriCompliance = UriCompliance.DEFAULT.with("test",
-            UriCompliance.Violation.BAD_UTF8_ENCODING);
+            UriCompliance.Violation.BAD_UTF8_ENCODING, UriCompliance.Violation.TRUNCATED_UTF8_ENCODING);
         testQueryExtractionBehavior(uriCompliance, inputQuery, expectedStatus, expectedKey, expectedValue);
     }
 
@@ -909,9 +901,7 @@ public class RequestTest
                     }
                     default:
                     {
-                        RuntimeException e = assertThrows(RuntimeException.class, () -> {
-                            Request.extractQueryParameters(request);
-                        });
+                        RuntimeException e = assertThrows(RuntimeException.class, () -> Request.extractQueryParameters(request));
                         callback.failed(e);
                     }
                 }
@@ -930,213 +920,5 @@ public class RequestTest
         String rawResponse = connector.getResponse(rawRequest);
         HttpTester.Response response = HttpTester.parseResponse(rawResponse);
         assertThat(response.getStatus(), is(expectedStatus));
-    }
-
-    @ParameterizedTest
-    @CsvSource({
-        // These are the values that pass in jetty-11.0.x
-        "'',            '',    'value'",
-        "'foo',         'foo', 'value'",
-        "'%E2%9C%94',   '✔',   'value'",
-        "'%E2%9C',      '*',   ''",         // truncated
-        "'%E2',         '*',   ''",         // truncated
-        "'%%foo%%',     '*',   ''",         // not % encoded
-        "'%',           '*',   ''",         // insufficient hex digits
-        "'%xx',         '*',   ''",         // bad hex
-        "'%C0%AF',      '*',   ''",         // overlong encoding of %2F
-        "'%F4%90%80%80','*',   ''",         // out of range
-        "'%ED%A0%80',   '*',   ''",         // Long surrogate
-        "'%80',         '*',   ''",         // stand along continuations
-        "'%E2%82',      '*',   ''",         // truncated sequence
-        "'%C1%BF',      '*',   ''",         // C1 never starts UTF-8
-        "'%E0%9F%80',   '*',   ''",         // E0 must be followed by A0–BF
-        "'f_%e0%b8',    '*',   ''",         // Client example
-        "'%£',          '400',  ''",        // Client example
-    })
-    public void testUtf8QueryDefault(String query, String expected0, String expected1) throws Exception
-    {
-        server.stop();
-        connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration().setUriCompliance(UriCompliance.DEFAULT);
-        server.setHandler(new Handler.Abstract.NonBlocking()
-        {
-            @Override
-            public boolean handle(Request request, Response response, Callback callback)
-            {
-                try
-                {
-                    Fields fields = Request.extractQueryParameters(request);
-                    String param = fields.getValue("expected");
-                    String other = fields.getValue("other");
-                    assertThat(param, is(expected0));
-                    assertThat(other, is(expected1));
-                    callback.succeeded();
-                }
-                catch (AssertionError e)
-                {
-                    callback.failed(e);
-                }
-                catch (Throwable t)
-                {
-                    if ("*".equals(expected0))
-                        callback.succeeded();
-                    else
-                        callback.failed(t);
-                }
-                return true;
-            }
-        });
-        server.start();
-
-        String request = """
-                GET /path?expected=%s&other=value HTTP/1.1\r
-                Host: whatever\r
-                Connection: close\r
-                \r
-                """.formatted(query);
-
-        String responses = connector.getResponse(request);
-        if ("400".equals(expected0))
-            assertThat(responses, startsWith("HTTP/1.1 400 "));
-        else
-            assertThat(responses, startsWith("HTTP/1.1 200 "));
-    }
-
-    @ParameterizedTest
-    @CsvSource({
-        // These are the values that pass in jetty-11.0.x
-        "'',            '',    'value'",
-        "'foo',         'foo', 'value'",
-        "'%E2%9C%94',   '✔',   'value'",
-        "'%E2%9C',      '�',   'value'",    // truncated
-        "'%E2',         '�',   'value'",    // truncated
-        "'%%foo%%',     '�oo�','value'",    // not % encoded
-        "'%',           '�',   'value'",    // insufficient hex digits
-        "'%xx',         '�',   'value'",    // bad hex
-        "'%C0%AF',      '��',  'value'",    // overlong encoding of %2F
-        "'%F4%90%80%80','����','value'",    // out of range
-        "'%ED%A0%80',   '���', 'value'",    // Long surrogate
-        "'%80',         '�',   'value'",    // stand along continuations
-        "'%E2%82',      '�',   'value'",    // truncated sequence
-        "'%C1%BF',      '��',  'value'",    // C1 never starts UTF-8
-        "'%E0%9F%80',   '���', 'value'",    // E0 must be followed by A0–BF
-        "'f_%e0%b8',    'f_�', 'value'",    // Client example
-        "'%£',          '�',   'value'",    // Client example
-    })
-    public void testUtf8QueryAllowBadUtf8(String query, String expected0, String expected1) throws Exception
-    {
-        server.stop();
-        connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration()
-            .setUriCompliance(UriCompliance.DEFAULT.with("test", UriCompliance.Violation.BAD_UTF8_ENCODING, UriCompliance.Violation.TRUNCATED_UTF8_ENCODING));
-        server.setHandler(new Handler.Abstract.NonBlocking()
-        {
-            @Override
-            public boolean handle(Request request, Response response, Callback callback)
-            {
-                try
-                {
-                    Fields fields = Request.extractQueryParameters(request);
-                    String param = fields.getValue("expected");
-                    String other = fields.getValue("other");
-                    assertThat(param, is(expected0));
-                    assertThat(other, is(expected1));
-                    callback.succeeded();
-                }
-                catch (AssertionError e)
-                {
-                    callback.failed(e);
-                }
-                catch (Throwable t)
-                {
-                    if ("*".equals(expected0))
-                        callback.succeeded();
-                    else
-                        callback.failed(t);
-                }
-                return true;
-            }
-        });
-        server.start();
-
-        String request = """
-                GET /path?expected=%s&other=value HTTP/1.1\r
-                Host: whatever\r
-                Connection: close\r
-                \r
-                """.formatted(query);
-
-        String responses = connector.getResponse(request);
-        if ("400".equals(expected0))
-            assertThat(responses, startsWith("HTTP/1.1 400 "));
-        else
-            assertThat(responses, startsWith("HTTP/1.1 200 "));
-    }
-
-    @ParameterizedTest
-    @CsvSource({
-        // These are the values that pass in jetty-11.0.x
-        "'',            '',    'value'",
-        "'foo',         'foo', 'value'",
-        "'%E2%9C%94',   '✔',   'value'",
-        "'%E2%9C',      '�',   'value'",    // truncated
-        "'%E2',         '�',   'value'",    // truncated
-        "'%%foo%%',     '*',   ''",         // not % encoded
-        "'%',           '*',   ''",         // insufficient hex digits
-        "'%xx',         '*',   ''",         // bad hex
-        "'%C0%AF',      '*',   ''",         // overlong encoding of %2F
-        "'%F4%90%80%80','*',   ''",         // out of range
-        "'%ED%A0%80',   '*',   ''",         // Long surrogate
-        "'%80',         '*',   ''",         // stand along continuations
-        "'%E2%82',      '�',   'value'",    // truncated sequence
-        "'%C1%BF',      '*',   ''",         // C1 never starts UTF-8
-        "'%E0%9F%80',   '*',   ''",         // E0 must be followed by A0–BF
-        "'f_%e0%b8',    'f_�',  'value'",   // Client example
-        "'%£',          '400',  ''",        // Client example
-    })
-    public void testUtf8QueryLegacy(String query, String expected0, String expected1) throws Exception
-    {
-        server.stop();
-        connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration().setUriCompliance(UriCompliance.LEGACY);
-        server.setHandler(new Handler.Abstract.NonBlocking()
-        {
-            @Override
-            public boolean handle(Request request, Response response, Callback callback)
-            {
-                try
-                {
-                    Fields fields = Request.extractQueryParameters(request);
-                    String param = fields.getValue("expected");
-                    String other = fields.getValue("other");
-                    assertThat(param, is(expected0));
-                    assertThat(other, is(expected1));
-                    callback.succeeded();
-                }
-                catch (AssertionError e)
-                {
-                    callback.failed(e);
-                }
-                catch (Throwable t)
-                {
-                    if ("*".equals(expected0))
-                        callback.succeeded();
-                    else
-                        callback.failed(t);
-                }
-                return true;
-            }
-        });
-        server.start();
-
-        String request = """
-                GET /path?expected=%s&other=value HTTP/1.1\r
-                Host: whatever\r
-                Connection: close\r
-                \r
-                """.formatted(query);
-
-        String responses = connector.getResponse(request);
-        if ("400".equals(expected0))
-            assertThat(responses, startsWith("HTTP/1.1 400 "));
-        else
-            assertThat(responses, startsWith("HTTP/1.1 200 "));
     }
 }

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
@@ -672,8 +672,6 @@ public class RequestTest
     {
         List<Arguments> cases = new ArrayList<>();
 
-        // TODO: All of these 500 response status codes should really be 400
-
         // Normal cases
         cases.add(Arguments.of("param=aaa", 200, "param", "aaa"));
         cases.add(Arguments.of("param=aaa&other=foo", 200, "param", "aaa"));

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
@@ -19,11 +19,9 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
-import org.eclipse.jetty.http.ComplianceViolation;
 import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.http.HttpCookie;
 import org.eclipse.jetty.http.HttpHeader;
@@ -44,7 +42,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -55,7 +52,6 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RequestTest
 {
@@ -549,77 +545,6 @@ public class RequestTest
         }
     }
 
-    /**
-     * Test to ensure that response.write() will add Content-Length on HTTP/1.1 responses.
-     */
-    @ParameterizedTest
-    @ValueSource(strings = { "true", "false"})
-    public void testBadUtf8Query(boolean allowBadUtf8) throws Exception
-    {
-        server.stop();
-        List<ComplianceViolation.Event> events = new CopyOnWriteArrayList<>();
-        ComplianceViolation.Listener listener = new ComplianceViolation.Listener()
-        {
-            @Override
-            public void onComplianceViolation(ComplianceViolation.Event event)
-            {
-                events.add(event);
-            }
-        };
-
-        if (allowBadUtf8)
-        {
-            for (Connector connector : server.getConnectors())
-            {
-                HttpConnectionFactory httpConnectionFactory = connector.getConnectionFactory(HttpConnectionFactory.class);
-                if (httpConnectionFactory != null)
-                {
-                    HttpConfiguration httpConfiguration = httpConnectionFactory.getHttpConfiguration();
-                    httpConfiguration.setUriCompliance(UriCompliance.DEFAULT.with("test", UriCompliance.Violation.BAD_UTF8_ENCODING));
-                    httpConfiguration.addComplianceViolationListener(listener);
-                }
-            }
-        }
-
-        server.setHandler(new Handler.Abstract.NonBlocking()
-        {
-            @Override
-            public boolean handle(Request request, Response response, Callback callback)
-            {
-                if (allowBadUtf8)
-                {
-                    Fields fields = Request.extractQueryParameters(request);
-                    assertThat(fields.getValue("param"), is("bad_�"));
-                    assertThat(fields.getValue("other"), is("short�"));
-                }
-                else
-                {
-                    assertThrows(IllegalArgumentException.class, () -> Request.extractQueryParameters(request));
-                }
-                callback.succeeded();
-                return true;
-            }
-        });
-        server.start();
-
-        String request = """
-            GET /foo?param=bad_%e0%b8&other=short%a HTTP/1.1\r
-            Host: local\r
-            \r
-            """;
-        HttpTester.Response response = HttpTester.parseResponse(connector.getResponse(request));
-        assertEquals(HttpStatus.OK_200, response.getStatus());
-        if (allowBadUtf8)
-        {
-            assertThat(events.size(), is(1));
-            assertThat(events.get(0).violation(), is(UriCompliance.Violation.BAD_UTF8_ENCODING));
-        }
-        else
-        {
-            assertThat(events.size(), is(0));
-        }
-    }
-
     @ParameterizedTest
     @CsvSource({
         // These are the values that pass in jetty-11.0.x
@@ -682,8 +607,6 @@ public class RequestTest
                 \r
                 """.formatted(query);
 
-        System.err.println(request);
-
         String responses = connector.getResponse(request);
         if ("400".equals(expected0))
             assertThat(responses, startsWith("HTTP/1.1 400 "));
@@ -715,7 +638,8 @@ public class RequestTest
     public void testUtf8QueryAllowBadUtf8(String query, String expected0, String expected1) throws Exception
     {
         server.stop();
-        connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration().setUriCompliance(UriCompliance.DEFAULT.with("test", UriCompliance.Violation.BAD_UTF8_ENCODING));
+        connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration()
+            .setUriCompliance(UriCompliance.DEFAULT.with("test", UriCompliance.Violation.BAD_UTF8_ENCODING, UriCompliance.Violation.TRUNCATED_UTF8_ENCODING));
         server.setHandler(new Handler.Abstract.NonBlocking()
         {
             @Override
@@ -723,7 +647,6 @@ public class RequestTest
             {
                 try
                 {
-                    System.err.println(request.getHttpURI());
                     Fields fields = Request.extractQueryParameters(request);
                     String param = fields.getValue("expected");
                     String other = fields.getValue("other");
@@ -733,20 +656,14 @@ public class RequestTest
                 }
                 catch (AssertionError e)
                 {
-                    e.printStackTrace();
                     callback.failed(e);
                 }
                 catch (Throwable t)
                 {
                     if ("*".equals(expected0))
-                    {
                         callback.succeeded();
-                    }
                     else
-                    {
-                        t.printStackTrace();
                         callback.failed(t);
-                    }
                 }
                 return true;
             }
@@ -759,8 +676,6 @@ public class RequestTest
                 Connection: close\r
                 \r
                 """.formatted(query);
-
-        System.err.println(request);
 
         String responses = connector.getResponse(request);
         if ("400".equals(expected0))
@@ -801,7 +716,6 @@ public class RequestTest
             {
                 try
                 {
-                    System.err.println(request.getHttpURI());
                     Fields fields = Request.extractQueryParameters(request);
                     String param = fields.getValue("expected");
                     String other = fields.getValue("other");
@@ -811,20 +725,14 @@ public class RequestTest
                 }
                 catch (AssertionError e)
                 {
-                    e.printStackTrace();
                     callback.failed(e);
                 }
                 catch (Throwable t)
                 {
                     if ("*".equals(expected0))
-                    {
                         callback.succeeded();
-                    }
                     else
-                    {
-                        t.printStackTrace();
                         callback.failed(t);
-                    }
                 }
                 return true;
             }
@@ -837,8 +745,6 @@ public class RequestTest
                 Connection: close\r
                 \r
                 """.formatted(query);
-
-        System.err.println(request);
 
         String responses = connector.getResponse(request);
         if ("400".equals(expected0))

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -50,6 +51,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -616,5 +618,232 @@ public class RequestTest
         {
             assertThat(events.size(), is(0));
         }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        // These are the values that pass in jetty-11.0.x
+        "'',            '',    'value'",
+        "'foo',         'foo', 'value'",
+        "'%E2%9C%94',   '✔',   'value'",
+        "'%E2%9C',      '*',   ''",         // truncated
+        "'%E2',         '*',   ''",         // truncated
+        "'%%foo%%',     '*',   ''",         // not % encoded
+        "'%',           '*',   ''",         // insufficient hex digits
+        "'%xx',         '*',   ''",         // bad hex
+        "'%C0%AF',      '*',   ''",         // overlong encoding of %2F
+        "'%F4%90%80%80','*',   ''",         // out of range
+        "'%ED%A0%80',   '*',   ''",         // Long surrogate
+        "'%80',         '*',   ''",         // stand along continuations
+        "'%E2%82',      '*',   ''",         // truncated sequence
+        "'%C1%BF',      '*',   ''",         // C1 never starts UTF-8
+        "'%E0%9F%80',   '*',   ''",         // E0 must be followed by A0–BF
+        "'f_%e0%b8',    '*',   ''",         // Client example
+        "'%£',          '400',  ''",        // Client example
+    })
+    public void testUtf8QueryDefault(String query, String expected0, String expected1) throws Exception
+    {
+        server.stop();
+        connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration().setUriCompliance(UriCompliance.DEFAULT);
+        server.setHandler(new Handler.Abstract.NonBlocking()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                try
+                {
+                    Fields fields = Request.extractQueryParameters(request);
+                    String param = fields.getValue("expected");
+                    String other = fields.getValue("other");
+                    assertThat(param, is(expected0));
+                    assertThat(other, is(expected1));
+                    callback.succeeded();
+                }
+                catch (AssertionError e)
+                {
+                    callback.failed(e);
+                }
+                catch (Throwable t)
+                {
+                    if ("*".equals(expected0))
+                        callback.succeeded();
+                    else
+                        callback.failed(t);
+                }
+                return true;
+            }
+        });
+        server.start();
+
+        String request = """
+                GET /path?expected=%s&other=value HTTP/1.1\r
+                Host: whatever\r
+                Connection: close\r
+                \r
+                """.formatted(query);
+
+        System.err.println(request);
+
+        String responses = connector.getResponse(request);
+        if ("400".equals(expected0))
+            assertThat(responses, startsWith("HTTP/1.1 400 "));
+        else
+            assertThat(responses, startsWith("HTTP/1.1 200 "));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        // These are the values that pass in jetty-11.0.x
+        "'',            '',    'value'",
+        "'foo',         'foo', 'value'",
+        "'%E2%9C%94',   '✔',   'value'",
+        "'%E2%9C',      '�',   'value'",    // truncated
+        "'%E2',         '�',   'value'",    // truncated
+        "'%%foo%%',     '�oo�','value'",    // not % encoded
+        "'%',           '�',   'value'",    // insufficient hex digits
+        "'%xx',         '�',   'value'",    // bad hex
+        "'%C0%AF',      '��',  'value'",    // overlong encoding of %2F
+        "'%F4%90%80%80','����','value'",    // out of range
+        "'%ED%A0%80',   '���', 'value'",    // Long surrogate
+        "'%80',         '�',   'value'",    // stand along continuations
+        "'%E2%82',      '�',   'value'",    // truncated sequence
+        "'%C1%BF',      '��',  'value'",    // C1 never starts UTF-8
+        "'%E0%9F%80',   '���', 'value'",    // E0 must be followed by A0–BF
+        "'f_%e0%b8',    'f_�', 'value'",    // Client example
+        "'%£',          '�',   'value'",    // Client example
+    })
+    public void testUtf8QueryAllowBadUtf8(String query, String expected0, String expected1) throws Exception
+    {
+        server.stop();
+        connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration().setUriCompliance(UriCompliance.DEFAULT.with("test", UriCompliance.Violation.BAD_UTF8_ENCODING));
+        server.setHandler(new Handler.Abstract.NonBlocking()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                try
+                {
+                    System.err.println(request.getHttpURI());
+                    Fields fields = Request.extractQueryParameters(request);
+                    String param = fields.getValue("expected");
+                    String other = fields.getValue("other");
+                    assertThat(param, is(expected0));
+                    assertThat(other, is(expected1));
+                    callback.succeeded();
+                }
+                catch (AssertionError e)
+                {
+                    e.printStackTrace();
+                    callback.failed(e);
+                }
+                catch (Throwable t)
+                {
+                    if ("*".equals(expected0))
+                    {
+                        callback.succeeded();
+                    }
+                    else
+                    {
+                        t.printStackTrace();
+                        callback.failed(t);
+                    }
+                }
+                return true;
+            }
+        });
+        server.start();
+
+        String request = """
+                GET /path?expected=%s&other=value HTTP/1.1\r
+                Host: whatever\r
+                Connection: close\r
+                \r
+                """.formatted(query);
+
+        System.err.println(request);
+
+        String responses = connector.getResponse(request);
+        if ("400".equals(expected0))
+            assertThat(responses, startsWith("HTTP/1.1 400 "));
+        else
+            assertThat(responses, startsWith("HTTP/1.1 200 "));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        // These are the values that pass in jetty-11.0.x
+        "'',            '',    'value'",
+        "'foo',         'foo', 'value'",
+        "'%E2%9C%94',   '✔',   'value'",
+        "'%E2%9C',      '�',   'value'",    // truncated
+        "'%E2',         '�',   'value'",    // truncated
+        "'%%foo%%',     '*',   ''",         // not % encoded
+        "'%',           '*',   ''",         // insufficient hex digits
+        "'%xx',         '*',   ''",         // bad hex
+        "'%C0%AF',      '*',   ''",         // overlong encoding of %2F
+        "'%F4%90%80%80','*',   ''",         // out of range
+        "'%ED%A0%80',   '*',   ''",         // Long surrogate
+        "'%80',         '*',   ''",         // stand along continuations
+        "'%E2%82',      '�',   'value'",    // truncated sequence
+        "'%C1%BF',      '*',   ''",         // C1 never starts UTF-8
+        "'%E0%9F%80',   '*',   ''",         // E0 must be followed by A0–BF
+        "'f_%e0%b8',    'f_�',  'value'",   // Client example
+        "'%£',          '400',  ''",        // Client example
+    })
+    public void testUtf8QueryLegacy(String query, String expected0, String expected1) throws Exception
+    {
+        server.stop();
+        connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration().setUriCompliance(UriCompliance.LEGACY);
+        server.setHandler(new Handler.Abstract.NonBlocking()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                try
+                {
+                    System.err.println(request.getHttpURI());
+                    Fields fields = Request.extractQueryParameters(request);
+                    String param = fields.getValue("expected");
+                    String other = fields.getValue("other");
+                    assertThat(param, is(expected0));
+                    assertThat(other, is(expected1));
+                    callback.succeeded();
+                }
+                catch (AssertionError e)
+                {
+                    e.printStackTrace();
+                    callback.failed(e);
+                }
+                catch (Throwable t)
+                {
+                    if ("*".equals(expected0))
+                    {
+                        callback.succeeded();
+                    }
+                    else
+                    {
+                        t.printStackTrace();
+                        callback.failed(t);
+                    }
+                }
+                return true;
+            }
+        });
+        server.start();
+
+        String request = """
+                GET /path?expected=%s&other=value HTTP/1.1\r
+                Host: whatever\r
+                Connection: close\r
+                \r
+                """.formatted(query);
+
+        System.err.println(request);
+
+        String responses = connector.getResponse(request);
+        if ("400".equals(expected0))
+            assertThat(responses, startsWith("HTTP/1.1 400 "));
+        else
+            assertThat(responses, startsWith("HTTP/1.1 200 "));
     }
 }

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.server;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
@@ -52,6 +53,7 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RequestTest
 {
@@ -543,6 +545,391 @@ public class RequestTest
                 assertThat(response, not(containsString(notContainsCookie)));
             }
         }
+    }
+
+    /**
+     * The set of behaviors collected from Jetty 11.
+     */
+    public static Stream<Arguments> queryBehaviorsLegacy()
+    {
+        List<Arguments> cases = new ArrayList<>();
+
+        // Normal cases
+        cases.add(Arguments.of("param=aaa", 200, "param", "aaa"));
+        cases.add(Arguments.of("param=aaa&other=foo", 200, "param", "aaa"));
+        cases.add(Arguments.of("param=", 200, "param", ""));
+        cases.add(Arguments.of("param=&other=foo", 200, "param", ""));
+        cases.add(Arguments.of("param=%E2%9C%94", 200, "param", "✔"));
+        cases.add(Arguments.of("param=%E2%9C%94&other=foo", 200, "param", "✔"));
+
+        // Truncated / Insufficient Hex cases
+        cases.add(Arguments.of("param=%E2%9C%9", 500, "param", ""));
+        cases.add(Arguments.of("param=%E2%9C%9&other=foo", 500, "param", ""));
+        cases.add(Arguments.of("param=%E2%9C%", 500, "param", ""));
+        cases.add(Arguments.of("param=%E2%9C%&other=foo", 500, "param", ""));
+        cases.add(Arguments.of("param=%E2%9C", 200, "param", "�"));
+        cases.add(Arguments.of("param=%E2%9C&other=foo", 200, "param", "�"));
+        cases.add(Arguments.of("param=%E2%9", 500, "param", ""));
+        cases.add(Arguments.of("param=%E2%9&other=foo", 500, "param", ""));
+        cases.add(Arguments.of("param=%E2%", 500, "param", ""));
+        cases.add(Arguments.of("param=%E2%&other=foo", 500, "param", ""));
+        cases.add(Arguments.of("param=%E2", 500, "param", "")); // Yes, this failed in Jetty 11
+        cases.add(Arguments.of("param=%E2&other=foo", 200, "param", "�")); // Yes, this worked in Jetty 11
+
+        // Tokenized cases
+        cases.add(Arguments.of("param=%%TOK%%", 500, "param", ""));
+        cases.add(Arguments.of("param=%%TOK%%&other=foo", 500, "param", ""));
+
+        // Bad Hex
+        cases.add(Arguments.of("param=%xx", 500, "param", ""));
+        cases.add(Arguments.of("param=%xx&other=foo", 500, "param", ""));
+
+        // Overlong UTF-8 Encoding
+        cases.add(Arguments.of("param=%C0%AF", 500, "param", ""));
+        cases.add(Arguments.of("param=%C0%AF&other=foo", 500, "param", ""));
+
+        // Out of range
+        cases.add(Arguments.of("param=%F4%90%80%80", 500, "param", ""));
+        cases.add(Arguments.of("param=%F4%90%80%80&other=foo", 500, "param", ""));
+
+        // Long surrogate
+        cases.add(Arguments.of("param=%ED%A0%80", 500, "param", ""));
+        cases.add(Arguments.of("param=%ED%A0%80&other=foo", 500, "param", ""));
+
+        // Standalone continuations
+        cases.add(Arguments.of("param=%80", 500, "param", ""));
+        cases.add(Arguments.of("param=%80&other=foo", 500, "param", ""));
+
+        // Truncated sequence
+        cases.add(Arguments.of("param=%E2%82", 200, "param", "�"));
+        cases.add(Arguments.of("param=%E2%82&other=foo", 200, "param", "�"));
+
+        // C1 never starts UTF-8
+        cases.add(Arguments.of("param=%C1%BF", 500, "param", ""));
+        cases.add(Arguments.of("param=%C1%BF&other=foo", 500, "param", ""));
+
+        // E0 must be followed by A0-BF
+        cases.add(Arguments.of("param=%E0%9F%80", 500, "param", ""));
+        cases.add(Arguments.of("param=%E0%9F%80&other=foo", 500, "param", ""));
+
+        // Community Examples
+        cases.add(Arguments.of("param=f_%e0%b8", 200, "param", "f_�"));
+        cases.add(Arguments.of("param=f_%e0%b8&other=foo", 200, "param", "f_�"));
+        cases.add(Arguments.of("param=%£", 400, "param", ""));
+        cases.add(Arguments.of("param=%£&other=foo", 400, "param", ""));
+
+        // Extra ampersands
+        cases.add(Arguments.of("param=aaa&&&", 200, "param", "aaa"));
+        cases.add(Arguments.of("&&&param=aaa", 200, "param", "aaa"));
+        cases.add(Arguments.of("&&param=aaa&&other=foo", 200, "param", "aaa"));
+        cases.add(Arguments.of("param=aaa&&other=foo&&", 200, "param", "aaa"));
+
+        // Encoded ampersands
+        cases.add(Arguments.of("param=aaa%26&other=foo", 200, "param", "aaa&"));
+        cases.add(Arguments.of("param=aaa&%26other=foo", 200, "&other", "foo"));
+
+        // pct-encoded parameter names ("帽子" means "hat" in japanese)
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%90=Beret", 200, "帽子", "Beret"));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%90=Beret&other=foo", 200, "帽子", "Beret"));
+        cases.add(Arguments.of("other=foo&%E5%B8%BD%E5%AD%90=Beret", 200, "帽子", "Beret"));
+
+        // bad pct-encoded parameter names
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%9=Beret", 200, "帽子", null));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%=Beret", 500, "帽子", null));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD=Beret", 200, "帽子", null));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%9=Beret&other=foo", 200, "帽子", null));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%=Beret&other=foo", 500, "帽子", null));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD=Beret&other=foo", 200, "帽子", null));
+
+        return cases.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("queryBehaviorsLegacy")
+    public void testQueryExtractionBehaviorLegacy(String inputQuery, int expectedStatus, String expectedKey, String expectedValue) throws Exception
+    {
+        UriCompliance uriCompliance = UriCompliance.LEGACY;
+        testQueryExtractionBehavior(uriCompliance, inputQuery, expectedStatus, expectedKey, expectedValue);
+    }
+
+    /**
+     * Behaviors as they existed in Jetty 12.0.16
+     */
+    public static Stream<Arguments> queryBehaviorsDefault()
+    {
+        List<Arguments> cases = new ArrayList<>();
+
+        // TODO: All of these 500 response status codes should really be 400
+
+        // Normal cases
+        cases.add(Arguments.of("param=aaa", 200, "param", "aaa"));
+        cases.add(Arguments.of("param=aaa&other=foo", 200, "param", "aaa"));
+        cases.add(Arguments.of("param=", 200, "param", ""));
+        cases.add(Arguments.of("param=&other=foo", 200, "param", ""));
+        cases.add(Arguments.of("param=%E2%9C%94", 200, "param", "✔"));
+        cases.add(Arguments.of("param=%E2%9C%94&other=foo", 200, "param", "✔"));
+
+        // Truncated / Insufficient Hex cases
+        cases.add(Arguments.of("param=%E2%9C%9", 500, "param", ""));
+        cases.add(Arguments.of("param=%E2%9C%9&other=foo", 500, "param", ""));
+        cases.add(Arguments.of("param=%E2%9C%", 500, "param", ""));
+        cases.add(Arguments.of("param=%E2%9C%&other=foo", 500, "param", ""));
+        cases.add(Arguments.of("param=%E2%9C", 500, "param", ""));
+        cases.add(Arguments.of("param=%E2%9C&other=foo", 500, "param", "�"));
+        cases.add(Arguments.of("param=%E2%9", 500, "param", ""));
+        cases.add(Arguments.of("param=%E2%9&other=foo", 500, "param", ""));
+        cases.add(Arguments.of("param=%E2%", 500, "param", ""));
+        cases.add(Arguments.of("param=%E2%&other=foo", 500, "param", ""));
+        cases.add(Arguments.of("param=%E2", 500, "param", ""));
+        cases.add(Arguments.of("param=%E2&other=foo", 500, "param", ""));
+
+        // Tokenized cases
+        cases.add(Arguments.of("param=%%TOK%%", 500, "param", ""));
+        cases.add(Arguments.of("param=%%TOK%%&other=foo", 500, "param", ""));
+
+        // Bad Hex
+        cases.add(Arguments.of("param=%xx", 500, "param", ""));
+        cases.add(Arguments.of("param=%xx&other=foo", 500, "param", ""));
+
+        // Overlong UTF-8 Encoding
+        cases.add(Arguments.of("param=%C0%AF", 500, "param", ""));
+        cases.add(Arguments.of("param=%C0%AF&other=foo", 500, "param", ""));
+
+        // Out of range
+        cases.add(Arguments.of("param=%F4%90%80%80", 500, "param", ""));
+        cases.add(Arguments.of("param=%F4%90%80%80&other=foo", 500, "param", ""));
+
+        // Long surrogate
+        cases.add(Arguments.of("param=%ED%A0%80", 500, "param", ""));
+        cases.add(Arguments.of("param=%ED%A0%80&other=foo", 500, "param", ""));
+
+        // Standalone continuations
+        cases.add(Arguments.of("param=%80", 500, "param", ""));
+        cases.add(Arguments.of("param=%80&other=foo", 500, "param", ""));
+
+        // Truncated sequence
+        cases.add(Arguments.of("param=%E2%82", 500, "param", ""));
+        cases.add(Arguments.of("param=%E2%82&other=foo", 500, "param", ""));
+
+        // C1 never starts UTF-8
+        cases.add(Arguments.of("param=%C1%BF", 500, "param", ""));
+        cases.add(Arguments.of("param=%C1%BF&other=foo", 500, "param", ""));
+
+        // E0 must be followed by A0-BF
+        cases.add(Arguments.of("param=%E0%9F%80", 500, "param", ""));
+        cases.add(Arguments.of("param=%E0%9F%80&other=foo", 500, "param", ""));
+
+        // Community Examples
+        cases.add(Arguments.of("param=f_%e0%b8", 500, "param", ""));
+        cases.add(Arguments.of("param=f_%e0%b8&other=foo", 500, "param", ""));
+        cases.add(Arguments.of("param=%£", 500, "param", ""));
+        cases.add(Arguments.of("param=%£&other=foo", 500, "param", ""));
+
+        // Extra ampersands
+        cases.add(Arguments.of("param=aaa&&&", 200, "param", "aaa"));
+        cases.add(Arguments.of("&&&param=aaa", 200, "param", "aaa"));
+        cases.add(Arguments.of("&&param=aaa&&other=foo", 200, "param", "aaa"));
+        cases.add(Arguments.of("param=aaa&&other=foo&&", 200, "param", "aaa"));
+
+        // Encoded ampersands
+        cases.add(Arguments.of("param=aaa%26&other=foo", 200, "param", "aaa&"));
+        cases.add(Arguments.of("param=aaa&%26other=foo", 200, "&other", "foo"));
+
+        // pct-encoded parameter names ("帽子" means "hat" in japanese)
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%90=Beret", 200, "帽子", "Beret"));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%90=Beret&other=foo", 200, "帽子", "Beret"));
+        cases.add(Arguments.of("other=foo&%E5%B8%BD%E5%AD%90=Beret", 200, "帽子", "Beret"));
+
+        // bad pct-encoded parameter names
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%9=Beret", 500, "帽子", null));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%=Beret", 500, "帽子", null));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD=Beret", 500, "帽子", null));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%9=Beret&other=foo", 500, "帽子", null));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%=Beret&other=foo", 500, "帽子", null));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD=Beret&other=foo", 500, "帽子", null));
+
+        return cases.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("queryBehaviorsDefault")
+    public void testQueryExtractionBehaviorDefault(String inputQuery, int expectedStatus, String expectedKey, String expectedValue) throws Exception
+    {
+        UriCompliance uriCompliance = UriCompliance.DEFAULT;
+        testQueryExtractionBehavior(uriCompliance, inputQuery, expectedStatus, expectedKey, expectedValue);
+    }
+
+    public static Stream<Arguments> queryBehaviorsBadUtf8Allowed()
+    {
+        List<Arguments> cases = new ArrayList<>();
+
+        // Normal cases
+        cases.add(Arguments.of("param=aaa", 200, "param", "aaa"));
+        cases.add(Arguments.of("param=aaa&other=foo", 200, "param", "aaa"));
+        cases.add(Arguments.of("param=", 200, "param", ""));
+        cases.add(Arguments.of("param=&other=foo", 200, "param", ""));
+        cases.add(Arguments.of("param=%E2%9C%94", 200, "param", "✔"));
+        cases.add(Arguments.of("param=%E2%9C%94&other=foo", 200, "param", "✔"));
+
+        // Truncated / Insufficient Hex cases
+        cases.add(Arguments.of("param=%E2%9C%9", 200, "param", "��"));
+        cases.add(Arguments.of("param=%E2%9C%9&other=foo", 200, "param", "��"));
+        cases.add(Arguments.of("param=%E2%9C%", 200, "param", "��"));
+        cases.add(Arguments.of("param=%E2%9C%&other=foo", 200, "param", "��"));
+        cases.add(Arguments.of("param=%E2%9C", 200, "param", "�"));
+        cases.add(Arguments.of("param=%E2%9C&other=foo", 200, "param", "�"));
+        cases.add(Arguments.of("param=%E2%9", 200, "param", "��"));
+        cases.add(Arguments.of("param=%E2%9&other=foo", 200, "param", "��"));
+        cases.add(Arguments.of("param=%E2%", 200, "param", "��"));
+        cases.add(Arguments.of("param=%E2%&other=foo", 200, "param", "��"));
+        cases.add(Arguments.of("param=%E2", 200, "param", "�"));
+        cases.add(Arguments.of("param=%E2&other=foo", 200, "param", "�"));
+
+        // Tokenized cases
+        cases.add(Arguments.of("param=%%TOK%%", 200, "param", "�OK�"));
+        cases.add(Arguments.of("param=%%TOK%%&other=foo", 200, "param", "�OK�"));
+
+        // Bad Hex
+        cases.add(Arguments.of("param=%xx", 200, "param", "�"));
+        cases.add(Arguments.of("param=%xx&other=foo", 200, "param", "�"));
+
+        // Overlong UTF-8 Encoding
+        cases.add(Arguments.of("param=%C0%AF", 200, "param", "��"));
+        cases.add(Arguments.of("param=%C0%AF&other=foo", 200, "param", "��"));
+
+        // Out of range
+        cases.add(Arguments.of("param=%F4%90%80%80", 200, "param", "����"));
+        cases.add(Arguments.of("param=%F4%90%80%80&other=foo", 200, "param", "����"));
+
+        // Long surrogate
+        cases.add(Arguments.of("param=%ED%A0%80", 200, "param", "���"));
+        cases.add(Arguments.of("param=%ED%A0%80&other=foo", 200, "param", "���"));
+
+        // Standalone continuations
+        cases.add(Arguments.of("param=%80", 200, "param", "�"));
+        cases.add(Arguments.of("param=%80&other=foo", 200, "param", "�"));
+
+        // Truncated sequence
+        cases.add(Arguments.of("param=%E2%82", 200, "param", "�"));
+        cases.add(Arguments.of("param=%E2%82&other=foo", 200, "param", "�"));
+
+        // C1 never starts UTF-8
+        cases.add(Arguments.of("param=%C1%BF", 200, "param", "��"));
+        cases.add(Arguments.of("param=%C1%BF&other=foo", 200, "param", "��"));
+
+        // E0 must be followed by A0-BF
+        cases.add(Arguments.of("param=%E0%9F%80", 200, "param", "���"));
+        cases.add(Arguments.of("param=%E0%9F%80&other=foo", 200, "param", "���"));
+
+        // Community Examples
+        cases.add(Arguments.of("param=f_%e0%b8", 200, "param", "f_�"));
+        cases.add(Arguments.of("param=f_%e0%b8&other=foo", 200, "param", "f_�"));
+        cases.add(Arguments.of("param=%£", 200, "param", "�"));
+        cases.add(Arguments.of("param=%£&other=foo", 200, "param", "�"));
+
+        // Extra ampersands
+        cases.add(Arguments.of("param=aaa&&&", 200, "param", "aaa"));
+        cases.add(Arguments.of("&&&param=aaa", 200, "param", "aaa"));
+        cases.add(Arguments.of("&&param=aaa&&other=foo", 200, "param", "aaa"));
+        cases.add(Arguments.of("param=aaa&&other=foo&&", 200, "param", "aaa"));
+
+        // Encoded ampersands
+        cases.add(Arguments.of("param=aaa%26&other=foo", 200, "param", "aaa&"));
+        cases.add(Arguments.of("param=aaa&%26other=foo", 200, "&other", "foo"));
+
+        // pct-encoded parameter names ("帽子" means "hat" in japanese)
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%90=Beret", 200, "帽子", "Beret"));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%90=Beret&other=foo", 200, "帽子", "Beret"));
+        cases.add(Arguments.of("other=foo&%E5%B8%BD%E5%AD%90=Beret", 200, "帽子", "Beret"));
+
+        // bad pct-encoded parameter names
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%9=Beret", 200, "帽孝Beret", null));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%=Beret", 200, "帽��eret", null));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD=Beret", 200, "帽�", "Beret"));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%9=Beret&other=foo", 200, "帽孝Beret", null));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%=Beret&other=foo", 200, "帽��eret", null));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD=Beret&other=foo", 200, "帽�", "Beret"));
+
+        return cases.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("queryBehaviorsBadUtf8Allowed")
+    public void testQueryExtractionBehaviorBadUtf8Allowed(String inputQuery, int expectedStatus, String expectedKey, String expectedValue) throws Exception
+    {
+        /*
+        UriCompliance uriCompliance = UriCompliance.DEFAULT.with("test",
+            UriCompliance.Violation.BAD_UTF8_ENCODING,
+            UriCompliance.Violation.TRUNCATED_UTF8_ENCODING);
+         */
+
+        UriCompliance uriCompliance = UriCompliance.DEFAULT.with("test",
+            UriCompliance.Violation.BAD_UTF8_ENCODING);
+        testQueryExtractionBehavior(uriCompliance, inputQuery, expectedStatus, expectedKey, expectedValue);
+    }
+
+    private void testQueryExtractionBehavior(UriCompliance uriCompliance, String inputQuery, int expectedStatus, String expectedKey, String expectedValue) throws Exception
+    {
+        server.stop();
+        connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration().setUriCompliance(uriCompliance);
+
+        server.setHandler(new Handler.Abstract.NonBlocking()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                switch (expectedStatus)
+                {
+                    case 200:
+                    {
+                        try
+                        {
+                            Fields fields = Request.extractQueryParameters(request);
+                            Fields.Field field = fields.get(expectedKey);
+                            assertNotNull(field);
+                            String value = field.getValue();
+
+                            if (expectedValue == null)
+                            {
+                                assertThat(field.getValue(), is(""));
+                            }
+                            else
+                            {
+                                assertThat(value, is(expectedValue));
+                            }
+                            response.setStatus(200);
+                            callback.succeeded();
+                            return true;
+                        }
+                        catch (Throwable t)
+                        {
+                            callback.failed(t);
+                            return true;
+                        }
+                    }
+                    default:
+                    {
+                        RuntimeException e = assertThrows(RuntimeException.class, () -> {
+                            Request.extractQueryParameters(request);
+                        });
+                        callback.failed(e);
+                    }
+                }
+                return true;
+            }
+        });
+        server.start();
+
+        //Send a request with query string with illegal hex code to cause
+        //an exception parsing the params
+        String rawRequest = String.format("GET /?%s HTTP/1.1\r\n" +
+            "Host: whatever\r\n" +
+            "Connection: close\n" +
+            "\n", inputQuery);
+
+        String rawResponse = connector.getResponse(rawRequest);
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(expectedStatus));
     }
 
     @ParameterizedTest

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
@@ -441,10 +441,15 @@ public class TypeUtil
      */
     public static int convertHexDigit(char c)
     {
-        int d = ((c & 0x1f) + ((c >> 6) * 0x19) - 0x10);
-        if (d < 0 || d > 15)
-            throw new NumberFormatException("!hex " + c);
-        return d;
+        int val = c - '0';
+        if (val >= 0 && val <= 9)
+            return val;
+
+        val = (c & ~0x20) - 'A';
+        if (val >= 0 && val <= 5)
+            return val + 10;
+
+        throw new NumberFormatException("!hex " + c);
     }
 
     /**

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/UrlEncoded.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/UrlEncoded.java
@@ -127,7 +127,7 @@ public class UrlEncoded
 
                     if (val != null)
                     {
-                        if (val.length() > 0)
+                        if (!val.isEmpty())
                         {
                             result.append('=');
                             result.append(encodeString(val, charset));
@@ -247,12 +247,11 @@ public class UrlEncoded
                     {
                         adder.accept(key, value);
                     }
-                    else if (value != null && value.length() > 0)
+                    else if (value != null && !value.isEmpty())
                     {
                         adder.accept(value, "");
                     }
                     key = null;
-                    value = null;
                     break;
                 case '=':
                     if (key != null)
@@ -279,7 +278,7 @@ public class UrlEncoded
             key = encoded
                 ? decodeString(content, mark + 1, content.length() - mark - 1, charset)
                 : content.substring(mark + 1);
-            if (key != null && key.length() > 0)
+            if (key != null && !key.isEmpty())
             {
                 adder.accept(key, "");
             }
@@ -396,26 +395,8 @@ public class UrlEncoded
             switch (c)
             {
                 case '&':
-                    if (allowTruncatedUtf8)
-                    {
-                        boolean codingError = buffer.hasCodingErrors();
-                        buffer.complete();
-                        if (!codingError && buffer.hasCodingErrors())
-                        {
-                            value = buffer.takeCompleteString(null);
-                            buffer.reset();
-                            if (badUtf8 != null)
-                                badUtf8.set(true);
-                        }
-                        else
-                        {
-                            value = buffer.takeCompleteString(onCodingError);
-                        }
-                    }
-                    else
-                    {
-                        value = buffer.takeCompleteString(onCodingError);
-                    }
+                    value = take(allowTruncatedUtf8, buffer, badUtf8, onCodingError);
+
                     if (key != null)
                     {
                         adder.accept(key, value);
@@ -434,26 +415,7 @@ public class UrlEncoded
                         break;
                     }
 
-                    if (allowTruncatedUtf8)
-                    {
-                        boolean codingError = buffer.hasCodingErrors();
-                        buffer.complete();
-                        if (!codingError && buffer.hasCodingErrors())
-                        {
-                            key = buffer.takeCompleteString(null);
-                            buffer.reset();
-                            if (badUtf8 != null)
-                                badUtf8.set(true);
-                        }
-                        else
-                        {
-                            key = buffer.takeCompleteString(onCodingError);
-                        }
-                    }
-                    else
-                    {
-                        key = buffer.takeCompleteString(onCodingError);
-                    }
+                    key = take(allowTruncatedUtf8, buffer, badUtf8, onCodingError);
                     break;
 
                 case '+':
@@ -513,15 +475,33 @@ public class UrlEncoded
 
         if (key != null)
         {
-            value = buffer.takeCompleteString(onCodingError);
+            value = take(allowTruncatedUtf8, buffer, badUtf8, onCodingError);
             adder.accept(key, value);
         }
         else if (buffer.length() > 0)
         {
-            adder.accept(buffer.toCompleteString(), "");
+            key = take(allowTruncatedUtf8, buffer, badUtf8, onCodingError);
+            adder.accept(key, "");
         }
 
         return badUtf8 == null || !badUtf8.get();
+    }
+
+    private static <X extends Throwable> String take(boolean allowTrauncatedUtf8, Utf8StringBuilder buffer, AtomicBoolean badUtf8, Supplier<X> onCodingError) throws X
+    {
+        if (!allowTrauncatedUtf8)
+            return buffer.takeCompleteString(onCodingError);
+
+        boolean codingError = buffer.hasCodingErrors();
+        buffer.complete();
+        if (codingError || !buffer.hasCodingErrors())
+            return buffer.takeCompleteString(onCodingError);
+
+        String result = buffer.takeCompleteString(null);
+        buffer.reset();
+        if (badUtf8 != null)
+            badUtf8.set(true);
+        return result;
     }
 
     /**
@@ -564,14 +544,14 @@ public class UrlEncoded
             switch ((char)b)
             {
                 case '&':
-                    value = buffer.length() == 0 ? "" : buffer.toString();
+                    value = buffer.isEmpty() ? "" : buffer.toString();
                     buffer.setLength(0);
                     if (key != null)
                     {
                         adder.accept(key, value);
                         keys++;
                     }
-                    else if (value.length() > 0)
+                    else if (!value.isEmpty())
                     {
                         adder.accept(value, "");
                         keys++;
@@ -609,12 +589,12 @@ public class UrlEncoded
 
         if (key != null)
         {
-            value = buffer.length() == 0 ? "" : buffer.toString();
+            value = buffer.isEmpty() ? "" : buffer.toString();
             buffer.setLength(0);
             adder.accept(key, value);
             keys++;
         }
-        else if (buffer.length() > 0)
+        else if (!buffer.isEmpty())
         {
             adder.accept(buffer.toString(), "");
             keys++;
@@ -686,7 +666,7 @@ public class UrlEncoded
                         adder.accept(key, value);
                         keys++;
                     }
-                    else if (value != null && value.length() > 0)
+                    else if (value != null && !value.isEmpty())
                     {
                         adder.accept(value, "");
                         keys++;
@@ -838,7 +818,7 @@ public class UrlEncoded
                             adder.accept(key, value);
                             keys++;
                         }
-                        else if (value != null && value.length() > 0)
+                        else if (value != null && !value.isEmpty())
                         {
                             adder.accept(value, "");
                             keys++;

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/UrlEncoded.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/UrlEncoded.java
@@ -409,7 +409,20 @@ public class UrlEncoded
                     {
                         char hi = query.charAt(++i);
                         char lo = query.charAt(++i);
-                        decodeHexByteTo(buffer, hi, lo, allowBadUtf8);
+                        try
+                        {
+                            decodeHexByteTo(buffer, hi, lo);
+                        }
+                        catch (NumberFormatException e)
+                        {
+                            buffer.append(Utf8StringBuilder.REPLACEMENT);
+                            if (!allowBadUtf8)
+                                throw e;
+                            if (query.charAt(i - 1) == '&')
+                                i = i - 2;
+                            else if (query.charAt(i) == '&')
+                                i = i - 1;
+                        }
                     }
                     else if (allowBadUtf8)
                     {
@@ -1031,19 +1044,9 @@ public class UrlEncoded
         }
     }
 
-    private static void decodeHexByteTo(Utf8StringBuilder buffer, char hi, char lo, boolean allowBadUtf8)
+    private static void decodeHexByteTo(Utf8StringBuilder buffer, char hi, char lo)
     {
-        try
-        {
-            buffer.append((byte)((convertHexDigit(hi) << 4) + convertHexDigit(lo)));
-        }
-        catch (NumberFormatException e)
-        {
-            if (allowBadUtf8)
-                buffer.append(Utf8StringBuilder.REPLACEMENT);
-            else
-                throw e;
-        }
+        buffer.append((byte)((convertHexDigit(hi) << 4) + convertHexDigit(lo)));
     }
 
     /**

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/UrlEncoded.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/UrlEncoded.java
@@ -471,18 +471,32 @@ public class UrlEncoded
                         }
                         catch (NumberFormatException e)
                         {
-                            buffer.append(Utf8StringBuilder.REPLACEMENT);
                             if (!allowBadUtf8)
                                 throw e;
-                            if (query.charAt(i - 1) == '&')
-                                i = i - 2;
-                            else if (query.charAt(i) == '&')
-                                i = i - 1;
+
+                            if (!buffer.replaceIncomplete())
+                                buffer.append(Utf8StringBuilder.REPLACEMENT);
+
+                            if (key == null)
+                            {
+                                if (query.charAt(i - 1) == '=')
+                                    i = i - 2;
+                                else if (query.charAt(i) == '=')
+                                    i = i - 1;
+                            }
+                            else
+                            {
+                                if (query.charAt(i - 1) == '&')
+                                    i = i - 2;
+                                else if (query.charAt(i) == '&')
+                                    i = i - 1;
+                            }
                         }
                     }
                     else if (allowBadUtf8)
                     {
-                        buffer.append(Utf8StringBuilder.REPLACEMENT);
+                        if (!buffer.replaceIncomplete())
+                            buffer.append(Utf8StringBuilder.REPLACEMENT);
                         i = end;
                     }
                     else

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/UrlEncoded.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/UrlEncoded.java
@@ -225,7 +225,7 @@ public class UrlEncoded
 
         if (StandardCharsets.UTF_8.equals(charset))
         {
-            decodeUtf8To(content, 0, content.length(), adder, false);
+            decodeUtf8To(content, 0, content.length(), adder);
             return;
         }
 
@@ -320,7 +320,7 @@ public class UrlEncoded
     @Deprecated
     public static void decodeUtf8To(String query, int offset, int length, MultiMap<String> map)
     {
-        decodeUtf8To(query, offset, length, map::add, false);
+        decodeUtf8To(query, offset, length, map::add);
     }
 
     /**
@@ -333,7 +333,7 @@ public class UrlEncoded
      */
     public static void decodeUtf8To(String uri, int offset, int length, Fields fields)
     {
-        decodeUtf8To(uri, offset, length, fields::add, false);
+        decodeUtf8To(uri, offset, length, fields::add);
     }
 
     /**
@@ -343,11 +343,28 @@ public class UrlEncoded
      * @param offset the offset at which query parameters start.
      * @param length the length of query parameters string to parse.
      * @param adder the method to call to add decoded parameters.
+     * @return {@code true} if the string was decoded without any bad UTF-8
+     * @throws org.eclipse.jetty.util.Utf8StringBuilder.Utf8IllegalArgumentException if there is illegal UTF-8 and `allowsBadUtf8` is {@code false}
+     */
+    public static boolean decodeUtf8To(String query, int offset, int length, BiConsumer<String, String> adder)
+        throws Utf8StringBuilder.Utf8IllegalArgumentException
+    {
+        return decodeUtf8To(query, offset, length, adder, false, false);
+    }
+
+    /**
+     * <p>Decodes URI query parameters as UTF8 string</p>
+     *
+     * @param query the URI string.
+     * @param offset the offset at which query parameters start.
+     * @param length the length of query parameters string to parse.
+     * @param adder the method to call to add decoded parameters.
+     * @param allowTruncatedUtf8 if {@code true} allow truncated UTF-8 and insert the replacement character.
      * @param allowBadUtf8 if {@code true} allow bad UTF-8 and insert the replacement character.
      * @return {@code true} if the string was decoded without any bad UTF-8
      * @throws org.eclipse.jetty.util.Utf8StringBuilder.Utf8IllegalArgumentException if there is illegal UTF-8 and `allowsBadUtf8` is {@code false}
      */
-    public static boolean decodeUtf8To(String query, int offset, int length, BiConsumer<String, String> adder, boolean allowBadUtf8)
+    public static boolean decodeUtf8To(String query, int offset, int length, BiConsumer<String, String> adder, boolean allowTruncatedUtf8, boolean allowBadUtf8)
         throws Utf8StringBuilder.Utf8IllegalArgumentException
     {
         Utf8StringBuilder buffer = new Utf8StringBuilder();
@@ -379,7 +396,26 @@ public class UrlEncoded
             switch (c)
             {
                 case '&':
-                    value = buffer.takeCompleteString(onCodingError);
+                    if (allowTruncatedUtf8)
+                    {
+                        boolean codingError = buffer.hasCodingErrors();
+                        buffer.complete();
+                        if (!codingError && buffer.hasCodingErrors())
+                        {
+                            value = buffer.takeCompleteString(null);
+                            buffer.reset();
+                            if (badUtf8 != null)
+                                badUtf8.set(true);
+                        }
+                        else
+                        {
+                            value = buffer.takeCompleteString(onCodingError);
+                        }
+                    }
+                    else
+                    {
+                        value = buffer.takeCompleteString(onCodingError);
+                    }
                     if (key != null)
                     {
                         adder.accept(key, value);
@@ -397,7 +433,27 @@ public class UrlEncoded
                         buffer.append(c);
                         break;
                     }
-                    key = buffer.takeCompleteString(onCodingError);
+
+                    if (allowTruncatedUtf8)
+                    {
+                        boolean codingError = buffer.hasCodingErrors();
+                        buffer.complete();
+                        if (!codingError && buffer.hasCodingErrors())
+                        {
+                            key = buffer.takeCompleteString(null);
+                            buffer.reset();
+                            if (badUtf8 != null)
+                                badUtf8.set(true);
+                        }
+                        else
+                        {
+                            key = buffer.takeCompleteString(onCodingError);
+                        }
+                    }
+                    else
+                    {
+                        key = buffer.takeCompleteString(onCodingError);
+                    }
                     break;
 
                 case '+':

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8StringBuilder.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8StringBuilder.java
@@ -22,8 +22,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * <p>UTF-8 StringBuilder.</p>
- * <p>
  * This class wraps a standard {@link StringBuilder} and provides methods to append
  * UTF-8 encoded bytes, that are converted into characters.
  * </p><p>
@@ -37,6 +35,7 @@ import org.slf4j.LoggerFactory;
  * {@link CharacterCodingException}. Already decoded characters may also be appended (e.g. {@link #append(char)}
  * making this class suitable for decoding % encoded strings of already decoded characters.
  * </p>
+ *
  * @see CharsetStringBuilder for decoding of arbitrary {@link java.nio.charset.Charset}s.
  */
 public class Utf8StringBuilder implements CharsetStringBuilder
@@ -136,6 +135,16 @@ public class Utf8StringBuilder implements CharsetStringBuilder
             _state = UTF8_ACCEPT;
             _codingErrors = true;
         }
+    }
+
+    public boolean replaceIncomplete()
+    {
+        if (_state == UTF8_ACCEPT)
+            return false;
+
+        bufferAppend(REPLACEMENT);
+        _state = UTF8_ACCEPT;
+        return true;
     }
 
     public void append(char c)
@@ -342,6 +351,7 @@ public class Utf8StringBuilder implements CharsetStringBuilder
 
     /**
      * Get the completely decoded string, which is equivalent to calling {@link #complete()} then {@link #toString()}.
+     *
      * @return The completely decoded string.
      */
     public String toCompleteString()
@@ -352,8 +362,9 @@ public class Utf8StringBuilder implements CharsetStringBuilder
 
     /**
      * Take the completely decoded string.
+     *
      * @param onCodingError A supplier of a {@link Throwable} to use if {@link #hasCodingErrors()} returns true,
-     *                      or null for no error action
+     * or null for no error action
      * @param <X> The type of the exception thrown
      * @return The complete string.
      * @throws X if {@link #hasCodingErrors()} is true after {@link #complete()}.
@@ -366,8 +377,9 @@ public class Utf8StringBuilder implements CharsetStringBuilder
 
     /**
      * Take the partially decoded string.
+     *
      * @param onCodingError A supplier of a {@link Throwable} to use if {@link #hasCodingErrors()} returns true,
-     *                      or null for no error action
+     * or null for no error action
      * @param <X> The type of the exception thrown
      * @return The complete string.
      * @throws X if {@link #hasCodingErrors()} is true after {@link #complete()}.

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8StringBuilder.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Utf8StringBuilder.java
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
+ * <p>
  * This class wraps a standard {@link StringBuilder} and provides methods to append
  * UTF-8 encoded bytes, that are converted into characters.
  * </p><p>

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/UrlEncodedUtf8Test.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/UrlEncodedUtf8Test.java
@@ -31,7 +31,7 @@ public class UrlEncodedUtf8Test
     @CsvSource(delimiter = '|', useHeadersInDisplayName = false,
         textBlock = """
         # query         | expectedName | expectedValue
-        a=bad_%e0%b     | a            | bad_��
+        a=bad_%e0%b     | a            | bad_�
         b=bad_%e0%ba    | b            | bad_�
         c=short%a       | c            | short�
         d=b%aam         | d            | b�m
@@ -39,8 +39,8 @@ public class UrlEncodedUtf8Test
         f=%aardvark     | f            | �rdvark
         g=b%ar          | g            | b�
         h=end%          | h            | end�
-        # This shows how the '&' symbol gets swallowed by a pct-encoding effort.
-        i=%&z=2         | i            | �=2
+        # This shows how the '&' symbol does not get swallowed by a bad pct-encoding.
+        i=%&z=2         | i            | �
         """)
     public void testDecodeAllowBadSequence(String query, String expectedName, String expectedValue)
     {

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/UrlEncodedUtf8Test.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/UrlEncodedUtf8Test.java
@@ -45,7 +45,7 @@ public class UrlEncodedUtf8Test
     public void testDecodeAllowBadSequence(String query, String expectedName, String expectedValue)
     {
         Fields fields = new Fields();
-        UrlEncoded.decodeUtf8To(query, 0, query.length(), fields::add, true);
+        UrlEncoded.decodeUtf8To(query, 0, query.length(), fields::add, true, true);
         Fields.Field field = fields.get(expectedName);
         assertThat("Name exists", field, notNullValue());
         assertThat("Value", field.getValue(), is(expectedValue));

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ErrorPageTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ErrorPageTest.java
@@ -1331,14 +1331,14 @@ public class ErrorPageTest
 
             String responseBody = response.getContent();
             assertThat(responseBody, Matchers.containsString("ERROR_PAGE: /BadMessageException"));
-            assertThat(responseBody, Matchers.containsString("ERROR_MESSAGE: Unable to parse URI query"));
+            assertThat(responseBody, Matchers.containsString("ERROR_MESSAGE: Bad query"));
             assertThat(responseBody, Matchers.containsString("ERROR_CODE: 400"));
-            assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION: org.eclipse.jetty.http.BadMessageException: 400: Unable to parse URI query"));
+            assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION: org.eclipse.jetty.http.BadMessageException: 400: Bad query"));
             assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION_TYPE: class org.eclipse.jetty.http.BadMessageException"));
             assertThat(responseBody, Matchers.containsString("ERROR_SERVLET: " + appServlet.getClass().getName()));
             assertThat(responseBody, Matchers.containsString("ERROR_REQUEST_URI: /app"));
             assertThat(responseBody, Matchers.containsString("getQueryString()=[baa=%88%A4]"));
-            assertThat(responseBody, Matchers.containsString("getParameterMap().size=0"));
+            assertThat(responseBody, Matchers.containsString("getParameterMap().size=org.eclipse.jetty.http.BadMessageException"));
         }
     }
 
@@ -1971,16 +1971,23 @@ public class ErrorPageTest
             writer.printf("getRequestURI()=%s%n", valueOf(request.getRequestURI()));
             writer.printf("getRequestURL()=%s%n", valueOf(request.getRequestURL()));
             writer.printf("getQueryString()=%s%n", valueOf(request.getQueryString()));
-            Map<String, String[]> params = request.getParameterMap();
-            writer.printf("getParameterMap().size=%d%n", params.size());
-            for (Map.Entry<String, String[]> entry : params.entrySet())
+            try
             {
-                String value = null;
-                if (entry.getValue() != null)
+                Map<String, String[]> params = request.getParameterMap();
+                writer.printf("getParameterMap().size=%d%n", params.size());
+                for (Map.Entry<String, String[]> entry : params.entrySet())
                 {
-                    value = String.join(", ", entry.getValue());
+                    String value = null;
+                    if (entry.getValue() != null)
+                    {
+                        value = String.join(", ", entry.getValue());
+                    }
+                    writer.printf("getParameterMap()[%s]=%s%n", entry.getKey(), valueOf(value));
                 }
-                writer.printf("getParameterMap()[%s]=%s%n", entry.getKey(), valueOf(value));
+            }
+            catch (Throwable t)
+            {
+                writer.printf("getParameterMap().size=%s%n", t);
             }
         }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/RequestTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/RequestTest.java
@@ -633,7 +633,8 @@ public class RequestTest
     @CsvSource(delimiter = '|', useHeadersInDisplayName = false,
         textBlock = """
         # query         | expectedName | expectedValue
-        a=bad_%e0%b     | a            | bad_��
+        a=bad_%e0%b     | a            | bad_�
+        a=bad_%e0%b&b=2 | a            | bad_�
         a=bad_%e0%ba    | a            | bad_�
         b=short%a       | b            | short�
         c=%%TOK%%       | c            | �OK�

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
@@ -426,8 +426,9 @@ public class Request implements HttpServletRequest
                 if (StandardCharsets.UTF_8.equals(_queryEncoding) || _queryEncoding == null && UrlEncoded.ENCODING.equals(StandardCharsets.UTF_8))
                 {
                     UriCompliance uriCompliance = getHttpChannel().getHttpConfiguration().getUriCompliance();
+                    boolean allowTruncatedUtf8 = uriCompliance.allows(UriCompliance.Violation.TRUNCATED_UTF8_ENCODING);
                     boolean allowBadUtf8 = uriCompliance.allows(UriCompliance.Violation.BAD_UTF8_ENCODING);
-                    if (!UrlEncoded.decodeUtf8To(query, 0, query.length(), _queryParameters::add, allowBadUtf8))
+                    if (!UrlEncoded.decodeUtf8To(query, 0, query.length(), _queryParameters::add, allowTruncatedUtf8, allowBadUtf8))
                     {
                         ComplianceViolation.Listener complianceViolationListener = getComplianceViolationListener();
                         if (complianceViolationListener != null)


### PR DESCRIPTION
Added tests for DEFAULT, ALLOW_BAD_UTF8 and LEGACY. LEGACY expectations are set to jetty-11 results