### PR TITLE
10.0.x: Fix SSL buffer leak

### DIFF
--- a/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
+++ b/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
@@ -1444,7 +1444,9 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
         @Override
         public boolean isInputShutdown()
         {
-            return BufferUtil.isEmpty(_decryptedInput) && (getEndPoint().isInputShutdown() || isInboundDone());
+            return (_encryptedInput == null || !_encryptedInput.hasRemaining()) &&
+                    BufferUtil.isEmpty(_decryptedInput) &&
+                    (getEndPoint().isInputShutdown() || isInboundDone());
         }
 
         private boolean isInboundDone()


### PR DESCRIPTION
Make sure `DecryptedEndpoint.isInputShutdown()` only returns true when both input buffers have been depleted, so that when for instance `HTTP2Connection.fill()` calls `isInputShutdown()`, the latter won't return true until the encrypted buffer has been fully consumed, forcing `HTTP2Connection.fill()` to call `EndPoint.fill()` again.