### PR TITLE
Introducing DeployStrategy concept

### DIFF
--- a/jetty-core/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/DeployStrategy.java
+++ b/jetty-core/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/DeployStrategy.java
@@ -1,0 +1,28 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.deploy;
+
+import org.eclipse.jetty.server.handler.ContextHandler;
+
+/**
+ * The strategy to use when a ContextHandler is created or removed.
+ */
+public interface DeployStrategy
+{
+    void onContextCreated(ContextHandler context);
+
+    void onContextRemoved(ContextHandler context);
+
+    void onContextFailed(Throwable cause);
+}

--- a/jetty-core/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/DeploymentManager.java
+++ b/jetty-core/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/DeploymentManager.java
@@ -295,7 +295,7 @@ public class DeploymentManager extends ContainerLifeCycle implements ContextHand
         ExceptionUtil.ifExceptionThrow(_onStartupErrors);
     }
 
-    private TrackedContext findTrackedContext(ContextHandler contextHandler)
+    protected TrackedContext findTrackedContext(ContextHandler contextHandler)
     {
         return _tracked.stream()
             .filter((e) -> e.contextHandler.equals(contextHandler))
@@ -326,7 +326,7 @@ public class DeploymentManager extends ContainerLifeCycle implements ContextHand
      * @param tracked the internal tracked context to move through the process
      * @param nodeName the name of the node to attain
      */
-    private void requestContextHandlerGoal(TrackedContext tracked, String nodeName)
+    protected void requestContextHandlerGoal(TrackedContext tracked, String nodeName)
     {
         Node destinationNode = _lifecycle.getNodeByName(nodeName);
         if (destinationNode == null)
@@ -393,7 +393,7 @@ public class DeploymentManager extends ContainerLifeCycle implements ContextHand
         }
     }
 
-    private TrackedContext startTracking(ContextHandler contextHandler)
+    protected TrackedContext startTracking(ContextHandler contextHandler)
     {
         TrackedContext entry = new TrackedContext();
         entry.contextHandler = contextHandler;
@@ -402,7 +402,7 @@ public class DeploymentManager extends ContainerLifeCycle implements ContextHand
         return entry;
     }
 
-    private void stopTracking(TrackedContext trackedContext)
+    protected void stopTracking(TrackedContext trackedContext)
     {
         _tracked.remove(trackedContext);
     }
@@ -410,7 +410,7 @@ public class DeploymentManager extends ContainerLifeCycle implements ContextHand
     /**
      * A mutable record tracking a single context within the deployment manager.
      */
-    private static class TrackedContext
+    protected static class TrackedContext
     {
         /**
          * The context being tracked.

--- a/jetty-core/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/DeploymentScanner.java
+++ b/jetty-core/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/DeploymentScanner.java
@@ -119,8 +119,8 @@ public class DeploymentScanner extends ContainerLifeCycle implements Scanner.Bul
     // old attributes prefix, now stripped.
     private static final String ATTRIBUTE_PREFIX = "jetty.deploy.attribute.";
 
+    private final DeployStrategy deployStrategy;
     private final Server server;
-    private final ContextHandlerDeployer contextHandlerDeployer;
     private final FilenameFilter filenameFilter;
     private final List<Path> monitoredDirs = new CopyOnWriteArrayList<>();
     private final PathsContextHandlerFactory contextHandlerFactory = new PathsContextHandlerFactory();
@@ -142,14 +142,13 @@ public class DeploymentScanner extends ContainerLifeCycle implements Scanner.Bul
      * </p>
      *
      * @param server the server reference to use for any XML based deployments.
-     * @param deploymentManager the DeploymentManager instance that is being used by this DeploymentScanner.
+     * @param deployStrategy the deploy strategy to use for contexts managed by this scanner.
      */
     public DeploymentScanner(
         @Name("server") Server server,
-        @Name("deploymentManager") DeploymentManager deploymentManager)
+        @Name("deployerStrategy") DeployStrategy deployStrategy)
     {
-        this(server, deploymentManager, null);
-        deploymentManager.addBean(this);
+        this(server, deployStrategy, null);
     }
 
     /**
@@ -160,33 +159,16 @@ public class DeploymentScanner extends ContainerLifeCycle implements Scanner.Bul
      * </p>
      *
      * @param server the server reference to use for any XML based deployments.
-     * @param contextHandlerDeployer the ContextHandlerDeployer to use for deploying the created ContextHandlers.
-     */
-    public DeploymentScanner(
-        @Name("server") Server server,
-        @Name("contextHandlerDeployer") ContextHandlerDeployer contextHandlerDeployer)
-    {
-        this(server, contextHandlerDeployer, null);
-    }
-
-    /**
-     * <p>
-     * Construct a raw DeploymentScanner that will (periodically) scan specific directories for paths that can be
-     * used to construct webapps that will be submitted to the DeploymentManager for eventual deployment to
-     * it's configured destination.
-     * </p>
-     *
-     * @param server the server reference to use for any XML based deployments.
-     * @param contextHandlerDeployer the ContextHandlerDeployer to use for deploying the created ContextHandlers.
+     * @param deployStrategy the deploy strategy to use for contexts managed by this scanner.
      * @param filter A custom FilenameFilter to control what files the {@link Scanner} monitors for changes.
      */
     public DeploymentScanner(
         @Name("server") Server server,
-        @Name("contextHandlerDeployer") ContextHandlerDeployer contextHandlerDeployer,
+        @Name("deployerStrategy") DeployStrategy deployStrategy,
         @Name("filenameFilter") FilenameFilter filter)
     {
         this.server = server;
-        this.contextHandlerDeployer = Objects.requireNonNull(contextHandlerDeployer);
+        this.deployStrategy = Objects.requireNonNull(deployStrategy);
         this.filenameFilter = Objects.requireNonNullElse(filter, new MonitoredPathFilter(monitoredDirs));
     }
 
@@ -695,7 +677,7 @@ public class DeploymentScanner extends ContainerLifeCycle implements Scanner.Bul
                     {
                         // Track removal
                         removedApps.add(app);
-                        contextHandlerDeployer.undeploy(app.getContextHandler());
+                        deployStrategy.onContextRemoved(app.getContextHandler());
                     }
                     case ADD ->
                     {
@@ -727,7 +709,7 @@ public class DeploymentScanner extends ContainerLifeCycle implements Scanner.Bul
 
                         // Introduce the ContextHandler to the DeploymentManager
                         startTracking(app);
-                        contextHandlerDeployer.deploy(app.getContextHandler());
+                        deployStrategy.onContextCreated(app.getContextHandler());
                     }
                 }
             }
@@ -735,7 +717,7 @@ public class DeploymentScanner extends ContainerLifeCycle implements Scanner.Bul
             {
                 LOG.warn("Failed to to perform action {} on {}", step.type(), app, t);
                 if (isStarting())
-                    contextHandlerDeployer.reportStartupFailure(t);
+                    deployStrategy.onContextFailed(t);
             }
             finally
             {

--- a/jetty-core/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/FineControlDeployStrategy.java
+++ b/jetty-core/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/FineControlDeployStrategy.java
@@ -1,0 +1,81 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.deploy;
+
+import org.eclipse.jetty.deploy.internal.DeploymentGraph;
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FineControlDeployStrategy implements DeployStrategy
+{
+    private static final Logger LOG = LoggerFactory.getLogger(SimpleDeployStrategy.class);
+    private DeploymentManager deploymentManager;
+    private String goalCreatedRunning = DeploymentGraph.STARTED;
+    private String goalCreatedStarted = DeploymentGraph.DEPLOYED;
+    private String goalRemoved = DeploymentGraph.UNDEPLOYED;
+    private String goalStopStracking = goalRemoved;
+
+    public FineControlDeployStrategy(DeploymentManager deploymentManager)
+    {
+        this.deploymentManager = deploymentManager;
+    }
+
+    @Override
+    public void onContextCreated(ContextHandler context)
+    {
+        DeploymentManager.TrackedContext trackedContext = deploymentManager.startTracking(context);
+        if (deploymentManager.getContexts().isRunning())
+        {
+            // Only move to STARTED state if the ContextHandlerCollection itself is started.
+            deploymentManager.requestContextHandlerGoal(trackedContext, goalCreatedRunning);
+        }
+        else
+        {
+            // Otherwise, just make sure it reaches the deployed state.
+            deploymentManager.requestContextHandlerGoal(trackedContext, goalCreatedStarted);
+        }
+    }
+
+    @Override
+    public void onContextRemoved(ContextHandler context)
+    {
+        move(context, goalRemoved);
+        if (goalStopStracking.equalsIgnoreCase(goalRemoved))
+            stopTracking(context);
+    }
+
+    public void move(ContextHandler context, String destinationGoal)
+    {
+        DeploymentManager.TrackedContext trackedContext = deploymentManager.findTrackedContext(context);
+        if (trackedContext != null)
+            deploymentManager.requestContextHandlerGoal(trackedContext, destinationGoal);
+    }
+
+    public void stopTracking(ContextHandler context)
+    {
+        DeploymentManager.TrackedContext trackedContext = deploymentManager.findTrackedContext(context);
+        if (trackedContext != null)
+            deploymentManager.stopTracking(trackedContext);
+    }
+
+    @Override
+    public void onContextFailed(Throwable cause)
+    {
+        if (deploymentManager.isStarting())
+            deploymentManager.reportStartupFailure(cause);
+        else
+            LOG.warn("Context Failure", cause);
+    }
+}

--- a/jetty-core/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/SimpleDeployStrategy.java
+++ b/jetty-core/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/SimpleDeployStrategy.java
@@ -1,0 +1,50 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.deploy;
+
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SimpleDeployStrategy implements DeployStrategy
+{
+    private static final Logger LOG = LoggerFactory.getLogger(SimpleDeployStrategy.class);
+    private DeploymentManager deploymentManager;
+
+    public SimpleDeployStrategy(DeploymentManager deploymentManager)
+    {
+        this.deploymentManager = deploymentManager;
+    }
+
+    @Override
+    public void onContextCreated(ContextHandler context)
+    {
+        deploymentManager.deploy(context);
+    }
+
+    @Override
+    public void onContextRemoved(ContextHandler context)
+    {
+        deploymentManager.undeploy(context);
+    }
+
+    @Override
+    public void onContextFailed(Throwable cause)
+    {
+        if (deploymentManager.isStarting())
+            deploymentManager.reportStartupFailure(cause);
+        else
+            LOG.warn("Context Failure", cause);
+    }
+}


### PR DESCRIPTION
Proposal for a DeployStrategy layer instead.

This makes the DeployScanner's only role (and similar deploy components) ...

* Create ContextHandler and notify strategy.onContextCreated
* Remove ContextHandler and notify strategy.onContextRemoved
* Notify on ContextHandler creation failures via strategy.onContextFailed

The idea of "simple" vs "fine" controlled deployment is entirely contained in this DeployStrategy.

The providers no longer decide "deploy" vs "undeploy" or any other kind of concept like that, that's controlled by whatever strategy you decide you want to use, and the DeploymentManager.

Be as simple or as complex as you want to be, but the provider doesn't make the decision anymore.