### PR TITLE
Fix issues with WebSocket UpgradeRequest after upgrade is complete

### DIFF
--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/internal/UpgradeRequestDelegate.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/internal/UpgradeRequestDelegate.java
@@ -36,19 +36,26 @@ class UpgradeRequestDelegate implements UpgradeRequest
 {
     private final ServerUpgradeRequest request;
     private final Map<String, List<String>> headers;
+    private final List<HttpCookie> cookies;
+    private final Principal userPrincipal;
 
     UpgradeRequestDelegate(ServerUpgradeRequest request)
     {
         this.request = request;
         this.headers = HttpFields.asMap(request.getHeaders());
+
+        Request.AuthenticationState authenticationState = Request.getAuthenticationState(request);
+        userPrincipal = (authenticationState == null) ? null : authenticationState.getUserPrincipal();
+
+        this.cookies = Request.getCookies(request).stream()
+            .map(org.eclipse.jetty.http.HttpCookie::asJavaNetHttpCookie)
+            .toList();
     }
 
     @Override
     public List<HttpCookie> getCookies()
     {
-        return Request.getCookies(request).stream()
-            .map(org.eclipse.jetty.http.HttpCookie::asJavaNetHttpCookie)
-            .toList();
+        return cookies;
     }
 
     @Override
@@ -149,8 +156,7 @@ class UpgradeRequestDelegate implements UpgradeRequest
     @Override
     public Principal getUserPrincipal()
     {
-        // TODO: no Principal concept in Jetty core.
-        return null;
+        return userPrincipal;
     }
 
     @Override

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/internal/UpgradeResponseDelegate.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/internal/UpgradeResponseDelegate.java
@@ -29,13 +29,15 @@ import org.eclipse.jetty.websocket.core.server.ServerUpgradeResponse;
 class UpgradeResponseDelegate implements UpgradeResponse
 {
     private final ServerUpgradeResponse response;
+    private final HttpFields httpFields;
     private final Map<String, List<String>> headers;
     private final int status;
 
     UpgradeResponseDelegate(ServerUpgradeResponse response)
     {
         this.response = response;
-        this.headers = HttpFields.asMap(response.getHeaders().asImmutable());
+        this.httpFields = response.getHeaders().asImmutable();
+        this.headers = HttpFields.asMap(httpFields);
 
         // Fake status code as it not set at the time this is created.
         HttpVersion httpVersion = response.getRequest().getConnectionMetaData().getHttpVersion();
@@ -59,13 +61,13 @@ class UpgradeResponseDelegate implements UpgradeResponse
     @Override
     public String getHeader(String name)
     {
-        return response.getHeaders().get(name);
+        return httpFields.get(name);
     }
 
     @Override
     public Set<String> getHeaderNames()
     {
-        return response.getHeaders().getFieldNamesCollection();
+        return httpFields.getFieldNamesCollection();
     }
 
     @Override
@@ -77,7 +79,7 @@ class UpgradeResponseDelegate implements UpgradeResponse
     @Override
     public List<String> getHeaders(String name)
     {
-        return response.getHeaders().getValuesList(name);
+        return httpFields.getValuesList(name);
     }
 
     @Override

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/internal/UpgradeResponseDelegate.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/internal/UpgradeResponseDelegate.java
@@ -19,6 +19,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.websocket.api.ExtensionConfig;
 import org.eclipse.jetty.websocket.api.UpgradeResponse;
 import org.eclipse.jetty.websocket.common.JettyExtensionConfig;
@@ -28,11 +30,16 @@ class UpgradeResponseDelegate implements UpgradeResponse
 {
     private final ServerUpgradeResponse response;
     private final Map<String, List<String>> headers;
+    private final int status;
 
     UpgradeResponseDelegate(ServerUpgradeResponse response)
     {
         this.response = response;
-        this.headers = HttpFields.asMap(response.getHeaders());
+        this.headers = HttpFields.asMap(response.getHeaders().asImmutable());
+
+        // Fake status code as it not set at the time this is created.
+        HttpVersion httpVersion = response.getRequest().getConnectionMetaData().getHttpVersion();
+        this.status = (httpVersion == HttpVersion.HTTP_1_1) ? HttpStatus.SWITCHING_PROTOCOLS_101 : HttpStatus.OK_200;
     }
 
     @Override
@@ -76,6 +83,6 @@ class UpgradeResponseDelegate implements UpgradeResponse
     @Override
     public int getStatusCode()
     {
-        return response.getStatus();
+        return status;
     }
 }

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/pom.xml
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/pom.xml
@@ -44,6 +44,11 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-security</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-slf4j-impl</artifactId>
       <scope>test</scope>
     </dependency>
@@ -70,11 +75,6 @@
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>jetty-websocket-jetty-server</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-security</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/pom.xml
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/pom.xml
@@ -73,6 +73,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-security</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <scope>test</scope>

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/ServerUpgradeRequestTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/ServerUpgradeRequestTest.java
@@ -11,24 +11,20 @@
 // ========================================================================
 //
 
-package org.eclipse.jetty.ee10.websocket.tests;
+package org.eclipse.jetty.websocket.tests;
 
 import java.net.URI;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
-import org.eclipse.jetty.ee10.servlet.security.ConstraintMapping;
-import org.eclipse.jetty.ee10.servlet.security.ConstraintSecurityHandler;
-import org.eclipse.jetty.ee10.websocket.server.config.JettyWebSocketServletContainerInitializer;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.security.AbstractLoginService;
 import org.eclipse.jetty.security.AuthenticationState;
 import org.eclipse.jetty.security.Constraint;
 import org.eclipse.jetty.security.DefaultIdentityService;
 import org.eclipse.jetty.security.IdentityService;
-import org.eclipse.jetty.security.LoginService;
 import org.eclipse.jetty.security.RolePrincipal;
+import org.eclipse.jetty.security.SecurityHandler;
 import org.eclipse.jetty.security.UserIdentity;
 import org.eclipse.jetty.security.UserPrincipal;
 import org.eclipse.jetty.security.authentication.LoginAuthenticator;
@@ -45,6 +41,7 @@ import org.eclipse.jetty.websocket.api.UpgradeResponse;
 import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.eclipse.jetty.websocket.server.WebSocketUpgradeHandler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -126,30 +123,26 @@ public class ServerUpgradeRequestTest
         _connector = new ServerConnector(_server);
         _server.addConnector(_connector);
 
-        ServletContextHandler servletContextHandler = new ServletContextHandler();
-        JettyWebSocketServletContainerInitializer.configure(servletContextHandler, (servletContext, container) ->
-            container.addMapping("/", (req, resp) ->
+        WebSocketUpgradeHandler upgradeHandler = WebSocketUpgradeHandler.from(_server, container ->
+        {
+            container.addMapping("/", (req, resp, cb) ->
             {
-                resp.setHeader("customHeader", "customHeaderValue");
+                resp.getHeaders().put("customHeader", "customHeaderValue");
                 resp.setAcceptedSubProtocol(req.getSubProtocols().get(0));
+
                 return new ServerSocket();
-            }));
+            });
+        });
 
+        SecurityHandler.PathMapped securityHandler = new SecurityHandler.PathMapped();
+        securityHandler.put("/*", Constraint.ANY_USER);
         DefaultIdentityService identityService = new DefaultIdentityService();
-        LoginService loginService = new TestLoginService(identityService);
-
-        ConstraintMapping constraintMapping = new ConstraintMapping();
-        constraintMapping.setPathSpec("/*");
-        constraintMapping.setConstraint(Constraint.ANY_USER);
-
-        ConstraintSecurityHandler securityHandler = new ConstraintSecurityHandler();
-        securityHandler.setConstraintMappings(List.of(constraintMapping));
-        securityHandler.setLoginService(loginService);
+        securityHandler.setLoginService(new TestLoginService(identityService));
         securityHandler.setIdentityService(identityService);
-        servletContextHandler.setSecurityHandler(securityHandler);
         securityHandler.setAuthenticator(new TestAuthenticator());
+        securityHandler.setHandler(upgradeHandler);
 
-        _server.setHandler(servletContextHandler);
+        _server.setHandler(securityHandler);
         _server.start();
 
         _client = new WebSocketClient();
@@ -237,7 +230,7 @@ public class ServerUpgradeRequestTest
         assertThat(received, containsString("getQueryString: queryParam1=queryParamValue1"));
         assertThat(received, containsString("getSubProtocols: [subProtocol1, subProtocol2]"));
         assertThat(received, containsString("getProtocolVersion: 13"));
-        assertThat(received, containsString("getCookies: [cookieHeader1=\"cookieValue1\"]"));
+        assertThat(received, containsString("getCookies: [cookieHeader1=cookieValue1]"));
         assertThat(received, containsString("getUserPrincipal: user123"));
         assertThat(received, containsString("getOrigin: jetty-test"));
         assertThat(received, containsString("isSecure: false"));

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/internal/DelegatedServerUpgradeRequest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/internal/DelegatedServerUpgradeRequest.java
@@ -42,23 +42,56 @@ import org.eclipse.jetty.websocket.core.server.ServerUpgradeRequest;
 
 public class DelegatedServerUpgradeRequest implements JettyServerUpgradeRequest
 {
+    private final boolean upgraded;
     private final URI requestURI;
     private final String queryString;
     private final ServerUpgradeRequest upgradeRequest;
     private final HttpServletRequest httpServletRequest;
     private final Principal userPrincipal;
+    private final String origin;
+    private final boolean isSecure;
     private final Map<String, List<String>> headers;
     private List<HttpCookie> cookies;
     private Map<String, List<String>> parameterMap;
 
     public DelegatedServerUpgradeRequest(ServerUpgradeRequest request)
     {
+        this(request, false);
+    }
+
+    public DelegatedServerUpgradeRequest(ServerUpgradeRequest request, boolean upgraded)
+    {
+        this.upgraded = upgraded;
         this.httpServletRequest = (HttpServletRequest)request
             .getAttribute(WebSocketConstants.WEBSOCKET_WRAPPED_REQUEST_ATTRIBUTE);
         this.upgradeRequest = request;
+        this.headers = HttpFields.asMap(upgradeRequest.getHeaders());
         this.queryString = httpServletRequest.getQueryString();
         this.userPrincipal = httpServletRequest.getUserPrincipal();
-        this.headers = HttpFields.asMap(upgradeRequest.getHeaders());
+        this.origin = httpServletRequest.getHeader(HttpHeader.ORIGIN.asString());
+        this.isSecure = httpServletRequest.isSecure();
+
+        Map<String, String[]> requestParams = httpServletRequest.getParameterMap();
+        if (requestParams != null)
+        {
+            parameterMap = new HashMap<>(requestParams.size());
+            for (Map.Entry<String, String[]> entry : requestParams.entrySet())
+            {
+                parameterMap.put(entry.getKey(), Arrays.asList(entry.getValue()));
+            }
+        }
+
+        Cookie[] reqCookies = httpServletRequest.getCookies();
+        if (reqCookies != null)
+        {
+            cookies = Arrays.stream(reqCookies)
+                .map(c -> new HttpCookie(c.getName(), c.getValue()))
+                .collect(Collectors.toList());
+        }
+        else
+        {
+            cookies = Collections.emptyList();
+        }
 
         try
         {
@@ -82,21 +115,6 @@ public class DelegatedServerUpgradeRequest implements JettyServerUpgradeRequest
     @Override
     public List<HttpCookie> getCookies()
     {
-        if (cookies == null)
-        {
-            Cookie[] reqCookies = httpServletRequest.getCookies();
-            if (reqCookies != null)
-            {
-                cookies = Arrays.stream(reqCookies)
-                    .map(c -> new HttpCookie(c.getName(), c.getValue()))
-                    .collect(Collectors.toList());
-            }
-            else
-            {
-                cookies = Collections.emptyList();
-            }
-        }
-
         return cookies;
     }
 
@@ -153,24 +171,12 @@ public class DelegatedServerUpgradeRequest implements JettyServerUpgradeRequest
     @Override
     public String getOrigin()
     {
-        return httpServletRequest.getHeader(HttpHeader.ORIGIN.asString());
+        return origin;
     }
 
     @Override
     public Map<String, List<String>> getParameterMap()
     {
-        if (parameterMap == null)
-        {
-            Map<String, String[]> requestParams = httpServletRequest.getParameterMap();
-            if (requestParams != null)
-            {
-                parameterMap = new HashMap<>(requestParams.size());
-                for (Map.Entry<String, String[]> entry : requestParams.entrySet())
-                {
-                    parameterMap.put(entry.getKey(), Arrays.asList(entry.getValue()));
-                }
-            }
-        }
         return parameterMap;
     }
 
@@ -195,6 +201,9 @@ public class DelegatedServerUpgradeRequest implements JettyServerUpgradeRequest
     @Override
     public HttpSession getSession()
     {
+        if (upgraded)
+            throw new IllegalStateException("Already Upgraded to WebSocket");
+
         return httpServletRequest.getSession();
     }
 
@@ -219,42 +228,60 @@ public class DelegatedServerUpgradeRequest implements JettyServerUpgradeRequest
     @Override
     public boolean isSecure()
     {
-        return httpServletRequest.isSecure();
+        return isSecure;
     }
 
     @Override
     public X509Certificate[] getCertificates()
     {
+        if (upgraded)
+            throw new IllegalStateException("Already Upgraded to WebSocket");
+
         return (X509Certificate[])httpServletRequest.getAttribute("jakarta.servlet.request.X509Certificate");
     }
 
     @Override
     public HttpServletRequest getHttpServletRequest()
     {
+        if (upgraded)
+            throw new IllegalStateException("Already Upgraded to WebSocket");
+
         return httpServletRequest;
     }
 
     @Override
     public Locale getLocale()
     {
+        if (upgraded)
+            throw new IllegalStateException("Already Upgraded to WebSocket");
+
         return httpServletRequest.getLocale();
     }
 
     @Override
     public Enumeration<Locale> getLocales()
     {
+        if (upgraded)
+            throw new IllegalStateException("Already Upgraded to WebSocket");
+
         return httpServletRequest.getLocales();
     }
 
     @Override
     public SocketAddress getLocalSocketAddress()
     {
+        if (upgraded)
+            throw new IllegalStateException("Already Upgraded to WebSocket");
+
         return upgradeRequest.getConnectionMetaData().getLocalSocketAddress();
     }
 
     @Override
     public SocketAddress getRemoteSocketAddress()
     {
+        if (upgraded)
+            throw new IllegalStateException("Already Upgraded to WebSocket");
+
         return upgradeRequest.getConnectionMetaData().getRemoteSocketAddress();
     }
 
@@ -267,12 +294,18 @@ public class DelegatedServerUpgradeRequest implements JettyServerUpgradeRequest
     @Override
     public Object getServletAttribute(String name)
     {
+        if (upgraded)
+            throw new IllegalStateException("Already Upgraded to WebSocket");
+
         return upgradeRequest.getAttribute(name);
     }
 
     @Override
     public Map<String, Object> getServletAttributes()
     {
+        if (upgraded)
+            throw new IllegalStateException("Already Upgraded to WebSocket");
+
         Map<String, Object> attributes = new HashMap<>(2);
         Enumeration<String> attributeNames = httpServletRequest.getAttributeNames();
         while (attributeNames.hasMoreElements())
@@ -286,18 +319,27 @@ public class DelegatedServerUpgradeRequest implements JettyServerUpgradeRequest
     @Override
     public Map<String, List<String>> getServletParameters()
     {
+        if (upgraded)
+            throw new IllegalStateException("Already Upgraded to WebSocket");
+
         return getParameterMap();
     }
 
     @Override
     public boolean isUserInRole(String role)
     {
+        if (upgraded)
+            throw new IllegalStateException("Already Upgraded to WebSocket");
+
         return httpServletRequest.isUserInRole(role);
     }
 
     @Override
     public void setServletAttribute(String name, Object value)
     {
+        if (upgraded)
+            throw new IllegalStateException("Already Upgraded to WebSocket");
+
         upgradeRequest.setAttribute(name, value);
     }
 }

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/internal/DelegatedServerUpgradeResponse.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/internal/DelegatedServerUpgradeResponse.java
@@ -38,6 +38,7 @@ public class DelegatedServerUpgradeResponse implements JettyServerUpgradeRespons
     private final HttpServletResponse httpServletResponse;
     private final Map<String, List<String>> headers;
     private final int status;
+    private final HttpFields.Mutable httpFields;
 
     public DelegatedServerUpgradeResponse(ServerUpgradeResponse response)
     {
@@ -50,7 +51,9 @@ public class DelegatedServerUpgradeResponse implements JettyServerUpgradeRespons
         this.upgradeResponse = response;
         this.httpServletResponse = (HttpServletResponse)Response.as(response, ServletContextResponse.class).getRequest()
             .getAttribute(WebSocketConstants.WEBSOCKET_WRAPPED_RESPONSE_ATTRIBUTE);
-        this.headers = HttpFields.asMap(upgraded ? upgradeResponse.getHeaders().asImmutable() : upgradeResponse.getHeaders());
+
+        this.httpFields = upgradeResponse.getHeaders();
+        this.headers = HttpFields.asMap(upgraded ? httpFields.asImmutable() : httpFields);
 
         // Fake status code if already upgraded, as it not set at the time this is created.
         HttpVersion httpVersion = response.getRequest().getConnectionMetaData().getHttpVersion();
@@ -63,7 +66,7 @@ public class DelegatedServerUpgradeResponse implements JettyServerUpgradeRespons
         if (upgraded)
             throw new IllegalStateException("Already Upgraded to WebSocket");
 
-        upgradeResponse.getHeaders().add(name, value);
+        httpFields.add(name, value);
     }
 
     @Override
@@ -72,7 +75,7 @@ public class DelegatedServerUpgradeResponse implements JettyServerUpgradeRespons
         if (upgraded)
             throw new IllegalStateException("Already Upgraded to WebSocket");
 
-        headers.put(name, List.of(value));
+        httpFields.put(name, List.of(value));
     }
 
     @Override
@@ -81,7 +84,7 @@ public class DelegatedServerUpgradeResponse implements JettyServerUpgradeRespons
         if (upgraded)
             throw new IllegalStateException("Already Upgraded to WebSocket");
 
-        headers.put(name, values);
+        httpFields.put(name, values);
     }
 
     @Override
@@ -99,13 +102,13 @@ public class DelegatedServerUpgradeResponse implements JettyServerUpgradeRespons
     @Override
     public String getHeader(String name)
     {
-        return upgradeResponse.getHeaders().get(name);
+        return httpFields.get(name);
     }
 
     @Override
     public Set<String> getHeaderNames()
     {
-        return upgradeResponse.getHeaders().getFieldNamesCollection();
+        return httpFields.getFieldNamesCollection();
     }
 
     @Override
@@ -117,7 +120,7 @@ public class DelegatedServerUpgradeResponse implements JettyServerUpgradeRespons
     @Override
     public List<String> getHeaders(String name)
     {
-        return upgradeResponse.getHeaders().getValuesList(name);
+        return httpFields.getValuesList(name);
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/internal/DelegatedServerUpgradeResponse.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/internal/DelegatedServerUpgradeResponse.java
@@ -24,6 +24,7 @@ import org.eclipse.jetty.ee10.servlet.ServletContextResponse;
 import org.eclipse.jetty.ee10.websocket.server.JettyServerUpgradeResponse;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.websocket.api.ExtensionConfig;
 import org.eclipse.jetty.websocket.common.JettyExtensionConfig;
@@ -32,36 +33,54 @@ import org.eclipse.jetty.websocket.core.server.ServerUpgradeResponse;
 
 public class DelegatedServerUpgradeResponse implements JettyServerUpgradeResponse
 {
+    private final boolean upgraded;
     private final ServerUpgradeResponse upgradeResponse;
     private final HttpServletResponse httpServletResponse;
     private final Map<String, List<String>> headers;
+    private final int status;
 
     public DelegatedServerUpgradeResponse(ServerUpgradeResponse response)
     {
-        upgradeResponse = response;
-        ServletContextResponse servletContextResponse = Response.as(response, ServletContextResponse.class);
-        this.httpServletResponse = (HttpServletResponse)servletContextResponse.getRequest()
+        this(response, false);
+    }
+
+    public DelegatedServerUpgradeResponse(ServerUpgradeResponse response, boolean upgraded)
+    {
+        this.upgraded = upgraded;
+        this.upgradeResponse = response;
+        this.httpServletResponse = (HttpServletResponse)Response.as(response, ServletContextResponse.class).getRequest()
             .getAttribute(WebSocketConstants.WEBSOCKET_WRAPPED_RESPONSE_ATTRIBUTE);
-        this.headers = HttpFields.asMap(upgradeResponse.getHeaders());
+        this.headers = HttpFields.asMap(upgraded ? upgradeResponse.getHeaders().asImmutable() : upgradeResponse.getHeaders());
+
+        // Fake status code if already upgraded, as it not set at the time this is created.
+        HttpVersion httpVersion = response.getRequest().getConnectionMetaData().getHttpVersion();
+        this.status = (httpVersion == HttpVersion.HTTP_1_1) ? HttpStatus.SWITCHING_PROTOCOLS_101 : HttpStatus.OK_200;
     }
 
     @Override
     public void addHeader(String name, String value)
     {
-        // TODO: This should go to the httpServletResponse for headers but then it won't do interception of the websocket headers
-        //  which are done through the jetty-core Response wrapping ServerUpgradeResponse done by websocket-core.
+        if (upgraded)
+            throw new IllegalStateException("Already Upgraded to WebSocket");
+
         upgradeResponse.getHeaders().add(name, value);
     }
 
     @Override
     public void setHeader(String name, String value)
     {
+        if (upgraded)
+            throw new IllegalStateException("Already Upgraded to WebSocket");
+
         headers.put(name, List.of(value));
     }
 
     @Override
     public void setHeader(String name, List<String> values)
     {
+        if (upgraded)
+            throw new IllegalStateException("Already Upgraded to WebSocket");
+
         headers.put(name, values);
     }
 
@@ -104,24 +123,36 @@ public class DelegatedServerUpgradeResponse implements JettyServerUpgradeRespons
     @Override
     public int getStatusCode()
     {
-        return httpServletResponse.getStatus();
+        if (upgraded)
+            return status;
+        else
+            return httpServletResponse.getStatus();
     }
 
     @Override
     public void sendForbidden(String message) throws IOException
     {
+        if (upgraded)
+            throw new IllegalStateException("Already Upgraded to WebSocket");
+
         httpServletResponse.sendError(HttpStatus.FORBIDDEN_403, message);
     }
 
     @Override
     public void setAcceptedSubProtocol(String protocol)
     {
+        if (upgraded)
+            throw new IllegalStateException("Already Upgraded to WebSocket");
+
         upgradeResponse.setAcceptedSubProtocol(protocol);
     }
 
     @Override
     public void setExtensions(List<ExtensionConfig> configs)
     {
+        if (upgraded)
+            throw new IllegalStateException("Already Upgraded to WebSocket");
+
         upgradeResponse.setExtensions(configs.stream()
             .map(c -> new org.eclipse.jetty.websocket.core.ExtensionConfig(c.getName(), c.getParameters()))
             .collect(Collectors.toList()));
@@ -130,18 +161,27 @@ public class DelegatedServerUpgradeResponse implements JettyServerUpgradeRespons
     @Override
     public void setStatusCode(int statusCode)
     {
+        if (upgraded)
+            throw new IllegalStateException("Already Upgraded to WebSocket");
+
         httpServletResponse.setStatus(statusCode);
     }
 
     @Override
     public boolean isCommitted()
     {
+        if (upgraded)
+            return true;
+
         return httpServletResponse.isCommitted();
     }
 
     @Override
     public void sendError(int statusCode, String message) throws IOException
     {
+        if (upgraded)
+            throw new IllegalStateException("Already Upgraded to WebSocket");
+
         httpServletResponse.sendError(statusCode, message);
     }
 }

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/internal/JettyServerFrameHandlerFactory.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/internal/JettyServerFrameHandlerFactory.java
@@ -40,8 +40,8 @@ public class JettyServerFrameHandlerFactory extends JettyWebSocketFrameHandlerFa
     public FrameHandler newFrameHandler(Object websocketPojo, ServerUpgradeRequest upgradeRequest, ServerUpgradeResponse upgradeResponse)
     {
         JettyWebSocketFrameHandler frameHandler = super.newJettyFrameHandler(websocketPojo);
-        frameHandler.setUpgradeRequest(new DelegatedServerUpgradeRequest(upgradeRequest));
-        frameHandler.setUpgradeResponse(new DelegatedServerUpgradeResponse(upgradeResponse));
+        frameHandler.setUpgradeRequest(new DelegatedServerUpgradeRequest(upgradeRequest, true));
+        frameHandler.setUpgradeResponse(new DelegatedServerUpgradeResponse(upgradeResponse, true));
         return frameHandler;
     }
 }


### PR DESCRIPTION
see https://github.com/jetty/jetty.project/issues/11294

The `UpgradeRequest`/`UpgradeResponse` interfaces are available from the `Session` in the Jetty WebSocket API.

These can be accessed after the upgrade, this PR introduces testing for these methods and fixes the ones which do not work.

For the EE10 environment it is possible for people to downcast the `UpgradeRequest` to a `JettyServerUpgradeRequest`, these methods now throw ISE after the upgrade, as they are only indented to be used during the negotiation.