### PR TITLE
Issue #12537 - LowResourceMonitor#setMonitorThreads

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/LowResourceMonitor.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/LowResourceMonitor.java
@@ -103,7 +103,9 @@ public class LowResourceMonitor extends ContainerLifeCycle
                 addLowResourceCheck(new ConnectorsThreadPoolLowResourceCheck());
         }
         else
+        {
             getBeans(ConnectorsThreadPoolLowResourceCheck.class).forEach(this::removeBean);
+        }
     }
 
     @ManagedAttribute("The reasons the monitored connectors are low on resources")

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/LowResourceMonitor.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/LowResourceMonitor.java
@@ -97,11 +97,13 @@ public class LowResourceMonitor extends ContainerLifeCycle
     public void setMonitorThreads(boolean monitorThreads)
     {
         if (monitorThreads)
+        {
             // already configured?
             if (!getMonitorThreads())
                 addLowResourceCheck(new ConnectorsThreadPoolLowResourceCheck());
-            else
-                getBeans(ConnectorsThreadPoolLowResourceCheck.class).forEach(this::removeBean);
+        }
+        else
+            getBeans(ConnectorsThreadPoolLowResourceCheck.class).forEach(this::removeBean);
     }
 
     @ManagedAttribute("The reasons the monitored connectors are low on resources")

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/LowResourcesMonitorTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/LowResourcesMonitorTest.java
@@ -79,6 +79,16 @@ public class LowResourcesMonitorTest
     }
 
     @Test
+    public void testSetMonitorThreads()
+    {
+        _lowResourcesMonitor.setMonitorThreads(true);
+        assertTrue(_lowResourcesMonitor.getMonitorThreads());
+
+        _lowResourcesMonitor.setMonitorThreads(false);
+        assertFalse(_lowResourcesMonitor.getMonitorThreads());
+    }
+
+    @Test
     public void testLowOnThreads() throws Exception
     {
         _lowResourcesMonitor.setMonitorThreads(true);


### PR DESCRIPTION
Add braces to LowResourceMonitor#setMonitorThreads(boolean monitorThreads) to make it look more reasonable.

Fix https://github.com/jetty/jetty.project/issues/12537