### PR TITLE
Improve TestOSGIUtil lookup of XML.

### DIFF
--- a/jetty-core/jetty-osgi/src/main/java/org/eclipse/jetty/osgi/JettyBootstrapActivator.java
+++ b/jetty-core/jetty-osgi/src/main/java/org/eclipse/jetty/osgi/JettyBootstrapActivator.java
@@ -55,9 +55,14 @@ public class JettyBootstrapActivator implements BundleActivator
     public static final String JETTY_ETC_FILES = OSGiServerConstants.MANAGED_JETTY_XML_CONFIG_URLS;
 
     /**
+     * List of XML reference strings to default XML files.
+     */
+    public static final List<String> DEFAULT_JETTY_XML_FILES = List.of("etc/jetty.xml", "etc/jetty-http.xml", "etc/jetty-deployment-manager.xml");
+
+    /**
      * Set of config files to apply to a jetty Server instance if none are supplied by SYS_PROP_JETTY_ETC_FILES
      */
-    public static final String DEFAULT_JETTY_ETC_FILES = "etc/jetty.xml,etc/jetty-http.xml,etc/jetty-deploy.xml";
+    public static final String DEFAULT_JETTY_ETC_FILES = String.join(",", DEFAULT_JETTY_XML_FILES);
 
     /**
      * Default location within bundle of a jetty home dir.

--- a/jetty-core/jetty-osgi/src/main/java/org/eclipse/jetty/osgi/JettyBootstrapActivator.java
+++ b/jetty-core/jetty-osgi/src/main/java/org/eclipse/jetty/osgi/JettyBootstrapActivator.java
@@ -57,7 +57,7 @@ public class JettyBootstrapActivator implements BundleActivator
     /**
      * List of XML reference strings to default XML files.
      */
-    public static final List<String> DEFAULT_JETTY_XML_FILES = List.of("etc/jetty.xml", "etc/jetty-http.xml", "etc/jetty-deployment-manager.xml");
+    public static final List<String> DEFAULT_JETTY_XML_FILES = List.of("etc/jetty.xml", "etc/jetty-http.xml", "etc/jetty-deploy.xml");
 
     /**
      * Set of config files to apply to a jetty Server instance if none are supplied by SYS_PROP_JETTY_ETC_FILES

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/java/org/eclipse/jetty/ee10/osgi/test/TestOSGiUtil.java
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/java/org/eclipse/jetty/ee10/osgi/test/TestOSGiUtil.java
@@ -13,14 +13,13 @@
 
 package org.eclipse.jetty.ee10.osgi.test;
 
-import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.Objects;
 
 import org.eclipse.jetty.osgi.JettyBootstrapActivator;
 import org.eclipse.jetty.osgi.OSGiServerConstants;
@@ -72,29 +71,24 @@ public class TestOSGiUtil
         Path etc = MavenPaths.projectBase().resolve("src/test/config/etc");
 
         List<Option> options = new ArrayList<>();
-        List<Path> xmlFiles = new ArrayList<>();
+        // List of XML URI Reference strings
+        List<String> xmlReferences = new ArrayList<>();
 
-        xmlFiles.add(etc.resolve("jetty.xml"));
+        xmlReferences.add(resolveFile(etc, "jetty.xml"));
         if (ssl)
         {
             options.add(CoreOptions.systemProperty("jetty.ssl.port").value("0"));
-            xmlFiles.add(etc.resolve("jetty-ssl.xml"));
-            xmlFiles.add(etc.resolve("jetty-ssl-context.xml"));
-            xmlFiles.add(etc.resolve("jetty-alpn.xml"));
-            xmlFiles.add(etc.resolve("jetty-https.xml"));
+            xmlReferences.add(resolveFile(etc, "jetty-ssl.xml"));
+            xmlReferences.add(resolveFile(etc, "jetty-ssl-context.xml"));
+            xmlReferences.add(resolveFile(etc, "jetty-alpn.xml"));
+            xmlReferences.add(resolveFile(etc, "jetty-https.xml"));
         }
-        xmlFiles.add(etc.resolve(jettySelectorFileName));
-        xmlFiles.add(etc.resolve("jetty-deploy.xml"));
-        xmlFiles.add(etc.resolve("jetty-testrealm.xml"));
+        xmlReferences.add(resolveFile(etc, jettySelectorFileName));
+        xmlReferences.add(resolveFile(etc, "jetty-deploy.xml"));
+        xmlReferences.add(resolveFile(etc, "jetty-testrealm.xml"));
 
-        // Sanity check that the referenced files actually exist.
-        xmlFiles.forEach(p -> assertTrue(p + " doesn't exists and/or isn't a file", Files.isRegularFile(p)));
-
-        // Convert list of XML to a list of URIs separated by ";" (not OS specific, but OSGI specific)
-        String xmlConfigLine = xmlFiles.stream()
-            .map(Path::toUri)
-            .map(URI::toASCIIString)
-            .collect(Collectors.joining(";"));
+        // Convert list of XML URI Reference to String separated by ";" (separator is not OS specific, but OSGI specific)
+        String xmlConfigLine = String.join(";", xmlReferences);
 
         options.add(systemProperty(OSGiServerConstants.MANAGED_JETTY_XML_CONFIG_URLS).value(xmlConfigLine));
         options.add(systemProperty("jetty.http.port").value("0"));
@@ -103,27 +97,21 @@ public class TestOSGiUtil
         return options;
     }
 
-    public static List<Option>  configureJettyHomeAndPortViaBootBundle(String jettyConnectorListenerFileName)
+    public static List<Option> configureJettyHomeAndPortViaBootBundle(String jettyConnectorListenerFileName)
     {
-        List<Option> options = new ArrayList<>();
-        List<Path> xmlFiles = new ArrayList<>();
         Path etc = MavenPaths.projectBase().resolve("src/test/config/etc");
-        xmlFiles.add(etc.resolve(jettyConnectorListenerFileName));
-        xmlFiles.add(etc.resolve("jetty-testrealm.xml"));
 
-        // Sanity check that the referenced files actually exist.
-        xmlFiles.forEach(p -> assertTrue(p + " doesn't exists and/or isn't a file", Files.isRegularFile(p)));
-
-        // Create ordered list of XML file reference strings.
+        List<Option> options = new ArrayList<>();
+        // List of XML URI Reference strings
         List<String> xmlReferences = new ArrayList<>();
+
         // Add relative reference paths that will be resolved within jetty-home bundle (not from src/test/config/etc)
         xmlReferences.addAll(JettyBootstrapActivator.DEFAULT_JETTY_XML_FILES);
-        xmlFiles.stream()
-            .map(Path::toUri)
-            .map(URI::toASCIIString)
-            .forEach(xmlReferences::add);
 
-        // Convert list of XML to a list of URIs separated by ";" (not OS specific, but OSGI specific)
+        xmlReferences.add(resolveFile(etc, jettyConnectorListenerFileName));
+        xmlReferences.add(resolveFile(etc, "jetty-testrealm.xml"));
+
+        // Convert list of XML URI Reference to String separated by ";" (separator is not OS specific, but OSGI specific)
         String xmlConfigLine = String.join(";", xmlReferences);
 
         options.add(systemProperty(OSGiServerConstants.MANAGED_JETTY_XML_CONFIG_URLS).value(xmlConfigLine));
@@ -132,7 +120,21 @@ public class TestOSGiUtil
         options.add(systemProperty("jetty.base").value(etc.getParent().toString()));
         return options;
     }
-    
+
+    /**
+     * Resolve a file path, ensuring that it exists, returning the URI String to said path.
+     *
+     * @param base the base path to look in
+     * @param relative the relative path to resolve
+     * @return the URI String of the resolved file.
+     */
+    private static String resolveFile(Path base, String relative)
+    {
+        Path file = base.resolve(Objects.requireNonNull(relative));
+        assertTrue("Unable to find file: " + file, Files.isRegularFile(file));
+        return file.toUri().toASCIIString();
+    }
+
     public static List<Option> configurePaxExamLogging()
     {
         //sort out logging from the pax-exam environment

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/java/org/eclipse/jetty/ee10/osgi/test/TestOSGiUtil.java
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/java/org/eclipse/jetty/ee10/osgi/test/TestOSGiUtil.java
@@ -68,12 +68,11 @@ public class TestOSGiUtil
 
     public static List<Option> configureJettyHomeAndPort(boolean ssl, String jettySelectorFileName)
     {
-        Path etc = MavenPaths.projectBase().resolve("src/test/config/etc");
-
         List<Option> options = new ArrayList<>();
         // List of XML URI Reference strings
         List<String> xmlReferences = new ArrayList<>();
 
+        Path etc = MavenPaths.projectBase().resolve("src/test/config/etc");
         xmlReferences.add(resolveFile(etc, "jetty.xml"));
         if (ssl)
         {
@@ -99,8 +98,6 @@ public class TestOSGiUtil
 
     public static List<Option> configureJettyHomeAndPortViaBootBundle(String jettyConnectorListenerFileName)
     {
-        Path etc = MavenPaths.projectBase().resolve("src/test/config/etc");
-
         List<Option> options = new ArrayList<>();
         // List of XML URI Reference strings
         List<String> xmlReferences = new ArrayList<>();
@@ -108,6 +105,7 @@ public class TestOSGiUtil
         // Add relative reference paths that will be resolved within jetty-home bundle (not from src/test/config/etc)
         xmlReferences.addAll(JettyBootstrapActivator.DEFAULT_JETTY_XML_FILES);
 
+        Path etc = MavenPaths.projectBase().resolve("src/test/config/etc");
         xmlReferences.add(resolveFile(etc, jettyConnectorListenerFileName));
         xmlReferences.add(resolveFile(etc, "jetty-testrealm.xml"));
 

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/java/org/eclipse/jetty/ee10/osgi/test/TestOSGiUtil.java
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/java/org/eclipse/jetty/ee10/osgi/test/TestOSGiUtil.java
@@ -13,15 +13,18 @@
 
 package org.eclipse.jetty.ee10.osgi.test;
 
-import java.io.File;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.eclipse.jetty.osgi.JettyBootstrapActivator;
 import org.eclipse.jetty.osgi.OSGiServerConstants;
-import org.eclipse.jetty.toolchain.test.FS;
+import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.ops4j.pax.exam.CoreOptions;
@@ -66,54 +69,67 @@ public class TestOSGiUtil
 
     public static List<Option> configureJettyHomeAndPort(boolean ssl, String jettySelectorFileName)
     {
-        File etc = new File(FS.separators("src/test/config/etc"));
+        Path etc = MavenPaths.projectBase().resolve("src/test/config/etc");
 
         List<Option> options = new ArrayList<>();
-        StringBuffer xmlConfigs = new StringBuffer();
-        xmlConfigs.append(new File(etc, "jetty.xml").toURI());
-        xmlConfigs.append(";");
+        List<Path> xmlFiles = new ArrayList<>();
+
+        xmlFiles.add(etc.resolve("jetty.xml"));
         if (ssl)
         {
             options.add(CoreOptions.systemProperty("jetty.ssl.port").value("0"));
-            xmlConfigs.append(new File(etc, "jetty-ssl.xml").toURI());
-            xmlConfigs.append(";");
-            xmlConfigs.append(new File(etc, "jetty-ssl-context.xml").toURI());
-            xmlConfigs.append(";");
-            xmlConfigs.append(new File(etc, "jetty-alpn.xml").toURI());
-            xmlConfigs.append(";");
-            xmlConfigs.append(new File(etc, "jetty-https.xml").toURI());
-            xmlConfigs.append(";");
+            xmlFiles.add(etc.resolve("jetty-ssl.xml"));
+            xmlFiles.add(etc.resolve("jetty-ssl-context.xml"));
+            xmlFiles.add(etc.resolve("jetty-alpn.xml"));
+            xmlFiles.add(etc.resolve("jetty-https.xml"));
         }
-        xmlConfigs.append(new File(etc, jettySelectorFileName).toURI());
-        xmlConfigs.append(";");
-        xmlConfigs.append(new File(etc, "jetty-deploy.xml").toURI());
-        xmlConfigs.append(";");
-        xmlConfigs.append(new File(etc, "jetty-testrealm.xml").toURI());
+        xmlFiles.add(etc.resolve(jettySelectorFileName));
+        xmlFiles.add(etc.resolve("jetty-deploy.xml"));
+        xmlFiles.add(etc.resolve("jetty-testrealm.xml"));
 
-        options.add(systemProperty(OSGiServerConstants.MANAGED_JETTY_XML_CONFIG_URLS).value(xmlConfigs.toString()));
+        // Sanity check that the referenced files actually exist.
+        xmlFiles.forEach(p -> assertTrue(p + " doesn't exists and/or isn't a file", Files.isRegularFile(p)));
+
+        // Convert list of XML to a list of URIs separated by ";" (not OS specific, but OSGI specific)
+        String xmlConfigLine = xmlFiles.stream()
+            .map(Path::toUri)
+            .map(URI::toASCIIString)
+            .collect(Collectors.joining(";"));
+
+        options.add(systemProperty(OSGiServerConstants.MANAGED_JETTY_XML_CONFIG_URLS).value(xmlConfigLine));
         options.add(systemProperty("jetty.http.port").value("0"));
-        options.add(systemProperty("jetty.home").value(etc.getParentFile().getAbsolutePath()));
-        options.add(systemProperty("jetty.base").value(etc.getParentFile().getAbsolutePath()));
+        options.add(systemProperty("jetty.home").value(etc.getParent().toString()));
+        options.add(systemProperty("jetty.base").value(etc.getParent().toString()));
         return options;
     }
 
     public static List<Option>  configureJettyHomeAndPortViaBootBundle(String jettyConnectorListenerFileName)
     {
-        //use the default set of config files embedded in jetty boot jar
         List<Option> options = new ArrayList<>();
-        StringBuffer xmlConfigs = new StringBuffer();
-        xmlConfigs.append(JettyBootstrapActivator.DEFAULT_JETTY_ETC_FILES);
-        xmlConfigs.append(",");
-        //add in a couple of external files needed for testing
-        File etc = new File(FS.separators("src/test/config/etc"));
-        xmlConfigs.append(new File(etc, jettyConnectorListenerFileName).toURI());
-        xmlConfigs.append(",");
-        xmlConfigs.append(new File(etc, "jetty-testrealm.xml").toURI());
+        List<Path> xmlFiles = new ArrayList<>();
+        Path etc = MavenPaths.projectBase().resolve("src/test/config/etc");
+        xmlFiles.add(etc.resolve(jettyConnectorListenerFileName));
+        xmlFiles.add(etc.resolve("jetty-testrealm.xml"));
 
-        options.add(systemProperty(OSGiServerConstants.MANAGED_JETTY_XML_CONFIG_URLS).value(xmlConfigs.toString()));
+        // Sanity check that the referenced files actually exist.
+        xmlFiles.forEach(p -> assertTrue(p + " doesn't exists and/or isn't a file", Files.isRegularFile(p)));
+
+        // Create ordered list of XML file reference strings.
+        List<String> xmlReferences = new ArrayList<>();
+        // Add relative reference paths that will be resolved within jetty-home bundle (not from src/test/config/etc)
+        xmlReferences.addAll(JettyBootstrapActivator.DEFAULT_JETTY_XML_FILES);
+        xmlFiles.stream()
+            .map(Path::toUri)
+            .map(URI::toASCIIString)
+            .forEach(xmlReferences::add);
+
+        // Convert list of XML to a list of URIs separated by ";" (not OS specific, but OSGI specific)
+        String xmlConfigLine = String.join(";", xmlReferences);
+
+        options.add(systemProperty(OSGiServerConstants.MANAGED_JETTY_XML_CONFIG_URLS).value(xmlConfigLine));
         options.add(systemProperty("jetty.http.port").value("0"));
         options.add(systemProperty(OSGiServerConstants.JETTY_HOME_BUNDLE).value("org.eclipse.jetty.ee10.osgi.boot"));
-        options.add(systemProperty("jetty.base").value(etc.getParentFile().getAbsolutePath()));
+        options.add(systemProperty("jetty.base").value(etc.getParent().toString()));
         return options;
     }
     

--- a/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/java/org/eclipse/jetty/ee11/osgi/test/TestOSGiUtil.java
+++ b/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/java/org/eclipse/jetty/ee11/osgi/test/TestOSGiUtil.java
@@ -103,7 +103,7 @@ public class TestOSGiUtil
         return options;
     }
 
-    public static List<Option>  configureJettyHomeAndPortViaBootBundle(String jettyConnectorListenerFileName)
+    public static List<Option> configureJettyHomeAndPortViaBootBundle(String jettyConnectorListenerFileName)
     {
         List<Option> options = new ArrayList<>();
         List<Path> xmlFiles = new ArrayList<>();
@@ -132,7 +132,7 @@ public class TestOSGiUtil
         options.add(systemProperty("jetty.base").value(etc.getParent().toString()));
         return options;
     }
-    
+
     public static List<Option> configurePaxExamLogging()
     {
         //sort out logging from the pax-exam environment

--- a/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/java/org/eclipse/jetty/ee11/osgi/test/TestOSGiUtil.java
+++ b/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/java/org/eclipse/jetty/ee11/osgi/test/TestOSGiUtil.java
@@ -68,12 +68,11 @@ public class TestOSGiUtil
 
     public static List<Option> configureJettyHomeAndPort(boolean ssl, String jettySelectorFileName)
     {
-        Path etc = MavenPaths.projectBase().resolve("src/test/config/etc");
-
         List<Option> options = new ArrayList<>();
         // List of XML URI Reference strings
         List<String> xmlReferences = new ArrayList<>();
 
+        Path etc = MavenPaths.projectBase().resolve("src/test/config/etc");
         xmlReferences.add(resolveFile(etc, "jetty.xml"));
         if (ssl)
         {
@@ -99,8 +98,6 @@ public class TestOSGiUtil
 
     public static List<Option> configureJettyHomeAndPortViaBootBundle(String jettyConnectorListenerFileName)
     {
-        Path etc = MavenPaths.projectBase().resolve("src/test/config/etc");
-
         List<Option> options = new ArrayList<>();
         // List of XML URI Reference strings
         List<String> xmlReferences = new ArrayList<>();
@@ -108,6 +105,7 @@ public class TestOSGiUtil
         // Add relative reference paths that will be resolved within jetty-home bundle (not from src/test/config/etc)
         xmlReferences.addAll(JettyBootstrapActivator.DEFAULT_JETTY_XML_FILES);
 
+        Path etc = MavenPaths.projectBase().resolve("src/test/config/etc");
         xmlReferences.add(resolveFile(etc, jettyConnectorListenerFileName));
         xmlReferences.add(resolveFile(etc, "jetty-testrealm.xml"));
 

--- a/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/java/org/eclipse/jetty/ee11/osgi/test/TestOSGiUtil.java
+++ b/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/java/org/eclipse/jetty/ee11/osgi/test/TestOSGiUtil.java
@@ -13,14 +13,13 @@
 
 package org.eclipse.jetty.ee11.osgi.test;
 
-import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.Objects;
 
 import org.eclipse.jetty.osgi.JettyBootstrapActivator;
 import org.eclipse.jetty.osgi.OSGiServerConstants;
@@ -72,29 +71,24 @@ public class TestOSGiUtil
         Path etc = MavenPaths.projectBase().resolve("src/test/config/etc");
 
         List<Option> options = new ArrayList<>();
-        List<Path> xmlFiles = new ArrayList<>();
+        // List of XML URI Reference strings
+        List<String> xmlReferences = new ArrayList<>();
 
-        xmlFiles.add(etc.resolve("jetty.xml"));
+        xmlReferences.add(resolveFile(etc, "jetty.xml"));
         if (ssl)
         {
             options.add(CoreOptions.systemProperty("jetty.ssl.port").value("0"));
-            xmlFiles.add(etc.resolve("jetty-ssl.xml"));
-            xmlFiles.add(etc.resolve("jetty-ssl-context.xml"));
-            xmlFiles.add(etc.resolve("jetty-alpn.xml"));
-            xmlFiles.add(etc.resolve("jetty-https.xml"));
+            xmlReferences.add(resolveFile(etc, "jetty-ssl.xml"));
+            xmlReferences.add(resolveFile(etc, "jetty-ssl-context.xml"));
+            xmlReferences.add(resolveFile(etc, "jetty-alpn.xml"));
+            xmlReferences.add(resolveFile(etc, "jetty-https.xml"));
         }
-        xmlFiles.add(etc.resolve(jettySelectorFileName));
-        xmlFiles.add(etc.resolve("jetty-deploy.xml"));
-        xmlFiles.add(etc.resolve("jetty-testrealm.xml"));
+        xmlReferences.add(resolveFile(etc, jettySelectorFileName));
+        xmlReferences.add(resolveFile(etc, "jetty-deploy.xml"));
+        xmlReferences.add(resolveFile(etc, "jetty-testrealm.xml"));
 
-        // Sanity check that the referenced files actually exist.
-        xmlFiles.forEach(p -> assertTrue(p + " doesn't exists and/or isn't a file", Files.isRegularFile(p)));
-
-        // Convert list of XML to a list of URIs separated by ";" (not OS specific, but OSGI specific)
-        String xmlConfigLine = xmlFiles.stream()
-            .map(Path::toUri)
-            .map(URI::toASCIIString)
-            .collect(Collectors.joining(";"));
+        // Convert list of XML URI Reference to String separated by ";" (separator is not OS specific, but OSGI specific)
+        String xmlConfigLine = String.join(";", xmlReferences);
 
         options.add(systemProperty(OSGiServerConstants.MANAGED_JETTY_XML_CONFIG_URLS).value(xmlConfigLine));
         options.add(systemProperty("jetty.http.port").value("0"));
@@ -105,25 +99,19 @@ public class TestOSGiUtil
 
     public static List<Option> configureJettyHomeAndPortViaBootBundle(String jettyConnectorListenerFileName)
     {
-        List<Option> options = new ArrayList<>();
-        List<Path> xmlFiles = new ArrayList<>();
         Path etc = MavenPaths.projectBase().resolve("src/test/config/etc");
-        xmlFiles.add(etc.resolve(jettyConnectorListenerFileName));
-        xmlFiles.add(etc.resolve("jetty-testrealm.xml"));
 
-        // Sanity check that the referenced files actually exist.
-        xmlFiles.forEach(p -> assertTrue(p + " doesn't exists and/or isn't a file", Files.isRegularFile(p)));
-
-        // Create ordered list of XML file reference strings.
+        List<Option> options = new ArrayList<>();
+        // List of XML URI Reference strings
         List<String> xmlReferences = new ArrayList<>();
+
         // Add relative reference paths that will be resolved within jetty-home bundle (not from src/test/config/etc)
         xmlReferences.addAll(JettyBootstrapActivator.DEFAULT_JETTY_XML_FILES);
-        xmlFiles.stream()
-            .map(Path::toUri)
-            .map(URI::toASCIIString)
-            .forEach(xmlReferences::add);
 
-        // Convert list of XML to a list of URIs separated by ";" (not OS specific, but OSGI specific)
+        xmlReferences.add(resolveFile(etc, jettyConnectorListenerFileName));
+        xmlReferences.add(resolveFile(etc, "jetty-testrealm.xml"));
+
+        // Convert list of XML URI Reference to String separated by ";" (separator is not OS specific, but OSGI specific)
         String xmlConfigLine = String.join(";", xmlReferences);
 
         options.add(systemProperty(OSGiServerConstants.MANAGED_JETTY_XML_CONFIG_URLS).value(xmlConfigLine));
@@ -131,6 +119,20 @@ public class TestOSGiUtil
         options.add(systemProperty(OSGiServerConstants.JETTY_HOME_BUNDLE).value("org.eclipse.jetty.ee11.osgi.boot"));
         options.add(systemProperty("jetty.base").value(etc.getParent().toString()));
         return options;
+    }
+
+    /**
+     * Resolve a file path, ensuring that it exists, returning the URI String to said path.
+     *
+     * @param base the base path to look in
+     * @param relative the relative path to resolve
+     * @return the URI String of the resolved file.
+     */
+    private static String resolveFile(Path base, String relative)
+    {
+        Path file = base.resolve(Objects.requireNonNull(relative));
+        assertTrue("Unable to find file: " + file, Files.isRegularFile(file));
+        return file.toUri().toASCIIString();
     }
 
     public static List<Option> configurePaxExamLogging()

--- a/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/java/org/eclipse/jetty/ee11/osgi/test/TestOSGiUtil.java
+++ b/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/java/org/eclipse/jetty/ee11/osgi/test/TestOSGiUtil.java
@@ -13,15 +13,18 @@
 
 package org.eclipse.jetty.ee11.osgi.test;
 
-import java.io.File;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.eclipse.jetty.osgi.JettyBootstrapActivator;
 import org.eclipse.jetty.osgi.OSGiServerConstants;
-import org.eclipse.jetty.toolchain.test.FS;
+import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.ops4j.pax.exam.CoreOptions;
@@ -66,54 +69,67 @@ public class TestOSGiUtil
 
     public static List<Option> configureJettyHomeAndPort(boolean ssl, String jettySelectorFileName)
     {
-        File etc = new File(FS.separators("src/test/config/etc"));
+        Path etc = MavenPaths.projectBase().resolve("src/test/config/etc");
 
         List<Option> options = new ArrayList<>();
-        StringBuffer xmlConfigs = new StringBuffer();
-        xmlConfigs.append(new File(etc, "jetty.xml").toURI());
-        xmlConfigs.append(";");
+        List<Path> xmlFiles = new ArrayList<>();
+
+        xmlFiles.add(etc.resolve("jetty.xml"));
         if (ssl)
         {
             options.add(CoreOptions.systemProperty("jetty.ssl.port").value("0"));
-            xmlConfigs.append(new File(etc, "jetty-ssl.xml").toURI());
-            xmlConfigs.append(";");
-            xmlConfigs.append(new File(etc, "jetty-ssl-context.xml").toURI());
-            xmlConfigs.append(";");
-            xmlConfigs.append(new File(etc, "jetty-alpn.xml").toURI());
-            xmlConfigs.append(";");
-            xmlConfigs.append(new File(etc, "jetty-https.xml").toURI());
-            xmlConfigs.append(";");
+            xmlFiles.add(etc.resolve("jetty-ssl.xml"));
+            xmlFiles.add(etc.resolve("jetty-ssl-context.xml"));
+            xmlFiles.add(etc.resolve("jetty-alpn.xml"));
+            xmlFiles.add(etc.resolve("jetty-https.xml"));
         }
-        xmlConfigs.append(new File(etc, jettySelectorFileName).toURI());
-        xmlConfigs.append(";");
-        xmlConfigs.append(new File(etc, "jetty-deploy.xml").toURI());
-        xmlConfigs.append(";");
-        xmlConfigs.append(new File(etc, "jetty-testrealm.xml").toURI());
+        xmlFiles.add(etc.resolve(jettySelectorFileName));
+        xmlFiles.add(etc.resolve("jetty-deploy.xml"));
+        xmlFiles.add(etc.resolve("jetty-testrealm.xml"));
 
-        options.add(systemProperty(OSGiServerConstants.MANAGED_JETTY_XML_CONFIG_URLS).value(xmlConfigs.toString()));
+        // Sanity check that the referenced files actually exist.
+        xmlFiles.forEach(p -> assertTrue(p + " doesn't exists and/or isn't a file", Files.isRegularFile(p)));
+
+        // Convert list of XML to a list of URIs separated by ";" (not OS specific, but OSGI specific)
+        String xmlConfigLine = xmlFiles.stream()
+            .map(Path::toUri)
+            .map(URI::toASCIIString)
+            .collect(Collectors.joining(";"));
+
+        options.add(systemProperty(OSGiServerConstants.MANAGED_JETTY_XML_CONFIG_URLS).value(xmlConfigLine));
         options.add(systemProperty("jetty.http.port").value("0"));
-        options.add(systemProperty("jetty.home").value(etc.getParentFile().getAbsolutePath()));
-        options.add(systemProperty("jetty.base").value(etc.getParentFile().getAbsolutePath()));
+        options.add(systemProperty("jetty.home").value(etc.getParent().toString()));
+        options.add(systemProperty("jetty.base").value(etc.getParent().toString()));
         return options;
     }
 
     public static List<Option>  configureJettyHomeAndPortViaBootBundle(String jettyConnectorListenerFileName)
     {
-        //use the default set of config files embedded in jetty boot jar
         List<Option> options = new ArrayList<>();
-        StringBuffer xmlConfigs = new StringBuffer();
-        xmlConfigs.append(JettyBootstrapActivator.DEFAULT_JETTY_ETC_FILES);
-        xmlConfigs.append(",");
-        //add in a couple of external files needed for testing
-        File etc = new File(FS.separators("src/test/config/etc"));
-        xmlConfigs.append(new File(etc, jettyConnectorListenerFileName).toURI());
-        xmlConfigs.append(",");
-        xmlConfigs.append(new File(etc, "jetty-testrealm.xml").toURI());
+        List<Path> xmlFiles = new ArrayList<>();
+        Path etc = MavenPaths.projectBase().resolve("src/test/config/etc");
+        xmlFiles.add(etc.resolve(jettyConnectorListenerFileName));
+        xmlFiles.add(etc.resolve("jetty-testrealm.xml"));
 
-        options.add(systemProperty(OSGiServerConstants.MANAGED_JETTY_XML_CONFIG_URLS).value(xmlConfigs.toString()));
+        // Sanity check that the referenced files actually exist.
+        xmlFiles.forEach(p -> assertTrue(p + " doesn't exists and/or isn't a file", Files.isRegularFile(p)));
+
+        // Create ordered list of XML file reference strings.
+        List<String> xmlReferences = new ArrayList<>();
+        // Add relative reference paths that will be resolved within jetty-home bundle (not from src/test/config/etc)
+        xmlReferences.addAll(JettyBootstrapActivator.DEFAULT_JETTY_XML_FILES);
+        xmlFiles.stream()
+            .map(Path::toUri)
+            .map(URI::toASCIIString)
+            .forEach(xmlReferences::add);
+
+        // Convert list of XML to a list of URIs separated by ";" (not OS specific, but OSGI specific)
+        String xmlConfigLine = String.join(";", xmlReferences);
+
+        options.add(systemProperty(OSGiServerConstants.MANAGED_JETTY_XML_CONFIG_URLS).value(xmlConfigLine));
         options.add(systemProperty("jetty.http.port").value("0"));
         options.add(systemProperty(OSGiServerConstants.JETTY_HOME_BUNDLE).value("org.eclipse.jetty.ee11.osgi.boot"));
-        options.add(systemProperty("jetty.base").value(etc.getParentFile().getAbsolutePath()));
+        options.add(systemProperty("jetty.base").value(etc.getParent().toString()));
         return options;
     }
     

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/java/org/eclipse/jetty/ee9/osgi/test/TestOSGiUtil.java
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/java/org/eclipse/jetty/ee9/osgi/test/TestOSGiUtil.java
@@ -13,15 +13,18 @@
 
 package org.eclipse.jetty.ee9.osgi.test;
 
-import java.io.File;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.eclipse.jetty.osgi.OSGiServerConstants;
-import org.eclipse.jetty.toolchain.test.FS;
+import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.ops4j.pax.exam.CoreOptions;
@@ -69,35 +72,39 @@ public class TestOSGiUtil
 
     public static List<Option> configureJettyHomeAndPort(boolean ssl, String jettySelectorFileName)
     {
-        File etc = new File(FS.separators("src/test/config/etc"));
+        Path etc = MavenPaths.projectBase().resolve("src/test/config/etc");
 
         List<Option> options = new ArrayList<>();
-        StringBuffer xmlConfigs = new StringBuffer();
-        xmlConfigs.append(new File(etc, "jetty.xml").toURI());
-        xmlConfigs.append(";");
+        List<Path> xmlFiles = new ArrayList<>();
+
+        xmlFiles.add(etc.resolve("jetty.xml"));
         if (ssl)
         {
             options.add(CoreOptions.systemProperty("jetty.ssl.port").value("0"));
-            xmlConfigs.append(new File(etc, "jetty-ssl.xml").toURI());
-            xmlConfigs.append(";");
-            xmlConfigs.append(new File(etc, "jetty-alpn.xml").toURI());
-            xmlConfigs.append(";");
-            xmlConfigs.append(new File(etc, "jetty-https.xml").toURI());
-            xmlConfigs.append(";");
+            xmlFiles.add(etc.resolve("jetty-ssl.xml"));
+            xmlFiles.add(etc.resolve("jetty-alpn.xml"));
+            xmlFiles.add(etc.resolve("jetty-https.xml"));
         }
-        xmlConfigs.append(new File(etc, jettySelectorFileName).toURI());
-        xmlConfigs.append(";");
-        xmlConfigs.append(new File(etc, "jetty-deploy.xml").toURI());
-        xmlConfigs.append(";");
-        xmlConfigs.append(new File(etc, "jetty-testrealm.xml").toURI());
+        xmlFiles.add(etc.resolve(jettySelectorFileName));
+        xmlFiles.add(etc.resolve("jetty-deploy.xml"));
+        xmlFiles.add(etc.resolve("jetty-testrealm.xml"));
 
-        options.add(systemProperty(OSGiServerConstants.MANAGED_JETTY_XML_CONFIG_URLS).value(xmlConfigs.toString()));
+        // Sanity check that the referenced files actually exist.
+        xmlFiles.forEach(p -> assertTrue(p + " doesn't exists and/or isn't a file", Files.isRegularFile(p)));
+
+        // Convert list of XML to a list of URIs separated by ";" (not OS specific, but OSGI specific)
+        String xmlConfigLine = xmlFiles.stream()
+            .map(Path::toUri)
+            .map(URI::toASCIIString)
+            .collect(Collectors.joining(";"));
+
+        options.add(systemProperty(OSGiServerConstants.MANAGED_JETTY_XML_CONFIG_URLS).value(xmlConfigLine));
         options.add(systemProperty("jetty.http.port").value("0"));
-        options.add(systemProperty("jetty.home").value(etc.getParentFile().getAbsolutePath()));
-        options.add(systemProperty("jetty.base").value(etc.getParentFile().getAbsolutePath()));
+        options.add(systemProperty("jetty.home").value(etc.getParent().toString()));
+        options.add(systemProperty("jetty.base").value(etc.getParent().toString()));
         return options;
     }
-    
+
     public static List<Option> configurePaxExamLogging()
     {
         //sort out logging from the pax-exam environment

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/java/org/eclipse/jetty/ee9/osgi/test/TestOSGiUtil.java
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/java/org/eclipse/jetty/ee9/osgi/test/TestOSGiUtil.java
@@ -71,12 +71,11 @@ public class TestOSGiUtil
 
     public static List<Option> configureJettyHomeAndPort(boolean ssl, String jettySelectorFileName)
     {
-        Path etc = MavenPaths.projectBase().resolve("src/test/config/etc");
-
         List<Option> options = new ArrayList<>();
         // List of XML URI Reference strings
         List<String> xmlReferences = new ArrayList<>();
 
+        Path etc = MavenPaths.projectBase().resolve("src/test/config/etc");
         xmlReferences.add(resolveFile(etc, "jetty.xml"));
         if (ssl)
         {

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/java/org/eclipse/jetty/ee9/osgi/test/TestOSGiUtil.java
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/java/org/eclipse/jetty/ee9/osgi/test/TestOSGiUtil.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.ee9.osgi.test;
 
-import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -21,7 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.Objects;
 
 import org.eclipse.jetty.osgi.OSGiServerConstants;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
@@ -75,34 +74,44 @@ public class TestOSGiUtil
         Path etc = MavenPaths.projectBase().resolve("src/test/config/etc");
 
         List<Option> options = new ArrayList<>();
-        List<Path> xmlFiles = new ArrayList<>();
+        // List of XML URI Reference strings
+        List<String> xmlReferences = new ArrayList<>();
 
-        xmlFiles.add(etc.resolve("jetty.xml"));
+        xmlReferences.add(resolveFile(etc, "jetty.xml"));
         if (ssl)
         {
             options.add(CoreOptions.systemProperty("jetty.ssl.port").value("0"));
-            xmlFiles.add(etc.resolve("jetty-ssl.xml"));
-            xmlFiles.add(etc.resolve("jetty-alpn.xml"));
-            xmlFiles.add(etc.resolve("jetty-https.xml"));
+            xmlReferences.add(resolveFile(etc, "jetty-ssl.xml"));
+            xmlReferences.add(resolveFile(etc, "jetty-ssl-context.xml"));
+            xmlReferences.add(resolveFile(etc, "jetty-alpn.xml"));
+            xmlReferences.add(resolveFile(etc, "jetty-https.xml"));
         }
-        xmlFiles.add(etc.resolve(jettySelectorFileName));
-        xmlFiles.add(etc.resolve("jetty-deploy.xml"));
-        xmlFiles.add(etc.resolve("jetty-testrealm.xml"));
+        xmlReferences.add(resolveFile(etc, jettySelectorFileName));
+        xmlReferences.add(resolveFile(etc, "jetty-deploy.xml"));
+        xmlReferences.add(resolveFile(etc, "jetty-testrealm.xml"));
 
-        // Sanity check that the referenced files actually exist.
-        xmlFiles.forEach(p -> assertTrue(p + " doesn't exists and/or isn't a file", Files.isRegularFile(p)));
-
-        // Convert list of XML to a list of URIs separated by ";" (not OS specific, but OSGI specific)
-        String xmlConfigLine = xmlFiles.stream()
-            .map(Path::toUri)
-            .map(URI::toASCIIString)
-            .collect(Collectors.joining(";"));
+        // Convert list of XML URI Reference to String separated by ";" (separator is not OS specific, but OSGI specific)
+        String xmlConfigLine = String.join(";", xmlReferences);
 
         options.add(systemProperty(OSGiServerConstants.MANAGED_JETTY_XML_CONFIG_URLS).value(xmlConfigLine));
         options.add(systemProperty("jetty.http.port").value("0"));
         options.add(systemProperty("jetty.home").value(etc.getParent().toString()));
         options.add(systemProperty("jetty.base").value(etc.getParent().toString()));
         return options;
+    }
+
+    /**
+     * Resolve a file path, ensuring that it exists, returning the URI String to said path.
+     *
+     * @param base the base path to look in
+     * @param relative the relative path to resolve
+     * @return the URI String of the resolved file.
+     */
+    private static String resolveFile(Path base, String relative)
+    {
+        Path file = base.resolve(Objects.requireNonNull(relative));
+        assertTrue("Unable to find file: " + file, Files.isRegularFile(file));
+        return file.toUri().toASCIIString();
     }
 
     public static List<Option> configurePaxExamLogging()


### PR DESCRIPTION
* Don't constantly split String if not needed.
* Don't use Deprecated classes.
* Don't manage OS separators ourselves, let Path do it. (test improvement)
* Validate that XML files can be found in testcase before attempting to configure attribute for them. (fail early if test environment isn't sane)