### PR TITLE
Cleanup Test XML

### DIFF
--- a/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot/src/main/resources/jettyhome/etc/jetty-deploy.xml
+++ b/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot/src/main/resources/jettyhome/etc/jetty-deploy.xml
@@ -1,19 +1,19 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
-    <!-- =========================================================== -->
-    <!-- Configure the deployment manager                            -->
-    <!-- =========================================================== -->
-    <Call name="addBean">
-      <Arg>
-        <New id="DeploymentManager" class="org.eclipse.jetty.deploy.DeploymentManager">
-          <Set name="contexts">
-            <Ref refid="Contexts" />
-          </Set>
-        </New>
-      </Arg>
-    </Call>
+  <!-- =========================================================== -->
+  <!-- Configure the deployment manager                            -->
+  <!-- =========================================================== -->
+  <Call name="addBean">
+    <Arg>
+      <New id="DeploymentManager" class="org.eclipse.jetty.deploy.DeploymentManager">
+        <Set name="contexts">
+          <Ref refid="Contexts" />
+        </Set>
+      </New>
+    </Arg>
+  </Call>
 
 </Configure>

--- a/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot/src/main/resources/jettyhome/etc/jetty-http.xml
+++ b/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot/src/main/resources/jettyhome/etc/jetty-http.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->
-<!-- by adding an HTTP connector.                                   -->
+<!-- by adding an HTTP connector.                                  -->
 <!-- This configuration must be used in conjunction with jetty.xml -->
 <!-- ============================================================= -->
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <!-- =========================================================== -->
-  <!-- Add an HTTP Connector.                                       -->
+  <!-- Add an HTTP Connector.                                      -->
   <!-- Configure an o.e.j.server.ServerConnector with a single     -->
   <!-- HttpConnectionFactory instance using the common httpConfig  -->
   <!-- instance defined in jetty.xml                               -->
@@ -21,19 +21,29 @@
   <Call name="addConnector">
     <Arg>
       <New id="httpConnector" class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+                <Arg name="config">
+                  <Ref refid="httpConfig" />
+                </Arg>
               </New>
             </Item>
           </Array>
         </Arg>
-        <Set name="host"><Property name="jetty.http.host" /></Set>
-        <Set name="port"><Property name="jetty.http.port" default="80" /></Set>
-        <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" default="30000"/></Set>
+        <Set name="host">
+          <Property name="jetty.http.host" />
+        </Set>
+        <Set name="port">
+          <Property name="jetty.http.port" default="80" />
+        </Set>
+        <Set name="idleTimeout">
+          <Property name="jetty.http.idleTimeout" default="30000" />
+        </Set>
       </New>
     </Arg>
   </Call>

--- a/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot/src/main/resources/jettyhome/etc/jetty.xml
+++ b/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot/src/main/resources/jettyhome/etc/jetty.xml
@@ -1,65 +1,80 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
-
 
 <!-- =============================================================== -->
 <!-- Configure the Jetty Server                                      -->
 <!--                                                                 -->
 <!-- Documentation of this file format can be found at:              -->
-<!-- https://jetty.org/docs/                        -->
+<!-- https://jetty.org/docs/                                         -->
 <!-- =============================================================== -->
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
-    <!-- =========================================================== -->
-    <!-- Server Thread Pool                                          -->
-    <!-- =========================================================== -->
-    <Get name="ThreadPool">
-      <Set name="minThreads">10</Set>
-      <Set name="maxThreads">200</Set>
-    </Get>
+  <!-- =========================================================== -->
+  <!-- Server Thread Pool                                          -->
+  <!-- =========================================================== -->
+  <Get name="ThreadPool">
+    <Set name="minThreads">10</Set>
+    <Set name="maxThreads">200</Set>
+  </Get>
 
+  <!-- =========================================================== -->
+  <!-- Set handler Collection Structure                            -->
+  <!-- =========================================================== -->
+  <Set name="handler">
+    <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection" />
+  </Set>
 
-    <!-- =========================================================== -->
-    <!-- Set handler Collection Structure                            -->
-    <!-- =========================================================== -->
-    <Set name="handler">
-      <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection"/>
+  <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+    <Set name="secureScheme" property="jetty.httpConfig.secureScheme" />
+    <Set name="securePort" property="jetty.httpConfig.securePort" />
+    <Set name="outputBufferSize" property="jetty.httpConfig.outputBufferSize" />
+    <Set name="outputAggregationSize" property="jetty.httpConfig.outputAggregationSize" />
+    <Set name="requestHeaderSize" property="jetty.httpConfig.requestHeaderSize" />
+    <Set name="responseHeaderSize" property="jetty.httpConfig.responseHeaderSize" />
+    <Set name="sendServerVersion" property="jetty.httpConfig.sendServerVersion" />
+    <Set name="sendDateHeader" property="jetty.httpConfig.sendDateHeader" />
+    <Set name="headerCacheSize" property="jetty.httpConfig.headerCacheSize" />
+    <Set name="delayDispatchUntilContent" property="jetty.httpConfig.delayDispatchUntilContent" />
+    <Set name="maxErrorDispatches" property="jetty.httpConfig.maxErrorDispatches" />
+    <Set name="persistentConnectionsEnabled" property="jetty.httpConfig.persistentConnectionsEnabled" />
+    <Set name="requestCookieCompliance">
+      <Call class="org.eclipse.jetty.http.CookieCompliance" name="valueOf">
+        <Arg>
+          <Property name="jetty.httpConfig.requestCookieCompliance" default="RFC6265" />
+        </Arg>
+      </Call>
     </Set>
+    <Set name="responseCookieCompliance">
+      <Call class="org.eclipse.jetty.http.CookieCompliance" name="valueOf">
+        <Arg>
+          <Property name="jetty.httpConfig.responseCookieCompliance" default="RFC6265" />
+        </Arg>
+      </Call>
+    </Set>
+  </New>
 
-     <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
-      <Set name="secureScheme" property="jetty.httpConfig.secureScheme"/>
-      <Set name="securePort" property="jetty.httpConfig.securePort"/>
-      <Set name="outputBufferSize" property="jetty.httpConfig.outputBufferSize"/>
-      <Set name="outputAggregationSize" property="jetty.httpConfig.outputAggregationSize"/>
-      <Set name="requestHeaderSize" property="jetty.httpConfig.requestHeaderSize"/>
-      <Set name="responseHeaderSize" property="jetty.httpConfig.responseHeaderSize"/>
-      <Set name="sendServerVersion" property="jetty.httpConfig.sendServerVersion"/>
-      <Set name="sendDateHeader" property="jetty.httpConfig.sendDateHeader"/>
-      <Set name="headerCacheSize" property="jetty.httpConfig.headerCacheSize"/>
-      <Set name="delayDispatchUntilContent" property="jetty.httpConfig.delayDispatchUntilContent"/>
-      <Set name="maxErrorDispatches" property="jetty.httpConfig.maxErrorDispatches"/>
-      <Set name="persistentConnectionsEnabled" property="jetty.httpConfig.persistentConnectionsEnabled"/>
-      <Set name="requestCookieCompliance"><Call class="org.eclipse.jetty.http.CookieCompliance" name="valueOf"><Arg><Property name="jetty.httpConfig.requestCookieCompliance" default="RFC6265"/></Arg></Call></Set>
-      <Set name="responseCookieCompliance"><Call class="org.eclipse.jetty.http.CookieCompliance" name="valueOf"><Arg><Property name="jetty.httpConfig.responseCookieCompliance" default="RFC6265"/></Arg></Call></Set>
-    </New>
- 
+  <!-- =========================================================== -->
+  <!-- extra options                                               -->
+  <!-- =========================================================== -->
+  <Set name="stopAtShutdown" property="jetty.server.stopAtShutdown" />
+  <Set name="stopTimeout">
+    <Property name="jetty.server.stopTimeout" default="5000" />
+  </Set>
+  <Set name="dumpAfterStart" property="jetty.server.dumpAfterStart" />
+  <Set name="dumpBeforeStop" property="jetty.server.dumpBeforeStop" />
 
-    <!-- =========================================================== -->
-    <!-- extra options                                               -->
-    <!-- =========================================================== -->
-    <Set name="stopAtShutdown" property="jetty.server.stopAtShutdown"/>
-    <Set name="stopTimeout"><Property name="jetty.server.stopTimeout" default="5000"/></Set>
-    <Set name="dumpAfterStart" property="jetty.server.dumpAfterStart"/>
-    <Set name="dumpBeforeStop" property="jetty.server.dumpBeforeStop"/>
-
-    <Call class="java.lang.System" name="setProperty">
-      <Arg>java.naming.factory.initial</Arg>
-      <Arg><Property name="java.naming.factory.initial" default="org.eclipse.jetty.jndi.InitialContextFactory"/></Arg>
-    </Call>
-    <Call class="java.lang.System" name="setProperty">
-      <Arg>java.naming.factory.url.pkgs</Arg>
-      <Arg><Property name="java.naming.factory.url.pkgs" default="org.eclipse.jetty.jndi"/></Arg>
-    </Call>
+  <Call class="java.lang.System" name="setProperty">
+    <Arg>java.naming.factory.initial</Arg>
+    <Arg>
+      <Property name="java.naming.factory.initial" default="org.eclipse.jetty.jndi.InitialContextFactory" />
+    </Arg>
+  </Call>
+  <Call class="java.lang.System" name="setProperty">
+    <Arg>java.naming.factory.url.pkgs</Arg>
+    <Arg>
+      <Property name="java.naming.factory.url.pkgs" default="org.eclipse.jetty.jndi" />
+    </Arg>
+  </Call>
 
 </Configure>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-alpn.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-alpn.xml
@@ -7,16 +7,20 @@
     <Arg>
       <New class="org.eclipse.jetty.server.SslConnectionFactory">
         <Arg name="next">alpn</Arg>
-        <Arg name="sslContextFactory"><Ref refid="sslContextFactory"/></Arg>
+        <Arg name="sslContextFactory">
+          <Ref refid="sslContextFactory" />
+        </Arg>
       </New>
     </Arg>
   </Call>
-  
+
   <Call name="addConnectionFactory">
     <Arg>
       <New id="alpn" class="org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory">
-        <Arg name="protocols" type="String"><Property name="jetty.alpn.protocols" default="h2,http/1.1" /></Arg>
-        <Set name="defaultProtocol" property="jetty.alpn.defaultProtocol"/>
+        <Arg name="protocols" type="String">
+          <Property name="jetty.alpn.protocols" default="h2,http/1.1" />
+        </Arg>
+        <Set name="defaultProtocol" property="jetty.alpn.defaultProtocol" />
       </New>
     </Arg>
   </Call>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-deploy.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-deploy.xml
@@ -1,19 +1,19 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
-    <!-- =========================================================== -->
-    <!-- Configure the deployment manager                            -->
-    <!-- =========================================================== -->
-    <Call name="addBean">
-      <Arg>
-        <New id="DeploymentManager" class="org.eclipse.jetty.deploy.DeploymentManager">
-          <Set name="contexts">
-            <Ref refid="Contexts" />
-          </Set>
-        </New>
-      </Arg>
-    </Call>
+  <!-- =========================================================== -->
+  <!-- Configure the deployment manager                            -->
+  <!-- =========================================================== -->
+  <Call name="addBean">
+    <Arg>
+      <New id="DeploymentManager" class="org.eclipse.jetty.deploy.DeploymentManager">
+        <Set name="contexts">
+          <Ref refid="Contexts" />
+        </Set>
+      </New>
+    </Arg>
+  </Call>
 
 </Configure>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-http-boot-with-annotations.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-http-boot-with-annotations.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->
-<!-- by adding an HTTP connector.                                   -->
+<!-- by adding an HTTP connector.                                  -->
 <!-- This configuration must be used in conjunction with jetty.xml -->
 <!-- ============================================================= -->
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <!-- =========================================================== -->
-  <!-- Add an HTTP Connector.                                       -->
+  <!-- Add an HTTP Connector.                                      -->
   <!-- Configure an o.e.j.server.ServerConnector with a single     -->
   <!-- HttpConnectionFactory instance using the common httpConfig  -->
   <!-- instance defined in jetty.xml                               -->
@@ -21,12 +21,16 @@
   <Call name="addConnector">
     <Arg>
       <New class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+                <Arg name="config">
+                  <Ref refid="httpConfig" />
+                </Arg>
               </New>
             </Item>
           </Array>
@@ -38,9 +42,13 @@
             </New>
           </Arg>
         </Call>
-        <Set name="host" property="jetty.http.host"/>
-        <Set name="port"><Property name="jetty.http.port" default="80"/></Set>
-        <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" default="30000"/></Set>
+        <Set name="host" property="jetty.http.host" />
+        <Set name="port">
+          <Property name="jetty.http.port" default="80" />
+        </Set>
+        <Set name="idleTimeout">
+          <Property name="jetty.http.idleTimeout" default="30000" />
+        </Set>
       </New>
     </Arg>
   </Call>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-http-boot-with-bundle.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-http-boot-with-bundle.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
@@ -21,12 +21,16 @@
   <Call name="addConnector">
     <Arg>
       <New class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+                <Arg name="config">
+                  <Ref refid="httpConfig" />
+                </Arg>
               </New>
             </Item>
           </Array>
@@ -38,9 +42,13 @@
             </New>
           </Arg>
         </Call>
-        <Set name="host" property="jetty.http.host"/>
-        <Set name="port"><Property name="jetty.http.port" default="80"/></Set>
-        <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" default="30000"/></Set>
+        <Set name="host" property="jetty.http.host" />
+        <Set name="port">
+          <Property name="jetty.http.port" default="80" />
+        </Set>
+        <Set name="idleTimeout">
+          <Property name="jetty.http.idleTimeout" default="30000" />
+        </Set>
       </New>
     </Arg>
   </Call>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-http-boot-with-jakarta-websocket.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-http-boot-with-jakarta-websocket.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
@@ -21,12 +21,16 @@
   <Call name="addConnector">
     <Arg>
       <New class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+                <Arg name="config">
+                  <Ref refid="httpConfig" />
+                </Arg>
               </New>
             </Item>
           </Array>
@@ -38,9 +42,13 @@
             </New>
           </Arg>
         </Call>
-        <Set name="host" property="jetty.http.host"/>
-        <Set name="port"><Property name="jetty.http.port" default="80"/></Set>
-        <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" default="30000"/></Set>
+        <Set name="host" property="jetty.http.host" />
+        <Set name="port">
+          <Property name="jetty.http.port" default="80" />
+        </Set>
+        <Set name="idleTimeout">
+          <Property name="jetty.http.idleTimeout" default="30000" />
+        </Set>
       </New>
     </Arg>
   </Call>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-http-boot-with-jsp.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-http-boot-with-jsp.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->
-<!-- by adding an HTTP connector.                                   -->
+<!-- by adding an HTTP connector.                                  -->
 <!-- This configuration must be used in conjunction with jetty.xml -->
 <!-- ============================================================= -->
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <!-- =========================================================== -->
-  <!-- Add an HTTP Connector.                                       -->
+  <!-- Add an HTTP Connector.                                      -->
   <!-- Configure an o.e.j.server.ServerConnector with a single     -->
   <!-- HttpConnectionFactory instance using the common httpConfig  -->
   <!-- instance defined in jetty.xml                               -->
@@ -21,12 +21,16 @@
   <Call name="addConnector">
     <Arg>
       <New class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+                <Arg name="config">
+                  <Ref refid="httpConfig" />
+                </Arg>
               </New>
             </Item>
           </Array>
@@ -38,9 +42,13 @@
             </New>
           </Arg>
         </Call>
-        <Set name="host" property="jetty.http.host"/>
-        <Set name="port"><Property name="jetty.http.port" default="80"/></Set>
-        <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" default="30000"/></Set>
+        <Set name="host" property="jetty.http.host" />
+        <Set name="port">
+          <Property name="jetty.http.port" default="80" />
+        </Set>
+        <Set name="idleTimeout">
+          <Property name="jetty.http.idleTimeout" default="30000" />
+        </Set>
       </New>
     </Arg>
   </Call>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-http-boot-with-resources.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-http-boot-with-resources.xml
@@ -1,14 +1,15 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://jetty.org/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->
-<!-- by adding an HTTP connector.                                   -->
+<!-- by adding an HTTP connector.                                  -->
 <!-- This configuration must be used in conjunction with jetty.xml -->
 <!-- ============================================================= -->
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <!-- =========================================================== -->
-  <!-- Add an HTTP Connector.                                       -->
+  <!-- Add an HTTP Connector.                                      -->
   <!-- Configure an o.e.j.server.ServerConnector with a single     -->
   <!-- HttpConnectionFactory instance using the common httpConfig  -->
   <!-- instance defined in jetty.xml                               -->
@@ -20,12 +21,16 @@
   <Call name="addConnector">
     <Arg>
       <New class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+                <Arg name="config">
+                  <Ref refid="httpConfig" />
+                </Arg>
               </New>
             </Item>
           </Array>
@@ -37,9 +42,15 @@
             </New>
           </Arg>
         </Call>
-        <Set name="host"><Property name="jetty.http.host" /></Set>
-        <Set name="port"><Property name="jetty.http.port" default="80" /></Set>
-        <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" default="30000"/></Set>
+        <Set name="host">
+          <Property name="jetty.http.host" />
+        </Set>
+        <Set name="port">
+          <Property name="jetty.http.port" default="80" />
+        </Set>
+        <Set name="idleTimeout">
+          <Property name="jetty.http.idleTimeout" default="30000" />
+        </Set>
       </New>
     </Arg>
   </Call>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-http-boot-with-websocket.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-http-boot-with-websocket.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->
-<!-- by adding an HTTP connector.                                   -->
+<!-- by adding an HTTP connector.                                  -->
 <!-- This configuration must be used in conjunction with jetty.xml -->
 <!-- ============================================================= -->
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <!-- =========================================================== -->
-  <!-- Add an HTTP Connector.                                       -->
+  <!-- Add an HTTP Connector.                                      -->
   <!-- Configure an o.e.j.server.ServerConnector with a single     -->
   <!-- HttpConnectionFactory instance using the common httpConfig  -->
   <!-- instance defined in jetty.xml                               -->
@@ -21,12 +21,16 @@
   <Call name="addConnector">
     <Arg>
       <New class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+                <Arg name="config">
+                  <Ref refid="httpConfig" />
+                </Arg>
               </New>
             </Item>
           </Array>
@@ -38,9 +42,13 @@
             </New>
           </Arg>
         </Call>
-        <Set name="host" property="jetty.http.host"/>
-        <Set name="port"><Property name="jetty.http.port" default="80"/></Set>
-        <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" default="30000"/></Set>
+        <Set name="host" property="jetty.http.host" />
+        <Set name="port">
+          <Property name="jetty.http.port" default="80" />
+        </Set>
+        <Set name="idleTimeout">
+          <Property name="jetty.http.idleTimeout" default="30000" />
+        </Set>
       </New>
     </Arg>
   </Call>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-http-connector-listener.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-http-connector-listener.xml
@@ -1,9 +1,9 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->
-<!-- by adding an HTTP connector.                                   -->
+<!-- by adding an HTTP connector.                                  -->
 <!-- This configuration must be used in conjunction with jetty.xml -->
 <!-- ============================================================= -->
 <Configure id="Server" class="org.eclipse.jetty.server.Server">

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-http2-jdk9.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-http2-jdk9.xml
@@ -2,23 +2,25 @@
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
-<!-- Configure an HTTP2 on the ssl connector.                       -->
+<!-- Configure an HTTP2 on the ssl connector.                      -->
 <!-- ============================================================= -->
 <Configure id="sslConnector" class="org.eclipse.jetty.server.ServerConnector">
   <Call name="addConnectionFactory">
     <Arg>
       <New class="org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory">
-        <Arg name="config"><Ref refid="sslHttpConfig"/></Arg>
-        <Set name="maxConcurrentStreams" property="jetty.http2.maxConcurrentStreams"/>
-        <Set name="initialStreamRecvWindow" property="jetty.http2.initialStreamRecvWindow"/>
-        <Set name="initialSessionRecvWindow" property="jetty.http2.initialSessionRecvWindow"/>
+        <Arg name="config">
+          <Ref refid="sslHttpConfig" />
+        </Arg>
+        <Set name="maxConcurrentStreams" property="jetty.http2.maxConcurrentStreams" />
+        <Set name="initialStreamRecvWindow" property="jetty.http2.initialStreamRecvWindow" />
+        <Set name="initialSessionRecvWindow" property="jetty.http2.initialSessionRecvWindow" />
       </New>
     </Arg>
   </Call>
 
   <Ref refid="sslContextFactory">
     <Set name="CipherComparator">
-      <Get class="org.eclipse.jetty.http2.HTTP2Cipher" name="COMPARATOR"/>
+      <Get class="org.eclipse.jetty.http2.HTTP2Cipher" name="COMPARATOR" />
     </Set>
     <Set name="useCipherSuitesOrder">true</Set>
   </Ref>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-http2.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-http2.xml
@@ -5,14 +5,20 @@
   <Call name="addConnectionFactory">
     <Arg>
       <New class="org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory">
-        <Arg name="config"><Ref refid="sslHttpConfig"/></Arg>
-        <Set name="maxConcurrentStreams" property="jetty.http2.maxConcurrentStreams"/>
-        <Set name="initialStreamRecvWindow" property="jetty.http2.initialStreamRecvWindow"/>
-        <Set name="initialSessionRecvWindow" property="jetty.http2.initialSessionRecvWindow"/>
-        <Set name="maxSettingsKeys"><Property name="jetty.http2.maxSettingsKeys" default="64"/></Set>
+        <Arg name="config">
+          <Ref refid="sslHttpConfig" />
+        </Arg>
+        <Set name="maxConcurrentStreams" property="jetty.http2.maxConcurrentStreams" />
+        <Set name="initialStreamRecvWindow" property="jetty.http2.initialStreamRecvWindow" />
+        <Set name="initialSessionRecvWindow" property="jetty.http2.initialSessionRecvWindow" />
+        <Set name="maxSettingsKeys">
+          <Property name="jetty.http2.maxSettingsKeys" default="64" />
+        </Set>
         <Set name="rateControlFactory">
           <New class="org.eclipse.jetty.http2.WindowRateControl$Factory">
-            <Arg type="int"><Property name="jetty.http2.rateControl.maxEventsPerSecond" default="50"/></Arg>
+            <Arg type="int">
+              <Property name="jetty.http2.rateControl.maxEventsPerSecond" default="50" />
+            </Arg>
           </New>
         </Set>
       </New>
@@ -21,7 +27,7 @@
 
   <Ref refid="sslContextFactory">
     <Set name="CipherComparator">
-      <Get class="org.eclipse.jetty.http2.HTTP2Cipher" name="COMPARATOR"/>
+      <Get class="org.eclipse.jetty.http2.HTTP2Cipher" name="COMPARATOR" />
     </Set>
     <Set name="useCipherSuitesOrder">true</Set>
   </Ref>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-https.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-https.xml
@@ -1,8 +1,8 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
-<!-- Configure an HTTPS connector.                                  -->
+<!-- Configure an HTTPS connector.                                 -->
 <!-- This configuration must be used in conjunction with jetty.xml -->
 <!-- and jetty-ssl.xml.                                            -->
 <!-- ============================================================= -->
@@ -12,7 +12,9 @@
     <Arg>
       <New class="org.eclipse.jetty.server.SslConnectionFactory">
         <Arg name="next">http/1.1</Arg>
-        <Arg name="sslContextFactory"><Ref refid="sslContextFactory"/></Arg>
+        <Arg name="sslContextFactory">
+          <Ref refid="sslContextFactory" />
+        </Arg>
       </New>
     </Arg>
   </Call>
@@ -20,9 +22,11 @@
   <Call name="addConnectionFactory">
     <Arg>
       <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-        <Arg name="config"><Ref refid="sslHttpConfig" /></Arg>
+        <Arg name="config">
+          <Ref refid="sslHttpConfig" />
+        </Arg>
       </New>
     </Arg>
   </Call>
-  
+
 </Configure>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-ssl-context.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-ssl-context.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call name="addBean">
@@ -7,18 +8,30 @@
         <Set name="Provider" property="jetty.sslContext.provider" />
         <Set name="KeyStorePath">
           <Call name="resolvePath" class="org.eclipse.jetty.xml.XmlConfiguration">
-            <Arg><Property name="jetty.base"/></Arg>
-            <Arg><Property name="jetty.sslContext.keyStorePath" default="etc/keystore.p12" /></Arg>
+            <Arg>
+              <Property name="jetty.base" />
+            </Arg>
+            <Arg>
+              <Property name="jetty.sslContext.keyStorePath" default="etc/keystore.p12" />
+            </Arg>
           </Call>
         </Set>
-        <Set name="KeyStorePassword"><Property name="jetty.sslContext.keyStorePassword" /></Set>
+        <Set name="KeyStorePassword">
+          <Property name="jetty.sslContext.keyStorePassword" />
+        </Set>
         <Set name="KeyStoreType" property="jetty.sslContext.keyStoreType" />
         <Set name="KeyStoreProvider" property="jetty.sslContext.keyStoreProvider" />
-        <Set name="KeyManagerPassword"><Property name="jetty.sslContext.keyManagerPassword" /></Set>
+        <Set name="KeyManagerPassword">
+          <Property name="jetty.sslContext.keyManagerPassword" />
+        </Set>
         <Set name="TrustStorePath">
           <Call name="resolvePath" class="org.eclipse.jetty.xml.XmlConfiguration">
-            <Arg><Property name="jetty.base"/></Arg>
-            <Arg><Property name="jetty.sslContext.trustStorePath" deprecated="jetty.sslContext.trustStoreAbsolutePath,jetty.truststore" /></Arg>
+            <Arg>
+              <Property name="jetty.base" />
+            </Arg>
+            <Arg>
+              <Property name="jetty.sslContext.trustStorePath" deprecated="jetty.sslContext.trustStoreAbsolutePath,jetty.truststore" />
+            </Arg>
           </Call>
         </Set>
         <Set name="TrustStorePassword" property="jetty.sslContext.trustStorePassword" />

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-ssl.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-ssl.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Base SSL configuration                                        -->
@@ -9,14 +9,20 @@
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <!-- =========================================================== -->
-  <!-- Add an SSL Connector with no protocol factories              -->
+  <!-- Add an SSL Connector with no protocol factories             -->
   <!-- =========================================================== -->
-  <Call  name="addConnector">
+  <Call name="addConnector">
     <Arg>
       <New id="sslConnector" class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
-        <Arg name="acceptors" type="int"><Property name="jetty.ssl.acceptors" default="1"/></Arg>
-        <Arg name="selectors" type="int"><Property name="jetty.ssl.selectors" default="-1"/></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
+        <Arg name="acceptors" type="int">
+          <Property name="jetty.ssl.acceptors" default="1" />
+        </Arg>
+        <Arg name="selectors" type="int">
+          <Property name="jetty.ssl.selectors" default="-1" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <!-- uncomment to support proxy protocol
@@ -26,18 +32,28 @@
           </Array>
         </Arg>
 
-        <Set name="host" property="jetty.ssl.host"/>
-        <Set name="port"><Property name="jetty.ssl.port" default="8443" /></Set>
-        <Set name="idleTimeout"><Property name="jetty.ssl.idleTimeout" default="30000"/></Set>
-        <Set name="acceptorPriorityDelta" property="jetty.ssl.acceptorPriorityDelta"/>
-        <Set name="acceptQueueSize" property="jetty.ssl.acceptQueueSize"/>
-        <Set name="reuseAddress"><Property name="jetty.ssl.reuseAddress" default="true"/></Set>
-        <Set name="reusePort"><Property name="jetty.ssl.reusePort" default="false"/></Set>
-        <Set name="acceptedTcpNoDelay"><Property name="jetty.ssl.acceptedTcpNoDelay" default="true"/></Set>
+        <Set name="host" property="jetty.ssl.host" />
+        <Set name="port">
+          <Property name="jetty.ssl.port" default="8443" />
+        </Set>
+        <Set name="idleTimeout">
+          <Property name="jetty.ssl.idleTimeout" default="30000" />
+        </Set>
+        <Set name="acceptorPriorityDelta" property="jetty.ssl.acceptorPriorityDelta" />
+        <Set name="acceptQueueSize" property="jetty.ssl.acceptQueueSize" />
+        <Set name="reuseAddress">
+          <Property name="jetty.ssl.reuseAddress" default="true" />
+        </Set>
+        <Set name="reusePort">
+          <Property name="jetty.ssl.reusePort" default="false" />
+        </Set>
+        <Set name="acceptedTcpNoDelay">
+          <Property name="jetty.ssl.acceptedTcpNoDelay" default="true" />
+        </Set>
         <Set name="acceptedReceiveBufferSize" property="jetty.ssl.acceptedReceiveBufferSize" />
         <Set name="acceptedSendBufferSize" property="jetty.ssl.acceptedSendBufferSize" />
         <Get name="SelectorManager">
-          <Set name="connectTimeout" property="jetty.ssl.connectTimeout"/>
+          <Set name="connectTimeout" property="jetty.ssl.connectTimeout" />
         </Get>
       </New>
     </Arg>
@@ -50,14 +66,24 @@
   <!-- session information                                         -->
   <!-- =========================================================== -->
   <New id="sslHttpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
-    <Arg><Ref refid="httpConfig"/></Arg>
+    <Arg>
+      <Ref refid="httpConfig" />
+    </Arg>
     <Call name="addCustomizer">
       <Arg>
         <New class="org.eclipse.jetty.server.SecureRequestCustomizer">
-          <Arg name="sniRequired" type="boolean"><Property name="jetty.ssl.sniRequired" default="false"/></Arg>
-          <Arg name="sniHostCheck" type="boolean"><Property name="jetty.ssl.sniHostCheck" default="true"/></Arg>
-          <Arg name="stsMaxAgeSeconds" type="int"><Property name="jetty.ssl.stsMaxAgeSeconds" default="-1"/></Arg>
-          <Arg name="stsIncludeSubdomains" type="boolean"><Property name="jetty.ssl.stsIncludeSubdomains" default="false"/></Arg>
+          <Arg name="sniRequired" type="boolean">
+            <Property name="jetty.ssl.sniRequired" default="false" />
+          </Arg>
+          <Arg name="sniHostCheck" type="boolean">
+            <Property name="jetty.ssl.sniHostCheck" default="true" />
+          </Arg>
+          <Arg name="stsMaxAgeSeconds" type="int">
+            <Property name="jetty.ssl.stsMaxAgeSeconds" default="-1" />
+          </Arg>
+          <Arg name="stsIncludeSubdomains" type="boolean">
+            <Property name="jetty.ssl.stsIncludeSubdomains" default="false" />
+          </Arg>
         </New>
       </Arg>
     </Call>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-testrealm.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-testrealm.xml
@@ -1,17 +1,21 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
+
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
-    <!-- =========================================================== -->
-    <!-- Configure Authentication Login Service                      -->
-    <!-- Realms may be configured for the entire server here, or     -->
-    <!-- they can be configured for a specific web app in a context  -->
-    <!-- configuration (see $(jetty.home)/webapps/test.xml for an    -->
-    <!-- example).                                                   -->
-    <!-- =========================================================== -->
-    <Call id="ResourceFactory" class="org.eclipse.jetty.util.resource.ResourceFactory" name="of">
-    <Arg><Ref refid="Server" /></Arg>
+  <!-- =========================================================== -->
+  <!-- Configure Authentication Login Service                      -->
+  <!-- Realms may be configured for the entire server here, or     -->
+  <!-- they can be configured for a specific web app in a context  -->
+  <!-- configuration (see $(jetty.base)/webapps/test.xml for an    -->
+  <!-- example).                                                   -->
+  <!-- =========================================================== -->
+  <Call id="ResourceFactory" class="org.eclipse.jetty.util.resource.ResourceFactory" name="of">
+    <Arg>
+      <Ref refid="Server" />
+    </Arg>
     <Call id="realmResource" name="newResource">
-        <Arg><Property name="jetty.demo.realm" default="src/test/config"/>/etc/realm.properties</Arg>
+      <Arg><Property name="jetty.demo.realm" default="src/test/config" />/etc/realm.properties
+      </Arg>
     </Call>
   </Call>
 
@@ -19,7 +23,9 @@
     <Arg>
       <New class="org.eclipse.jetty.security.HashLoginService">
         <Set name="name">Test Realm</Set>
-        <Set name="config"><Ref refid="realmResource"/></Set>
+        <Set name="config">
+          <Ref refid="realmResource" />
+        </Set>
         <Set name="hotReload">false</Set>
       </New>
     </Arg>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-with-custom-class.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-with-custom-class.xml
@@ -1,87 +1,89 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
-
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure the Jetty Server                                      -->
 <!--                                                                 -->
 <!-- Documentation of this file format can be found at:              -->
-<!-- http://wiki.eclipse.org/Jetty/Reference/jetty.xml_syntax        -->
+<!-- https://jetty.org/docs/                                         -->
 <!-- =============================================================== -->
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
-    <!-- =========================================================== -->
-    <!-- Server Thread Pool                                          -->
-    <!-- =========================================================== -->
-    <Get name="ThreadPool">
-      <Set name="minThreads">10</Set>
-      <Set name="maxThreads">200</Set>
-    </Get>
+  <!-- =========================================================== -->
+  <!-- Server Thread Pool                                          -->
+  <!-- =========================================================== -->
+  <Get name="ThreadPool">
+    <Set name="minThreads">10</Set>
+    <Set name="maxThreads">200</Set>
+  </Get>
 
-	<New class="org.eclipse.jetty.ee10.osgi.test.SomeCustomBean" id="mycustombean"></New>
+  <New class="org.eclipse.jetty.ee10.osgi.test.SomeCustomBean" id="mycustombean"></New>
 
+  <!-- =========================================================== -->
+  <!-- Set handler Collection Structure                            -->
+  <!-- =========================================================== -->
+  <Set name="handler">
+    <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection" />
+  </Set>
 
-    <!-- =========================================================== -->
-    <!-- Set handler Collection Structure                            -->
-    <!-- =========================================================== -->
-    <Set name="handler">
-      <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection"/>
+  <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+    <Set name="secureScheme">https</Set>
+    <Set name="securePort">
+      <Property name="jetty.httpConfig.securePort" default="8443" />
     </Set>
+    <Set name="outputBufferSize">32768</Set>
+    <Set name="requestHeaderSize">8192</Set>
+    <Set name="responseHeaderSize">8192</Set>
+    <Set name="sendServerVersion">true</Set>
+    <Set name="sendDateHeader">false</Set>
+    <Set name="headerCacheSize">512</Set>
+  </New>
 
-    <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
-      <Set name="secureScheme">https</Set>
-      <Set name="securePort"><Property name="jetty.httpConfig.securePort" default="8443" /></Set>
-      <Set name="outputBufferSize">32768</Set>
-      <Set name="requestHeaderSize">8192</Set>
-      <Set name="responseHeaderSize">8192</Set>
-      <Set name="sendServerVersion">true</Set>
-      <Set name="sendDateHeader">false</Set>
-      <Set name="headerCacheSize">512</Set>
-    </New>
+  <!-- =========================================================== -->
+  <!-- extra options                                               -->
+  <!-- =========================================================== -->
+  <Set name="stopAtShutdown">true</Set>
+  <Set name="stopTimeout">1000</Set>
+  <Set name="dumpAfterStart">false</Set>
+  <Set name="dumpBeforeStop">false</Set>
 
+  <!-- =========================================================== -->
+  <!-- Set up the list of default configuration classes            -->
+  <!-- =========================================================== -->
+  <Call class="org.eclipse.jetty.ee10.webapp.Configurations" name="setKnown">
+    <Arg>
+      <Array type="String">
+        <Item>org.eclipse.jetty.ee10.webapp.FragmentConfiguration</Item>
+        <Item>org.eclipse.jetty.ee10.webapp.JettyWebXmlConfiguration</Item>
+        <Item>org.eclipse.jetty.ee10.webapp.WebXmlConfiguration</Item>
+        <Item>org.eclipse.jetty.ee10.webapp.WebAppConfiguration</Item>
+        <Item>org.eclipse.jetty.ee10.webapp.ServletsConfiguration</Item>
+        <Item>org.eclipse.jetty.ee10.webapp.JspConfiguration</Item>
+        <Item>org.eclipse.jetty.ee10.webapp.JaasConfiguration</Item>
+        <Item>org.eclipse.jetty.ee10.webapp.JndiConfiguration</Item>
+        <Item>org.eclipse.jetty.ee10.plus.webapp.PlusConfiguration</Item>
+        <Item>org.eclipse.jetty.ee10.plus.webapp.EnvConfiguration</Item>
+        <Item>org.eclipse.jetty.ee10.webapp.JmxConfiguration</Item>
+        <Item>org.eclipse.jetty.ee10.websocket.server.config.JettyWebSocketConfiguration</Item>
+        <Item>org.eclipse.jetty.ee10.websocket.jakarta.server.config.JakartaWebSocketConfiguration</Item>
+        <Item>org.eclipse.jetty.ee10.osgi.annotations.AnnotationConfiguration</Item>
+        <Item>org.eclipse.jetty.ee10.osgi.boot.OSGiMetaInfConfiguration</Item>
+      </Array>
+    </Arg>
+  </Call>
 
-    <!-- =========================================================== -->
-    <!-- extra options                                               -->
-    <!-- =========================================================== -->
-    <Set name="stopAtShutdown">true</Set>
-    <Set name="stopTimeout">1000</Set>
-    <Set name="dumpAfterStart">false</Set>
-    <Set name="dumpBeforeStop">false</Set>
-
-
-    <!-- =========================================================== -->
-    <!-- Set up the list of default configuration classes            -->
-    <!-- =========================================================== -->    
-    <Call class="org.eclipse.jetty.ee10.webapp.Configurations" name="setKnown">
-      <Arg>
-        <Array type="String">
-         <Item>org.eclipse.jetty.ee10.webapp.FragmentConfiguration</Item>
-         <Item>org.eclipse.jetty.ee10.webapp.JettyWebXmlConfiguration</Item>
-         <Item>org.eclipse.jetty.ee10.webapp.WebXmlConfiguration</Item>
-         <Item>org.eclipse.jetty.ee10.webapp.WebAppConfiguration</Item>
-         <Item>org.eclipse.jetty.ee10.webapp.ServletsConfiguration</Item>
-         <Item>org.eclipse.jetty.ee10.webapp.JspConfiguration</Item>
-         <Item>org.eclipse.jetty.ee10.webapp.JaasConfiguration</Item>
-         <Item>org.eclipse.jetty.ee10.webapp.JndiConfiguration</Item>
-         <Item>org.eclipse.jetty.ee10.plus.webapp.PlusConfiguration</Item>
-         <Item>org.eclipse.jetty.ee10.plus.webapp.EnvConfiguration</Item>
-         <Item>org.eclipse.jetty.ee10.webapp.JmxConfiguration</Item>
-         <Item>org.eclipse.jetty.ee10.websocket.server.config.JettyWebSocketConfiguration</Item>
-         <Item>org.eclipse.jetty.ee10.websocket.jakarta.server.config.JakartaWebSocketConfiguration</Item>
-         <Item>org.eclipse.jetty.ee10.osgi.annotations.AnnotationConfiguration</Item>
-         <Item>org.eclipse.jetty.ee10.osgi.boot.OSGiMetaInfConfiguration</Item>
-        </Array>
-      </Arg>
-    </Call>
-
-    <Call class="java.lang.System" name="setProperty">
-      <Arg>java.naming.factory.initial</Arg>
-      <Arg><Property name="java.naming.factory.initial" default="org.eclipse.jetty.jndi.InitialContextFactory"/></Arg>
-    </Call>
-    <Call class="java.lang.System" name="setProperty">
-      <Arg>java.naming.factory.url.pkgs</Arg>
-      <Arg><Property name="java.naming.factory.url.pkgs" default="org.eclipse.jetty.jndi"/></Arg>
-    </Call>
+  <Call class="java.lang.System" name="setProperty">
+    <Arg>java.naming.factory.initial</Arg>
+    <Arg>
+      <Property name="java.naming.factory.initial" default="org.eclipse.jetty.jndi.InitialContextFactory" />
+    </Arg>
+  </Call>
+  <Call class="java.lang.System" name="setProperty">
+    <Arg>java.naming.factory.url.pkgs</Arg>
+    <Arg>
+      <Property name="java.naming.factory.url.pkgs" default="org.eclipse.jetty.jndi" />
+    </Arg>
+  </Call>
 
 </Configure>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty.xml
@@ -1,65 +1,80 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
-
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure the Jetty Server                                      -->
 <!--                                                                 -->
 <!-- Documentation of this file format can be found at:              -->
-<!-- https://jetty.org/docs/                        -->
+<!-- https://jetty.org/docs/                                         -->
 <!-- =============================================================== -->
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
-    <!-- =========================================================== -->
-    <!-- Server Thread Pool                                          -->
-    <!-- =========================================================== -->
-    <Get name="ThreadPool">
-      <Set name="minThreads">10</Set>
-      <Set name="maxThreads">200</Set>
-    </Get>
+  <!-- =========================================================== -->
+  <!-- Server Thread Pool                                          -->
+  <!-- =========================================================== -->
+  <Get name="ThreadPool">
+    <Set name="minThreads">10</Set>
+    <Set name="maxThreads">200</Set>
+  </Get>
 
+  <!-- =========================================================== -->
+  <!-- Set handler Collection Structure                            -->
+  <!-- =========================================================== -->
+  <Set name="handler">
+    <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection" />
+  </Set>
 
-    <!-- =========================================================== -->
-    <!-- Set handler Collection Structure                            -->
-    <!-- =========================================================== -->
-    <Set name="handler">
-      <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection"/>
+  <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+    <Set name="secureScheme" property="jetty.httpConfig.secureScheme" />
+    <Set name="securePort" property="jetty.httpConfig.securePort" />
+    <Set name="outputBufferSize" property="jetty.httpConfig.outputBufferSize" />
+    <Set name="outputAggregationSize" property="jetty.httpConfig.outputAggregationSize" />
+    <Set name="requestHeaderSize" property="jetty.httpConfig.requestHeaderSize" />
+    <Set name="responseHeaderSize" property="jetty.httpConfig.responseHeaderSize" />
+    <Set name="sendServerVersion" property="jetty.httpConfig.sendServerVersion" />
+    <Set name="sendDateHeader" property="jetty.httpConfig.sendDateHeader" />
+    <Set name="headerCacheSize" property="jetty.httpConfig.headerCacheSize" />
+    <Set name="delayDispatchUntilContent" property="jetty.httpConfig.delayDispatchUntilContent" />
+    <Set name="maxErrorDispatches" property="jetty.httpConfig.maxErrorDispatches" />
+    <Set name="persistentConnectionsEnabled" property="jetty.httpConfig.persistentConnectionsEnabled" />
+    <Set name="requestCookieCompliance">
+      <Call class="org.eclipse.jetty.http.CookieCompliance" name="valueOf">
+        <Arg>
+          <Property name="jetty.httpConfig.requestCookieCompliance" default="RFC6265" />
+        </Arg>
+      </Call>
     </Set>
+    <Set name="responseCookieCompliance">
+      <Call class="org.eclipse.jetty.http.CookieCompliance" name="valueOf">
+        <Arg>
+          <Property name="jetty.httpConfig.responseCookieCompliance" default="RFC6265" />
+        </Arg>
+      </Call>
+    </Set>
+  </New>
 
-     <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
-      <Set name="secureScheme" property="jetty.httpConfig.secureScheme"/>
-      <Set name="securePort" property="jetty.httpConfig.securePort"/>
-      <Set name="outputBufferSize" property="jetty.httpConfig.outputBufferSize"/>
-      <Set name="outputAggregationSize" property="jetty.httpConfig.outputAggregationSize"/>
-      <Set name="requestHeaderSize" property="jetty.httpConfig.requestHeaderSize"/>
-      <Set name="responseHeaderSize" property="jetty.httpConfig.responseHeaderSize"/>
-      <Set name="sendServerVersion" property="jetty.httpConfig.sendServerVersion"/>
-      <Set name="sendDateHeader" property="jetty.httpConfig.sendDateHeader"/>
-      <Set name="headerCacheSize" property="jetty.httpConfig.headerCacheSize"/>
-      <Set name="delayDispatchUntilContent" property="jetty.httpConfig.delayDispatchUntilContent"/>
-      <Set name="maxErrorDispatches" property="jetty.httpConfig.maxErrorDispatches"/>
-      <Set name="persistentConnectionsEnabled" property="jetty.httpConfig.persistentConnectionsEnabled"/>
-      <Set name="requestCookieCompliance"><Call class="org.eclipse.jetty.http.CookieCompliance" name="valueOf"><Arg><Property name="jetty.httpConfig.requestCookieCompliance" default="RFC6265"/></Arg></Call></Set>
-      <Set name="responseCookieCompliance"><Call class="org.eclipse.jetty.http.CookieCompliance" name="valueOf"><Arg><Property name="jetty.httpConfig.responseCookieCompliance" default="RFC6265"/></Arg></Call></Set>
-    </New>
- 
+  <!-- =========================================================== -->
+  <!-- extra options                                               -->
+  <!-- =========================================================== -->
+  <Set name="stopAtShutdown" property="jetty.server.stopAtShutdown" />
+  <Set name="stopTimeout">
+    <Property name="jetty.server.stopTimeout" default="5000" />
+  </Set>
+  <Set name="dumpAfterStart" property="jetty.server.dumpAfterStart" />
+  <Set name="dumpBeforeStop" property="jetty.server.dumpBeforeStop" />
 
-    <!-- =========================================================== -->
-    <!-- extra options                                               -->
-    <!-- =========================================================== -->
-    <Set name="stopAtShutdown" property="jetty.server.stopAtShutdown"/>
-    <Set name="stopTimeout"><Property name="jetty.server.stopTimeout" default="5000"/></Set>
-    <Set name="dumpAfterStart" property="jetty.server.dumpAfterStart"/>
-    <Set name="dumpBeforeStop" property="jetty.server.dumpBeforeStop"/>
-
-    <Call class="java.lang.System" name="setProperty">
-      <Arg>java.naming.factory.initial</Arg>
-      <Arg><Property name="java.naming.factory.initial" default="org.eclipse.jetty.jndi.InitialContextFactory"/></Arg>
-    </Call>
-    <Call class="java.lang.System" name="setProperty">
-      <Arg>java.naming.factory.url.pkgs</Arg>
-      <Arg><Property name="java.naming.factory.url.pkgs" default="org.eclipse.jetty.jndi"/></Arg>
-    </Call>
+  <Call class="java.lang.System" name="setProperty">
+    <Arg>java.naming.factory.initial</Arg>
+    <Arg>
+      <Property name="java.naming.factory.initial" default="org.eclipse.jetty.jndi.InitialContextFactory" />
+    </Arg>
+  </Call>
+  <Call class="java.lang.System" name="setProperty">
+    <Arg>java.naming.factory.url.pkgs</Arg>
+    <Arg>
+      <Property name="java.naming.factory.url.pkgs" default="org.eclipse.jetty.jndi" />
+    </Arg>
+  </Call>
 
 </Configure>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/resources/DefaultHandler.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/resources/DefaultHandler.xml
@@ -1,12 +1,12 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
     <Set name="secureScheme">https</Set>
     <Set name="securePort">
-      <Property name="jetty.secure.port" default="8443"/>
+      <Property name="jetty.secure.port" default="8443" />
     </Set>
     <Set name="outputBufferSize">32768</Set>
     <Set name="requestHeaderSize">8192</Set>
@@ -25,9 +25,10 @@
         <Arg>
           <New id="defcontext" class="org.eclipse.jetty.server.handler.ContextHandler">
             <Set name="contextPath">/tests</Set>
-            <Set name="baseResourceAsString"><Property name="test.docroot.base"/>/default</Set>
+            <Set name="baseResourceAsString"><Property name="test.docroot.base" />/default
+            </Set>
             <Set name="Handler">
-              <New id="reshandler" class="org.eclipse.jetty.server.handler.ResourceHandler"/>
+              <New id="reshandler" class="org.eclipse.jetty.server.handler.ResourceHandler" />
             </Set>
             <Set name="DisplayName">default</Set>
           </New>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/resources/NIOHttp.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/resources/NIOHttp.xml
@@ -1,28 +1,34 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
-    <!-- =========================================================== -->
-    <!-- Set connectors                                              -->
-    <!-- =========================================================== -->
-    
-    <Call name="addConnector">
+  <!-- =========================================================== -->
+  <!-- Set connectors                                              -->
+  <!-- =========================================================== -->
+
+  <Call name="addConnector">
     <Arg>
       <New class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+                <Arg name="config">
+                  <Ref refid="httpConfig" />
+                </Arg>
               </New>
             </Item>
           </Array>
         </Arg>
         <Set name="host" property="jetty.http.host" />
         <Set name="port" property="jetty.http.port" />
-        <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" default="30000"/></Set>
+        <Set name="idleTimeout">
+          <Property name="jetty.http.idleTimeout" default="30000" />
+        </Set>
       </New>
     </Arg>
   </Call>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/resources/NIOHttps.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/resources/NIOHttps.xml
@@ -1,26 +1,32 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
-    <!-- =========================================================== -->
-    <!-- Set connectors                                              -->
-    <!-- =========================================================== -->
+  <!-- =========================================================== -->
+  <!-- Set connectors                                              -->
+  <!-- =========================================================== -->
 
-    <Call name="addConnector">
+  <Call name="addConnector">
     <Arg>
       <New class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.SslConnectionFactory">
                 <Arg name="next">http/1.1</Arg>
-                <Arg name="sslContextFactory"><Ref refid="sslContextFactory"/></Arg>
+                <Arg name="sslContextFactory">
+                  <Ref refid="sslContextFactory" />
+                </Arg>
               </New>
             </Item>
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-                <Arg name="config"><Ref refid="sslHttpConfig"/></Arg>
+                <Arg name="config">
+                  <Ref refid="sslHttpConfig" />
+                </Arg>
               </New>
             </Item>
           </Array>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/resources/RFC2616Base.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/resources/RFC2616Base.xml
@@ -1,99 +1,105 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure the Jetty Server                                      -->
 <!--                                                                 -->
 <!-- Documentation of this file format can be found at:              -->
-<!-- http://docs.codehaus.org/display/JETTY/jetty.xml                -->
-<!--                                                                 -->
+<!-- https://jetty.org/docs/                                         -->
 <!-- =============================================================== -->
-
-
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
+  <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+    <Set name="secureScheme">https</Set>
+    <Set name="securePort">
+      <Property name="jetty.secure.port" default="8443" />
+    </Set>
+    <Set name="outputBufferSize">32768</Set>
+    <Set name="requestHeaderSize">8192</Set>
+    <Set name="responseHeaderSize">8192</Set>
+    <Set name="sendServerVersion">true</Set>
+    <Set name="sendDateHeader">true</Set>
+    <Set name="headerCacheSize">1024</Set>
 
-    <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
-      <Set name="secureScheme">https</Set>
-      <Set name="securePort"><Property name="jetty.secure.port" default="8443" /></Set>
-      <Set name="outputBufferSize">32768</Set>
-      <Set name="requestHeaderSize">8192</Set>
-      <Set name="responseHeaderSize">8192</Set>
-      <Set name="sendServerVersion">true</Set>
-      <Set name="sendDateHeader">true</Set>
-      <Set name="headerCacheSize">1024</Set>
-
-      <Set name="httpCompliance">
-        <Call class="org.eclipse.jetty.http.HttpCompliance" name="from">
-          <Arg>RFC2616</Arg>
-        </Call>
-      </Set>
-
-      <!-- Uncomment to enable handling of X-Forwarded- style headers
-      <Call name="addCustomizer">
-        <Arg><New class="org.eclipse.jetty.server.ForwardedRequestCustomizer"/></Arg>
+    <Set name="httpCompliance">
+      <Call class="org.eclipse.jetty.http.HttpCompliance" name="from">
+        <Arg>RFC2616</Arg>
       </Call>
-      -->
-    </New>
-
-    <!-- =========================================================== -->
-    <!-- Set handler Collection Structure                            -->
-    <!-- =========================================================== -->
-    <Set name="handler">
-      <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection">
-        <Arg>
-          <Array type="org.eclipse.jetty.server.handler.ContextHandler">
-            <Item>
-              <New id="vcontexts" class="org.eclipse.jetty.server.handler.ContextHandler">
-                <Set name="contextPath">/tests</Set>
-                <Set name="VirtualHosts">
-                  <Array type="java.lang.String">
-                    <Item>VirtualHost</Item>
-                  </Array>
-                </Set>
-                <Set name="BaseResourceAsString"><Property name="test.docroot.base"/>/virtualhost</Set>
-                <Set name="Handler"><New id="reshandler1" class="org.eclipse.jetty.server.handler.ResourceHandler"/></Set>
-                <Set name="DisplayName">virtual</Set>
-              </New>
-            </Item>
-            <Item>
-              <New id="defcontext" class="org.eclipse.jetty.server.handler.ContextHandler">
-                <Set name="contextPath">/tests</Set>
-                <Set name="BaseResourceAsString"><Property name="test.docroot.base"/>/default</Set>
-                <Set name="Handler"><New id="reshandler2" class="org.eclipse.jetty.server.handler.ResourceHandler"/></Set>
-                <Set name="DisplayName">default</Set>
-              </New>
-            </Item>
-            <Item>
-              <New id="echocontext" class="org.eclipse.jetty.server.handler.ContextHandler">
-                <Set name="contextPath">/echo</Set>
-                <Set name="Handler"><New id="echohandler" class="org.eclipse.jetty.ee10.test.rfcs.RFC2616BaseTest$EchoHandler"/></Set>
-                <Set name="DisplayName">echo</Set>
-              </New>
-            </Item>
-          </Array>
-        </Arg>
-      </New>
     </Set>
 
-    <Call id="Environment" class="org.eclipse.jetty.util.component.Environment" name="ensure">
-      <Arg>ee10</Arg>
+    <!-- Uncomment to enable handling of X-Forwarded- style headers
+    <Call name="addCustomizer">
+      <Arg><New class="org.eclipse.jetty.server.ForwardedRequestCustomizer"/></Arg>
     </Call>
-    <Ref refid="Environment">
-      <Call name="setAttribute">
-        <Arg>contextHandlerClass</Arg>
-        <Arg>org.eclipse.jetty.ee10.webapp.WebAppContext</Arg>
-      </Call>
-    </Ref>
+    -->
+  </New>
 
-    <Call name="addBean">
+  <!-- =========================================================== -->
+  <!-- Set handler Collection Structure                            -->
+  <!-- =========================================================== -->
+  <Set name="handler">
+    <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection">
       <Arg>
-        <New id="DeploymentManager" class="org.eclipse.jetty.deploy.DeploymentManager">
-          <Set name="contexts">
-            <Ref refid="Contexts" />
-          </Set>
-        
-          <Call name="addAppProvider">
-           <Arg>
+        <Array type="org.eclipse.jetty.server.handler.ContextHandler">
+          <Item>
+            <New id="vcontexts" class="org.eclipse.jetty.server.handler.ContextHandler">
+              <Set name="contextPath">/tests</Set>
+              <Set name="VirtualHosts">
+                <Array type="java.lang.String">
+                  <Item>VirtualHost</Item>
+                </Array>
+              </Set>
+              <Set name="BaseResourceAsString"><Property name="test.docroot.base" />/virtualhost
+              </Set>
+              <Set name="Handler">
+                <New id="reshandler1" class="org.eclipse.jetty.server.handler.ResourceHandler" />
+              </Set>
+              <Set name="DisplayName">virtual</Set>
+            </New>
+          </Item>
+          <Item>
+            <New id="defcontext" class="org.eclipse.jetty.server.handler.ContextHandler">
+              <Set name="contextPath">/tests</Set>
+              <Set name="BaseResourceAsString"><Property name="test.docroot.base" />/default
+              </Set>
+              <Set name="Handler">
+                <New id="reshandler2" class="org.eclipse.jetty.server.handler.ResourceHandler" />
+              </Set>
+              <Set name="DisplayName">default</Set>
+            </New>
+          </Item>
+          <Item>
+            <New id="echocontext" class="org.eclipse.jetty.server.handler.ContextHandler">
+              <Set name="contextPath">/echo</Set>
+              <Set name="Handler">
+                <New id="echohandler" class="org.eclipse.jetty.ee10.test.rfcs.RFC2616BaseTest$EchoHandler" />
+              </Set>
+              <Set name="DisplayName">echo</Set>
+            </New>
+          </Item>
+        </Array>
+      </Arg>
+    </New>
+  </Set>
+
+  <Call id="Environment" class="org.eclipse.jetty.util.component.Environment" name="ensure">
+    <Arg>ee10</Arg>
+  </Call>
+  <Ref refid="Environment">
+    <Call name="setAttribute">
+      <Arg>contextHandlerClass</Arg>
+      <Arg>org.eclipse.jetty.ee10.webapp.WebAppContext</Arg>
+    </Call>
+  </Ref>
+
+  <Call name="addBean">
+    <Arg>
+      <New id="DeploymentManager" class="org.eclipse.jetty.deploy.DeploymentManager">
+        <Set name="contexts">
+          <Ref refid="Contexts" />
+        </Set>
+
+        <Call name="addAppProvider">
+          <Arg>
             <New id="WebAppProvider" class="org.eclipse.jetty.deploy.providers.ContextProvider">
               <Set name="environmentName">ee10</Set>
               <Set name="monitoredDirName">
@@ -112,21 +118,21 @@
                   </Property>
                 </Put>
                 <Put name="jetty.deploy.webInfScanJarPattern">
-                  <Property name="jetty.deploy.webInfScanJarPattern"/>
+                  <Property name="jetty.deploy.webInfScanJarPattern" />
                 </Put>
                 <Put name="jetty.deploy.servletContainerInitializerExclusionPattern">
-                  <Property name="jetty.deploy.servletContainerInitializerExclusionPattern"/>
+                  <Property name="jetty.deploy.servletContainerInitializerExclusionPattern" />
                 </Put>
                 <Put name="jetty.deploy.servletContainerInitializerOrder">
-                  <Property name="jetty.deploy.servletContainerInitializerOrder"/>
+                  <Property name="jetty.deploy.servletContainerInitializerOrder" />
                 </Put>
               </Get>
             </New>
           </Arg>
         </Call>
-       </New>
-      </Arg>
-    </Call>
+      </New>
+    </Arg>
+  </Call>
 
   <!-- =========================================================== -->
   <!-- extra options                                               -->

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/resources/RFC2616_Filters.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/resources/RFC2616_Filters.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/resources/RFC2616_Redirects.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/resources/RFC2616_Redirects.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <!-- =========================================================== -->

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/resources/add-jetty-test-webapp.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/resources/add-jetty-test-webapp.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection">
   <Call name="addHandler">

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/resources/basic-server.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/resources/basic-server.xml
@@ -1,11 +1,11 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
     <Set name="secureScheme">https</Set>
     <Set name="securePort">
-      <Property name="jetty.secure.port" default="8443"/>
+      <Property name="jetty.secure.port" default="8443" />
     </Set>
     <Set name="outputBufferSize">32768</Set>
     <Set name="requestHeaderSize">8192</Set>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/resources/deploy.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/resources/deploy.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call id="Environment" class="org.eclipse.jetty.util.component.Environment" name="ensure">
@@ -18,43 +18,41 @@
         <Set name="contexts">
           <Ref refid="Contexts" />
         </Set>
-        
+
         <Call name="addAppProvider">
-         <Arg>
-          <New id="WebAppProvider" class="org.eclipse.jetty.deploy.providers.ContextProvider">
-            <Set name="environmentName">ee10</Set>
-            <Set name="monitoredDirName">
-              <Call name="resolvePath" class="org.eclipse.jetty.xml.XmlConfiguration">
-                <Arg>target</Arg>
-                <Arg>webapps</Arg>
-              </Call>
-            </Set>
+          <Arg>
+            <New id="WebAppProvider" class="org.eclipse.jetty.deploy.providers.ContextProvider">
+              <Set name="environmentName">ee10</Set>
+              <Set name="monitoredDirName">
+                <Call name="resolvePath" class="org.eclipse.jetty.xml.XmlConfiguration">
+                  <Arg>target</Arg>
+                  <Arg>webapps</Arg>
+                </Call>
+              </Set>
 
-            <Set name="scanInterval">1</Set>
-            <Set name="extractWars">true</Set>
+              <Set name="scanInterval">1</Set>
+              <Set name="extractWars">true</Set>
 
-            <Get name="properties">
-              <Put name="jetty.deploy.containerScanJarPattern">
-                <Property name="jetty.deploy.containerScanJarPattern">
-                  <Default>.*/jakarta.servlet-api-[^/]*\.jar$|.*jakarta.servlet.jsp.jstl-.*\.jar$</Default>
-                </Property>
-              </Put>
-              <Put name="jetty.deploy.webInfScanJarPattern">
-                <Property name="jetty.deploy.webInfScanJarPattern"/>
-              </Put>
-              <Put name="jetty.deploy.servletContainerInitializerExclusionPattern">
-                <Property name="jetty.deploy.servletContainerInitializerExclusionPattern"/>
-              </Put>
-              <Put name="jetty.deploy.servletContainerInitializerOrder">
-                <Property name="jetty.deploy.servletContainerInitializerOrder"/>
-              </Put>
-            </Get>
-          </New>
-        </Arg>
-      </Call>
-        
-        
-        
+              <Get name="properties">
+                <Put name="jetty.deploy.containerScanJarPattern">
+                  <Property name="jetty.deploy.containerScanJarPattern">
+                    <Default>.*/jakarta.servlet-api-[^/]*\.jar$|.*jakarta.servlet.jsp.jstl-.*\.jar$</Default>
+                  </Property>
+                </Put>
+                <Put name="jetty.deploy.webInfScanJarPattern">
+                  <Property name="jetty.deploy.webInfScanJarPattern" />
+                </Put>
+                <Put name="jetty.deploy.servletContainerInitializerExclusionPattern">
+                  <Property name="jetty.deploy.servletContainerInitializerExclusionPattern" />
+                </Put>
+                <Put name="jetty.deploy.servletContainerInitializerOrder">
+                  <Property name="jetty.deploy.servletContainerInitializerOrder" />
+                </Put>
+              </Get>
+            </New>
+          </Arg>
+        </Call>
+
       </New>
     </Arg>
   </Call>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/resources/login-service.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/resources/login-service.xml
@@ -1,26 +1,32 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <!-- =========================================================== -->
   <!-- Configure Authentication Login Service                      -->
   <!-- Realms may be configured for the entire server here, or     -->
   <!-- they can be configured for a specific web app in a context  -->
-  <!-- configuration (see $(jetty.home)/webapps/test.xml for an    -->
+  <!-- configuration (see $(jetty.base)/webapps/test.xml for an    -->
   <!-- example).                                                   -->
   <!-- =========================================================== -->
-    <Call id="ResourceFactory" class="org.eclipse.jetty.util.resource.ResourceFactory" name="of">
-    <Arg><Ref refid="Server" /></Arg>
+  <Call id="ResourceFactory" class="org.eclipse.jetty.util.resource.ResourceFactory" name="of">
+    <Arg>
+      <Ref refid="Server" />
+    </Arg>
     <Call id="realmResource" name="newResource">
-      <Arg><Property name="login.realm" default="src/test/resources/realm.properties"/></Arg>
+      <Arg>
+        <Property name="login.realm" default="src/test/resources/realm.properties" />
+      </Arg>
     </Call>
   </Call>
-  
+
   <Call name="addBean">
     <Arg>
       <New class="org.eclipse.jetty.security.HashLoginService">
         <Set name="name">Test Realm</Set>
-        <Set name="config"><Ref refid="realmResource"/></Set>
+        <Set name="config">
+          <Ref refid="realmResource" />
+        </Set>
         <Set name="hotReload">false</Set>
       </New>
     </Arg>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/resources/ssl.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/resources/ssl.xml
@@ -1,9 +1,14 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
+
 <Configure id="sslContextFactory" class="org.eclipse.jetty.util.ssl.SslContextFactory$Server">
 
-  <Set name="KeyStorePath"><Property name="jetty.sslContext.keyStorePath"/></Set>
-  <Set name="KeyStorePassword"><Property name="jetty.sslContext.keyStorePassword"/></Set>
+  <Set name="KeyStorePath">
+    <Property name="jetty.sslContext.keyStorePath" />
+  </Set>
+  <Set name="KeyStorePassword">
+    <Property name="jetty.sslContext.keyStorePassword" />
+  </Set>
 
   <!-- =========================================================== -->
   <!-- Create a TLS specific HttpConfiguration based on the        -->
@@ -12,7 +17,9 @@
   <!-- session information                                         -->
   <!-- =========================================================== -->
   <New id="sslHttpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
-    <Arg><Ref refid="httpConfig"/></Arg>
+    <Arg>
+      <Ref refid="httpConfig" />
+    </Arg>
     <Call name="addCustomizer">
       <Arg>
         <New class="org.eclipse.jetty.server.SecureRequestCustomizer">

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/resources/webapp-contexts/RFC2616/rfc2616-webapp.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/resources/webapp-contexts/RFC2616/rfc2616-webapp.xml
@@ -1,14 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
+
 <Configure class="org.eclipse.jetty.ee10.webapp.WebAppContext">
   <Set name="contextPath">/rfc2616-webapp</Set>
   <Set name="war"><Property name="test.webapps" default="target/webapps" />/ee10-test-rfc2616.war</Set>
   <Get name="ProtectedClassMatcher">
-    <Call name="add"><Arg>org.slf4j.</Arg></Call>
-    <Call name="add"><Arg>org.eclipse.jetty.logging.</Arg></Call>
+    <Call name="add">
+      <Arg>org.slf4j.</Arg>
+    </Call>
+    <Call name="add">
+      <Arg>org.eclipse.jetty.logging.</Arg>
+    </Call>
   </Get>
   <Get name="HiddenClassMatcher">
-    <Call name="add"><Arg>-org.slf4j.</Arg></Call>
-    <Call name="add"><Arg>-org.eclipse.jetty.logging.</Arg></Call>
+    <Call name="add">
+      <Arg>-org.slf4j.</Arg>
+    </Call>
+    <Call name="add">
+      <Arg>-org.eclipse.jetty.logging.</Arg>
+    </Call>
   </Get>
 </Configure>

--- a/jetty-ee11/jetty-ee11-osgi/jetty-ee11-osgi-boot/src/main/resources/jettyhome/etc/jetty-deploy.xml
+++ b/jetty-ee11/jetty-ee11-osgi/jetty-ee11-osgi-boot/src/main/resources/jettyhome/etc/jetty-deploy.xml
@@ -1,19 +1,19 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
-    <!-- =========================================================== -->
-    <!-- Configure the deployment manager                            -->
-    <!-- =========================================================== -->
-    <Call name="addBean">
-      <Arg>
-        <New id="DeploymentManager" class="org.eclipse.jetty.deploy.DeploymentManager">
-          <Set name="contexts">
-            <Ref refid="Contexts" />
-          </Set>
-        </New>
-      </Arg>
-    </Call>
+  <!-- =========================================================== -->
+  <!-- Configure the deployment manager                            -->
+  <!-- =========================================================== -->
+  <Call name="addBean">
+    <Arg>
+      <New id="DeploymentManager" class="org.eclipse.jetty.deploy.DeploymentManager">
+        <Set name="contexts">
+          <Ref refid="Contexts" />
+        </Set>
+      </New>
+    </Arg>
+  </Call>
 
 </Configure>

--- a/jetty-ee11/jetty-ee11-osgi/jetty-ee11-osgi-boot/src/main/resources/jettyhome/etc/jetty-http.xml
+++ b/jetty-ee11/jetty-ee11-osgi/jetty-ee11-osgi-boot/src/main/resources/jettyhome/etc/jetty-http.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->
-<!-- by adding an HTTP connector.                                   -->
+<!-- by adding an HTTP connector.                                  -->
 <!-- This configuration must be used in conjunction with jetty.xml -->
 <!-- ============================================================= -->
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <!-- =========================================================== -->
-  <!-- Add an HTTP Connector.                                       -->
+  <!-- Add an HTTP Connector.                                      -->
   <!-- Configure an o.e.j.server.ServerConnector with a single     -->
   <!-- HttpConnectionFactory instance using the common httpConfig  -->
   <!-- instance defined in jetty.xml                               -->
@@ -21,19 +21,29 @@
   <Call name="addConnector">
     <Arg>
       <New id="httpConnector" class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+                <Arg name="config">
+                  <Ref refid="httpConfig" />
+                </Arg>
               </New>
             </Item>
           </Array>
         </Arg>
-        <Set name="host"><Property name="jetty.http.host" /></Set>
-        <Set name="port"><Property name="jetty.http.port" default="80" /></Set>
-        <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" default="30000"/></Set>
+        <Set name="host">
+          <Property name="jetty.http.host" />
+        </Set>
+        <Set name="port">
+          <Property name="jetty.http.port" default="80" />
+        </Set>
+        <Set name="idleTimeout">
+          <Property name="jetty.http.idleTimeout" default="30000" />
+        </Set>
       </New>
     </Arg>
   </Call>

--- a/jetty-ee11/jetty-ee11-osgi/jetty-ee11-osgi-boot/src/main/resources/jettyhome/etc/jetty.xml
+++ b/jetty-ee11/jetty-ee11-osgi/jetty-ee11-osgi-boot/src/main/resources/jettyhome/etc/jetty.xml
@@ -1,65 +1,80 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
-
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure the Jetty Server                                      -->
 <!--                                                                 -->
 <!-- Documentation of this file format can be found at:              -->
-<!-- https://jetty.org/docs/                        -->
+<!-- https://jetty.org/docs/                                         -->
 <!-- =============================================================== -->
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
-    <!-- =========================================================== -->
-    <!-- Server Thread Pool                                          -->
-    <!-- =========================================================== -->
-    <Get name="ThreadPool">
-      <Set name="minThreads">10</Set>
-      <Set name="maxThreads">200</Set>
-    </Get>
+  <!-- =========================================================== -->
+  <!-- Server Thread Pool                                          -->
+  <!-- =========================================================== -->
+  <Get name="ThreadPool">
+    <Set name="minThreads">10</Set>
+    <Set name="maxThreads">200</Set>
+  </Get>
 
+  <!-- =========================================================== -->
+  <!-- Set handler Collection Structure                            -->
+  <!-- =========================================================== -->
+  <Set name="handler">
+    <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection" />
+  </Set>
 
-    <!-- =========================================================== -->
-    <!-- Set handler Collection Structure                            -->
-    <!-- =========================================================== -->
-    <Set name="handler">
-      <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection"/>
+  <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+    <Set name="secureScheme" property="jetty.httpConfig.secureScheme" />
+    <Set name="securePort" property="jetty.httpConfig.securePort" />
+    <Set name="outputBufferSize" property="jetty.httpConfig.outputBufferSize" />
+    <Set name="outputAggregationSize" property="jetty.httpConfig.outputAggregationSize" />
+    <Set name="requestHeaderSize" property="jetty.httpConfig.requestHeaderSize" />
+    <Set name="responseHeaderSize" property="jetty.httpConfig.responseHeaderSize" />
+    <Set name="sendServerVersion" property="jetty.httpConfig.sendServerVersion" />
+    <Set name="sendDateHeader" property="jetty.httpConfig.sendDateHeader" />
+    <Set name="headerCacheSize" property="jetty.httpConfig.headerCacheSize" />
+    <Set name="delayDispatchUntilContent" property="jetty.httpConfig.delayDispatchUntilContent" />
+    <Set name="maxErrorDispatches" property="jetty.httpConfig.maxErrorDispatches" />
+    <Set name="persistentConnectionsEnabled" property="jetty.httpConfig.persistentConnectionsEnabled" />
+    <Set name="requestCookieCompliance">
+      <Call class="org.eclipse.jetty.http.CookieCompliance" name="valueOf">
+        <Arg>
+          <Property name="jetty.httpConfig.requestCookieCompliance" default="RFC6265" />
+        </Arg>
+      </Call>
     </Set>
+    <Set name="responseCookieCompliance">
+      <Call class="org.eclipse.jetty.http.CookieCompliance" name="valueOf">
+        <Arg>
+          <Property name="jetty.httpConfig.responseCookieCompliance" default="RFC6265" />
+        </Arg>
+      </Call>
+    </Set>
+  </New>
 
-     <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
-      <Set name="secureScheme" property="jetty.httpConfig.secureScheme"/>
-      <Set name="securePort" property="jetty.httpConfig.securePort"/>
-      <Set name="outputBufferSize" property="jetty.httpConfig.outputBufferSize"/>
-      <Set name="outputAggregationSize" property="jetty.httpConfig.outputAggregationSize"/>
-      <Set name="requestHeaderSize" property="jetty.httpConfig.requestHeaderSize"/>
-      <Set name="responseHeaderSize" property="jetty.httpConfig.responseHeaderSize"/>
-      <Set name="sendServerVersion" property="jetty.httpConfig.sendServerVersion"/>
-      <Set name="sendDateHeader" property="jetty.httpConfig.sendDateHeader"/>
-      <Set name="headerCacheSize" property="jetty.httpConfig.headerCacheSize"/>
-      <Set name="delayDispatchUntilContent" property="jetty.httpConfig.delayDispatchUntilContent"/>
-      <Set name="maxErrorDispatches" property="jetty.httpConfig.maxErrorDispatches"/>
-      <Set name="persistentConnectionsEnabled" property="jetty.httpConfig.persistentConnectionsEnabled"/>
-      <Set name="requestCookieCompliance"><Call class="org.eclipse.jetty.http.CookieCompliance" name="valueOf"><Arg><Property name="jetty.httpConfig.requestCookieCompliance" default="RFC6265"/></Arg></Call></Set>
-      <Set name="responseCookieCompliance"><Call class="org.eclipse.jetty.http.CookieCompliance" name="valueOf"><Arg><Property name="jetty.httpConfig.responseCookieCompliance" default="RFC6265"/></Arg></Call></Set>
-    </New>
- 
+  <!-- =========================================================== -->
+  <!-- extra options                                               -->
+  <!-- =========================================================== -->
+  <Set name="stopAtShutdown" property="jetty.server.stopAtShutdown" />
+  <Set name="stopTimeout">
+    <Property name="jetty.server.stopTimeout" default="5000" />
+  </Set>
+  <Set name="dumpAfterStart" property="jetty.server.dumpAfterStart" />
+  <Set name="dumpBeforeStop" property="jetty.server.dumpBeforeStop" />
 
-    <!-- =========================================================== -->
-    <!-- extra options                                               -->
-    <!-- =========================================================== -->
-    <Set name="stopAtShutdown" property="jetty.server.stopAtShutdown"/>
-    <Set name="stopTimeout"><Property name="jetty.server.stopTimeout" default="5000"/></Set>
-    <Set name="dumpAfterStart" property="jetty.server.dumpAfterStart"/>
-    <Set name="dumpBeforeStop" property="jetty.server.dumpBeforeStop"/>
-
-    <Call class="java.lang.System" name="setProperty">
-      <Arg>java.naming.factory.initial</Arg>
-      <Arg><Property name="java.naming.factory.initial" default="org.eclipse.jetty.jndi.InitialContextFactory"/></Arg>
-    </Call>
-    <Call class="java.lang.System" name="setProperty">
-      <Arg>java.naming.factory.url.pkgs</Arg>
-      <Arg><Property name="java.naming.factory.url.pkgs" default="org.eclipse.jetty.jndi"/></Arg>
-    </Call>
+  <Call class="java.lang.System" name="setProperty">
+    <Arg>java.naming.factory.initial</Arg>
+    <Arg>
+      <Property name="java.naming.factory.initial" default="org.eclipse.jetty.jndi.InitialContextFactory" />
+    </Arg>
+  </Call>
+  <Call class="java.lang.System" name="setProperty">
+    <Arg>java.naming.factory.url.pkgs</Arg>
+    <Arg>
+      <Property name="java.naming.factory.url.pkgs" default="org.eclipse.jetty.jndi" />
+    </Arg>
+  </Call>
 
 </Configure>

--- a/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-alpn.xml
+++ b/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-alpn.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="sslConnector" class="org.eclipse.jetty.server.ServerConnector">
 
@@ -7,16 +7,20 @@
     <Arg>
       <New class="org.eclipse.jetty.server.SslConnectionFactory">
         <Arg name="next">alpn</Arg>
-        <Arg name="sslContextFactory"><Ref refid="sslContextFactory"/></Arg>
+        <Arg name="sslContextFactory">
+          <Ref refid="sslContextFactory" />
+        </Arg>
       </New>
     </Arg>
   </Call>
-  
+
   <Call name="addConnectionFactory">
     <Arg>
       <New id="alpn" class="org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory">
-        <Arg name="protocols" type="String"><Property name="jetty.alpn.protocols" default="h2,http/1.1" /></Arg>
-        <Set name="defaultProtocol" property="jetty.alpn.defaultProtocol"/>
+        <Arg name="protocols" type="String">
+          <Property name="jetty.alpn.protocols" default="h2,http/1.1" />
+        </Arg>
+        <Set name="defaultProtocol" property="jetty.alpn.defaultProtocol" />
       </New>
     </Arg>
   </Call>

--- a/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-deploy.xml
+++ b/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-deploy.xml
@@ -1,19 +1,19 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
-    <!-- =========================================================== -->
-    <!-- Configure the deployment manager                            -->
-    <!-- =========================================================== -->
-    <Call name="addBean">
-      <Arg>
-        <New id="DeploymentManager" class="org.eclipse.jetty.deploy.DeploymentManager">
-          <Set name="contexts">
-            <Ref refid="Contexts" />
-          </Set>
-        </New>
-      </Arg>
-    </Call>
+  <!-- =========================================================== -->
+  <!-- Configure the deployment manager                            -->
+  <!-- =========================================================== -->
+  <Call name="addBean">
+    <Arg>
+      <New id="DeploymentManager" class="org.eclipse.jetty.deploy.DeploymentManager">
+        <Set name="contexts">
+          <Ref refid="Contexts" />
+        </Set>
+      </New>
+    </Arg>
+  </Call>
 
 </Configure>

--- a/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-http-boot-with-annotations.xml
+++ b/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-http-boot-with-annotations.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->
-<!-- by adding an HTTP connector.                                   -->
+<!-- by adding an HTTP connector.                                  -->
 <!-- This configuration must be used in conjunction with jetty.xml -->
 <!-- ============================================================= -->
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <!-- =========================================================== -->
-  <!-- Add an HTTP Connector.                                       -->
+  <!-- Add an HTTP Connector.                                      -->
   <!-- Configure an o.e.j.server.ServerConnector with a single     -->
   <!-- HttpConnectionFactory instance using the common httpConfig  -->
   <!-- instance defined in jetty.xml                               -->
@@ -21,12 +21,16 @@
   <Call name="addConnector">
     <Arg>
       <New class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+                <Arg name="config">
+                  <Ref refid="httpConfig" />
+                </Arg>
               </New>
             </Item>
           </Array>
@@ -38,9 +42,13 @@
             </New>
           </Arg>
         </Call>
-        <Set name="host" property="jetty.http.host"/>
-        <Set name="port"><Property name="jetty.http.port" default="80"/></Set>
-        <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" default="30000"/></Set>
+        <Set name="host" property="jetty.http.host" />
+        <Set name="port">
+          <Property name="jetty.http.port" default="80" />
+        </Set>
+        <Set name="idleTimeout">
+          <Property name="jetty.http.idleTimeout" default="30000" />
+        </Set>
       </New>
     </Arg>
   </Call>

--- a/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-http-boot-with-bundle.xml
+++ b/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-http-boot-with-bundle.xml
@@ -1,9 +1,9 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->
-<!-- by adding a HTTP connector.                                   -->
+<!-- by adding an HTTP connector.                                  -->
 <!-- This configuration must be used in conjunction with jetty.xml -->
 <!-- ============================================================= -->
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
@@ -21,12 +21,16 @@
   <Call name="addConnector">
     <Arg>
       <New class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+                <Arg name="config">
+                  <Ref refid="httpConfig" />
+                </Arg>
               </New>
             </Item>
           </Array>
@@ -38,9 +42,13 @@
             </New>
           </Arg>
         </Call>
-        <Set name="host" property="jetty.http.host"/>
-        <Set name="port"><Property name="jetty.http.port" default="80"/></Set>
-        <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" default="30000"/></Set>
+        <Set name="host" property="jetty.http.host" />
+        <Set name="port">
+          <Property name="jetty.http.port" default="80" />
+        </Set>
+        <Set name="idleTimeout">
+          <Property name="jetty.http.idleTimeout" default="30000" />
+        </Set>
       </New>
     </Arg>
   </Call>

--- a/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-http-boot-with-jakarta-websocket.xml
+++ b/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-http-boot-with-jakarta-websocket.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->
-<!-- by adding an HTTP connector.                                   -->
+<!-- by adding an HTTP connector.                                  -->
 <!-- This configuration must be used in conjunction with jetty.xml -->
 <!-- ============================================================= -->
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <!-- =========================================================== -->
-  <!-- Add an HTTP Connector.                                       -->
+  <!-- Add an HTTP Connector.                                      -->
   <!-- Configure an o.e.j.server.ServerConnector with a single     -->
   <!-- HttpConnectionFactory instance using the common httpConfig  -->
   <!-- instance defined in jetty.xml                               -->
@@ -21,12 +21,16 @@
   <Call name="addConnector">
     <Arg>
       <New class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+                <Arg name="config">
+                  <Ref refid="httpConfig" />
+                </Arg>
               </New>
             </Item>
           </Array>
@@ -38,9 +42,13 @@
             </New>
           </Arg>
         </Call>
-        <Set name="host" property="jetty.http.host"/>
-        <Set name="port"><Property name="jetty.http.port" default="80"/></Set>
-        <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" default="30000"/></Set>
+        <Set name="host" property="jetty.http.host" />
+        <Set name="port">
+          <Property name="jetty.http.port" default="80" />
+        </Set>
+        <Set name="idleTimeout">
+          <Property name="jetty.http.idleTimeout" default="30000" />
+        </Set>
       </New>
     </Arg>
   </Call>

--- a/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-http-boot-with-jsp.xml
+++ b/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-http-boot-with-jsp.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->
-<!-- by adding an HTTP connector.                                   -->
+<!-- by adding an HTTP connector.                                  -->
 <!-- This configuration must be used in conjunction with jetty.xml -->
 <!-- ============================================================= -->
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <!-- =========================================================== -->
-  <!-- Add an HTTP Connector.                                       -->
+  <!-- Add an HTTP Connector.                                      -->
   <!-- Configure an o.e.j.server.ServerConnector with a single     -->
   <!-- HttpConnectionFactory instance using the common httpConfig  -->
   <!-- instance defined in jetty.xml                               -->
@@ -21,12 +21,16 @@
   <Call name="addConnector">
     <Arg>
       <New class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+                <Arg name="config">
+                  <Ref refid="httpConfig" />
+                </Arg>
               </New>
             </Item>
           </Array>
@@ -38,9 +42,13 @@
             </New>
           </Arg>
         </Call>
-        <Set name="host" property="jetty.http.host"/>
-        <Set name="port"><Property name="jetty.http.port" default="80"/></Set>
-        <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" default="30000"/></Set>
+        <Set name="host" property="jetty.http.host" />
+        <Set name="port">
+          <Property name="jetty.http.port" default="80" />
+        </Set>
+        <Set name="idleTimeout">
+          <Property name="jetty.http.idleTimeout" default="30000" />
+        </Set>
       </New>
     </Arg>
   </Call>

--- a/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-http-boot-with-resources.xml
+++ b/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-http-boot-with-resources.xml
@@ -1,14 +1,15 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->
-<!-- by adding an HTTP connector.                                   -->
+<!-- by adding an HTTP connector.                                  -->
 <!-- This configuration must be used in conjunction with jetty.xml -->
 <!-- ============================================================= -->
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <!-- =========================================================== -->
-  <!-- Add an HTTP Connector.                                       -->
+  <!-- Add an HTTP Connector.                                      -->
   <!-- Configure an o.e.j.server.ServerConnector with a single     -->
   <!-- HttpConnectionFactory instance using the common httpConfig  -->
   <!-- instance defined in jetty.xml                               -->
@@ -20,12 +21,16 @@
   <Call name="addConnector">
     <Arg>
       <New class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+                <Arg name="config">
+                  <Ref refid="httpConfig" />
+                </Arg>
               </New>
             </Item>
           </Array>
@@ -37,9 +42,15 @@
             </New>
           </Arg>
         </Call>
-        <Set name="host"><Property name="jetty.http.host" /></Set>
-        <Set name="port"><Property name="jetty.http.port" default="80" /></Set>
-        <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" default="30000"/></Set>
+        <Set name="host">
+          <Property name="jetty.http.host" />
+        </Set>
+        <Set name="port">
+          <Property name="jetty.http.port" default="80" />
+        </Set>
+        <Set name="idleTimeout">
+          <Property name="jetty.http.idleTimeout" default="30000" />
+        </Set>
       </New>
     </Arg>
   </Call>

--- a/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-http-boot-with-websocket.xml
+++ b/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-http-boot-with-websocket.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->
-<!-- by adding an HTTP connector.                                   -->
+<!-- by adding an HTTP connector.                                  -->
 <!-- This configuration must be used in conjunction with jetty.xml -->
 <!-- ============================================================= -->
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <!-- =========================================================== -->
-  <!-- Add an HTTP Connector.                                       -->
+  <!-- Add an HTTP Connector.                                      -->
   <!-- Configure an o.e.j.server.ServerConnector with a single     -->
   <!-- HttpConnectionFactory instance using the common httpConfig  -->
   <!-- instance defined in jetty.xml                               -->
@@ -21,12 +21,16 @@
   <Call name="addConnector">
     <Arg>
       <New class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+                <Arg name="config">
+                  <Ref refid="httpConfig" />
+                </Arg>
               </New>
             </Item>
           </Array>
@@ -38,9 +42,13 @@
             </New>
           </Arg>
         </Call>
-        <Set name="host" property="jetty.http.host"/>
-        <Set name="port"><Property name="jetty.http.port" default="80"/></Set>
-        <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" default="30000"/></Set>
+        <Set name="host" property="jetty.http.host" />
+        <Set name="port">
+          <Property name="jetty.http.port" default="80" />
+        </Set>
+        <Set name="idleTimeout">
+          <Property name="jetty.http.idleTimeout" default="30000" />
+        </Set>
       </New>
     </Arg>
   </Call>

--- a/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-http-connector-listener.xml
+++ b/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-http-connector-listener.xml
@@ -1,9 +1,9 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->
-<!-- by adding an HTTP connector.                                   -->
+<!-- by adding an HTTP connector.                                  -->
 <!-- This configuration must be used in conjunction with jetty.xml -->
 <!-- ============================================================= -->
 <Configure id="Server" class="org.eclipse.jetty.server.Server">

--- a/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-http2-jdk9.xml
+++ b/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-http2-jdk9.xml
@@ -1,24 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
-<!-- Configure an HTTP2 on the ssl connector.                       -->
+<!-- Configure an HTTP2 on the ssl connector.                      -->
 <!-- ============================================================= -->
 <Configure id="sslConnector" class="org.eclipse.jetty.server.ServerConnector">
   <Call name="addConnectionFactory">
     <Arg>
       <New class="org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory">
-        <Arg name="config"><Ref refid="sslHttpConfig"/></Arg>
-        <Set name="maxConcurrentStreams" property="jetty.http2.maxConcurrentStreams"/>
-        <Set name="initialStreamRecvWindow" property="jetty.http2.initialStreamRecvWindow"/>
-        <Set name="initialSessionRecvWindow" property="jetty.http2.initialSessionRecvWindow"/>
+        <Arg name="config">
+          <Ref refid="sslHttpConfig" />
+        </Arg>
+        <Set name="maxConcurrentStreams" property="jetty.http2.maxConcurrentStreams" />
+        <Set name="initialStreamRecvWindow" property="jetty.http2.initialStreamRecvWindow" />
+        <Set name="initialSessionRecvWindow" property="jetty.http2.initialSessionRecvWindow" />
       </New>
     </Arg>
   </Call>
 
   <Ref refid="sslContextFactory">
     <Set name="CipherComparator">
-      <Get class="org.eclipse.jetty.http2.HTTP2Cipher" name="COMPARATOR"/>
+      <Get class="org.eclipse.jetty.http2.HTTP2Cipher" name="COMPARATOR" />
     </Set>
     <Set name="useCipherSuitesOrder">true</Set>
   </Ref>

--- a/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-http2.xml
+++ b/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-http2.xml
@@ -1,18 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="sslConnector" class="org.eclipse.jetty.server.ServerConnector">
   <Call name="addConnectionFactory">
     <Arg>
       <New class="org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory">
-        <Arg name="config"><Ref refid="sslHttpConfig"/></Arg>
-        <Set name="maxConcurrentStreams" property="jetty.http2.maxConcurrentStreams"/>
-        <Set name="initialStreamRecvWindow" property="jetty.http2.initialStreamRecvWindow"/>
-        <Set name="initialSessionRecvWindow" property="jetty.http2.initialSessionRecvWindow"/>
-        <Set name="maxSettingsKeys"><Property name="jetty.http2.maxSettingsKeys" default="64"/></Set>
+        <Arg name="config">
+          <Ref refid="sslHttpConfig" />
+        </Arg>
+        <Set name="maxConcurrentStreams" property="jetty.http2.maxConcurrentStreams" />
+        <Set name="initialStreamRecvWindow" property="jetty.http2.initialStreamRecvWindow" />
+        <Set name="initialSessionRecvWindow" property="jetty.http2.initialSessionRecvWindow" />
+        <Set name="maxSettingsKeys">
+          <Property name="jetty.http2.maxSettingsKeys" default="64" />
+        </Set>
         <Set name="rateControlFactory">
           <New class="org.eclipse.jetty.http2.WindowRateControl$Factory">
-            <Arg type="int"><Property name="jetty.http2.rateControl.maxEventsPerSecond" default="50"/></Arg>
+            <Arg type="int">
+              <Property name="jetty.http2.rateControl.maxEventsPerSecond" default="50" />
+            </Arg>
           </New>
         </Set>
       </New>
@@ -21,7 +27,7 @@
 
   <Ref refid="sslContextFactory">
     <Set name="CipherComparator">
-      <Get class="org.eclipse.jetty.http2.HTTP2Cipher" name="COMPARATOR"/>
+      <Get class="org.eclipse.jetty.http2.HTTP2Cipher" name="COMPARATOR" />
     </Set>
     <Set name="useCipherSuitesOrder">true</Set>
   </Ref>

--- a/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-https.xml
+++ b/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-https.xml
@@ -1,8 +1,8 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
-<!-- Configure an HTTPS connector.                                  -->
+<!-- Configure an HTTPS connector.                                 -->
 <!-- This configuration must be used in conjunction with jetty.xml -->
 <!-- and jetty-ssl.xml.                                            -->
 <!-- ============================================================= -->
@@ -12,7 +12,9 @@
     <Arg>
       <New class="org.eclipse.jetty.server.SslConnectionFactory">
         <Arg name="next">http/1.1</Arg>
-        <Arg name="sslContextFactory"><Ref refid="sslContextFactory"/></Arg>
+        <Arg name="sslContextFactory">
+          <Ref refid="sslContextFactory" />
+        </Arg>
       </New>
     </Arg>
   </Call>
@@ -20,9 +22,11 @@
   <Call name="addConnectionFactory">
     <Arg>
       <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-        <Arg name="config"><Ref refid="sslHttpConfig" /></Arg>
+        <Arg name="config">
+          <Ref refid="sslHttpConfig" />
+        </Arg>
       </New>
     </Arg>
   </Call>
-  
+
 </Configure>

--- a/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-ssl-context.xml
+++ b/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-ssl-context.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call name="addBean">
@@ -7,18 +8,30 @@
         <Set name="Provider" property="jetty.sslContext.provider" />
         <Set name="KeyStorePath">
           <Call name="resolvePath" class="org.eclipse.jetty.xml.XmlConfiguration">
-            <Arg><Property name="jetty.base"/></Arg>
-            <Arg><Property name="jetty.sslContext.keyStorePath" default="etc/keystore.p12" /></Arg>
+            <Arg>
+              <Property name="jetty.base" />
+            </Arg>
+            <Arg>
+              <Property name="jetty.sslContext.keyStorePath" default="etc/keystore.p12" />
+            </Arg>
           </Call>
         </Set>
-        <Set name="KeyStorePassword"><Property name="jetty.sslContext.keyStorePassword" /></Set>
+        <Set name="KeyStorePassword">
+          <Property name="jetty.sslContext.keyStorePassword" />
+        </Set>
         <Set name="KeyStoreType" property="jetty.sslContext.keyStoreType" />
         <Set name="KeyStoreProvider" property="jetty.sslContext.keyStoreProvider" />
-        <Set name="KeyManagerPassword"><Property name="jetty.sslContext.keyManagerPassword" /></Set>
+        <Set name="KeyManagerPassword">
+          <Property name="jetty.sslContext.keyManagerPassword" />
+        </Set>
         <Set name="TrustStorePath">
           <Call name="resolvePath" class="org.eclipse.jetty.xml.XmlConfiguration">
-            <Arg><Property name="jetty.base"/></Arg>
-            <Arg><Property name="jetty.sslContext.trustStorePath" deprecated="jetty.sslContext.trustStoreAbsolutePath,jetty.truststore" /></Arg>
+            <Arg>
+              <Property name="jetty.base" />
+            </Arg>
+            <Arg>
+              <Property name="jetty.sslContext.trustStorePath" deprecated="jetty.sslContext.trustStoreAbsolutePath,jetty.truststore" />
+            </Arg>
           </Call>
         </Set>
         <Set name="TrustStorePassword" property="jetty.sslContext.trustStorePassword" />

--- a/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-ssl.xml
+++ b/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-ssl.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Base SSL configuration                                        -->
@@ -11,12 +11,18 @@
   <!-- =========================================================== -->
   <!-- Add an SSL Connector with no protocol factories              -->
   <!-- =========================================================== -->
-  <Call  name="addConnector">
+  <Call name="addConnector">
     <Arg>
       <New id="sslConnector" class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
-        <Arg name="acceptors" type="int"><Property name="jetty.ssl.acceptors" default="1"/></Arg>
-        <Arg name="selectors" type="int"><Property name="jetty.ssl.selectors" default="-1"/></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
+        <Arg name="acceptors" type="int">
+          <Property name="jetty.ssl.acceptors" default="1" />
+        </Arg>
+        <Arg name="selectors" type="int">
+          <Property name="jetty.ssl.selectors" default="-1" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <!-- uncomment to support proxy protocol
@@ -26,18 +32,28 @@
           </Array>
         </Arg>
 
-        <Set name="host" property="jetty.ssl.host"/>
-        <Set name="port"><Property name="jetty.ssl.port" default="8443" /></Set>
-        <Set name="idleTimeout"><Property name="jetty.ssl.idleTimeout" default="30000"/></Set>
-        <Set name="acceptorPriorityDelta" property="jetty.ssl.acceptorPriorityDelta"/>
-        <Set name="acceptQueueSize" property="jetty.ssl.acceptQueueSize"/>
-        <Set name="reuseAddress"><Property name="jetty.ssl.reuseAddress" default="true"/></Set>
-        <Set name="reusePort"><Property name="jetty.ssl.reusePort" default="false"/></Set>
-        <Set name="acceptedTcpNoDelay"><Property name="jetty.ssl.acceptedTcpNoDelay" default="true"/></Set>
+        <Set name="host" property="jetty.ssl.host" />
+        <Set name="port">
+          <Property name="jetty.ssl.port" default="8443" />
+        </Set>
+        <Set name="idleTimeout">
+          <Property name="jetty.ssl.idleTimeout" default="30000" />
+        </Set>
+        <Set name="acceptorPriorityDelta" property="jetty.ssl.acceptorPriorityDelta" />
+        <Set name="acceptQueueSize" property="jetty.ssl.acceptQueueSize" />
+        <Set name="reuseAddress">
+          <Property name="jetty.ssl.reuseAddress" default="true" />
+        </Set>
+        <Set name="reusePort">
+          <Property name="jetty.ssl.reusePort" default="false" />
+        </Set>
+        <Set name="acceptedTcpNoDelay">
+          <Property name="jetty.ssl.acceptedTcpNoDelay" default="true" />
+        </Set>
         <Set name="acceptedReceiveBufferSize" property="jetty.ssl.acceptedReceiveBufferSize" />
         <Set name="acceptedSendBufferSize" property="jetty.ssl.acceptedSendBufferSize" />
         <Get name="SelectorManager">
-          <Set name="connectTimeout" property="jetty.ssl.connectTimeout"/>
+          <Set name="connectTimeout" property="jetty.ssl.connectTimeout" />
         </Get>
       </New>
     </Arg>
@@ -50,14 +66,24 @@
   <!-- session information                                         -->
   <!-- =========================================================== -->
   <New id="sslHttpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
-    <Arg><Ref refid="httpConfig"/></Arg>
+    <Arg>
+      <Ref refid="httpConfig" />
+    </Arg>
     <Call name="addCustomizer">
       <Arg>
         <New class="org.eclipse.jetty.server.SecureRequestCustomizer">
-          <Arg name="sniRequired" type="boolean"><Property name="jetty.ssl.sniRequired" default="false"/></Arg>
-          <Arg name="sniHostCheck" type="boolean"><Property name="jetty.ssl.sniHostCheck" default="true"/></Arg>
-          <Arg name="stsMaxAgeSeconds" type="int"><Property name="jetty.ssl.stsMaxAgeSeconds" default="-1"/></Arg>
-          <Arg name="stsIncludeSubdomains" type="boolean"><Property name="jetty.ssl.stsIncludeSubdomains" default="false"/></Arg>
+          <Arg name="sniRequired" type="boolean">
+            <Property name="jetty.ssl.sniRequired" default="false" />
+          </Arg>
+          <Arg name="sniHostCheck" type="boolean">
+            <Property name="jetty.ssl.sniHostCheck" default="true" />
+          </Arg>
+          <Arg name="stsMaxAgeSeconds" type="int">
+            <Property name="jetty.ssl.stsMaxAgeSeconds" default="-1" />
+          </Arg>
+          <Arg name="stsIncludeSubdomains" type="boolean">
+            <Property name="jetty.ssl.stsIncludeSubdomains" default="false" />
+          </Arg>
         </New>
       </Arg>
     </Call>

--- a/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-testrealm.xml
+++ b/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-testrealm.xml
@@ -1,17 +1,21 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
+
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
-    <!-- =========================================================== -->
-    <!-- Configure Authentication Login Service                      -->
-    <!-- Realms may be configured for the entire server here, or     -->
-    <!-- they can be configured for a specific web app in a context  -->
-    <!-- configuration (see $(jetty.home)/webapps/test.xml for an    -->
-    <!-- example).                                                   -->
-    <!-- =========================================================== -->
-    <Call id="ResourceFactory" class="org.eclipse.jetty.util.resource.ResourceFactory" name="of">
-    <Arg><Ref refid="Server" /></Arg>
+  <!-- =========================================================== -->
+  <!-- Configure Authentication Login Service                      -->
+  <!-- Realms may be configured for the entire server here, or     -->
+  <!-- they can be configured for a specific web app in a context  -->
+  <!-- configuration (see $(jetty.base)/webapps/test.xml for an    -->
+  <!-- example).                                                   -->
+  <!-- =========================================================== -->
+  <Call id="ResourceFactory" class="org.eclipse.jetty.util.resource.ResourceFactory" name="of">
+    <Arg>
+      <Ref refid="Server" />
+    </Arg>
     <Call id="realmResource" name="newResource">
-        <Arg><Property name="jetty.demo.realm" default="src/test/config"/>/etc/realm.properties</Arg>
+      <Arg><Property name="jetty.demo.realm" default="src/test/config" />/etc/realm.properties
+      </Arg>
     </Call>
   </Call>
 
@@ -19,7 +23,9 @@
     <Arg>
       <New class="org.eclipse.jetty.security.HashLoginService">
         <Set name="name">Test Realm</Set>
-        <Set name="config"><Ref refid="realmResource"/></Set>
+        <Set name="config">
+          <Ref refid="realmResource" />
+        </Set>
         <Set name="hotReload">false</Set>
       </New>
     </Arg>

--- a/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-with-custom-class.xml
+++ b/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-with-custom-class.xml
@@ -1,12 +1,11 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
-
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure the Jetty Server                                      -->
 <!--                                                                 -->
 <!-- Documentation of this file format can be found at:              -->
-<!-- http://wiki.eclipse.org/Jetty/Reference/jetty.xml_syntax        -->
+<!-- https://jetty.org/docs/                                         -->
 <!-- =============================================================== -->
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">

--- a/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty.xml
+++ b/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty.xml
@@ -1,65 +1,80 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
-
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure the Jetty Server                                      -->
 <!--                                                                 -->
 <!-- Documentation of this file format can be found at:              -->
-<!-- https://jetty.org/docs/                        -->
+<!-- https://jetty.org/docs/                                         -->
 <!-- =============================================================== -->
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
-    <!-- =========================================================== -->
-    <!-- Server Thread Pool                                          -->
-    <!-- =========================================================== -->
-    <Get name="ThreadPool">
-      <Set name="minThreads">10</Set>
-      <Set name="maxThreads">200</Set>
-    </Get>
+  <!-- =========================================================== -->
+  <!-- Server Thread Pool                                          -->
+  <!-- =========================================================== -->
+  <Get name="ThreadPool">
+    <Set name="minThreads">10</Set>
+    <Set name="maxThreads">200</Set>
+  </Get>
 
+  <!-- =========================================================== -->
+  <!-- Set handler Collection Structure                            -->
+  <!-- =========================================================== -->
+  <Set name="handler">
+    <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection" />
+  </Set>
 
-    <!-- =========================================================== -->
-    <!-- Set handler Collection Structure                            -->
-    <!-- =========================================================== -->
-    <Set name="handler">
-      <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection"/>
+  <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+    <Set name="secureScheme" property="jetty.httpConfig.secureScheme" />
+    <Set name="securePort" property="jetty.httpConfig.securePort" />
+    <Set name="outputBufferSize" property="jetty.httpConfig.outputBufferSize" />
+    <Set name="outputAggregationSize" property="jetty.httpConfig.outputAggregationSize" />
+    <Set name="requestHeaderSize" property="jetty.httpConfig.requestHeaderSize" />
+    <Set name="responseHeaderSize" property="jetty.httpConfig.responseHeaderSize" />
+    <Set name="sendServerVersion" property="jetty.httpConfig.sendServerVersion" />
+    <Set name="sendDateHeader" property="jetty.httpConfig.sendDateHeader" />
+    <Set name="headerCacheSize" property="jetty.httpConfig.headerCacheSize" />
+    <Set name="delayDispatchUntilContent" property="jetty.httpConfig.delayDispatchUntilContent" />
+    <Set name="maxErrorDispatches" property="jetty.httpConfig.maxErrorDispatches" />
+    <Set name="persistentConnectionsEnabled" property="jetty.httpConfig.persistentConnectionsEnabled" />
+    <Set name="requestCookieCompliance">
+      <Call class="org.eclipse.jetty.http.CookieCompliance" name="valueOf">
+        <Arg>
+          <Property name="jetty.httpConfig.requestCookieCompliance" default="RFC6265" />
+        </Arg>
+      </Call>
     </Set>
+    <Set name="responseCookieCompliance">
+      <Call class="org.eclipse.jetty.http.CookieCompliance" name="valueOf">
+        <Arg>
+          <Property name="jetty.httpConfig.responseCookieCompliance" default="RFC6265" />
+        </Arg>
+      </Call>
+    </Set>
+  </New>
 
-     <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
-      <Set name="secureScheme" property="jetty.httpConfig.secureScheme"/>
-      <Set name="securePort" property="jetty.httpConfig.securePort"/>
-      <Set name="outputBufferSize" property="jetty.httpConfig.outputBufferSize"/>
-      <Set name="outputAggregationSize" property="jetty.httpConfig.outputAggregationSize"/>
-      <Set name="requestHeaderSize" property="jetty.httpConfig.requestHeaderSize"/>
-      <Set name="responseHeaderSize" property="jetty.httpConfig.responseHeaderSize"/>
-      <Set name="sendServerVersion" property="jetty.httpConfig.sendServerVersion"/>
-      <Set name="sendDateHeader" property="jetty.httpConfig.sendDateHeader"/>
-      <Set name="headerCacheSize" property="jetty.httpConfig.headerCacheSize"/>
-      <Set name="delayDispatchUntilContent" property="jetty.httpConfig.delayDispatchUntilContent"/>
-      <Set name="maxErrorDispatches" property="jetty.httpConfig.maxErrorDispatches"/>
-      <Set name="persistentConnectionsEnabled" property="jetty.httpConfig.persistentConnectionsEnabled"/>
-      <Set name="requestCookieCompliance"><Call class="org.eclipse.jetty.http.CookieCompliance" name="valueOf"><Arg><Property name="jetty.httpConfig.requestCookieCompliance" default="RFC6265"/></Arg></Call></Set>
-      <Set name="responseCookieCompliance"><Call class="org.eclipse.jetty.http.CookieCompliance" name="valueOf"><Arg><Property name="jetty.httpConfig.responseCookieCompliance" default="RFC6265"/></Arg></Call></Set>
-    </New>
- 
+  <!-- =========================================================== -->
+  <!-- extra options                                               -->
+  <!-- =========================================================== -->
+  <Set name="stopAtShutdown" property="jetty.server.stopAtShutdown" />
+  <Set name="stopTimeout">
+    <Property name="jetty.server.stopTimeout" default="5000" />
+  </Set>
+  <Set name="dumpAfterStart" property="jetty.server.dumpAfterStart" />
+  <Set name="dumpBeforeStop" property="jetty.server.dumpBeforeStop" />
 
-    <!-- =========================================================== -->
-    <!-- extra options                                               -->
-    <!-- =========================================================== -->
-    <Set name="stopAtShutdown" property="jetty.server.stopAtShutdown"/>
-    <Set name="stopTimeout"><Property name="jetty.server.stopTimeout" default="5000"/></Set>
-    <Set name="dumpAfterStart" property="jetty.server.dumpAfterStart"/>
-    <Set name="dumpBeforeStop" property="jetty.server.dumpBeforeStop"/>
-
-    <Call class="java.lang.System" name="setProperty">
-      <Arg>java.naming.factory.initial</Arg>
-      <Arg><Property name="java.naming.factory.initial" default="org.eclipse.jetty.jndi.InitialContextFactory"/></Arg>
-    </Call>
-    <Call class="java.lang.System" name="setProperty">
-      <Arg>java.naming.factory.url.pkgs</Arg>
-      <Arg><Property name="java.naming.factory.url.pkgs" default="org.eclipse.jetty.jndi"/></Arg>
-    </Call>
+  <Call class="java.lang.System" name="setProperty">
+    <Arg>java.naming.factory.initial</Arg>
+    <Arg>
+      <Property name="java.naming.factory.initial" default="org.eclipse.jetty.jndi.InitialContextFactory" />
+    </Arg>
+  </Call>
+  <Call class="java.lang.System" name="setProperty">
+    <Arg>java.naming.factory.url.pkgs</Arg>
+    <Arg>
+      <Property name="java.naming.factory.url.pkgs" default="org.eclipse.jetty.jndi" />
+    </Arg>
+  </Call>
 
 </Configure>

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/resources/DefaultHandler.xml
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/resources/DefaultHandler.xml
@@ -1,12 +1,12 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
     <Set name="secureScheme">https</Set>
     <Set name="securePort">
-      <Property name="jetty.secure.port" default="8443"/>
+      <Property name="jetty.secure.port" default="8443" />
     </Set>
     <Set name="outputBufferSize">32768</Set>
     <Set name="requestHeaderSize">8192</Set>
@@ -25,9 +25,10 @@
         <Arg>
           <New id="defcontext" class="org.eclipse.jetty.server.handler.ContextHandler">
             <Set name="contextPath">/tests</Set>
-            <Set name="baseResourceAsString"><Property name="test.docroot.base"/>/default</Set>
+            <Set name="baseResourceAsString"><Property name="test.docroot.base" />/default
+            </Set>
             <Set name="Handler">
-              <New id="reshandler" class="org.eclipse.jetty.server.handler.ResourceHandler"/>
+              <New id="reshandler" class="org.eclipse.jetty.server.handler.ResourceHandler" />
             </Set>
             <Set name="DisplayName">default</Set>
           </New>

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/resources/NIOHttp.xml
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/resources/NIOHttp.xml
@@ -1,28 +1,34 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
-    <!-- =========================================================== -->
-    <!-- Set connectors                                              -->
-    <!-- =========================================================== -->
-    
-    <Call name="addConnector">
+  <!-- =========================================================== -->
+  <!-- Set connectors                                              -->
+  <!-- =========================================================== -->
+
+  <Call name="addConnector">
     <Arg>
       <New class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+                <Arg name="config">
+                  <Ref refid="httpConfig" />
+                </Arg>
               </New>
             </Item>
           </Array>
         </Arg>
         <Set name="host" property="jetty.http.host" />
         <Set name="port" property="jetty.http.port" />
-        <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" default="30000"/></Set>
+        <Set name="idleTimeout">
+          <Property name="jetty.http.idleTimeout" default="30000" />
+        </Set>
       </New>
     </Arg>
   </Call>

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/resources/NIOHttps.xml
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/resources/NIOHttps.xml
@@ -1,26 +1,32 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
-    <!-- =========================================================== -->
-    <!-- Set connectors                                              -->
-    <!-- =========================================================== -->
+  <!-- =========================================================== -->
+  <!-- Set connectors                                              -->
+  <!-- =========================================================== -->
 
-    <Call name="addConnector">
+  <Call name="addConnector">
     <Arg>
       <New class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.SslConnectionFactory">
                 <Arg name="next">http/1.1</Arg>
-                <Arg name="sslContextFactory"><Ref refid="sslContextFactory"/></Arg>
+                <Arg name="sslContextFactory">
+                  <Ref refid="sslContextFactory" />
+                </Arg>
               </New>
             </Item>
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-                <Arg name="config"><Ref refid="sslHttpConfig"/></Arg>
+                <Arg name="config">
+                  <Ref refid="sslHttpConfig" />
+                </Arg>
               </New>
             </Item>
           </Array>

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/resources/RFC2616Base.xml
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/resources/RFC2616Base.xml
@@ -1,99 +1,107 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure the Jetty Server                                      -->
 <!--                                                                 -->
 <!-- Documentation of this file format can be found at:              -->
-<!-- http://docs.codehaus.org/display/JETTY/jetty.xml                -->
-<!--                                                                 -->
+<!-- https://jetty.org/docs/                                         -->
 <!-- =============================================================== -->
-
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
-    <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
-      <Set name="secureScheme">https</Set>
-      <Set name="securePort"><Property name="jetty.secure.port" default="8443" /></Set>
-      <Set name="outputBufferSize">32768</Set>
-      <Set name="requestHeaderSize">8192</Set>
-      <Set name="responseHeaderSize">8192</Set>
-      <Set name="sendServerVersion">true</Set>
-      <Set name="sendDateHeader">true</Set>
-      <Set name="headerCacheSize">1024</Set>
+  <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+    <Set name="secureScheme">https</Set>
+    <Set name="securePort">
+      <Property name="jetty.secure.port" default="8443" />
+    </Set>
+    <Set name="outputBufferSize">32768</Set>
+    <Set name="requestHeaderSize">8192</Set>
+    <Set name="responseHeaderSize">8192</Set>
+    <Set name="sendServerVersion">true</Set>
+    <Set name="sendDateHeader">true</Set>
+    <Set name="headerCacheSize">1024</Set>
 
-      <Set name="httpCompliance">
-        <Call class="org.eclipse.jetty.http.HttpCompliance" name="from">
-          <Arg>RFC2616</Arg>
-        </Call>
-      </Set>
-
-      <!-- Uncomment to enable handling of X-Forwarded- style headers
-      <Call name="addCustomizer">
-        <Arg><New class="org.eclipse.jetty.server.ForwardedRequestCustomizer"/></Arg>
+    <Set name="httpCompliance">
+      <Call class="org.eclipse.jetty.http.HttpCompliance" name="from">
+        <Arg>RFC2616</Arg>
       </Call>
-      -->
-    </New>
-
-    <!-- =========================================================== -->
-    <!-- Set handler Collection Structure                            -->
-    <!-- =========================================================== -->
-    <Set name="handler">
-      <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection">
-        <Arg>
-          <Array type="org.eclipse.jetty.server.handler.ContextHandler">
-            <Item>
-              <New id="vcontexts" class="org.eclipse.jetty.server.handler.ContextHandler">
-                <Set name="contextPath">/tests</Set>
-                <Set name="VirtualHosts">
-                  <Array type="java.lang.String">
-                    <Item>VirtualHost</Item>
-                  </Array>
-                </Set>
-                <Set name="BaseResourceAsString"><Property name="test.docroot.base"/>/virtualhost</Set>
-                <Set name="Handler"><New id="reshandler1" class="org.eclipse.jetty.server.handler.ResourceHandler"/></Set>
-                <Set name="DisplayName">virtual</Set>
-              </New>
-            </Item>
-            <Item>
-              <New id="defcontext" class="org.eclipse.jetty.server.handler.ContextHandler">
-                <Set name="contextPath">/tests</Set>
-                <Set name="BaseResourceAsString"><Property name="test.docroot.base"/>/default</Set>
-                <Set name="Handler"><New id="reshandler2" class="org.eclipse.jetty.server.handler.ResourceHandler"/></Set>
-                <Set name="DisplayName">default</Set>
-              </New>
-            </Item>
-            <Item>
-              <New id="echocontext" class="org.eclipse.jetty.server.handler.ContextHandler">
-                <Set name="contextPath">/echo</Set>
-                <Set name="Handler"><New id="echohandler" class="org.eclipse.jetty.ee11.test.rfcs.RFC2616BaseTest$EchoHandler"/></Set>
-                <Set name="DisplayName">echo</Set>
-              </New>
-            </Item>
-          </Array>
-        </Arg>
-      </New>
     </Set>
 
-    <Call id="Environment" class="org.eclipse.jetty.util.component.Environment" name="ensure">
-      <Arg>ee11</Arg>
+    <!-- Uncomment to enable handling of X-Forwarded- style headers
+    <Call name="addCustomizer">
+      <Arg><New class="org.eclipse.jetty.server.ForwardedRequestCustomizer"/></Arg>
     </Call>
-    <Ref refid="Environment">
-      <Call name="setAttribute">
-        <Arg>contextHandlerClass</Arg>
-        <Arg>org.eclipse.jetty.ee11.webapp.WebAppContext</Arg>
-      </Call>
-    </Ref>
+    -->
+  </New>
 
-    <Call name="addBean">
+  <!-- =========================================================== -->
+  <!-- Set handler Collection Structure                            -->
+  <!-- =========================================================== -->
+  <Set name="handler">
+    <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection">
       <Arg>
-        <New id="DeploymentManager" class="org.eclipse.jetty.deploy.DeploymentManager">
-          <Set name="contexts">
-            <Ref refid="Contexts" />
-          </Set>
-        
-          <Call name="addAppProvider">
-           <Arg>
+        <Array type="org.eclipse.jetty.server.handler.ContextHandler">
+          <Item>
+            <New id="vcontexts" class="org.eclipse.jetty.server.handler.ContextHandler">
+              <Set name="contextPath">/tests</Set>
+              <Set name="VirtualHosts">
+                <Array type="java.lang.String">
+                  <Item>VirtualHost</Item>
+                </Array>
+              </Set>
+              <Set name="BaseResourceAsString"><Property name="test.docroot.base" />/virtualhost
+              </Set>
+              <Set name="Handler">
+                <New id="reshandler1" class="org.eclipse.jetty.server.handler.ResourceHandler" />
+              </Set>
+              <Set name="DisplayName">virtual</Set>
+            </New>
+          </Item>
+          <Item>
+            <New id="defcontext" class="org.eclipse.jetty.server.handler.ContextHandler">
+              <Set name="contextPath">/tests</Set>
+              <Set name="BaseResourceAsString"><Property name="test.docroot.base" />/default
+              </Set>
+              <Set name="Handler">
+                <New id="reshandler2" class="org.eclipse.jetty.server.handler.ResourceHandler" />
+              </Set>
+              <Set name="DisplayName">default</Set>
+            </New>
+          </Item>
+          <Item>
+            <New id="echocontext" class="org.eclipse.jetty.server.handler.ContextHandler">
+              <Set name="contextPath">/echo</Set>
+              <Set name="Handler">
+                <New id="echohandler" class="org.eclipse.jetty.ee11.test.rfcs.RFC2616BaseTest$EchoHandler" />
+              </Set>
+              <Set name="DisplayName">echo</Set>
+            </New>
+          </Item>
+        </Array>
+      </Arg>
+    </New>
+  </Set>
+
+  <Call id="Environment" class="org.eclipse.jetty.util.component.Environment" name="ensure">
+    <Arg>ee11</Arg>
+  </Call>
+  <Ref refid="Environment">
+    <Call name="setAttribute">
+      <Arg>contextHandlerClass</Arg>
+      <Arg>org.eclipse.jetty.ee11.webapp.WebAppContext</Arg>
+    </Call>
+  </Ref>
+
+  <Call name="addBean">
+    <Arg>
+      <New id="DeploymentManager" class="org.eclipse.jetty.deploy.DeploymentManager">
+        <Set name="contexts">
+          <Ref refid="Contexts" />
+        </Set>
+
+        <Call name="addAppProvider">
+          <Arg>
             <New id="WebAppProvider" class="org.eclipse.jetty.deploy.providers.ContextProvider">
               <Set name="environmentName">ee11</Set>
               <Set name="monitoredDirName">
@@ -112,21 +120,21 @@
                   </Property>
                 </Put>
                 <Put name="jetty.deploy.webInfScanJarPattern">
-                  <Property name="jetty.deploy.webInfScanJarPattern"/>
+                  <Property name="jetty.deploy.webInfScanJarPattern" />
                 </Put>
                 <Put name="jetty.deploy.servletContainerInitializerExclusionPattern">
-                  <Property name="jetty.deploy.servletContainerInitializerExclusionPattern"/>
+                  <Property name="jetty.deploy.servletContainerInitializerExclusionPattern" />
                 </Put>
                 <Put name="jetty.deploy.servletContainerInitializerOrder">
-                  <Property name="jetty.deploy.servletContainerInitializerOrder"/>
+                  <Property name="jetty.deploy.servletContainerInitializerOrder" />
                 </Put>
               </Get>
             </New>
           </Arg>
         </Call>
-       </New>
-      </Arg>
-    </Call>
+      </New>
+    </Arg>
+  </Call>
 
   <!-- =========================================================== -->
   <!-- extra options                                               -->

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/resources/RFC2616_Filters.xml
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/resources/RFC2616_Filters.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/resources/RFC2616_Redirects.xml
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/resources/RFC2616_Redirects.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <!-- =========================================================== -->

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/resources/add-jetty-test-webapp.xml
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/resources/add-jetty-test-webapp.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection">
   <Call name="addHandler">

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/resources/basic-server.xml
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/resources/basic-server.xml
@@ -1,11 +1,11 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
     <Set name="secureScheme">https</Set>
     <Set name="securePort">
-      <Property name="jetty.secure.port" default="8443"/>
+      <Property name="jetty.secure.port" default="8443" />
     </Set>
     <Set name="outputBufferSize">32768</Set>
     <Set name="requestHeaderSize">8192</Set>

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/resources/deploy.xml
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/resources/deploy.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call id="Environment" class="org.eclipse.jetty.util.component.Environment" name="ensure">
@@ -18,43 +18,41 @@
         <Set name="contexts">
           <Ref refid="Contexts" />
         </Set>
-        
+
         <Call name="addAppProvider">
-         <Arg>
-          <New id="WebAppProvider" class="org.eclipse.jetty.deploy.providers.ContextProvider">
-            <Set name="environmentName">ee11</Set>
-            <Set name="monitoredDirName">
-              <Call name="resolvePath" class="org.eclipse.jetty.xml.XmlConfiguration">
-                <Arg>target</Arg>
-                <Arg>webapps</Arg>
-              </Call>
-            </Set>
+          <Arg>
+            <New id="WebAppProvider" class="org.eclipse.jetty.deploy.providers.ContextProvider">
+              <Set name="environmentName">ee11</Set>
+              <Set name="monitoredDirName">
+                <Call name="resolvePath" class="org.eclipse.jetty.xml.XmlConfiguration">
+                  <Arg>target</Arg>
+                  <Arg>webapps</Arg>
+                </Call>
+              </Set>
 
-            <Set name="scanInterval">1</Set>
-            <Set name="extractWars">true</Set>
+              <Set name="scanInterval">1</Set>
+              <Set name="extractWars">true</Set>
 
-            <Get name="properties">
-              <Put name="jetty.deploy.containerScanJarPattern">
-                <Property name="jetty.deploy.containerScanJarPattern">
-                  <Default>.*/jakarta.servlet-api-[^/]*\.jar$|.*jakarta.servlet.jsp.jstl-.*\.jar$</Default>
-                </Property>
-              </Put>
-              <Put name="jetty.deploy.webInfScanJarPattern">
-                <Property name="jetty.deploy.webInfScanJarPattern"/>
-              </Put>
-              <Put name="jetty.deploy.servletContainerInitializerExclusionPattern">
-                <Property name="jetty.deploy.servletContainerInitializerExclusionPattern"/>
-              </Put>
-              <Put name="jetty.deploy.servletContainerInitializerOrder">
-                <Property name="jetty.deploy.servletContainerInitializerOrder"/>
-              </Put>
-            </Get>
-          </New>
-        </Arg>
-      </Call>
-        
-        
-        
+              <Get name="properties">
+                <Put name="jetty.deploy.containerScanJarPattern">
+                  <Property name="jetty.deploy.containerScanJarPattern">
+                    <Default>.*/jakarta.servlet-api-[^/]*\.jar$|.*jakarta.servlet.jsp.jstl-.*\.jar$</Default>
+                  </Property>
+                </Put>
+                <Put name="jetty.deploy.webInfScanJarPattern">
+                  <Property name="jetty.deploy.webInfScanJarPattern" />
+                </Put>
+                <Put name="jetty.deploy.servletContainerInitializerExclusionPattern">
+                  <Property name="jetty.deploy.servletContainerInitializerExclusionPattern" />
+                </Put>
+                <Put name="jetty.deploy.servletContainerInitializerOrder">
+                  <Property name="jetty.deploy.servletContainerInitializerOrder" />
+                </Put>
+              </Get>
+            </New>
+          </Arg>
+        </Call>
+
       </New>
     </Arg>
   </Call>

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/resources/login-service.xml
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/resources/login-service.xml
@@ -1,26 +1,32 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <!-- =========================================================== -->
   <!-- Configure Authentication Login Service                      -->
   <!-- Realms may be configured for the entire server here, or     -->
   <!-- they can be configured for a specific web app in a context  -->
-  <!-- configuration (see $(jetty.home)/webapps/test.xml for an    -->
+  <!-- configuration (see $(jetty.base)/webapps/test.xml for an    -->
   <!-- example).                                                   -->
   <!-- =========================================================== -->
-    <Call id="ResourceFactory" class="org.eclipse.jetty.util.resource.ResourceFactory" name="of">
-    <Arg><Ref refid="Server" /></Arg>
+  <Call id="ResourceFactory" class="org.eclipse.jetty.util.resource.ResourceFactory" name="of">
+    <Arg>
+      <Ref refid="Server" />
+    </Arg>
     <Call id="realmResource" name="newResource">
-      <Arg><Property name="login.realm" default="src/test/resources/realm.properties"/></Arg>
+      <Arg>
+        <Property name="login.realm" default="src/test/resources/realm.properties" />
+      </Arg>
     </Call>
   </Call>
-  
+
   <Call name="addBean">
     <Arg>
       <New class="org.eclipse.jetty.security.HashLoginService">
         <Set name="name">Test Realm</Set>
-        <Set name="config"><Ref refid="realmResource"/></Set>
+        <Set name="config">
+          <Ref refid="realmResource" />
+        </Set>
         <Set name="hotReload">false</Set>
       </New>
     </Arg>

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/resources/ssl.xml
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/resources/ssl.xml
@@ -1,9 +1,14 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
+
 <Configure id="sslContextFactory" class="org.eclipse.jetty.util.ssl.SslContextFactory$Server">
 
-  <Set name="KeyStorePath"><Property name="jetty.sslContext.keyStorePath"/></Set>
-  <Set name="KeyStorePassword"><Property name="jetty.sslContext.keyStorePassword"/></Set>
+  <Set name="KeyStorePath">
+    <Property name="jetty.sslContext.keyStorePath" />
+  </Set>
+  <Set name="KeyStorePassword">
+    <Property name="jetty.sslContext.keyStorePassword" />
+  </Set>
 
   <!-- =========================================================== -->
   <!-- Create a TLS specific HttpConfiguration based on the        -->
@@ -12,7 +17,9 @@
   <!-- session information                                         -->
   <!-- =========================================================== -->
   <New id="sslHttpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
-    <Arg><Ref refid="httpConfig"/></Arg>
+    <Arg>
+      <Ref refid="httpConfig" />
+    </Arg>
     <Call name="addCustomizer">
       <Arg>
         <New class="org.eclipse.jetty.server.SecureRequestCustomizer">

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/resources/webapp-contexts/RFC2616/rfc2616-webapp.xml
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/resources/webapp-contexts/RFC2616/rfc2616-webapp.xml
@@ -1,14 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
+
 <Configure class="org.eclipse.jetty.ee11.webapp.WebAppContext">
   <Set name="contextPath">/rfc2616-webapp</Set>
   <Set name="war"><Property name="test.webapps" default="target/webapps" />/ee11-test-rfc2616.war</Set>
   <Get name="ProtectedClassMatcher">
-    <Call name="add"><Arg>org.slf4j.</Arg></Call>
-    <Call name="add"><Arg>org.eclipse.jetty.logging.</Arg></Call>
+    <Call name="add">
+      <Arg>org.slf4j.</Arg>
+    </Call>
+    <Call name="add">
+      <Arg>org.eclipse.jetty.logging.</Arg>
+    </Call>
   </Get>
   <Get name="HiddenClassMatcher">
-    <Call name="add"><Arg>-org.slf4j.</Arg></Call>
-    <Call name="add"><Arg>-org.eclipse.jetty.logging.</Arg></Call>
+    <Call name="add">
+      <Arg>-org.slf4j.</Arg>
+    </Call>
+    <Call name="add">
+      <Arg>-org.eclipse.jetty.logging.</Arg>
+    </Call>
   </Get>
 </Configure>

--- a/jetty-ee9/jetty-ee9-osgi/jetty-ee9-osgi-boot/src/main/resources/jettyhome/etc/jetty-deploy.xml
+++ b/jetty-ee9/jetty-ee9-osgi/jetty-ee9-osgi-boot/src/main/resources/jettyhome/etc/jetty-deploy.xml
@@ -1,19 +1,19 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
-    <!-- =========================================================== -->
-    <!-- Configure the deployment manager                            -->
-    <!-- =========================================================== -->
-    <Call name="addBean">
-      <Arg>
-        <New id="DeploymentManager" class="org.eclipse.jetty.deploy.DeploymentManager">
-          <Set name="contexts">
-            <Ref refid="Contexts" />
-          </Set>
-        </New>
-      </Arg>
-    </Call>
+  <!-- =========================================================== -->
+  <!-- Configure the deployment manager                            -->
+  <!-- =========================================================== -->
+  <Call name="addBean">
+    <Arg>
+      <New id="DeploymentManager" class="org.eclipse.jetty.deploy.DeploymentManager">
+        <Set name="contexts">
+          <Ref refid="Contexts" />
+        </Set>
+      </New>
+    </Arg>
+  </Call>
 
 </Configure>

--- a/jetty-ee9/jetty-ee9-osgi/jetty-ee9-osgi-boot/src/main/resources/jettyhome/etc/jetty-http.xml
+++ b/jetty-ee9/jetty-ee9-osgi/jetty-ee9-osgi-boot/src/main/resources/jettyhome/etc/jetty-http.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->
-<!-- by adding an HTTP connector.                                   -->
+<!-- by adding an HTTP connector.                                  -->
 <!-- This configuration must be used in conjunction with jetty.xml -->
 <!-- ============================================================= -->
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <!-- =========================================================== -->
-  <!-- Add an HTTP Connector.                                       -->
+  <!-- Add an HTTP Connector.                                      -->
   <!-- Configure an o.e.j.server.ServerConnector with a single     -->
   <!-- HttpConnectionFactory instance using the common httpConfig  -->
   <!-- instance defined in jetty.xml                               -->
@@ -21,19 +21,29 @@
   <Call name="addConnector">
     <Arg>
       <New class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+                <Arg name="config">
+                  <Ref refid="httpConfig" />
+                </Arg>
               </New>
             </Item>
           </Array>
         </Arg>
-        <Set name="host"><Property name="jetty.http.host" /></Set>
-        <Set name="port"><Property name="jetty.http.port" default="80" /></Set>
-        <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" default="30000"/></Set>
+        <Set name="host">
+          <Property name="jetty.http.host" />
+        </Set>
+        <Set name="port">
+          <Property name="jetty.http.port" default="80" />
+        </Set>
+        <Set name="idleTimeout">
+          <Property name="jetty.http.idleTimeout" default="30000" />
+        </Set>
       </New>
     </Arg>
   </Call>

--- a/jetty-ee9/jetty-ee9-osgi/jetty-ee9-osgi-boot/src/main/resources/jettyhome/etc/jetty.xml
+++ b/jetty-ee9/jetty-ee9-osgi/jetty-ee9-osgi-boot/src/main/resources/jettyhome/etc/jetty.xml
@@ -1,63 +1,110 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure the Jetty Server                                      -->
 <!--                                                                 -->
 <!-- Documentation of this file format can be found at:              -->
-<!-- https://jetty.org/docs/                    -->
+<!-- https://jetty.org/docs/                                         -->
 <!-- =============================================================== -->
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
-    <!-- =========================================================== -->
-    <!-- Server Thread Pool                                          -->
-    <!-- =========================================================== -->
-    <Get name="ThreadPool">
-      <Set name="minThreads">10</Set>
-      <Set name="maxThreads">200</Set>
-    </Get>
+  <!-- =========================================================== -->
+  <!-- Server Thread Pool                                          -->
+  <!-- =========================================================== -->
+  <Get name="ThreadPool">
+    <Set name="minThreads">10</Set>
+    <Set name="maxThreads">200</Set>
+  </Get>
 
+  <!-- =========================================================== -->
+  <!-- Set handler Collection Structure                            -->
+  <!-- =========================================================== -->
+  <Set name="handler">
+    <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection" />
+  </Set>
 
-    <!-- =========================================================== -->
-    <!-- Set handler Collection Structure                            -->
-    <!-- =========================================================== -->
-    <Set name="handler">
-      <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection"/>
+  <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+    <Set name="secureScheme">
+      <Property name="jetty.httpConfig.secureScheme" default="https" />
     </Set>
+    <Set name="securePort">
+      <Property name="jetty.httpConfig.securePort" default="8443" />
+    </Set>
+    <Set name="outputBufferSize">
+      <Property name="jetty.httpConfig.outputBufferSize" default="32768" />
+    </Set>
+    <Set name="outputAggregationSize">
+      <Property name="jetty.httpConfig.outputAggregationSize" default="8192" />
+    </Set>
+    <Set name="requestHeaderSize">
+      <Property name="jetty.httpConfig.requestHeaderSize" default="8192" />
+    </Set>
+    <Set name="responseHeaderSize">
+      <Property name="jetty.httpConfig.responseHeaderSize" default="8192" />
+    </Set>
+    <Set name="sendServerVersion">
+      <Property name="jetty.httpConfig.sendServerVersion" default="true" />
+    </Set>
+    <Set name="sendDateHeader">
+      <Property name="jetty.httpConfig.sendDateHeader" default="false" />
+    </Set>
+    <Set name="headerCacheSize">
+      <Property name="jetty.httpConfig.headerCacheSize" default="1024" />
+    </Set>
+    <Set name="delayDispatchUntilContent">
+      <Property name="jetty.httpConfig.delayDispatchUntilContent" default="true" />
+    </Set>
+    <Set name="maxErrorDispatches">
+      <Property name="jetty.httpConfig.maxErrorDispatches" default="10" />
+    </Set>
+    <Set name="persistentConnectionsEnabled">
+      <Property name="jetty.httpConfig.persistentConnectionsEnabled" default="true" />
+    </Set>
+    <Set name="requestCookieCompliance">
+      <Call class="org.eclipse.jetty.http.CookieCompliance" name="valueOf">
+        <Arg>
+          <Property name="jetty.httpConfig.requestCookieCompliance" default="RFC6265" />
+        </Arg>
+      </Call>
+    </Set>
+    <Set name="responseCookieCompliance">
+      <Call class="org.eclipse.jetty.http.CookieCompliance" name="valueOf">
+        <Arg>
+          <Property name="jetty.httpConfig.responseCookieCompliance" default="RFC6265" />
+        </Arg>
+      </Call>
+    </Set>
+  </New>
 
-    <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
-      <Set name="secureScheme"><Property name="jetty.httpConfig.secureScheme" default="https" /></Set>
-      <Set name="securePort"><Property name="jetty.httpConfig.securePort" default="8443" /></Set>
-      <Set name="outputBufferSize"><Property name="jetty.httpConfig.outputBufferSize" default="32768" /></Set>
-      <Set name="outputAggregationSize"><Property name="jetty.httpConfig.outputAggregationSize" default="8192" /></Set>
-      <Set name="requestHeaderSize"><Property name="jetty.httpConfig.requestHeaderSize" default="8192" /></Set>
-      <Set name="responseHeaderSize"><Property name="jetty.httpConfig.responseHeaderSize" default="8192" /></Set>
-      <Set name="sendServerVersion"><Property name="jetty.httpConfig.sendServerVersion" default="true" /></Set>
-      <Set name="sendDateHeader"><Property name="jetty.httpConfig.sendDateHeader" default="false" /></Set>
-      <Set name="headerCacheSize"><Property name="jetty.httpConfig.headerCacheSize" default="1024" /></Set>
-      <Set name="delayDispatchUntilContent"><Property name="jetty.httpConfig.delayDispatchUntilContent" default="true"/></Set>
-      <Set name="maxErrorDispatches"><Property name="jetty.httpConfig.maxErrorDispatches" default="10"/></Set>
-      <Set name="persistentConnectionsEnabled"><Property name="jetty.httpConfig.persistentConnectionsEnabled" default="true"/></Set>
-      <Set name="requestCookieCompliance"><Call class="org.eclipse.jetty.http.CookieCompliance" name="valueOf"><Arg><Property name="jetty.httpConfig.requestCookieCompliance" default="RFC6265"/></Arg></Call></Set>
-      <Set name="responseCookieCompliance"><Call class="org.eclipse.jetty.http.CookieCompliance" name="valueOf"><Arg><Property name="jetty.httpConfig.responseCookieCompliance" default="RFC6265"/></Arg></Call></Set>
-    </New>
+  <!-- =========================================================== -->
+  <!-- extra options                                               -->
+  <!-- =========================================================== -->
+  <Set name="stopAtShutdown">
+    <Property name="jetty.server.stopAtShutdown" default="true" />
+  </Set>
+  <Set name="stopTimeout">
+    <Property name="jetty.server.stopTimeout" default="5000" />
+  </Set>
+  <Set name="dumpAfterStart">
+    <Property name="jetty.server.dumpAfterStart" default="false" />
+  </Set>
+  <Set name="dumpBeforeStop">
+    <Property name="jetty.server.dumpBeforeStop" default="false" />
+  </Set>
 
-    <!-- =========================================================== -->
-    <!-- extra options                                               -->
-    <!-- =========================================================== -->
-    <Set name="stopAtShutdown"><Property name="jetty.server.stopAtShutdown" default="true"/></Set>
-    <Set name="stopTimeout"><Property name="jetty.server.stopTimeout" default="5000"/></Set>
-    <Set name="dumpAfterStart"><Property name="jetty.server.dumpAfterStart" default="false"/></Set>
-    <Set name="dumpBeforeStop"><Property name="jetty.server.dumpBeforeStop" default="false"/></Set>
-
-    <Call class="java.lang.System" name="setProperty">
-      <Arg>java.naming.factory.initial</Arg>
-      <Arg><Property name="java.naming.factory.initial" default="org.eclipse.jetty.jndi.InitialContextFactory"/></Arg>
-    </Call>
-    <Call class="java.lang.System" name="setProperty">
-      <Arg>java.naming.factory.url.pkgs</Arg>
-      <Arg><Property name="java.naming.factory.url.pkgs" default="org.eclipse.jetty.jndi"/></Arg>
-    </Call>
+  <Call class="java.lang.System" name="setProperty">
+    <Arg>java.naming.factory.initial</Arg>
+    <Arg>
+      <Property name="java.naming.factory.initial" default="org.eclipse.jetty.jndi.InitialContextFactory" />
+    </Arg>
+  </Call>
+  <Call class="java.lang.System" name="setProperty">
+    <Arg>java.naming.factory.url.pkgs</Arg>
+    <Arg>
+      <Property name="java.naming.factory.url.pkgs" default="org.eclipse.jetty.jndi" />
+    </Arg>
+  </Call>
 
 </Configure>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-alpn.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-alpn.xml
@@ -7,16 +7,20 @@
     <Arg>
       <New class="org.eclipse.jetty.server.SslConnectionFactory">
         <Arg name="next">alpn</Arg>
-        <Arg name="sslContextFactory"><Ref refid="sslContextFactory"/></Arg>
+        <Arg name="sslContextFactory">
+          <Ref refid="sslContextFactory" />
+        </Arg>
       </New>
     </Arg>
   </Call>
-  
+
   <Call name="addConnectionFactory">
     <Arg>
       <New id="alpn" class="org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory">
-        <Arg name="protocols" type="String"><Property name="jetty.alpn.protocols" default="h2,http/1.1" /></Arg>
-        <Set name="defaultProtocol" property="jetty.alpn.defaultProtocol"/>
+        <Arg name="protocols" type="String">
+          <Property name="jetty.alpn.protocols" default="h2,http/1.1" />
+        </Arg>
+        <Set name="defaultProtocol" property="jetty.alpn.defaultProtocol" />
       </New>
     </Arg>
   </Call>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-deploy.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-deploy.xml
@@ -1,23 +1,23 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
-    <!-- =========================================================== -->
-    <!-- Configure the deployment manager                            -->
-    <!-- =========================================================== -->
-    <Call name="addBean">
-      <Arg>
-        <New id="DeploymentManager" class="org.eclipse.jetty.deploy.DeploymentManager">
-          <Set name="contexts">
-            <Ref refid="Contexts" />
-          </Set>
-          <!-- Call name="setContextAttribute">
-            <Arg>org.eclipse.jetty.server.webapp.ContainerIncludeJarPattern</Arg>
-            <Arg>.*/jsp-api-[^/]*\.jar$|.*/jsp-[^/]*\.jar$</Arg>
-          </Call -->
-        </New>
-      </Arg>
-    </Call>
+  <!-- =========================================================== -->
+  <!-- Configure the deployment manager                            -->
+  <!-- =========================================================== -->
+  <Call name="addBean">
+    <Arg>
+      <New id="DeploymentManager" class="org.eclipse.jetty.deploy.DeploymentManager">
+        <Set name="contexts">
+          <Ref refid="Contexts" />
+        </Set>
+        <!-- Call name="setContextAttribute">
+          <Arg>org.eclipse.jetty.server.webapp.ContainerIncludeJarPattern</Arg>
+          <Arg>.*/jsp-api-[^/]*\.jar$|.*/jsp-[^/]*\.jar$</Arg>
+        </Call -->
+      </New>
+    </Arg>
+  </Call>
 
 </Configure>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-http-boot-context-as-service.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-http-boot-context-as-service.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->
-<!-- by adding an HTTP connector.                                   -->
+<!-- by adding an HTTP connector.                                  -->
 <!-- This configuration must be used in conjunction with jetty.xml -->
 <!-- ============================================================= -->
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <!-- =========================================================== -->
-  <!-- Add an HTTP Connector.                                       -->
+  <!-- Add an HTTP Connector.                                      -->
   <!-- Configure an o.e.j.server.ServerConnector with a single     -->
   <!-- HttpConnectionFactory instance using the common httpConfig  -->
   <!-- instance defined in jetty.xml                               -->
@@ -21,12 +21,16 @@
   <Call name="addConnector">
     <Arg>
       <New class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+                <Arg name="config">
+                  <Ref refid="httpConfig" />
+                </Arg>
               </New>
             </Item>
           </Array>
@@ -38,9 +42,13 @@
             </New>
           </Arg>
         </Call>
-        <Set name="host" property="jetty.http.host"/>
-        <Set name="port"><Property name="jetty.http.port" default="80"/></Set>
-        <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" default="30000"/></Set>
+        <Set name="host" property="jetty.http.host" />
+        <Set name="port">
+          <Property name="jetty.http.port" default="80" />
+        </Set>
+        <Set name="idleTimeout">
+          <Property name="jetty.http.idleTimeout" default="30000" />
+        </Set>
       </New>
     </Arg>
   </Call>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-http-boot-webapp-as-service.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-http-boot-webapp-as-service.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->
-<!-- by adding an HTTP connector.                                   -->
+<!-- by adding an HTTP connector.                                  -->
 <!-- This configuration must be used in conjunction with jetty.xml -->
 <!-- ============================================================= -->
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <!-- =========================================================== -->
-  <!-- Add an HTTP Connector.                                       -->
+  <!-- Add an HTTP Connector.                                      -->
   <!-- Configure an o.e.j.server.ServerConnector with a single     -->
   <!-- HttpConnectionFactory instance using the common httpConfig  -->
   <!-- instance defined in jetty.xml                               -->
@@ -21,12 +21,16 @@
   <Call name="addConnector">
     <Arg>
       <New class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+                <Arg name="config">
+                  <Ref refid="httpConfig" />
+                </Arg>
               </New>
             </Item>
           </Array>
@@ -38,9 +42,13 @@
             </New>
           </Arg>
         </Call>
-        <Set name="host" property="jetty.http.host"/>
-        <Set name="port"><Property name="jetty.http.port" default="80"/></Set>
-        <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" default="30000"/></Set>
+        <Set name="host" property="jetty.http.host" />
+        <Set name="port">
+          <Property name="jetty.http.port" default="80" />
+        </Set>
+        <Set name="idleTimeout">
+          <Property name="jetty.http.idleTimeout" default="30000" />
+        </Set>
       </New>
     </Arg>
   </Call>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-http-boot-with-annotations.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-http-boot-with-annotations.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->
-<!-- by adding an HTTP connector.                                   -->
+<!-- by adding an HTTP connector.                                  -->
 <!-- This configuration must be used in conjunction with jetty.xml -->
 <!-- ============================================================= -->
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <!-- =========================================================== -->
-  <!-- Add an HTTP Connector.                                       -->
+  <!-- Add an HTTP Connector.                                      -->
   <!-- Configure an o.e.j.server.ServerConnector with a single     -->
   <!-- HttpConnectionFactory instance using the common httpConfig  -->
   <!-- instance defined in jetty.xml                               -->
@@ -21,12 +21,16 @@
   <Call name="addConnector">
     <Arg>
       <New class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+                <Arg name="config">
+                  <Ref refid="httpConfig" />
+                </Arg>
               </New>
             </Item>
           </Array>
@@ -38,9 +42,13 @@
             </New>
           </Arg>
         </Call>
-        <Set name="host" property="jetty.http.host"/>
-        <Set name="port"><Property name="jetty.http.port" default="80"/></Set>
-        <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" default="30000"/></Set>
+        <Set name="host" property="jetty.http.host" />
+        <Set name="port">
+          <Property name="jetty.http.port" default="80" />
+        </Set>
+        <Set name="idleTimeout">
+          <Property name="jetty.http.idleTimeout" default="30000" />
+        </Set>
       </New>
     </Arg>
   </Call>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-http-boot-with-bundle.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-http-boot-with-bundle.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
@@ -21,12 +21,16 @@
   <Call name="addConnector">
     <Arg>
       <New class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+                <Arg name="config">
+                  <Ref refid="httpConfig" />
+                </Arg>
               </New>
             </Item>
           </Array>
@@ -38,9 +42,13 @@
             </New>
           </Arg>
         </Call>
-        <Set name="host" property="jetty.http.host"/>
-        <Set name="port"><Property name="jetty.http.port" default="80"/></Set>
-        <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" default="30000"/></Set>
+        <Set name="host" property="jetty.http.host" />
+        <Set name="port">
+          <Property name="jetty.http.port" default="80" />
+        </Set>
+        <Set name="idleTimeout">
+          <Property name="jetty.http.idleTimeout" default="30000" />
+        </Set>
       </New>
     </Arg>
   </Call>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-http-boot-with-jakarta-websocket.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-http-boot-with-jakarta-websocket.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->
-<!-- by adding an HTTP connector.                                   -->
+<!-- by adding an HTTP connector.                                  -->
 <!-- This configuration must be used in conjunction with jetty.xml -->
 <!-- ============================================================= -->
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <!-- =========================================================== -->
-  <!-- Add an HTTP Connector.                                       -->
+  <!-- Add an HTTP Connector.                                      -->
   <!-- Configure an o.e.j.server.ServerConnector with a single     -->
   <!-- HttpConnectionFactory instance using the common httpConfig  -->
   <!-- instance defined in jetty.xml                               -->
@@ -21,12 +21,16 @@
   <Call name="addConnector">
     <Arg>
       <New class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+                <Arg name="config">
+                  <Ref refid="httpConfig" />
+                </Arg>
               </New>
             </Item>
           </Array>
@@ -38,9 +42,13 @@
             </New>
           </Arg>
         </Call>
-        <Set name="host" property="jetty.http.host"/>
-        <Set name="port"><Property name="jetty.http.port" default="80"/></Set>
-        <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" default="30000"/></Set>
+        <Set name="host" property="jetty.http.host" />
+        <Set name="port">
+          <Property name="jetty.http.port" default="80" />
+        </Set>
+        <Set name="idleTimeout">
+          <Property name="jetty.http.idleTimeout" default="30000" />
+        </Set>
       </New>
     </Arg>
   </Call>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-http-boot-with-jsp.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-http-boot-with-jsp.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->
-<!-- by adding an HTTP connector.                                   -->
+<!-- by adding an HTTP connector.                                  -->
 <!-- This configuration must be used in conjunction with jetty.xml -->
 <!-- ============================================================= -->
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <!-- =========================================================== -->
-  <!-- Add an HTTP Connector.                                       -->
+  <!-- Add an HTTP Connector.                                      -->
   <!-- Configure an o.e.j.server.ServerConnector with a single     -->
   <!-- HttpConnectionFactory instance using the common httpConfig  -->
   <!-- instance defined in jetty.xml                               -->
@@ -21,12 +21,16 @@
   <Call name="addConnector">
     <Arg>
       <New class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+                <Arg name="config">
+                  <Ref refid="httpConfig" />
+                </Arg>
               </New>
             </Item>
           </Array>
@@ -38,9 +42,13 @@
             </New>
           </Arg>
         </Call>
-        <Set name="host" property="jetty.http.host"/>
-        <Set name="port"><Property name="jetty.http.port" default="80"/></Set>
-        <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" default="30000"/></Set>
+        <Set name="host" property="jetty.http.host" />
+        <Set name="port">
+          <Property name="jetty.http.port" default="80" />
+        </Set>
+        <Set name="idleTimeout">
+          <Property name="jetty.http.idleTimeout" default="30000" />
+        </Set>
       </New>
     </Arg>
   </Call>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-http-boot-with-resources.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-http-boot-with-resources.xml
@@ -1,14 +1,15 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->
-<!-- by adding an HTTP connector.                                   -->
+<!-- by adding an HTTP connector.                                  -->
 <!-- This configuration must be used in conjunction with jetty.xml -->
 <!-- ============================================================= -->
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <!-- =========================================================== -->
-  <!-- Add an HTTP Connector.                                       -->
+  <!-- Add an HTTP Connector.                                      -->
   <!-- Configure an o.e.j.server.ServerConnector with a single     -->
   <!-- HttpConnectionFactory instance using the common httpConfig  -->
   <!-- instance defined in jetty.xml                               -->
@@ -20,12 +21,16 @@
   <Call name="addConnector">
     <Arg>
       <New class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+                <Arg name="config">
+                  <Ref refid="httpConfig" />
+                </Arg>
               </New>
             </Item>
           </Array>
@@ -37,9 +42,15 @@
             </New>
           </Arg>
         </Call>
-        <Set name="host"><Property name="jetty.http.host" /></Set>
-        <Set name="port"><Property name="jetty.http.port" default="80" /></Set>
-        <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" default="30000"/></Set>
+        <Set name="host">
+          <Property name="jetty.http.host" />
+        </Set>
+        <Set name="port">
+          <Property name="jetty.http.port" default="80" />
+        </Set>
+        <Set name="idleTimeout">
+          <Property name="jetty.http.idleTimeout" default="30000" />
+        </Set>
       </New>
     </Arg>
   </Call>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-http-boot-with-websocket.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-http-boot-with-websocket.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->
-<!-- by adding an HTTP connector.                                   -->
+<!-- by adding an HTTP connector.                                  -->
 <!-- This configuration must be used in conjunction with jetty.xml -->
 <!-- ============================================================= -->
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <!-- =========================================================== -->
-  <!-- Add an HTTP Connector.                                       -->
+  <!-- Add an HTTP Connector.                                      -->
   <!-- Configure an o.e.j.server.ServerConnector with a single     -->
   <!-- HttpConnectionFactory instance using the common httpConfig  -->
   <!-- instance defined in jetty.xml                               -->
@@ -21,12 +21,16 @@
   <Call name="addConnector">
     <Arg>
       <New class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+                <Arg name="config">
+                  <Ref refid="httpConfig" />
+                </Arg>
               </New>
             </Item>
           </Array>
@@ -38,9 +42,13 @@
             </New>
           </Arg>
         </Call>
-        <Set name="host" property="jetty.http.host"/>
-        <Set name="port"><Property name="jetty.http.port" default="80"/></Set>
-        <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" default="30000"/></Set>
+        <Set name="host" property="jetty.http.host" />
+        <Set name="port">
+          <Property name="jetty.http.port" default="80" />
+        </Set>
+        <Set name="idleTimeout">
+          <Property name="jetty.http.idleTimeout" default="30000" />
+        </Set>
       </New>
     </Arg>
   </Call>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-http.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-http.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->
-<!-- by adding an HTTP connector.                                   -->
+<!-- by adding an HTTP connector.                                  -->
 <!-- This configuration must be used in conjunction with jetty.xml -->
 <!-- ============================================================= -->
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <!-- =========================================================== -->
-  <!-- Add an HTTP Connector.                                       -->
+  <!-- Add an HTTP Connector.                                      -->
   <!-- Configure an o.e.j.server.ServerConnector with a single     -->
   <!-- HttpConnectionFactory instance using the common httpConfig  -->
   <!-- instance defined in jetty.xml                               -->
@@ -21,12 +21,16 @@
   <Call name="addConnector">
     <Arg>
       <New class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+                <Arg name="config">
+                  <Ref refid="httpConfig" />
+                </Arg>
               </New>
             </Item>
           </Array>
@@ -38,9 +42,13 @@
             </New>
           </Arg>
         </Call>
-        <Set name="host" property="jetty.http.host"/>
-        <Set name="port"><Property name="jetty.http.port" default="80"/></Set>
-        <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" default="30000"/></Set>
+        <Set name="host" property="jetty.http.host" />
+        <Set name="port">
+          <Property name="jetty.http.port" default="80" />
+        </Set>
+        <Set name="idleTimeout">
+          <Property name="jetty.http.idleTimeout" default="30000" />
+        </Set>
       </New>
     </Arg>
   </Call>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-http2-jdk9.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-http2-jdk9.xml
@@ -8,17 +8,19 @@
   <Call name="addConnectionFactory">
     <Arg>
       <New class="org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory">
-        <Arg name="config"><Ref refid="sslHttpConfig"/></Arg>
-        <Set name="maxConcurrentStreams" property="jetty.http2.maxConcurrentStreams"/>
-        <Set name="initialStreamRecvWindow" property="jetty.http2.initialStreamRecvWindow"/>
-        <Set name="initialSessionRecvWindow" property="jetty.http2.initialSessionRecvWindow"/>
+        <Arg name="config">
+          <Ref refid="sslHttpConfig" />
+        </Arg>
+        <Set name="maxConcurrentStreams" property="jetty.http2.maxConcurrentStreams" />
+        <Set name="initialStreamRecvWindow" property="jetty.http2.initialStreamRecvWindow" />
+        <Set name="initialSessionRecvWindow" property="jetty.http2.initialSessionRecvWindow" />
       </New>
     </Arg>
   </Call>
 
   <Ref refid="sslContextFactory">
     <Set name="CipherComparator">
-      <Get class="org.eclipse.jetty.http2.HTTP2Cipher" name="COMPARATOR"/>
+      <Get class="org.eclipse.jetty.http2.HTTP2Cipher" name="COMPARATOR" />
     </Set>
     <Set name="useCipherSuitesOrder">true</Set>
   </Ref>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-http2.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-http2.xml
@@ -2,23 +2,25 @@
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
-<!-- Configure an HTTP2 on the ssl connector.                       -->
+<!-- Configure an HTTP2 on the ssl connector.                      -->
 <!-- ============================================================= -->
 <Configure id="sslConnector" class="org.eclipse.jetty.server.ServerConnector">
   <Call name="addConnectionFactory">
     <Arg>
       <New class="org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory">
-        <Arg name="config"><Ref refid="sslHttpConfig"/></Arg>
-        <Set name="maxConcurrentStreams" property="jetty.http2.maxConcurrentStreams"/>
-        <Set name="initialStreamRecvWindow" property="jetty.http2.initialStreamRecvWindow"/>
-        <Set name="initialSessionRecvWindow" property="jetty.http2.initialSessionRecvWindow"/>
+        <Arg name="config">
+          <Ref refid="sslHttpConfig" />
+        </Arg>
+        <Set name="maxConcurrentStreams" property="jetty.http2.maxConcurrentStreams" />
+        <Set name="initialStreamRecvWindow" property="jetty.http2.initialStreamRecvWindow" />
+        <Set name="initialSessionRecvWindow" property="jetty.http2.initialSessionRecvWindow" />
       </New>
     </Arg>
   </Call>
 
   <Ref refid="sslContextFactory">
     <Set name="CipherComparator">
-      <Get class="org.eclipse.jetty.http2.HTTP2Cipher" name="COMPARATOR"/>
+      <Get class="org.eclipse.jetty.http2.HTTP2Cipher" name="COMPARATOR" />
     </Set>
     <Set name="useCipherSuitesOrder">true</Set>
     <Call name="addExcludeProtocols">

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-https.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-https.xml
@@ -1,8 +1,8 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
-<!-- Configure an HTTPS connector.                                  -->
+<!-- Configure an HTTPS connector.                                 -->
 <!-- This configuration must be used in conjunction with jetty.xml -->
 <!-- and jetty-ssl.xml.                                            -->
 <!-- ============================================================= -->
@@ -12,23 +12,27 @@
     <Arg>
       <New class="org.eclipse.jetty.server.SslConnectionFactory">
         <Arg name="next">http/1.1</Arg>
-        <Arg name="sslContextFactory"><Ref refid="sslContextFactory"/></Arg>
+        <Arg name="sslContextFactory">
+          <Ref refid="sslContextFactory" />
+        </Arg>
       </New>
     </Arg>
   </Call>
-        <Call name="addEventListener">
-          <Arg>
-            <New class="org.eclipse.jetty.ee9.osgi.boot.utils.ServerConnectorListener">
-              <Set name="sysPropertyName">boot.https.port</Set>
-            </New>
-          </Arg>
-        </Call>
+  <Call name="addEventListener">
+    <Arg>
+      <New class="org.eclipse.jetty.ee9.osgi.boot.utils.ServerConnectorListener">
+        <Set name="sysPropertyName">boot.https.port</Set>
+      </New>
+    </Arg>
+  </Call>
   <Call name="addConnectionFactory">
     <Arg>
       <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-        <Arg name="config"><Ref refid="sslHttpConfig" /></Arg>
+        <Arg name="config">
+          <Ref refid="sslHttpConfig" />
+        </Arg>
       </New>
     </Arg>
   </Call>
-  
+
 </Configure>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-ssl.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-ssl.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- ============================================================= -->
@@ -9,20 +9,26 @@
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <!-- =========================================================== -->
-  <!-- Add an SSL Connector with no protocol factories              -->
+  <!-- Add an SSL Connector with no protocol factories             -->
   <!-- =========================================================== -->
-  <Call  name="addConnector">
+  <Call name="addConnector">
     <Arg>
       <New id="sslConnector" class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
-          <Arg name="factories">
-            <Array type="org.eclipse.jetty.server.ConnectionFactory">
-            </Array>
-          </Arg>
-          <Set name="host" property="jetty.ssl.host"/>
-          <Set name="port"><Property name="jetty.ssl.port" default="443"/></Set>
-          <Set name="idleTimeout"><Property name="jetty.ssl.idleTimeout" default="30000"/></Set>
-        </New>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
+        <Arg name="factories">
+          <Array type="org.eclipse.jetty.server.ConnectionFactory">
+          </Array>
+        </Arg>
+        <Set name="host" property="jetty.ssl.host" />
+        <Set name="port">
+          <Property name="jetty.ssl.port" default="443" />
+        </Set>
+        <Set name="idleTimeout">
+          <Property name="jetty.ssl.idleTimeout" default="30000" />
+        </Set>
+      </New>
     </Arg>
   </Call>
 
@@ -30,13 +36,23 @@
   <!-- Create a TLS (SSL) Context Factory  for later reuse           -->
   <!-- ============================================================= -->
   <New id="sslContextFactory" class="org.eclipse.jetty.util.ssl.SslContextFactory$Server">
-    <Set name="Provider"><SystemProperty name="jetty.sslContext.provider"/></Set>
-    <Set name="KeyStorePath"><Property name="jetty.base"/>/<Property name="jetty.sslContext.keyStorePath" default="etc/keystore.p12"/></Set>
-    <Set name="KeyStorePassword"><Property name="jetty.sslContext.keyStorePassword" default="OBF:1vny1zlo1x8e1vnw1vn61x8g1zlu1vn4"/></Set>
-    <Set name="TrustStorePath"><Property name="jetty.base"/>/<Property name="jetty.sslContext.trustStorePath" default="etc/keystore.p12"/></Set>
-    <Set name="TrustStorePassword"><Property name="jetty.sslContext.trustStorePassword" default="OBF:1vny1zlo1x8e1vnw1vn61x8g1zlu1vn4"/></Set>
-    <Set name="NeedClientAuth" property="jetty.sslContext.needClientAuth"/>
-    <Set name="WantClientAuth" property="jetty.sslContext.wantClientAuth"/>
+    <Set name="Provider">
+      <SystemProperty name="jetty.sslContext.provider" />
+    </Set>
+    <Set name="KeyStorePath"><Property name="jetty.base" />/
+      <Property name="jetty.sslContext.keyStorePath" default="etc/keystore.p12" />
+    </Set>
+    <Set name="KeyStorePassword">
+      <Property name="jetty.sslContext.keyStorePassword" default="OBF:1vny1zlo1x8e1vnw1vn61x8g1zlu1vn4" />
+    </Set>
+    <Set name="TrustStorePath"><Property name="jetty.base" />/
+      <Property name="jetty.sslContext.trustStorePath" default="etc/keystore.p12" />
+    </Set>
+    <Set name="TrustStorePassword">
+      <Property name="jetty.sslContext.trustStorePassword" default="OBF:1vny1zlo1x8e1vnw1vn61x8g1zlu1vn4" />
+    </Set>
+    <Set name="NeedClientAuth" property="jetty.sslContext.needClientAuth" />
+    <Set name="WantClientAuth" property="jetty.sslContext.wantClientAuth" />
   </New>
 
   <!-- =========================================================== -->
@@ -46,9 +62,13 @@
   <!-- session information                                         -->
   <!-- =========================================================== -->
   <New id="sslHttpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
-    <Arg><Ref refid="httpConfig"/></Arg>
+    <Arg>
+      <Ref refid="httpConfig" />
+    </Arg>
     <Call name="addCustomizer">
-      <Arg><New class="org.eclipse.jetty.server.SecureRequestCustomizer"/></Arg>
+      <Arg>
+        <New class="org.eclipse.jetty.server.SecureRequestCustomizer" />
+      </Arg>
     </Call>
   </New>
 

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-testrealm.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-testrealm.xml
@@ -1,17 +1,21 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
+
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
-    <!-- =========================================================== -->
-    <!-- Configure Authentication Login Service                      -->
-    <!-- Realms may be configured for the entire server here, or     -->
-    <!-- they can be configured for a specific web app in a context  -->
-    <!-- configuration (see $(jetty.home)/webapps/test.xml for an    -->
-    <!-- example).                                                   -->
-    <!-- =========================================================== -->
-    <Call id="ResourceFactory" class="org.eclipse.jetty.util.resource.ResourceFactory" name="of">
-    <Arg><Ref refid="Server" /></Arg>
+  <!-- =========================================================== -->
+  <!-- Configure Authentication Login Service                      -->
+  <!-- Realms may be configured for the entire server here, or     -->
+  <!-- they can be configured for a specific web app in a context  -->
+  <!-- configuration (see $(jetty.base)/webapps/test.xml for an    -->
+  <!-- example).                                                   -->
+  <!-- =========================================================== -->
+  <Call id="ResourceFactory" class="org.eclipse.jetty.util.resource.ResourceFactory" name="of">
+    <Arg>
+      <Ref refid="Server" />
+    </Arg>
     <Call id="realmResource" name="newResource">
-        <Arg><Property name="jetty.demo.realm" default="src/test/config"/>/etc/realm.properties</Arg>
+      <Arg><Property name="jetty.demo.realm" default="src/test/config" />/etc/realm.properties
+      </Arg>
     </Call>
   </Call>
 
@@ -19,7 +23,9 @@
     <Arg>
       <New class="org.eclipse.jetty.security.HashLoginService">
         <Set name="name">Test Realm</Set>
-        <Set name="config"><Ref refid="realmResource"/></Set>
+        <Set name="config">
+          <Ref refid="realmResource" />
+        </Set>
         <Set name="hotReload">false</Set>
       </New>
     </Arg>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-with-custom-class.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-with-custom-class.xml
@@ -1,88 +1,90 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
-
 
 <!-- =============================================================== -->
 <!-- Configure the Jetty Server                                      -->
 <!--                                                                 -->
 <!-- Documentation of this file format can be found at:              -->
-<!-- http://wiki.eclipse.org/Jetty/Reference/jetty.xml_syntax        -->
+<!-- https://jetty.org/docs/                                         -->
 <!-- =============================================================== -->
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
-    <!-- =========================================================== -->
-    <!-- Server Thread Pool                                          -->
-    <!-- =========================================================== -->
-    <Get name="ThreadPool">
-      <Set name="minThreads">10</Set>
-      <Set name="maxThreads">200</Set>
-    </Get>
+  <!-- =========================================================== -->
+  <!-- Server Thread Pool                                          -->
+  <!-- =========================================================== -->
+  <Get name="ThreadPool">
+    <Set name="minThreads">10</Set>
+    <Set name="maxThreads">200</Set>
+  </Get>
 
-	<New class="org.eclipse.jetty.ee9.osgi.test.SomeCustomBean" id="mycustombean"></New>
+  <New class="org.eclipse.jetty.ee9.osgi.test.SomeCustomBean" id="mycustombean"></New>
 
+  <!-- =========================================================== -->
+  <!-- Set handler Collection Structure                            -->
+  <!-- =========================================================== -->
+  <Set name="handler">
+    <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection" />
+  </Set>
 
-    <!-- =========================================================== -->
-    <!-- Set handler Collection Structure                            -->
-    <!-- =========================================================== -->
-    <Set name="handler">
-      <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection"/>
+  <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+    <Set name="secureScheme">https</Set>
+    <Set name="securePort">
+      <Property name="jetty.httpConfig.securePort" default="8443" />
     </Set>
+    <Set name="outputBufferSize">32768</Set>
+    <Set name="requestHeaderSize">8192</Set>
+    <Set name="responseHeaderSize">8192</Set>
+    <Set name="sendServerVersion">true</Set>
+    <Set name="sendDateHeader">false</Set>
+    <Set name="headerCacheSize">512</Set>
+  </New>
 
-    <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
-      <Set name="secureScheme">https</Set>
-      <Set name="securePort"><Property name="jetty.httpConfig.securePort" default="8443" /></Set>
-      <Set name="outputBufferSize">32768</Set>
-      <Set name="requestHeaderSize">8192</Set>
-      <Set name="responseHeaderSize">8192</Set>
-      <Set name="sendServerVersion">true</Set>
-      <Set name="sendDateHeader">false</Set>
-      <Set name="headerCacheSize">512</Set>
-    </New>
+  <!-- =========================================================== -->
+  <!-- extra options                                               -->
+  <!-- =========================================================== -->
+  <Set name="stopAtShutdown">true</Set>
+  <Set name="stopTimeout">1000</Set>
+  <Set name="dumpAfterStart">false</Set>
+  <Set name="dumpBeforeStop">false</Set>
 
+  <!-- =========================================================== -->
+  <!-- Set up the list of default configuration classes            -->
+  <!-- =========================================================== -->
+  <Call class="org.eclipse.jetty.ee9.webapp.Configurations" name="setKnown">
+    <Arg>
+      <Array type="String">
+        <Item>org.eclipse.jetty.ee9.webapp.FragmentConfiguration</Item>
+        <Item>org.eclipse.jetty.ee9.webapp.JettyWebXmlConfiguration</Item>
+        <Item>org.eclipse.jetty.ee9.webapp.WebXmlConfiguration</Item>
+        <Item>org.eclipse.jetty.ee9.webapp.WebAppConfiguration</Item>
+        <Item>org.eclipse.jetty.ee9.webapp.ServletsConfiguration</Item>
+        <Item>org.eclipse.jetty.ee9.webapp.JspConfiguration</Item>
+        <Item>org.eclipse.jetty.ee9.webapp.JaasConfiguration</Item>
+        <Item>org.eclipse.jetty.ee9.webapp.JndiConfiguration</Item>
+        <Item>org.eclipse.jetty.plus.webapp.PlusConfiguration</Item>
+        <Item>org.eclipse.jetty.plus.webapp.EnvConfiguration</Item>
+        <Item>org.eclipse.jetty.ee9.webapp.JmxConfiguration</Item>
+        <Item>org.eclipse.jetty.ee9.websocket.server.config.JettyWebSocketConfiguration</Item>
+        <Item>org.eclipse.jetty.websocket.jakarta.server.config.JakartaWebSocketConfiguration</Item>
+        <Item>org.eclipse.jetty.ee9.osgi.annotations.AnnotationConfiguration</Item>
+        <Item>org.eclipse.jetty.ee9.osgi.boot.OSGiWebInfConfiguration</Item>
+        <Item>org.eclipse.jetty.ee9.osgi.boot.OSGiMetaInfConfiguration</Item>
+      </Array>
+    </Arg>
+  </Call>
 
-    <!-- =========================================================== -->
-    <!-- extra options                                               -->
-    <!-- =========================================================== -->
-    <Set name="stopAtShutdown">true</Set>
-    <Set name="stopTimeout">1000</Set>
-    <Set name="dumpAfterStart">false</Set>
-    <Set name="dumpBeforeStop">false</Set>
-
-
-    <!-- =========================================================== -->
-    <!-- Set up the list of default configuration classes            -->
-    <!-- =========================================================== -->    
-    <Call class="org.eclipse.jetty.ee9.webapp.Configurations" name="setKnown">
-      <Arg>
-        <Array type="String">
-         <Item>org.eclipse.jetty.ee9.webapp.FragmentConfiguration</Item>
-         <Item>org.eclipse.jetty.ee9.webapp.JettyWebXmlConfiguration</Item>
-         <Item>org.eclipse.jetty.ee9.webapp.WebXmlConfiguration</Item>
-         <Item>org.eclipse.jetty.ee9.webapp.WebAppConfiguration</Item>
-         <Item>org.eclipse.jetty.ee9.webapp.ServletsConfiguration</Item>
-         <Item>org.eclipse.jetty.ee9.webapp.JspConfiguration</Item>
-         <Item>org.eclipse.jetty.ee9.webapp.JaasConfiguration</Item>
-         <Item>org.eclipse.jetty.ee9.webapp.JndiConfiguration</Item>
-         <Item>org.eclipse.jetty.plus.webapp.PlusConfiguration</Item>
-         <Item>org.eclipse.jetty.plus.webapp.EnvConfiguration</Item>
-         <Item>org.eclipse.jetty.ee9.webapp.JmxConfiguration</Item>
-         <Item>org.eclipse.jetty.ee9.websocket.server.config.JettyWebSocketConfiguration</Item>
-         <Item>org.eclipse.jetty.websocket.jakarta.server.config.JakartaWebSocketConfiguration</Item>
-         <Item>org.eclipse.jetty.ee9.osgi.annotations.AnnotationConfiguration</Item>
-         <Item>org.eclipse.jetty.ee9.osgi.boot.OSGiWebInfConfiguration</Item>
-         <Item>org.eclipse.jetty.ee9.osgi.boot.OSGiMetaInfConfiguration</Item>
-        </Array>
-      </Arg>
-    </Call>
-
-    <Call class="java.lang.System" name="setProperty">
-      <Arg>java.naming.factory.initial</Arg>
-      <Arg><Property name="java.naming.factory.initial" default="org.eclipse.jetty.jndi.InitialContextFactory"/></Arg>
-    </Call>
-    <Call class="java.lang.System" name="setProperty">
-      <Arg>java.naming.factory.url.pkgs</Arg>
-      <Arg><Property name="java.naming.factory.url.pkgs" default="org.eclipse.jetty.jndi"/></Arg>
-    </Call>
+  <Call class="java.lang.System" name="setProperty">
+    <Arg>java.naming.factory.initial</Arg>
+    <Arg>
+      <Property name="java.naming.factory.initial" default="org.eclipse.jetty.jndi.InitialContextFactory" />
+    </Arg>
+  </Call>
+  <Call class="java.lang.System" name="setProperty">
+    <Arg>java.naming.factory.url.pkgs</Arg>
+    <Arg>
+      <Property name="java.naming.factory.url.pkgs" default="org.eclipse.jetty.jndi" />
+    </Arg>
+  </Call>
 
 </Configure>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty.xml
@@ -1,65 +1,80 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
-
 
 <!-- =============================================================== -->
 <!-- Configure the Jetty Server                                      -->
 <!--                                                                 -->
 <!-- Documentation of this file format can be found at:              -->
-<!-- https://jetty.org/docs/                    -->
+<!-- https://jetty.org/docs/                                         -->
 <!-- =============================================================== -->
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
-    <!-- =========================================================== -->
-    <!-- Server Thread Pool                                          -->
-    <!-- =========================================================== -->
-    <Get name="ThreadPool">
-      <Set name="minThreads">10</Set>
-      <Set name="maxThreads">200</Set>
-    </Get>
+  <!-- =========================================================== -->
+  <!-- Server Thread Pool                                          -->
+  <!-- =========================================================== -->
+  <Get name="ThreadPool">
+    <Set name="minThreads">10</Set>
+    <Set name="maxThreads">200</Set>
+  </Get>
 
+  <!-- =========================================================== -->
+  <!-- Set handler Collection Structure                            -->
+  <!-- =========================================================== -->
+  <Set name="handler">
+    <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection" />
+  </Set>
 
-    <!-- =========================================================== -->
-    <!-- Set handler Collection Structure                            -->
-    <!-- =========================================================== -->
-    <Set name="handler">
-      <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection"/>
+  <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+    <Set name="secureScheme" property="jetty.httpConfig.secureScheme" />
+    <Set name="securePort" property="jetty.httpConfig.securePort" />
+    <Set name="outputBufferSize" property="jetty.httpConfig.outputBufferSize" />
+    <Set name="outputAggregationSize" property="jetty.httpConfig.outputAggregationSize" />
+    <Set name="requestHeaderSize" property="jetty.httpConfig.requestHeaderSize" />
+    <Set name="responseHeaderSize" property="jetty.httpConfig.responseHeaderSize" />
+    <Set name="sendServerVersion" property="jetty.httpConfig.sendServerVersion" />
+    <Set name="sendDateHeader" property="jetty.httpConfig.sendDateHeader" />
+    <Set name="headerCacheSize" property="jetty.httpConfig.headerCacheSize" />
+    <Set name="delayDispatchUntilContent" property="jetty.httpConfig.delayDispatchUntilContent" />
+    <Set name="maxErrorDispatches" property="jetty.httpConfig.maxErrorDispatches" />
+    <Set name="persistentConnectionsEnabled" property="jetty.httpConfig.persistentConnectionsEnabled" />
+    <Set name="requestCookieCompliance">
+      <Call class="org.eclipse.jetty.http.CookieCompliance" name="valueOf">
+        <Arg>
+          <Property name="jetty.httpConfig.requestCookieCompliance" default="RFC6265" />
+        </Arg>
+      </Call>
     </Set>
+    <Set name="responseCookieCompliance">
+      <Call class="org.eclipse.jetty.http.CookieCompliance" name="valueOf">
+        <Arg>
+          <Property name="jetty.httpConfig.responseCookieCompliance" default="RFC6265" />
+        </Arg>
+      </Call>
+    </Set>
+  </New>
 
-     <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
-      <Set name="secureScheme" property="jetty.httpConfig.secureScheme"/>
-      <Set name="securePort" property="jetty.httpConfig.securePort"/>
-      <Set name="outputBufferSize" property="jetty.httpConfig.outputBufferSize"/>
-      <Set name="outputAggregationSize" property="jetty.httpConfig.outputAggregationSize"/>
-      <Set name="requestHeaderSize" property="jetty.httpConfig.requestHeaderSize"/>
-      <Set name="responseHeaderSize" property="jetty.httpConfig.responseHeaderSize"/>
-      <Set name="sendServerVersion" property="jetty.httpConfig.sendServerVersion"/>
-      <Set name="sendDateHeader" property="jetty.httpConfig.sendDateHeader"/>
-      <Set name="headerCacheSize" property="jetty.httpConfig.headerCacheSize"/>
-      <Set name="delayDispatchUntilContent" property="jetty.httpConfig.delayDispatchUntilContent"/>
-      <Set name="maxErrorDispatches" property="jetty.httpConfig.maxErrorDispatches"/>
-      <Set name="persistentConnectionsEnabled" property="jetty.httpConfig.persistentConnectionsEnabled"/>
-      <Set name="requestCookieCompliance"><Call class="org.eclipse.jetty.http.CookieCompliance" name="valueOf"><Arg><Property name="jetty.httpConfig.requestCookieCompliance" default="RFC6265"/></Arg></Call></Set>
-      <Set name="responseCookieCompliance"><Call class="org.eclipse.jetty.http.CookieCompliance" name="valueOf"><Arg><Property name="jetty.httpConfig.responseCookieCompliance" default="RFC6265"/></Arg></Call></Set>
-    </New>
- 
+  <!-- =========================================================== -->
+  <!-- extra options                                               -->
+  <!-- =========================================================== -->
+  <Set name="stopAtShutdown" property="jetty.server.stopAtShutdown" />
+  <Set name="stopTimeout">
+    <Property name="jetty.server.stopTimeout" default="5000" />
+  </Set>
+  <Set name="dumpAfterStart" property="jetty.server.dumpAfterStart" />
+  <Set name="dumpBeforeStop" property="jetty.server.dumpBeforeStop" />
 
-    <!-- =========================================================== -->
-    <!-- extra options                                               -->
-    <!-- =========================================================== -->
-    <Set name="stopAtShutdown" property="jetty.server.stopAtShutdown"/>
-    <Set name="stopTimeout"><Property name="jetty.server.stopTimeout" default="5000"/></Set>
-    <Set name="dumpAfterStart" property="jetty.server.dumpAfterStart"/>
-    <Set name="dumpBeforeStop" property="jetty.server.dumpBeforeStop"/>
-
-    <Call class="java.lang.System" name="setProperty">
-      <Arg>java.naming.factory.initial</Arg>
-      <Arg><Property name="java.naming.factory.initial" default="org.eclipse.jetty.jndi.InitialContextFactory"/></Arg>
-    </Call>
-    <Call class="java.lang.System" name="setProperty">
-      <Arg>java.naming.factory.url.pkgs</Arg>
-      <Arg><Property name="java.naming.factory.url.pkgs" default="org.eclipse.jetty.jndi"/></Arg>
-    </Call>
+  <Call class="java.lang.System" name="setProperty">
+    <Arg>java.naming.factory.initial</Arg>
+    <Arg>
+      <Property name="java.naming.factory.initial" default="org.eclipse.jetty.jndi.InitialContextFactory" />
+    </Arg>
+  </Call>
+  <Call class="java.lang.System" name="setProperty">
+    <Arg>java.naming.factory.url.pkgs</Arg>
+    <Arg>
+      <Property name="java.naming.factory.url.pkgs" default="org.eclipse.jetty.jndi" />
+    </Arg>
+  </Call>
 
 </Configure>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/resources/DefaultHandler.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/resources/DefaultHandler.xml
@@ -1,12 +1,12 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
     <Set name="secureScheme">https</Set>
     <Set name="securePort">
-      <Property name="jetty.secure.port" default="8443"/>
+      <Property name="jetty.secure.port" default="8443" />
     </Set>
     <Set name="outputBufferSize">32768</Set>
     <Set name="requestHeaderSize">8192</Set>
@@ -25,14 +25,14 @@
         <Arg>
           <New id="defcontext" class="org.eclipse.jetty.server.handler.ContextHandler">
             <Set name="contextPath">/tests</Set>
-            <Set name="baseResourceAsString"><Property name="test.docroot.base"/>/default
+            <Set name="baseResourceAsString"><Property name="test.docroot.base" />/default
             </Set>
             <Set name="Handler">
-              <New id="reshandler" class="org.eclipse.jetty.server.handler.ResourceHandler"/>
+              <New id="reshandler" class="org.eclipse.jetty.server.handler.ResourceHandler" />
             </Set>
             <Set name="DisplayName">default</Set>
           </New>
-          </Arg>
+        </Arg>
       </Call>
     </New>
   </Set>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/resources/NIOHttp.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/resources/NIOHttp.xml
@@ -1,28 +1,34 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
-    <!-- =========================================================== -->
-    <!-- Set connectors                                              -->
-    <!-- =========================================================== -->
-    
-    <Call name="addConnector">
+  <!-- =========================================================== -->
+  <!-- Set connectors                                              -->
+  <!-- =========================================================== -->
+
+  <Call name="addConnector">
     <Arg>
       <New class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+                <Arg name="config">
+                  <Ref refid="httpConfig" />
+                </Arg>
               </New>
             </Item>
           </Array>
         </Arg>
         <Set name="host" property="jetty.http.host" />
         <Set name="port" property="jetty.http.port" />
-        <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" default="30000"/></Set>
+        <Set name="idleTimeout">
+          <Property name="jetty.http.idleTimeout" default="30000" />
+        </Set>
       </New>
     </Arg>
   </Call>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/resources/NIOHttps.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/resources/NIOHttps.xml
@@ -1,26 +1,32 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
-    <!-- =========================================================== -->
-    <!-- Set connectors                                              -->
-    <!-- =========================================================== -->
+  <!-- =========================================================== -->
+  <!-- Set connectors                                              -->
+  <!-- =========================================================== -->
 
-    <Call name="addConnector">
+  <Call name="addConnector">
     <Arg>
       <New class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="server">
+          <Ref refid="Server" />
+        </Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.SslConnectionFactory">
                 <Arg name="next">http/1.1</Arg>
-                <Arg name="sslContextFactory"><Ref refid="sslContextFactory"/></Arg>
+                <Arg name="sslContextFactory">
+                  <Ref refid="sslContextFactory" />
+                </Arg>
               </New>
             </Item>
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
-                <Arg name="config"><Ref refid="sslHttpConfig"/></Arg>
+                <Arg name="config">
+                  <Ref refid="sslHttpConfig" />
+                </Arg>
               </New>
             </Item>
           </Array>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/resources/RFC2616Base.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/resources/RFC2616Base.xml
@@ -1,19 +1,20 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure the Jetty Server                                      -->
 <!--                                                                 -->
 <!-- Documentation of this file format can be found at:              -->
-<!-- http://docs.codehaus.org/display/JETTY/jetty.xml                -->
-<!--                                                                 -->
+<!-- https://jetty.org/docs/                                         -->
 <!-- =============================================================== -->
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
     <Set name="secureScheme">https</Set>
-    <Set name="securePort"><Property name="jetty.secure.port" default="8443" /></Set>
+    <Set name="securePort">
+      <Property name="jetty.secure.port" default="8443" />
+    </Set>
     <Set name="outputBufferSize">32768</Set>
     <Set name="requestHeaderSize">8192</Set>
     <Set name="responseHeaderSize">8192</Set>
@@ -43,23 +44,31 @@
                   <Item>VirtualHost</Item>
                 </Array>
               </Set>
-              <Set name="baseResourceAsString"><Property name="test.docroot.base"/>/virtualhost</Set>
-              <Set name="Handler"><New id="reshandler1" class="org.eclipse.jetty.server.handler.ResourceHandler"/></Set>
+              <Set name="baseResourceAsString"><Property name="test.docroot.base" />/virtualhost
+              </Set>
+              <Set name="Handler">
+                <New id="reshandler1" class="org.eclipse.jetty.server.handler.ResourceHandler" />
+              </Set>
               <Set name="DisplayName">virtual</Set>
             </New>
           </Item>
           <Item>
             <New id="defcontext" class="org.eclipse.jetty.server.handler.ContextHandler">
               <Set name="contextPath">/tests</Set>
-              <Set name="baseResourceAsString"><Property name="test.docroot.base"/>/default</Set>
-              <Set name="Handler"><New id="reshandler2" class="org.eclipse.jetty.server.handler.ResourceHandler"/></Set>
+              <Set name="baseResourceAsString"><Property name="test.docroot.base" />/default
+              </Set>
+              <Set name="Handler">
+                <New id="reshandler2" class="org.eclipse.jetty.server.handler.ResourceHandler" />
+              </Set>
               <Set name="DisplayName">default</Set>
             </New>
           </Item>
           <Item>
             <New id="echocontext" class="org.eclipse.jetty.server.handler.ContextHandler">
               <Set name="contextPath">/echo</Set>
-              <Set name="Handler"><New id="echohandler" class="org.eclipse.jetty.ee9.test.rfcs.RFC2616BaseTest$EchoHandler"/></Set>
+              <Set name="Handler">
+                <New id="echohandler" class="org.eclipse.jetty.ee9.test.rfcs.RFC2616BaseTest$EchoHandler" />
+              </Set>
               <Set name="DisplayName">echo</Set>
             </New>
           </Item>
@@ -68,17 +77,17 @@
     </New>
   </Set>
 
-   <Call id="Environment" class="org.eclipse.jetty.util.component.Environment" name="ensure">
+  <Call id="Environment" class="org.eclipse.jetty.util.component.Environment" name="ensure">
     <Arg>ee9</Arg>
-   </Call>
-   <Ref refid="Environment">
+  </Call>
+  <Ref refid="Environment">
     <Call name="setAttribute">
       <Arg>contextHandlerClass</Arg>
       <Arg>org.eclipse.jetty.ee9.webapp.WebAppContext</Arg>
     </Call>
-   </Ref>   
+  </Ref>
 
-   <Call name="addBean">
+  <Call name="addBean">
     <Arg>
       <New id="DeploymentManager" class="org.eclipse.jetty.deploy.DeploymentManager">
         <Set name="contexts">
@@ -86,40 +95,40 @@
         </Set>
 
         <Call name="addAppProvider">
-         <Arg>
-          <New id="WebAppProvider" class="org.eclipse.jetty.deploy.providers.ContextProvider">
-            <Set name="environmentName">ee9</Set>
-            <Set name="monitoredDirName">
-              <Call name="resolvePath" class="org.eclipse.jetty.xml.XmlConfiguration">
-                <Arg>src/test/resources/</Arg>
-                <Arg>webapp-contexts/RFC2616/</Arg>
-              </Call>
-            </Set>
+          <Arg>
+            <New id="WebAppProvider" class="org.eclipse.jetty.deploy.providers.ContextProvider">
+              <Set name="environmentName">ee9</Set>
+              <Set name="monitoredDirName">
+                <Call name="resolvePath" class="org.eclipse.jetty.xml.XmlConfiguration">
+                  <Arg>src/test/resources/</Arg>
+                  <Arg>webapp-contexts/RFC2616/</Arg>
+                </Call>
+              </Set>
 
-            <Set name="scanInterval">1</Set>
-            <Set name="extractWars">true</Set>
-            <Get name="properties">
-              <Put name="jetty.deploy.containerScanJarPattern">
-                <Property name="jetty.deploy.containerScanJarPattern">
-                  <Default>.*/jakarta.servlet-api-[^/]*\.jar$|.*jakarta.servlet.jsp.jstl-.*\.jar$</Default>
-                </Property>
-              </Put>
-              <Put name="jetty.deploy.webInfScanJarPattern">
-                <Property name="jetty.deploy.webInfScanJarPattern"/>
-              </Put>
-              <Put name="jetty.deploy.servletContainerInitializerExclusionPattern">
-                <Property name="jetty.deploy.servletContainerInitializerExclusionPattern"/>
-              </Put>
-              <Put name="jetty.deploy.servletContainerInitializerOrder">
-                <Property name="jetty.deploy.servletContainerInitializerOrder"/>
-              </Put>
-            </Get>
-          </New>
-        </Arg>
-      </Call>
-     </New>
+              <Set name="scanInterval">1</Set>
+              <Set name="extractWars">true</Set>
+              <Get name="properties">
+                <Put name="jetty.deploy.containerScanJarPattern">
+                  <Property name="jetty.deploy.containerScanJarPattern">
+                    <Default>.*/jakarta.servlet-api-[^/]*\.jar$|.*jakarta.servlet.jsp.jstl-.*\.jar$</Default>
+                  </Property>
+                </Put>
+                <Put name="jetty.deploy.webInfScanJarPattern">
+                  <Property name="jetty.deploy.webInfScanJarPattern" />
+                </Put>
+                <Put name="jetty.deploy.servletContainerInitializerExclusionPattern">
+                  <Property name="jetty.deploy.servletContainerInitializerExclusionPattern" />
+                </Put>
+                <Put name="jetty.deploy.servletContainerInitializerOrder">
+                  <Property name="jetty.deploy.servletContainerInitializerOrder" />
+                </Put>
+              </Get>
+            </New>
+          </Arg>
+        </Call>
+      </New>
     </Arg>
-   </Call>
+  </Call>
 
   <!-- =========================================================== -->
   <!-- extra options                                               -->

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/resources/RFC2616_Filters.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/resources/RFC2616_Filters.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/resources/RFC2616_Redirects.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/resources/RFC2616_Redirects.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <!-- =========================================================== -->

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/resources/add-jetty-test-webapp.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/resources/add-jetty-test-webapp.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="contexts" class="org.eclipse.jetty.server.handler.HandlerCollection">
   <Call name="addHandler">

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/resources/basic-server.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/resources/basic-server.xml
@@ -1,11 +1,11 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
     <Set name="secureScheme">https</Set>
     <Set name="securePort">
-      <Property name="jetty.secure.port" default="8443"/>
+      <Property name="jetty.secure.port" default="8443" />
     </Set>
     <Set name="outputBufferSize">32768</Set>
     <Set name="requestHeaderSize">8192</Set>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/resources/deploy.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/resources/deploy.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <Call id="Environment" class="org.eclipse.jetty.util.component.Environment" name="ensure">
@@ -20,37 +20,37 @@
         </Set>
 
         <Call name="addAppProvider">
-         <Arg>
-          <New id="WebAppProvider" class="org.eclipse.jetty.deploy.providers.ContextProvider">
-            <Set name="environmentName">ee9</Set>
-            <Set name="monitoredDirName">
-              <Call name="resolvePath" class="org.eclipse.jetty.xml.XmlConfiguration">
-                <Arg>target</Arg>
-                <Arg>webapps</Arg>
-              </Call>
-            </Set>
+          <Arg>
+            <New id="WebAppProvider" class="org.eclipse.jetty.deploy.providers.ContextProvider">
+              <Set name="environmentName">ee9</Set>
+              <Set name="monitoredDirName">
+                <Call name="resolvePath" class="org.eclipse.jetty.xml.XmlConfiguration">
+                  <Arg>target</Arg>
+                  <Arg>webapps</Arg>
+                </Call>
+              </Set>
 
-            <Set name="scanInterval">1</Set>
-            <Set name="extractWars">true</Set>
+              <Set name="scanInterval">1</Set>
+              <Set name="extractWars">true</Set>
 
-            <Get name="properties">
-              <Put name="jetty.deploy.containerScanJarPattern">
-                <Property name="jetty.deploy.containerScanJarPattern">
-                  <Default>.*/jakarta.servlet-api-[^/]*\.jar$|.*jakarta.servlet.jsp.jstl-.*\.jar$</Default>
-                </Property>
-              </Put>
-              <Put name="jetty.deploy.webInfScanJarPattern">
-                <Property name="jetty.deploy.webInfScanJarPattern"/>
-              </Put>
-              <Put name="jetty.deploy.servletContainerInitializerExclusionPattern">
-                <Property name="jetty.deploy.servletContainerInitializerExclusionPattern"/>
-              </Put>
-              <Put name="jetty.deploy.servletContainerInitializerOrder">
-                <Property name="jetty.deploy.servletContainerInitializerOrder"/>
-              </Put>
-            </Get>
-          </New>
-         </Arg>
+              <Get name="properties">
+                <Put name="jetty.deploy.containerScanJarPattern">
+                  <Property name="jetty.deploy.containerScanJarPattern">
+                    <Default>.*/jakarta.servlet-api-[^/]*\.jar$|.*jakarta.servlet.jsp.jstl-.*\.jar$</Default>
+                  </Property>
+                </Put>
+                <Put name="jetty.deploy.webInfScanJarPattern">
+                  <Property name="jetty.deploy.webInfScanJarPattern" />
+                </Put>
+                <Put name="jetty.deploy.servletContainerInitializerExclusionPattern">
+                  <Property name="jetty.deploy.servletContainerInitializerExclusionPattern" />
+                </Put>
+                <Put name="jetty.deploy.servletContainerInitializerOrder">
+                  <Property name="jetty.deploy.servletContainerInitializerOrder" />
+                </Put>
+              </Get>
+            </New>
+          </Arg>
         </Call>
       </New>
     </Arg>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/resources/login-service.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/resources/login-service.xml
@@ -1,28 +1,33 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <!-- =========================================================== -->
   <!-- Configure Authentication Login Service                      -->
   <!-- Realms may be configured for the entire server here, or     -->
   <!-- they can be configured for a specific web app in a context  -->
-  <!-- configuration (see $(jetty.home)/webapps/test.xml for an    -->
+  <!-- configuration (see $(jetty.base)/webapps/test.xml for an    -->
   <!-- example).                                                   -->
   <!-- =========================================================== -->
 
   <Call id="ResourceFactory" class="org.eclipse.jetty.util.resource.ResourceFactory" name="of">
-    <Arg><Ref refid="Server" /></Arg>
+    <Arg>
+      <Ref refid="Server" />
+    </Arg>
     <Call id="realmResource" name="newResource">
-      <Arg><Property name="login.realm" default="src/test/resources/realm.properties"/></Arg>
+      <Arg>
+        <Property name="login.realm" default="src/test/resources/realm.properties" />
+      </Arg>
     </Call>
   </Call>
-  
 
   <Call name="addBean">
     <Arg>
       <New class="org.eclipse.jetty.security.HashLoginService">
         <Set name="name">Test Realm</Set>
-        <Set name="config"><Ref refid="realmResource"/></Set>
+        <Set name="config">
+          <Ref refid="realmResource" />
+        </Set>
         <Set name="hotReload">false</Set>
       </New>
     </Arg>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/resources/ssl.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/resources/ssl.xml
@@ -1,9 +1,14 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
+
 <Configure id="sslContextFactory" class="org.eclipse.jetty.util.ssl.SslContextFactory$Server">
 
-  <Set name="KeyStorePath"><Property name="jetty.sslContext.keyStorePath"/></Set>
-  <Set name="KeyStorePassword"><Property name="jetty.sslContext.keyStorePassword"/></Set>
+  <Set name="KeyStorePath">
+    <Property name="jetty.sslContext.keyStorePath" />
+  </Set>
+  <Set name="KeyStorePassword">
+    <Property name="jetty.sslContext.keyStorePassword" />
+  </Set>
 
   <!-- =========================================================== -->
   <!-- Create a TLS specific HttpConfiguration based on the        -->
@@ -12,7 +17,9 @@
   <!-- session information                                         -->
   <!-- =========================================================== -->
   <New id="sslHttpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
-    <Arg><Ref refid="httpConfig"/></Arg>
+    <Arg>
+      <Ref refid="httpConfig" />
+    </Arg>
     <Call name="addCustomizer">
       <Arg>
         <New class="org.eclipse.jetty.server.SecureRequestCustomizer">

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/resources/webapp-contexts/RFC2616/rfc2616-webapp.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/resources/webapp-contexts/RFC2616/rfc2616-webapp.xml
@@ -1,14 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
+
 <Configure class="org.eclipse.jetty.ee9.webapp.WebAppContext">
   <Set name="contextPath">/rfc2616-webapp</Set>
   <Set name="war"><Property name="test.webapps" default="target/webapps" />/ee9-test-rfc2616.war</Set>
   <Get name="systemClassMatcher">
-    <Call name="add"><Arg>org.slf4j.</Arg></Call>
-    <Call name="add"><Arg>org.eclipse.jetty.logging.</Arg></Call>
+    <Call name="add">
+      <Arg>org.slf4j.</Arg>
+    </Call>
+    <Call name="add">
+      <Arg>org.eclipse.jetty.logging.</Arg>
+    </Call>
   </Get>
   <Get name="serverClassMatcher">
-    <Call name="add"><Arg>-org.slf4j.</Arg></Call>
-    <Call name="add"><Arg>-org.eclipse.jetty.logging.</Arg></Call>
+    <Call name="add">
+      <Arg>-org.slf4j.</Arg>
+    </Call>
+    <Call name="add">
+      <Arg>-org.eclipse.jetty.logging.</Arg>
+    </Call>
   </Get>
 </Configure>


### PR DESCRIPTION
The XML used only for testing, in the various jetty-ee##-osgi and jetty-ee##-integration sub-modules could use a cleanup.

* Fix DOCTYPE to use non-deprecated URL location
* Reformat XML
* Fix XML comments for format
* Fix XML comments still referring to old concepts (eg: demo-base)
* Fix XML comments linking to old website URLs (eg: docs.codehaus.org, wiki.eclipse.org, jetty.eclipse.org, eclipse.org/jetty, etc)