### PR TITLE
Fixes #12882 - HttpConfiguration setResponseHeaderSize is ineffective in 12.0.17.

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/AbstractHTTP2ServerConnectionFactory.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/AbstractHTTP2ServerConnectionFactory.java
@@ -306,7 +306,10 @@ public abstract class AbstractHTTP2ServerConnectionFactory extends AbstractConne
         ServerSessionListener listener = newSessionListener(connector, endPoint);
 
         Generator generator = new Generator(connector.getByteBufferPool(), isUseOutputDirectByteBuffers(), getMaxHeaderBlockFragment());
-        generator.getHpackEncoder().setMaxHeaderListSize(getHttpConfiguration().getMaxResponseHeaderSize());
+        int maxResponseHeaderSize = getHttpConfiguration().getMaxResponseHeaderSize();
+        if (maxResponseHeaderSize < 0)
+            maxResponseHeaderSize = getHttpConfiguration().getResponseHeaderSize();
+        generator.getHpackEncoder().setMaxHeaderListSize(maxResponseHeaderSize);
 
         FlowControlStrategy flowControl = getFlowControlStrategyFactory().newFlowControlStrategy();
 

--- a/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/AbstractHTTP3ServerConnectionFactory.java
+++ b/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/AbstractHTTP3ServerConnectionFactory.java
@@ -53,7 +53,10 @@ public abstract class AbstractHTTP3ServerConnectionFactory extends AbstractConne
         http3Configuration.setUseInputDirectByteBuffers(httpConfiguration.isUseInputDirectByteBuffers());
         http3Configuration.setUseOutputDirectByteBuffers(httpConfiguration.isUseOutputDirectByteBuffers());
         http3Configuration.setMaxRequestHeadersSize(httpConfiguration.getRequestHeaderSize());
-        http3Configuration.setMaxResponseHeadersSize(httpConfiguration.getMaxResponseHeaderSize());
+        int maxResponseHeaderSize = httpConfiguration.getMaxResponseHeaderSize();
+        if (maxResponseHeaderSize < 0)
+            maxResponseHeaderSize = getHttpConfiguration().getResponseHeaderSize();
+        http3Configuration.setMaxResponseHeadersSize(maxResponseHeaderSize);
     }
 
     public ServerQuicConfiguration getQuicConfiguration()

--- a/jetty-core/jetty-server/src/main/config/etc/jetty.xml
+++ b/jetty-core/jetty-server/src/main/config/etc/jetty.xml
@@ -56,6 +56,7 @@
       <Set name="outputAggregationSize" property="jetty.httpConfig.outputAggregationSize"/>
       <Set name="requestHeaderSize" property="jetty.httpConfig.requestHeaderSize"/>
       <Set name="responseHeaderSize" property="jetty.httpConfig.responseHeaderSize"/>
+      <Set name="maxResponseHeaderSize"><Property name="jetty.httpConfig.maxResponseHeaderSize" default="16384"/></Set>
       <Set name="sendServerVersion" property="jetty.httpConfig.sendServerVersion"/>
       <Set name="sendDateHeader"><Property name="jetty.httpConfig.sendDateHeader" default="false"/></Set>
       <Set name="headerCacheSize" property="jetty.httpConfig.headerCacheSize"/>

--- a/jetty-core/jetty-server/src/main/config/modules/server.mod
+++ b/jetty-core/jetty-server/src/main/config/modules/server.mod
@@ -44,8 +44,11 @@ etc/jetty.xml
 ## Max request headers size (in bytes)
 # jetty.httpConfig.requestHeaderSize=8192
 
-## Max response headers size (in bytes)
+## Response headers size (in bytes)
 # jetty.httpConfig.responseHeaderSize=8192
+
+## Max response headers size (in bytes)
+# jetty.httpConfig.maxResponseHeaderSize=16384
 
 ## Whether to send the Server: header
 # jetty.httpConfig.sendServerVersion=true

--- a/jetty-core/jetty-server/src/main/config/modules/server.mod
+++ b/jetty-core/jetty-server/src/main/config/modules/server.mod
@@ -47,7 +47,7 @@ etc/jetty.xml
 ## Response headers size (in bytes)
 # jetty.httpConfig.responseHeaderSize=8192
 
-## Max response headers size (in bytes)
+## Max response headers size (in bytes), or -1 to use jetty.httpConfig.responseHeaderSize as the max.
 # jetty.httpConfig.maxResponseHeaderSize=16384
 
 ## Whether to send the Server: header

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java
@@ -62,7 +62,7 @@ public class HttpConfiguration implements Dumpable
     private int _outputAggregationSize = _outputBufferSize / 4;
     private int _requestHeaderSize = 8 * 1024;
     private int _responseHeaderSize = 8 * 1024;
-    private int _maxResponseHeaderSize = 16 * 1024;
+    private int _maxResponseHeaderSize = -1;
     private int _headerCacheSize = 1024;
     private boolean _headerCacheCaseSensitive = false;
     private int _securePort;

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java
@@ -447,10 +447,14 @@ public class HttpConfiguration implements Dumpable
     }
 
     /**
-     * <p>Larger headers will allow for more and/or larger cookies and longer HTTP headers (eg for redirection).
-     * However, larger headers will also consume more memory.</p>
+     * <p>Sets the default size in bytes for the HTTP response line and headers.</p>
+     * <p>Consider using a value that fits most responses, and use {@link #setMaxResponseHeaderSize(int)}
+     * for larger responses.</p>
+     * <p>Large values allow for more and/or larger cookies and longer HTTP headers (for example,
+     * very long redirect URIs). However, large values will also consume more memory.</p>
      *
      * @param responseHeaderSize the default size in bytes of the response headers buffer
+     * @see #setMaxResponseHeaderSize(int)
      */
     public void setResponseHeaderSize(int responseHeaderSize)
     {
@@ -458,10 +462,13 @@ public class HttpConfiguration implements Dumpable
     }
 
     /**
-     * <p>Larger headers will allow for more and/or larger cookies and longer HTTP headers (eg for redirection).
-     * However, larger headers will also consume more memory.</p>
+     * <p>Sets the maximum size in bytes for the HTTP response line and headers.</p>
+     * <p>When the value is negative, then the value of {@link #getResponseHeaderSize()} is used.</p>
+     * <p>Large values allow for more and/or larger cookies and longer HTTP headers (for example,
+     * very long redirect URIs). However, large values will also consume more memory.</p>
      *
      * @param maxResponseHeaderSize the maximum size in bytes of the response headers buffer
+     * @see #setResponseHeaderSize(int)
      */
     public void setMaxResponseHeaderSize(int maxResponseHeaderSize)
     {

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -753,6 +753,7 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
                 throw new IllegalStateException();
 
             int responseHeadersSize = getHttpConfiguration().getResponseHeaderSize();
+            int maxResponseHeadersSize = getHttpConfiguration().getMaxResponseHeaderSize();
             boolean useDirectByteBuffers = isUseOutputDirectByteBuffers();
             while (true)
             {
@@ -776,14 +777,16 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
                     }
                     case NEED_HEADER:
                     {
-                        _generator.setMaxHeaderBytes(getHttpConfiguration().getMaxResponseHeaderSize());
+                        int maxHeaderBytes = maxResponseHeadersSize;
+                        if (maxHeaderBytes < 0)
+                            maxHeaderBytes = getHttpConfiguration().getResponseHeaderSize();
+                        _generator.setMaxHeaderBytes(maxHeaderBytes);
                         _header = _bufferPool.acquire(responseHeadersSize, useDirectByteBuffers);
                         continue;
                     }
                     case HEADER_OVERFLOW:
                     {
-                        int maxResponseHeadersSize = getHttpConfiguration().getMaxResponseHeaderSize();
-                        if (maxResponseHeadersSize > responseHeadersSize)
+                        if (maxResponseHeadersSize > 0 && maxResponseHeadersSize > responseHeadersSize)
                         {
                             _generator.reset();
                             _header.release();

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConnectionTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConnectionTest.java
@@ -1188,8 +1188,6 @@ public class HttpConnectionTest
     @Test
     public void testOversizedResponse() throws Exception
     {
-        httpConfig.setMaxResponseHeaderSize(httpConfig.getResponseHeaderSize());
-
         String str = "thisisastringthatshouldreachover1kbytes-";
         for (int i = 0; i < 500; i++)
         {

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/LargeHeaderTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/LargeHeaderTest.java
@@ -62,7 +62,7 @@ public class LargeHeaderTest
         server = new Server();
 
         HttpConfiguration config = new HttpConfiguration();
-        config.setMaxResponseHeaderSize(config.getResponseHeaderSize());
+        config.setMaxResponseHeaderSize(-1);
         HttpConnectionFactory http = new HttpConnectionFactory(config);
 
         ServerConnector connector = new ServerConnector(server, http);


### PR DESCRIPTION
Provides backward compatibility for applications that were using `HttpConfiguration.setResponseHeaderSize()` to limit the response headers.

Now `HttpConfiguration.maxResponseHeaderSize` defaults to -1; the code checks for negative values, and if so uses `HttpConfiguration.responseHeaderSize`.

Modified `server.mod` and `jetty.xml` accordingly to actually set a positive value for `HttpConfiguration.maxResponseHeaderSize`.