### PR TITLE
Issue #12828 support relative uris for Response.encodeURI

### DIFF
--- a/jetty-core/jetty-session/src/main/java/org/eclipse/jetty/session/AbstractSessionManager.java
+++ b/jetty-core/jetty-session/src/main/java/org/eclipse/jetty/session/AbstractSessionManager.java
@@ -714,9 +714,6 @@ public abstract class AbstractSessionManager extends ContainerLifeCycle implemen
 
         String id = session.getExtendedId();
 
-        if (httpURI == null)
-            httpURI = HttpURI.from(uri);
-
         // Already encoded
         int prefix = uri.indexOf(sessionURLPrefix);
         if (prefix != -1)
@@ -735,16 +732,37 @@ public abstract class AbstractSessionManager extends ContainerLifeCycle implemen
         int suffix = uri.indexOf('?');
         if (suffix < 0)
             suffix = uri.indexOf('#');
+
         if (suffix < 0)
         {
-            return uri +
-                ((HttpScheme.HTTPS.is(httpURI.getScheme()) || HttpScheme.HTTP.is(httpURI.getScheme())) && httpURI.getPath() == null ? "/" : "") + //if no path, insert the root path
-                sessionURLPrefix + id;
+            if (URIUtil.isRelative(uri))
+            {
+                return uri + sessionURLPrefix + id;
+            }
+            else
+            {
+                if (httpURI == null)
+                    httpURI = HttpURI.from(uri);
+
+                return uri +
+                    ((HttpScheme.HTTPS.is(httpURI.getScheme()) || HttpScheme.HTTP.is(httpURI.getScheme())) && httpURI.getPath() == null ? "/" : "") + //if no path, insert the root path
+                    sessionURLPrefix + id;
+            }
         }
 
-        return uri.substring(0, suffix) +
-            ((HttpScheme.HTTPS.is(httpURI.getScheme()) || HttpScheme.HTTP.is(httpURI.getScheme())) && httpURI.getPath() == null ? "/" : "") + //if no path so insert the root path
-            sessionURLPrefix + id + uri.substring(suffix);
+        if (URIUtil.isRelative(uri))
+        {
+            return  uri.substring(0, suffix) + sessionURLPrefix + id + uri.substring(suffix);
+        }
+        else
+        {
+            if (httpURI == null)
+                httpURI = HttpURI.from(uri);
+
+            return uri.substring(0, suffix) +
+                ((HttpScheme.HTTPS.is(httpURI.getScheme()) || HttpScheme.HTTP.is(httpURI.getScheme())) && httpURI.getPath() == null ? "/" : "") + //if no path so insert the root path
+                sessionURLPrefix + id + uri.substring(suffix);
+        }
     }
 
     @Override

--- a/jetty-core/jetty-session/src/test/java/org/eclipse/jetty/session/SessionHandlerTest.java
+++ b/jetty-core/jetty-session/src/test/java/org/eclipse/jetty/session/SessionHandlerTest.java
@@ -155,7 +155,13 @@ public class SessionHandlerTest
                             out.append("Attribute ").append(name).append(" = ").append(session.getAttribute(name)).append('\n');
                         out.append("URI [")
                             .append(session.encodeURI(request, "/some/path", request.getHeaders().contains(HttpHeader.COOKIE)))
-                            .append("]");
+                            .append("]\n");
+                        out.append("RELATIVE URI [")
+                            .append(session.encodeURI(request, "../", request.getHeaders().contains(HttpHeader.COOKIE)))
+                            .append("]\n");
+                        out.append("ABSOLUTE URI [")
+                            .append(session.encodeURI(request, "http://localhost:80/foo/bar/", request.getHeaders().contains(HttpHeader.COOKIE)))
+                            .append("]\n");
                     }
                     else
                     {
@@ -488,6 +494,8 @@ public class SessionHandlerTest
             String content = response.getContent();
             assertThat(content, startsWith("Session="));
             assertThat(content, containsString("URI [/some/path;session_id=%s]".formatted(id))); // Cookies not known to be in use
+            assertThat(content, containsString("RELATIVE URI [../;session_id=%s]".formatted(id))); // Cookies not known to be in use
+            assertThat(content, containsString("ABSOLUTE URI [http://localhost:80/foo/bar/;session_id=%s]".formatted(id))); // Cookies not known to be in use
 
             // Get with cookie
             endPoint.addInput("""
@@ -503,6 +511,8 @@ public class SessionHandlerTest
             content = response.getContent();
             assertThat(content, containsString("Session=" + id.substring(0, id.indexOf(".node0"))));
             assertThat(content, containsString("URI [/some/path]")); // Cookies known to be in use
+            assertThat(content, containsString("RELATIVE URI [../]"));
+            assertThat(content, containsString("ABSOLUTE URI [http://localhost:80/foo/bar/"));
 
             // Get with parameter
             endPoint.addInput("""
@@ -517,6 +527,8 @@ public class SessionHandlerTest
             content = response.getContent();
             assertThat(content, containsString("Session=" + id.substring(0, id.indexOf(".node0"))));
             assertThat(content, containsString("URI [/some/path;session_id=%s]".formatted(id))); // Cookies not in use
+            assertThat(content, containsString("RELATIVE URI [../;session_id=%s]".formatted(id)));
+            assertThat(content, containsString("ABSOLUTE URI [http://localhost:80/foo/bar/;session_id=%s]".formatted(id)));
 
             // Get with both, but param wrong
             endPoint.addInput("""
@@ -532,6 +544,8 @@ public class SessionHandlerTest
             content = response.getContent();
             assertThat(content, containsString("Session=" + id.substring(0, id.indexOf(".node0"))));
             assertThat(content, containsString("URI [/some/path]")); // Cookies known to be in use
+            assertThat(content, containsString("RELATIVE URI [../]"));
+            assertThat(content, containsString("ABSOLUTE URI [http://localhost:80/foo/bar/]"));
 
             // Get with both, but cookie wrong
             endPoint.addInput("""
@@ -547,6 +561,8 @@ public class SessionHandlerTest
             content = response.getContent();
             assertThat(content, containsString("Session=" + id.substring(0, id.indexOf(".node0"))));
             assertThat(content, containsString("URI [/some/path]")); // Cookies known to be in use
+            assertThat(content, containsString("RELATIVE URI [../]"));
+            assertThat(content, containsString("ABSOLUTE URI [http://localhost:80/foo/bar/]"));
         }
     }
 
@@ -789,5 +805,4 @@ public class SessionHandlerTest
         assertThat(content, containsString("Session=" + id.substring(0, id.indexOf(".node0"))));
         assertThat(content, containsString("attribute = value"));
     }
-
 }


### PR DESCRIPTION
Closes #12828 

Jetty throws IllegalArgumentException during `Response.encodeURI` for uris like `../`.

This PR ensures we encode uris such as this correctly. 