### PR TITLE
Always resolve pathSpec with asPathSpec in ConstraintSecurityHandler

### DIFF
--- a/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/ConstraintSecurityHandler.java
+++ b/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/ConstraintSecurityHandler.java
@@ -424,11 +424,12 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
      */
     protected void processConstraintMapping(ConstraintMapping mapping)
     {
-        Map<String, RoleInfo> mappings = _constraintRoles.get(asPathSpec(mapping));
+        PathSpec pathSpec = asPathSpec(mapping);
+        Map<String, RoleInfo> mappings = _constraintRoles.get(pathSpec);
         if (mappings == null)
         {
             mappings = new HashMap<>();
-            _constraintRoles.put(mapping.getPathSpec(), mappings);
+            _constraintRoles.put(pathSpec, mappings);
         }
         RoleInfo allMethodsRoleInfo = mappings.get(ALL_METHODS);
         if (allMethodsRoleInfo != null && allMethodsRoleInfo.isForbidden())


### PR DESCRIPTION
Currently in `ConstraintSecurityHandler.processConstraintMapping` we first use `asPathSpec()` but then use the `_constraintRoles.put` variant taking a `String` which also resolve the pathSpec internally with `PathSpec.from()`, and this value can be different to what is resolved from `asPathSpec()` if the method is overriden.