### PR TITLE
Fix config for jspc plugin for eeX jsp demos

### DIFF
--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-jsp-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-jsp-webapp/pom.xml
@@ -97,8 +97,8 @@
             </configuration>
           </plugin>
           <plugin>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-jspc-maven-plugin</artifactId>
+            <groupId>org.eclipse.jetty.ee10</groupId>
+            <artifactId>jetty-ee10-jspc-maven-plugin</artifactId>
             <version>${project.version}</version>
             <executions>
               <execution>

--- a/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-jsp-webapp/pom.xml
+++ b/jetty-ee8/jetty-ee8-demos/jetty-ee8-demo-jsp-webapp/pom.xml
@@ -95,12 +95,12 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-war-plugin</artifactId>
             <configuration>
-              <webXml>${basedir}/target/web.xml</webXml>
+              <webXml>${basedir}/target/webapp/WEB-INF/web.xml</webXml>
             </configuration>
           </plugin>
           <plugin>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-jspc-maven-plugin</artifactId>
+            <groupId>org.eclipse.jetty.ee8</groupId>
+            <artifactId>jetty-ee8-jspc-maven-plugin</artifactId>
             <version>${project.version}</version>
             <executions>
               <execution>
@@ -108,14 +108,15 @@
                 <goals>
                   <goal>jspc</goal>
                 </goals>
-                <!-- example configuration
-                 <configuration>
+                <configuration>
+                  <!-- example configuration
                    <includes>**/*.foo</includes>
                    <excludes>**/*.fff</excludes>
                    <sourceVersion>1.8</sourceVersion>
                    <targetVersion>1.8</targetVersion>
-                 </configuration>
                  -->
+                  <webAppSourceDirectory>${basedir}/target/webapp</webAppSourceDirectory>
+                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-jsp-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-demos/jetty-ee9-demo-jsp-webapp/pom.xml
@@ -97,8 +97,8 @@
             </configuration>
           </plugin>
           <plugin>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-jspc-maven-plugin</artifactId>
+            <groupId>org.eclipse.jetty.ee9</groupId>
+            <artifactId>jetty-ee9-jspc-maven-plugin</artifactId>
             <version>${project.version}</version>
             <executions>
               <execution>


### PR DESCRIPTION
All of the eeX jsp demos have wrong configuration for the jspc plugin. This PR fixes those.
Note that on merge through to jetty-12.1.x this will need further work as the structure is different.