### PR TITLE
Fixes #12852 - Jetty's 12.1.x ArrayByteBufferPool.Quadratic java.lang.ArrayIndexOutOfBoundsException

### DIFF
--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -872,48 +872,66 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
      */
     public static class Quadratic extends ArrayByteBufferPool
     {
+        // Allows to skip tiny buckets of capacity 1, 2, 4, 8, etc.
+        private static final int DEFAULT_MIN_CAPACITY = 1024;
+
+        /**
+         * Creates a pool with buckets starting at 1 KiB up to 64 KiB.
+         */
         public Quadratic()
         {
             this(-1, -1, Integer.MAX_VALUE);
         }
 
+        /**
+         * <p>Creates a pool with the specified {@code minCapacity}, {@code maxCapacity}
+         * and {@code maxBucketSize}, see {@link #Quadratic(int, int, int, long, long)}.</p>
+         *
+         * @param minCapacity the capacity under which buffers will not be pooled
+         * @param maxCapacity the capacity above which buffers will not be pooled
+         * @param maxBucketSize the max number of buffers in a bucket
+         */
         public Quadratic(int minCapacity, int maxCapacity, int maxBucketSize)
         {
             this(minCapacity, maxCapacity, maxBucketSize, 0L, 0L);
         }
 
+        /**
+         * <p>Creates a pool with buckets starting at the closest power of 2 larger than {@code minCapacity},
+         * up to the closest power of 2 larger than {@code maxCapacity}.</p>
+         * <p>For example, with {@code minCapacity=100} and {@code maxCapacity=800}, the buckets will have
+         * capacities {@code 128, 256, 512, 1024}.</p>
+         * <p>A non-positive {@code minCapacity} establishes the first bucket at 1 KiB.</p>
+         * <p>A non-positive {@code maxCapacity} establishes the last bucket at 64 KiB.</p>
+         *
+         * @param minCapacity the capacity under which buffers will not be pooled
+         * @param maxCapacity the capacity above which buffers will not be pooled
+         * @param maxBucketSize the max number of buffers in a bucket
+         * @param maxHeapMemory the max heap memory in bytes, -1 for unlimited memory or 0 to use default heuristic
+         * @param maxDirectMemory the max direct memory in bytes, -1 for unlimited memory or 0 to use default heuristic
+         */
         public Quadratic(int minCapacity, int maxCapacity, int maxBucketSize, long maxHeapMemory, long maxDirectMemory)
         {
-            super(computeMinCapacity(minCapacity),
+            super(minCapacity,
                 -1,
-                computeMaxCapacity(maxCapacity),
+                maxCapacity,
                 maxBucketSize,
                 maxHeapMemory,
                 maxDirectMemory,
-                bucketIndexFor(computeMinCapacity(minCapacity)),
-                bucketCapacityFor(computeMinCapacity(minCapacity))
+                bucketIndexFor(minCapacity),
+                bucketCapacityFor(minCapacity)
             );
-        }
-
-        private static int computeMinCapacity(int minCapacity)
-        {
-            return minCapacity <= 0 ? 1024 : minCapacity;
-        }
-
-        private static int computeMaxCapacity(int maxCapacity)
-        {
-            return maxCapacity <= 0 ? 65536 : maxCapacity;
         }
 
         private static IntUnaryOperator bucketIndexFor(int minCapacity)
         {
-            int minCapIdx = MathUtils.ceilLog2(minCapacity);
-            return c -> MathUtils.ceilLog2(c) - minCapIdx;
+            int minCapIdx = MathUtils.ceilLog2(minCapacity <= 0 ? DEFAULT_MIN_CAPACITY : minCapacity);
+            return c -> Math.max(0, MathUtils.ceilLog2(c) - minCapIdx);
         }
 
         private static IntUnaryOperator bucketCapacityFor(int minCapacity)
         {
-            int minCapIdx = MathUtils.ceilLog2(minCapacity);
+            int minCapIdx = MathUtils.ceilLog2(minCapacity <= 0 ? DEFAULT_MIN_CAPACITY : minCapacity);
             return i -> 1 << (i + minCapIdx);
         }
     }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -73,7 +73,7 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
     private final long _maxHeapMemory;
     private final long _maxDirectMemory;
     private final IntUnaryOperator _bucketIndexFor;
-    private final IntUnaryOperator _bucketCapacity;
+    private final IntUnaryOperator _bucketCapacityFor;
     private final AtomicBoolean _evictor = new AtomicBoolean(false);
     private final AtomicLong _reserved = new AtomicLong();
     private final ConcurrentMap<Integer, Long> _noBucketDirectAcquires = new ConcurrentHashMap<>();
@@ -141,30 +141,27 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
      * @param maxHeapMemory the max heap memory in bytes, -1 for unlimited memory or 0 to use default heuristic
      * @param maxDirectMemory the max direct memory in bytes, -1 for unlimited memory or 0 to use default heuristic
      * @param bucketIndexFor a {@link IntUnaryOperator} that takes a capacity and returns a bucket index
-     * @param bucketCapacity a {@link IntUnaryOperator} that takes a bucket index and returns a capacity
+     * @param bucketCapacityFor a {@link IntUnaryOperator} that takes a bucket index and returns a capacity
      */
-    protected ArrayByteBufferPool(int minCapacity, int factor, int maxCapacity, int maxBucketSize, long maxHeapMemory, long maxDirectMemory, IntUnaryOperator bucketIndexFor, IntUnaryOperator bucketCapacity)
+    protected ArrayByteBufferPool(int minCapacity, int factor, int maxCapacity, int maxBucketSize, long maxHeapMemory, long maxDirectMemory, IntUnaryOperator bucketIndexFor, IntUnaryOperator bucketCapacityFor)
     {
         if (minCapacity <= 0)
             minCapacity = 0;
         factor = factor <= 0 ? DEFAULT_FACTOR : factor;
         if (maxCapacity <= 0)
             maxCapacity = DEFAULT_MAX_CAPACITY_BY_FACTOR * factor;
-        if ((maxCapacity % factor) != 0 || factor >= maxCapacity)
-            throw new IllegalArgumentException(String.format("The capacity factor(%d) must be a divisor of maxCapacity(%d)", factor, maxCapacity));
 
-        int f = factor;
         if (bucketIndexFor == null)
-            bucketIndexFor = c -> (c - 1) / f;
-        if (bucketCapacity == null)
-            bucketCapacity = i -> (i + 1) * f;
+            bucketIndexFor = defaultBucketIndexFor(minCapacity, factor);
+        if (bucketCapacityFor == null)
+            bucketCapacityFor = defaultBucketCapacityFor(minCapacity, factor);
 
         int length = bucketIndexFor.applyAsInt(maxCapacity) + 1;
         RetainedBucket[] directArray = new RetainedBucket[length];
         RetainedBucket[] indirectArray = new RetainedBucket[length];
         for (int i = 0; i < directArray.length; i++)
         {
-            int capacity = Math.min(bucketCapacity.applyAsInt(i), maxCapacity);
+            int capacity = bucketCapacityFor.applyAsInt(i);
             directArray[i] = new RetainedBucket(capacity, maxBucketSize);
             indirectArray[i] = new RetainedBucket(capacity, maxBucketSize);
         }
@@ -176,7 +173,20 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
         _maxHeapMemory = maxMemory(maxHeapMemory);
         _maxDirectMemory = maxMemory(maxDirectMemory);
         _bucketIndexFor = bucketIndexFor;
-        _bucketCapacity = bucketCapacity;
+        _bucketCapacityFor = bucketCapacityFor;
+    }
+
+    private static IntUnaryOperator defaultBucketIndexFor(int minCapacity, int factor)
+    {
+        int minCapIdx = (minCapacity - 1) / factor;
+        return capacity -> ((capacity - 1) / factor) - minCapIdx;
+    }
+
+    private static IntUnaryOperator defaultBucketCapacityFor(int minCapacity, int factor)
+    {
+        int minCapIdx = (minCapacity - 1) / factor;
+        // Add 1 because indexes are zero-based.
+        return idx -> (idx + minCapIdx + 1) * factor;
     }
 
     private long maxMemory(long maxMemory)
@@ -252,7 +262,7 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
         {
             ConcurrentMap<Integer, Long> map = direct ? _noBucketDirectAcquires : _noBucketIndirectAcquires;
             int idx = _bucketIndexFor.applyAsInt(size);
-            int key = _bucketCapacity.applyAsInt(idx);
+            int key = _bucketCapacityFor.applyAsInt(idx);
             map.compute(key, (k, v) ->
             {
                 if (v == null)
@@ -367,12 +377,10 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
 
     private RetainedBucket bucketFor(int capacity, boolean direct)
     {
-        if (capacity < getMinCapacity())
+        if (capacity < getMinCapacity() || capacity > getMaxCapacity())
             return null;
         int idx = _bucketIndexFor.applyAsInt(capacity);
         RetainedBucket[] buckets = direct ? _direct : _indirect;
-        if (idx >= buckets.length)
-            return null;
         return buckets[idx];
     }
 
@@ -795,8 +803,13 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
 
         public WithBucketCapacities(long maxHeapMemory, long maxDirectMemory, int... capacities)
         {
-            super(-1, 1, sort(capacities)[capacities.length - 1], Integer.MAX_VALUE, maxHeapMemory, maxDirectMemory,
-                c -> floorBucketIndexFor(c, capacities), i -> bucketCapacityForIndex(i, capacities));
+            this(sort(Arrays.copyOf(capacities, capacities.length)), maxHeapMemory, maxDirectMemory);
+        }
+
+        private WithBucketCapacities(int[] capacities, long maxHeapMemory, long maxDirectMemory)
+        {
+            super(0, -1, capacities[capacities.length - 1], Integer.MAX_VALUE, maxHeapMemory, maxDirectMemory,
+                bucketIndexFor(capacities), bucketCapacityFor(capacities));
         }
 
         private static int[] sort(int... values)
@@ -807,43 +820,48 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
             return values;
         }
 
-        private static int bucketCapacityForIndex(int idx, int... capacities)
+        private static IntUnaryOperator bucketIndexFor(int[] capacities)
         {
-            if (idx >= capacities.length)
+            return capacity ->
             {
-                // An index over the capacities array's length is considered
-                // to refer to a multiple of the largest configured capacity;
-                // this logic is only meant for recordNoBucketAcquire().
-                int largestCapacity = capacities[capacities.length - 1];
-                int virtualIdx = idx - (capacities.length - 1);
-                return (virtualIdx + 1) * largestCapacity;
-            }
-            return capacities[idx];
-        }
-
-        private static int floorBucketIndexFor(int capacity, int... capacities)
-        {
-            int largestCapacity = capacities[capacities.length - 1];
-            if (capacity > largestCapacity)
-            {
+                int maxIdx = capacities.length - 1;
+                int largestCapacity = capacities[maxIdx];
+                if (capacity <= largestCapacity)
+                {
+                    for (int i = 0; i <= maxIdx; i++)
+                    {
+                        if (capacities[i] > capacity)
+                            return i;
+                    }
+                    return maxIdx;
+                }
                 // A capacity over the largest configured capacity returns an
                 // index that corresponds to where in the capacities array it
                 // would stand if the latter had more entries that would all
                 // be multiples of the largest configured capacity;
                 // this logic is only meant for recordNoBucketAcquire().
-                int remainder = capacity % largestCapacity != 0 ? 1 : 0;
-                int overLargestCapacityFactor = (capacity / largestCapacity) + remainder;
-                return overLargestCapacityFactor - 1 + capacities.length - 1;
-            }
+                int remainder = (capacity % largestCapacity) != 0 ? 1 : 0;
+                // The index of the virtual bucket, starting from maxIdx;
+                // the first virtual bucket would have idx=1, and so on.
+                int overMaxIdx = (capacity / largestCapacity) + remainder;
+                return maxIdx + overMaxIdx - 1;
+            };
+        }
 
-            int idx = 0;
-            for (int i = 0; i < capacities.length; i++)
+        private static IntUnaryOperator bucketCapacityFor(int[] capacities)
+        {
+            return idx ->
             {
-                idx = i;
-                if (capacities[i] > capacity)
-                    break;
-            }
-            return idx;
+                int maxIdx = capacities.length - 1;
+                if (idx <= maxIdx)
+                    return capacities[idx];
+                // An index over the capacities array's length is considered
+                // to refer to a multiple of the largest configured capacity;
+                // this logic is only meant for recordNoBucketAcquire().
+                int largestCapacity = capacities[maxIdx];
+                int overMaxIdx = idx - maxIdx + 1;
+                return overMaxIdx * largestCapacity;
+            };
         }
     }
 
@@ -866,17 +884,14 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
 
         public Quadratic(int minCapacity, int maxCapacity, int maxBucketSize, long maxHeapMemory, long maxDirectMemory)
         {
-            super(minCapacity,
-                computeMinCapacity(minCapacity),
+            super(computeMinCapacity(minCapacity),
+                -1,
                 computeMaxCapacity(maxCapacity),
                 maxBucketSize,
                 maxHeapMemory,
                 maxDirectMemory,
-                // The bucket indices are the powers of 2, but those powers up to minCapacity are skipped so they must be
-                // substracted when computing the index and added when computing the capacity; so if minCapacity is 1024, any
-                // number from 0 to 1024 must return index 0, and index 0 must return capacity 1024.
-                c -> Integer.SIZE - Integer.numberOfLeadingZeros(c - 1) - MathUtils.ceilLog2(computeMinCapacity(minCapacity)),
-                i -> 1 << i + MathUtils.ceilLog2(computeMinCapacity(minCapacity))
+                bucketIndexFor(computeMinCapacity(minCapacity)),
+                bucketCapacityFor(computeMinCapacity(minCapacity))
             );
         }
 
@@ -888,6 +903,18 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
         private static int computeMaxCapacity(int maxCapacity)
         {
             return maxCapacity <= 0 ? 65536 : maxCapacity;
+        }
+
+        private static IntUnaryOperator bucketIndexFor(int minCapacity)
+        {
+            int minCapIdx = MathUtils.ceilLog2(minCapacity);
+            return c -> MathUtils.ceilLog2(c) - minCapIdx;
+        }
+
+        private static IntUnaryOperator bucketCapacityFor(int minCapacity)
+        {
+            int minCapIdx = MathUtils.ceilLog2(minCapacity);
+            return i -> 1 << (i + minCapIdx);
         }
     }
 

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
@@ -24,6 +24,8 @@ import org.eclipse.jetty.util.ConcurrentPool;
 import org.eclipse.jetty.util.Pool;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -275,30 +277,50 @@ public class ArrayByteBufferPoolTest
         assertThat(pool.getAvailableDirectMemory(), is(30L));
     }
 
-    @Test
-    public void testFactorAndCapacity()
+    @ParameterizedTest
+    @CsvSource(useHeadersInDisplayName = true, textBlock = """
+        minCapacity, factor, maxCapacity, buckets
+                 10,      3,          20, 12;15;18;21
+                 10,      4,          20, 12;16;20
+                 10,      5,          20, 10;15;20
+                 10,     10,          20, 10;20
+        """)
+    public void testFactorCapacityAcquireRelease(int minCapacity, int factor, int maxCapacity, String buckets)
     {
-        ArrayByteBufferPool pool = new ArrayByteBufferPool(10, 10, 20, Integer.MAX_VALUE);
+        ArrayByteBufferPool pool = new ArrayByteBufferPool(minCapacity, factor, maxCapacity, Integer.MAX_VALUE);
+        pool.setStatisticsEnabled(true);
 
-        RetainableByteBuffer buf1 = pool.acquire(1, true);
-        RetainableByteBuffer buf2 = pool.acquire(10, true);
-        RetainableByteBuffer buf3 = pool.acquire(20, true);
-        RetainableByteBuffer buf4 = pool.acquire(30, true);
+        String[] expectedBuckets = buckets.split(";");
+        int bucketCount = expectedBuckets.length;
+        List<Map<String, Object>> stats = pool.getDirectBucketsStatistics();
+        assertEquals(bucketCount, stats.size());
+        for (int i = 0; i < bucketCount; ++i)
+        {
+            assertEquals(expectedBuckets[i], String.valueOf(stats.get(i).get("capacity")));
+        }
+
+        RetainableByteBuffer bufUnder = pool.acquire(1, true);
+        RetainableByteBuffer bufMin = pool.acquire(minCapacity, true);
+        RetainableByteBuffer bufMid = pool.acquire((minCapacity + maxCapacity) / 2, true);
+        RetainableByteBuffer bufMax = pool.acquire(maxCapacity, true);
+        RetainableByteBuffer bufOver = pool.acquire(maxCapacity + 1, true);
 
         assertThat(pool.getDirectByteBufferCount(), is(0L));
         assertThat(pool.getDirectMemory(), is(0L));
         assertThat(pool.getAvailableDirectByteBufferCount(), is(0L));
         assertThat(pool.getAvailableDirectMemory(), is(0L));
 
-        assertTrue(buf1.release()); // not pooled, < minCapacity
-        assertTrue(buf2.release()); // pooled
-        assertTrue(buf3.release()); // pooled
-        assertTrue(buf4.release()); // not pooled, > maxCapacity
+        assertTrue(bufUnder.release()); // not pooled, < minCapacity
+        assertTrue(bufMin.release()); // pooled
+        assertTrue(bufMid.release()); // pooled
+        assertTrue(bufMax.release()); // pooled
+        assertTrue(bufOver.release()); // not pooled, > maxCapacity
 
-        assertThat(pool.getDirectByteBufferCount(), is(2L));
-        assertThat(pool.getDirectMemory(), is(30L));
-        assertThat(pool.getAvailableDirectByteBufferCount(), is(2L));
-        assertThat(pool.getAvailableDirectMemory(), is(30L));
+        assertThat(pool.getDirectByteBufferCount(), is(3L));
+        assertThat(pool.getAvailableDirectByteBufferCount(), is(3L));
+
+        Map<Integer, Long> noBucketAcquires = pool.getNoBucketDirectAcquires();
+        assertEquals(2, noBucketAcquires.size());
     }
 
     @Test
@@ -406,40 +428,54 @@ public class ArrayByteBufferPoolTest
         assertThat(pool.getHeapMemory(), is(0L));
     }
 
-    @Test
-    public void testQuadraticPoolBucketSizes()
+    @ParameterizedTest
+    @CsvSource(useHeadersInDisplayName = true, textBlock = """
+        minCapacity, maxCapacity, buckets
+                 -1,          -1, 1024;2048;4096;8192;16384;32768;65536
+                100,         800, 128;256;512;1024
+                  2,         200, 2;4;8;16;32;64;128;256
+        """)
+    public void testQuadraticFactorCapacityAcquireRelease(int minCapacity, int maxCapacity, String buckets)
     {
-        ArrayByteBufferPool pool1 = new ArrayByteBufferPool.Quadratic();
-        String dump1 = pool1.dump();
-        assertThat(dump1, containsString("direct size=7\n"));
-        assertThat(dump1, containsString("[capacity=1024,"));
-        assertThat(dump1, containsString("[capacity=2048,"));
-        assertThat(dump1, containsString("[capacity=4096,"));
-        assertThat(dump1, containsString("[capacity=8192,"));
-        assertThat(dump1, containsString("[capacity=16384,"));
-        assertThat(dump1, containsString("[capacity=32768,"));
-        assertThat(dump1, containsString("[capacity=65536,"));
+        ArrayByteBufferPool pool = new ArrayByteBufferPool.Quadratic(minCapacity, maxCapacity, Integer.MAX_VALUE);
+        pool.setStatisticsEnabled(true);
 
-        ArrayByteBufferPool pool2 = new ArrayByteBufferPool.Quadratic(100, 800, Integer.MAX_VALUE);
-        String dump2 = pool2.dump();
-        assertThat(dump2, containsString("direct size=4\n"));
-        assertThat(dump2, containsString("[capacity=128,"));
-        assertThat(dump2, containsString("[capacity=256,"));
-        assertThat(dump2, containsString("[capacity=512,"));
-        assertThat(dump2, containsString("[capacity=800,"));
+        String[] expectedBuckets = buckets.split(";");
+        int bucketCount = expectedBuckets.length;
+        List<Map<String, Object>> stats = pool.getHeapBucketsStatistics();
+        assertEquals(bucketCount, stats.size());
+        for (int i = 0; i < bucketCount; ++i)
+        {
+            assertEquals(expectedBuckets[i], String.valueOf(stats.get(i).get("capacity")));
+        }
 
-        ArrayByteBufferPool pool3 = new ArrayByteBufferPool.Quadratic(1, 200, Integer.MAX_VALUE);
-        String dump3 = pool3.dump();
-        assertThat(dump3, containsString("direct size=9\n"));
-        assertThat(dump3, containsString("[capacity=1,"));
-        assertThat(dump3, containsString("[capacity=2,"));
-        assertThat(dump3, containsString("[capacity=4,"));
-        assertThat(dump3, containsString("[capacity=8,"));
-        assertThat(dump3, containsString("[capacity=16,"));
-        assertThat(dump3, containsString("[capacity=32,"));
-        assertThat(dump3, containsString("[capacity=64,"));
-        assertThat(dump3, containsString("[capacity=128,"));
-        assertThat(dump3, containsString("[capacity=200,"));
+        if (minCapacity < 0)
+            minCapacity = (int)stats.get(0).get("capacity");
+        if (maxCapacity < 0)
+            maxCapacity = (int)stats.get(stats.size() - 1).get("capacity");
+
+        RetainableByteBuffer bufUnder = pool.acquire(1, false);
+        RetainableByteBuffer bufMin = pool.acquire(minCapacity, false);
+        RetainableByteBuffer bufMid = pool.acquire((minCapacity + maxCapacity) / 2, false);
+        RetainableByteBuffer bufMax = pool.acquire(maxCapacity, false);
+        RetainableByteBuffer bufOver = pool.acquire(maxCapacity + 1, false);
+
+        assertThat(pool.getDirectByteBufferCount(), is(0L));
+        assertThat(pool.getDirectMemory(), is(0L));
+        assertThat(pool.getAvailableDirectByteBufferCount(), is(0L));
+        assertThat(pool.getAvailableDirectMemory(), is(0L));
+
+        assertTrue(bufUnder.release()); // not pooled, < minCapacity
+        assertTrue(bufMin.release()); // pooled
+        assertTrue(bufMid.release()); // pooled
+        assertTrue(bufMax.release()); // pooled
+        assertTrue(bufOver.release()); // not pooled, > maxCapacity
+
+        assertThat(pool.getHeapByteBufferCount(), is(3L));
+        assertThat(pool.getAvailableHeapByteBufferCount(), is(3L));
+
+        Map<Integer, Long> noBucketAcquires = pool.getNoBucketHeapAcquires();
+        assertEquals(2, noBucketAcquires.size());
     }
 
     @Test

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
@@ -316,8 +316,9 @@ public class ArrayByteBufferPoolTest
         assertTrue(bufMax.release()); // pooled
         assertTrue(bufOver.release()); // not pooled, > maxCapacity
 
-        assertThat(pool.getDirectByteBufferCount(), is(3L));
-        assertThat(pool.getAvailableDirectByteBufferCount(), is(3L));
+        long bufferCount = 3;
+        assertThat(pool.getDirectByteBufferCount(), is(bufferCount));
+        assertThat(pool.getAvailableDirectByteBufferCount(), is(bufferCount));
 
         Map<Integer, Long> noBucketAcquires = pool.getNoBucketDirectAcquires();
         assertEquals(2, noBucketAcquires.size());
@@ -450,7 +451,7 @@ public class ArrayByteBufferPoolTest
         }
 
         if (minCapacity < 0)
-            minCapacity = (int)stats.get(0).get("capacity");
+            minCapacity = 0;
         if (maxCapacity < 0)
             maxCapacity = (int)stats.get(stats.size() - 1).get("capacity");
 
@@ -465,17 +466,19 @@ public class ArrayByteBufferPoolTest
         assertThat(pool.getAvailableDirectByteBufferCount(), is(0L));
         assertThat(pool.getAvailableDirectMemory(), is(0L));
 
-        assertTrue(bufUnder.release()); // not pooled, < minCapacity
+        assertTrue(bufUnder.release()); // pooled = minCapacity < 1
         assertTrue(bufMin.release()); // pooled
         assertTrue(bufMid.release()); // pooled
         assertTrue(bufMax.release()); // pooled
         assertTrue(bufOver.release()); // not pooled, > maxCapacity
 
-        assertThat(pool.getHeapByteBufferCount(), is(3L));
-        assertThat(pool.getAvailableHeapByteBufferCount(), is(3L));
+        boolean bufUnderIsPooled = minCapacity < 1;
+        long bufferCount = bufUnderIsPooled ? 4L : 3L;
+        assertThat(pool.getHeapByteBufferCount(), is(bufferCount));
+        assertThat(pool.getAvailableHeapByteBufferCount(), is(bufferCount));
 
         Map<Integer, Long> noBucketAcquires = pool.getNoBucketHeapAcquires();
-        assertEquals(2, noBucketAcquires.size());
+        assertEquals(bufUnderIsPooled ? 1 : 2, noBucketAcquires.size());
     }
 
     @Test


### PR DESCRIPTION
Reviewed the logic for creating the buckets in  ABBP, Quadratic and WithBucketCapacities.