### PR TITLE
Jetty 12.1.x Flaky test, use of Environment.ensure not thread safe

### DIFF
--- a/jetty-core/jetty-ee/src/test/java/org/eclipse/jetty/ee/WebAppClassLoaderTest.java
+++ b/jetty-core/jetty-ee/src/test/java/org/eclipse/jetty/ee/WebAppClassLoaderTest.java
@@ -34,6 +34,7 @@ import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import static org.eclipse.jetty.toolchain.test.ExtraMatchers.ordered;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -47,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+@Isolated("Use of Environment.ensure(\"testable\") not thread safe")
 public class WebAppClassLoaderTest
 {
     private Path _testWebappDir;


### PR DESCRIPTION
Stack trace
```
java.util.ConcurrentModificationException
	at java.base/java.util.TreeMap.callMappingFunctionWithCheck(TreeMap.java:785)
	at java.base/java.util.TreeMap.computeIfAbsent(TreeMap.java:639)
	at org.eclipse.jetty.util@12.1.0-SNAPSHOT/org.eclipse.jetty.util.component.Environment.ensure(Environment.java:45)
	at org.eclipse.jetty.ee@12.1.0-SNAPSHOT/org.eclipse.jetty.ee.TestableWebAppClassLoaderContext.initEnvironment(TestableWebAppClassLoaderContext.java:36)
	at org.eclipse.jetty.ee@12.1.0-SNAPSHOT/org.eclipse.jetty.ee.WebAppClassLoaderTest.init(WebAppClassLoaderTest.java:60)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)
```

Signed-off-by: Olivier Lamy <olamy@apache.org>:


