### PR TITLE
Update jetty-acceptratelimit.xml

### DIFF
--- a/jetty-core/jetty-server/src/main/config/etc/jetty-acceptratelimit.xml
+++ b/jetty-core/jetty-server/src/main/config/etc/jetty-acceptratelimit.xml
@@ -4,7 +4,7 @@
   <Call name="addBean">
     <Arg>
       <New class="org.eclipse.jetty.server.AcceptRateLimit">
-        <Arg name="maxRate" type="int"><Property name="jetty.acceptratelimit.acceptRateLimit" default="1000" /></Arg>
+        <Arg name="acceptRateLimit" type="int"><Property name="jetty.acceptratelimit.acceptRateLimit" default="1000" /></Arg>
         <Arg name="period" type="long"><Property name="jetty.acceptratelimit.period" default="1000" /></Arg>
         <Arg name="units"><Call class="java.util.concurrent.TimeUnit" name="valueOf"><Arg>
           <Property name="jetty.acceptratelimit.units" default="MILLISECONDS" />


### PR DESCRIPTION
Default config in file etc\jetty-acceptratelimit.xml cause for exception  java.lang.IllegalStateException: No suitable constructor

Because first argument for class org.eclipse.jetty.server.AcceptRateLimit in config is "maxRate"
but should be "acceptRateLimit" 
 
How to reproduce
 1. unzip jetty-home-12.0.16.zip
 2. java -jar start.jar --add-modules=acceptratelimit,http
 3. java -jar start.jar 
 
error: 
Caused by: java.lang.IllegalStateException: No suitable constructor: <New class="org.eclipse.jetty.server.AcceptRateLimit"><Arg name="maxRate" type="int"><Property name="jetty.acceptratelimit.acceptRateLimit" default="1000"/></Arg><Arg name="period" type="long"><Property name="jetty.acceptratelimit.period" default="1000"/></Arg><Arg name="units"><Call class="java.util.concurrent.TimeUnit" name="valueOf"><Arg>                                                                        <Property name="jetty.acceptratelimit.units" default="MILLISECONDS"/>                                                                                                                                                                      </Arg></Call></Arg><Arg name="server"><Ref refid="Server"/></Arg></New> on oejs.Server@3e44f2a5{STOPPED}[12.0.16,sto=0]                                                                                                                      at org.eclipse.jetty.xml.XmlConfiguration$JettyXmlConfiguration.newObj(XmlConfiguration.java:1046)                                                                                                                                           at org.eclipse.jetty.xml.XmlConfiguration$JettyXmlConfiguration.itemValue(XmlConfiguration.java:1568)                                                                                                                                        at org.eclipse.jetty.xml.XmlConfiguration$JettyXmlConfiguration.value(XmlConfiguration.java:1469)                                                                                                                                            at org.eclipse.jetty.xml.XmlConfiguration$JettyXmlConfiguration$Args.<init>(XmlConfiguration.java:1727)                                                                                                                                      at org.eclipse.jetty.xml.XmlConfiguration$JettyXmlConfiguration.call(XmlConfiguration.java:975)                                                                                                                                              at org.eclipse.jetty.xml.XmlConfiguration$JettyXmlConfiguration.configure(XmlConfiguration.java:533)                                                                                                                                         at org.eclipse.jetty.xml.XmlConfiguration$JettyXmlConfiguration.configure(XmlConfiguration.java:486)                                                                                                                                         at org.eclipse.jetty.xml.XmlConfiguration.configure(XmlConfiguration.java:388)                         
