### PR TITLE
Issue #12802 set server on Server.setErrorHandler arg if a Handler

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java
@@ -321,6 +321,8 @@ public class Server extends Handler.Wrapper implements Attributes
 
     public void setErrorHandler(Request.Handler errorHandler)
     {
+        if (errorHandler instanceof Handler handler)
+            handler.setServer(this);
         updateBean(_errorHandler, errorHandler);
         _errorHandler = errorHandler;
     }


### PR DESCRIPTION
closes #12802 

If the `org.eclipse.jetty.server.Request.Handler` instance passed to `Server.setErrorHandler` is a `org.eclipse.jetty.server.Handler`, call `setServer` on it.

This makes behaviour consistent between `Server.setDefaultHandler` and `Server.setErrorHandler`.