### PR TITLE
Fix `StatisticsHandlerTest`'s non-compliant tests

### DIFF
--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/StatisticsHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/StatisticsHandlerTest.java
@@ -23,7 +23,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-
 import org.eclipse.jetty.io.ConnectionStatistics;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.logging.StacklessLogging;
@@ -226,9 +225,9 @@ public class StatisticsHandlerTest
         _server.start();
 
         String request = """
-                GET / HTTP/1.1
-                Host: localhost
-                
+                GET / HTTP/1.1\r
+                Host: localhost\r
+                \r
                 """;
 
         LocalConnector.LocalEndPoint endPoint = _connector.executeRequest(request);
@@ -324,13 +323,13 @@ public class StatisticsHandlerTest
         _server.start();
 
         String request = """
-                POST / HTTP/1.1
-                Host: localhost
-                Transfer-Encoding: chunked
-                Connection: close
-                
-                0a
-                0123456789
+                POST / HTTP/1.1\r
+                Host: localhost\r
+                Transfer-Encoding: chunked\r
+                Connection: close\r
+                \r
+                0a\r
+                0123456789\r
                 """;
 
         String response = _connector.getResponse(request);

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/StatisticsHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/StatisticsHandlerTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+
 import org.eclipse.jetty.io.ConnectionStatistics;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.logging.StacklessLogging;


### PR DESCRIPTION
A couple of tests are failing because of non-compliant requests that choke on `LF_CHUNK_TERMINATION` compliance check.