### PR TITLE
Issue #12869 - XmlConfiguration should only load XML files that end in `.xml` extension.

### DIFF
--- a/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
+++ b/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
@@ -1884,7 +1884,7 @@ public class XmlConfiguration
             List<Object> objects = new ArrayList<>(args.length);
             for (String arg : args)
             {
-                if (!arg.toLowerCase(Locale.ENGLISH).endsWith(".properties") && (arg.indexOf('=') < 0))
+                if (arg.toLowerCase(Locale.ENGLISH).endsWith(".xml"))
                 {
                     XmlConfiguration configuration = new XmlConfiguration(Resource.newResource(arg));
                     if (last != null)

--- a/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
+++ b/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
@@ -1863,12 +1863,18 @@ public class XmlConfiguration
             // For all arguments, load properties
             if (LOG.isDebugEnabled())
                 LOG.debug("args={}", Arrays.asList(args));
-            for (String arg : args)
+
+            List<String> remainingArgs = new ArrayList<>(Arrays.asList(args));
+
+            // Process properties first, as the XML needs them.
+            // We don't want to start processing the XML then come across a property that is needed.
+            for (String arg : remainingArgs)
             {
                 if (arg.indexOf('=') >= 0)
                 {
                     int i = arg.indexOf('=');
                     properties.put(arg.substring(0, i), arg.substring(i + 1));
+                    remainingArgs.remove(arg); // remove, now that we've seen/handled this arg.
                 }
                 else if (arg.toLowerCase(Locale.ENGLISH).endsWith(".properties"))
                 {
@@ -1876,13 +1882,15 @@ public class XmlConfiguration
                     {
                         properties.load(inputStream);
                     }
+                    remainingArgs.remove(arg); // remove, now that we've seen/handled this arg.
                 }
+                // all other args are processed later.
             }
 
-            // For all arguments, parse XMLs
+            // For all remaining arguments, parse XMLs
             XmlConfiguration last = null;
             List<Object> objects = new ArrayList<>(args.length);
-            for (String arg : args)
+            for (String arg : remainingArgs)
             {
                 if (arg.toLowerCase(Locale.ENGLISH).endsWith(".xml"))
                 {
@@ -1901,6 +1909,10 @@ public class XmlConfiguration
                     if (obj != null && !objects.contains(obj))
                         objects.add(obj);
                     last = configuration;
+                }
+                else
+                {
+                    LOG.warn("Ignoring unrecognized arg [{}]", arg);
                 }
             }
 

--- a/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
+++ b/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
@@ -39,6 +39,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -1868,13 +1869,16 @@ public class XmlConfiguration
 
             // Process properties first, as the XML needs them.
             // We don't want to start processing the XML then come across a property that is needed.
-            for (String arg : remainingArgs)
+            ListIterator<String> argIter = remainingArgs.listIterator();
+            while (argIter.hasNext())
             {
+                String arg = argIter.next();
                 if (arg.indexOf('=') >= 0)
                 {
                     int i = arg.indexOf('=');
                     properties.put(arg.substring(0, i), arg.substring(i + 1));
-                    remainingArgs.remove(arg); // remove, now that we've seen/handled this arg.
+                    // remove, now that we've seen/handled this arg.
+                    argIter.remove();
                 }
                 else if (arg.toLowerCase(Locale.ENGLISH).endsWith(".properties"))
                 {
@@ -1882,7 +1886,8 @@ public class XmlConfiguration
                     {
                         properties.load(inputStream);
                     }
-                    remainingArgs.remove(arg); // remove, now that we've seen/handled this arg.
+                    // remove, now that we've seen/handled this arg.
+                    argIter.remove();
                 }
                 // all other args are processed later.
             }


### PR DESCRIPTION
Jetty 10.0.x fix.

Will be merged to Jetty 11.0.x as well.
This problem does not exist Jetty 12.0.x.

Do we want to backport this fix to Jetty 9.4.x?

Fixes #12869