### PR TITLE
Fix ssl and h2 buffer leak

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Connection.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Connection.java
@@ -262,28 +262,7 @@ public class HTTP2Connection extends AbstractConnection implements Parser.Listen
     @Override
     public void onData(DataFrame frame)
     {
-        RetainableByteBuffer.Mutable networkBuffer;
-        try (AutoLock ignore = producer.lock.lock())
-        {
-            networkBuffer = producer.networkBuffer;
-        }
-        session.onData(new StreamData(frame, networkBuffer, () ->
-        {
-            // This releaser is run for every release, not just the last one!
-            try (AutoLock ignore = producer.lock.lock())
-            {
-                RetainableByteBuffer.Mutable held = producer.heldBuffer;
-                if (producer.networkBuffer == null && held == null)
-                {
-                    producer.networkBuffer = HTTP2Producer.RELEASE_MARKER;
-                }
-                else if (held != null)
-                {
-                    held.release();
-                    producer.heldBuffer = null;
-                }
-            }
-        }));
+        session.onData(producer.newStreamData(frame));
     }
 
     @Override
@@ -456,7 +435,7 @@ public class HTTP2Connection extends AbstractConnection implements Parser.Listen
             {
                 try (AutoLock ignore = lock.lock())
                 {
-                    if (networkBuffer.isRetained() && this.networkBuffer != RELEASE_MARKER && !shutdown)
+                    if (networkBuffer.isRetained() && this.heldBuffer != RELEASE_MARKER && !shutdown)
                     {
                         lockedHoldBuffer(networkBuffer);
                     }
@@ -471,6 +450,32 @@ public class HTTP2Connection extends AbstractConnection implements Parser.Listen
 
                 if (interested)
                     fillInterested(fillableCallback);
+            }
+        }
+
+        private StreamData newStreamData(DataFrame frame)
+        {
+            try (AutoLock ignore = lock.lock())
+            {
+                return new StreamData(frame, networkBuffer, this::releaseHeldBuffer);
+            }
+        }
+
+        private void releaseHeldBuffer()
+        {
+            try (AutoLock ignore = lock.lock())
+            {
+                LOG.info("releaseHeldBuffer networkBuffer={} heldBuffer={}", networkBuffer, heldBuffer);
+                RetainableByteBuffer.Mutable held = heldBuffer;
+                if (held == null)
+                {
+                    heldBuffer = HTTP2Producer.RELEASE_MARKER;
+                }
+                else
+                {
+                    held.release();
+                    heldBuffer = null;
+                }
             }
         }
 
@@ -590,7 +595,8 @@ public class HTTP2Connection extends AbstractConnection implements Parser.Listen
         public boolean release()
         {
             boolean released = retainable.release();
-            releaser.run();
+            if (!released && !isRetained())
+                releaser.run();
             return released;
         }
     }

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Connection.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Connection.java
@@ -20,7 +20,6 @@ import java.util.Queue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.jetty.http2.api.Stream;
 import org.eclipse.jetty.http2.frames.DataFrame;
@@ -263,8 +262,28 @@ public class HTTP2Connection extends AbstractConnection implements Parser.Listen
     @Override
     public void onData(DataFrame frame)
     {
-        RetainableByteBuffer.Mutable networkBuffer = producer.networkBuffer;
-        session.onData(new StreamData(frame, networkBuffer));
+        RetainableByteBuffer.Mutable networkBuffer;
+        try (AutoLock ignore = producer.lock.lock())
+        {
+            networkBuffer = producer.networkBuffer;
+        }
+        session.onData(new StreamData(frame, networkBuffer, () ->
+        {
+            // This releaser is run for every release, not just the last one!
+            try (AutoLock ignore = producer.lock.lock())
+            {
+                RetainableByteBuffer.Mutable held = producer.heldBuffer;
+                if (producer.networkBuffer == null && held == null)
+                {
+                    producer.networkBuffer = HTTP2Producer.RELEASE_MARKER;
+                }
+                else if (held != null)
+                {
+                    held.release();
+                    producer.heldBuffer = null;
+                }
+            }
+        }));
     }
 
     @Override
@@ -325,18 +344,26 @@ public class HTTP2Connection extends AbstractConnection implements Parser.Listen
     protected class HTTP2Producer implements ExecutionStrategy.Producer
     {
         private static final RetainableByteBuffer.Mutable STOPPED = new RetainableByteBuffer.NonRetainableByteBuffer(BufferUtil.EMPTY_BUFFER);
+        private static final RetainableByteBuffer.Mutable RELEASE_MARKER = new RetainableByteBuffer.NonRetainableByteBuffer(BufferUtil.EMPTY_BUFFER);
         private final Callback fillableCallback = new FillableCallback();
-        private final AtomicReference<RetainableByteBuffer.Mutable> heldBuffer = new AtomicReference<>();
+        private final AutoLock lock = new AutoLock();
+        private RetainableByteBuffer.Mutable heldBuffer;
         private RetainableByteBuffer.Mutable networkBuffer;
         private boolean shutdown;
         private boolean failed;
 
         private void setInputBuffer(ByteBuffer byteBuffer)
         {
-            RetainableByteBuffer.Mutable networkBuffer = acquireBuffer();
-            if (!networkBuffer.append(byteBuffer))
-                throw new IllegalStateException("overflow");
-            holdBuffer(networkBuffer);
+            try (AutoLock ignore = lock.lock())
+            {
+                RetainableByteBuffer.Mutable networkBuffer = lockedAcquireBuffer();
+                if (!networkBuffer.append(byteBuffer))
+                {
+                    networkBuffer.release();
+                    throw new IllegalStateException("overflow");
+                }
+                lockedHoldBuffer(networkBuffer);
+            }
         }
 
         @Override
@@ -352,7 +379,11 @@ public class HTTP2Connection extends AbstractConnection implements Parser.Listen
                 return null;
 
             boolean interested = false;
-            networkBuffer = acquireBuffer();
+            RetainableByteBuffer.Mutable networkBuffer;
+            try (AutoLock ignore = lock.lock())
+            {
+                this.networkBuffer = networkBuffer = lockedAcquireBuffer();
+            }
             try
             {
                 boolean parse = networkBuffer.hasRemaining();
@@ -391,7 +422,10 @@ public class HTTP2Connection extends AbstractConnection implements Parser.Listen
                             if (LOG.isDebugEnabled())
                                 LOG.debug("Released retained {}", networkBuffer);
                             networkBuffer.release();
-                            networkBuffer = acquireBuffer();
+                            try (AutoLock ignore = lock.lock())
+                            {
+                                this.networkBuffer = networkBuffer = lockedAcquireBuffer();
+                            }
                         }
                     }
 
@@ -420,26 +454,32 @@ public class HTTP2Connection extends AbstractConnection implements Parser.Listen
             }
             finally
             {
-// TODO this keeps a buffer around when the client is at rest
-//                if (networkBuffer.isRetained() && !shutdown)
-//                {
-//                    holdBuffer(networkBuffer);
-//                }
-//                else
+                try (AutoLock ignore = lock.lock())
                 {
-                    if (LOG.isDebugEnabled())
-                        LOG.debug("Released after process {}", networkBuffer);
-                    networkBuffer.release();
+                    if (networkBuffer.isRetained() && this.networkBuffer != RELEASE_MARKER && !shutdown)
+                    {
+                        lockedHoldBuffer(networkBuffer);
+                    }
+                    else
+                    {
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("Released after process {}", networkBuffer);
+                        networkBuffer.release();
+                    }
+                    this.networkBuffer = null;
                 }
-                networkBuffer = null;
+
                 if (interested)
                     fillInterested(fillableCallback);
             }
         }
 
-        private RetainableByteBuffer.Mutable acquireBuffer()
+        private RetainableByteBuffer.Mutable lockedAcquireBuffer()
         {
-            RetainableByteBuffer.Mutable buffer = heldBuffer.getAndSet(null);
+            assert lock.isHeldByCurrentThread();
+
+            RetainableByteBuffer.Mutable buffer = heldBuffer;
+            heldBuffer = null;
             RetainableByteBuffer.Mutable held = buffer;
             if (buffer == null)
                 buffer = bufferPool.acquire(bufferSize, isUseInputDirectByteBuffers()).asMutable();
@@ -448,16 +488,19 @@ public class HTTP2Connection extends AbstractConnection implements Parser.Listen
             return buffer;
         }
 
-        private void holdBuffer(RetainableByteBuffer.Mutable buffer)
+        private void lockedHoldBuffer(RetainableByteBuffer.Mutable buffer)
         {
-            if (heldBuffer.compareAndSet(null, buffer))
+            assert lock.isHeldByCurrentThread();
+
+            if (heldBuffer == null)
             {
+                heldBuffer = buffer;
                 if (LOG.isDebugEnabled())
                     LOG.debug("Held {} in {}", buffer, HTTP2Connection.this);
             }
             else
             {
-                if (heldBuffer.get() == STOPPED)
+                if (heldBuffer == STOPPED)
                 {
                     if (LOG.isDebugEnabled())
                         LOG.debug("Released instead of holding {}", buffer);
@@ -472,12 +515,16 @@ public class HTTP2Connection extends AbstractConnection implements Parser.Listen
 
         private void stop()
         {
-            RetainableByteBuffer.Mutable buffer = heldBuffer.getAndSet(STOPPED);
-            if (buffer != null)
+            try (AutoLock ignore = lock.lock())
             {
-                if (LOG.isDebugEnabled())
-                    LOG.debug("Released in stop {}", buffer);
-                buffer.release();
+                RetainableByteBuffer.Mutable buffer = heldBuffer;
+                heldBuffer = STOPPED;
+                if (buffer != null)
+                {
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("Released in stop {}", buffer);
+                    buffer.release();
+                }
             }
         }
 
@@ -512,11 +559,13 @@ public class HTTP2Connection extends AbstractConnection implements Parser.Listen
     private static class StreamData extends Stream.Data
     {
         private final Retainable retainable;
+        private final Runnable releaser;
 
-        private StreamData(DataFrame frame, Retainable retainable)
+        private StreamData(DataFrame frame, Retainable retainable, Runnable releaser)
         {
             super(frame);
             this.retainable = retainable;
+            this.releaser = releaser;
         }
 
         @Override
@@ -540,7 +589,9 @@ public class HTTP2Connection extends AbstractConnection implements Parser.Listen
         @Override
         public boolean release()
         {
-            return retainable.release();
+            boolean released = retainable.release();
+            releaser.run();
+            return released;
         }
     }
 }

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Connection.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Connection.java
@@ -435,7 +435,15 @@ public class HTTP2Connection extends AbstractConnection implements Parser.Listen
             {
                 try (AutoLock ignore = lock.lock())
                 {
-                    if (networkBuffer.isRetained() && this.heldBuffer != RELEASE_MARKER && !shutdown)
+                    // There is a race between the producer thread and the one executing user code:
+                    // this finally block may execute before or after releaseHeldBuffer() and
+                    // the last thread must be the one doing the release. If heldBuffer contains
+                    // the release marker, this means the producer thread lost the race, and we
+                    // must release the buffer here to avoid leaving a buffer at rest out of the pool.
+                    // Note that networkBuffer.isRetained() is always true if the parser generated a
+                    // data frame as the networkBuffer has been sliced to create the data frame
+                    // and the latter is waiting in a queue for the user code to read it.
+                    if (networkBuffer.isRetained() && heldBuffer != RELEASE_MARKER && !shutdown)
                     {
                         lockedHoldBuffer(networkBuffer);
                     }
@@ -465,14 +473,20 @@ public class HTTP2Connection extends AbstractConnection implements Parser.Listen
         {
             try (AutoLock ignore = lock.lock())
             {
-                LOG.info("releaseHeldBuffer networkBuffer={} heldBuffer={}", networkBuffer, heldBuffer);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("releaseHeldBuffer networkBuffer={} heldBuffer={}", networkBuffer, heldBuffer);
                 RetainableByteBuffer.Mutable held = heldBuffer;
                 if (held == null)
                 {
+                    // If no buffer is held and the networkBuffer did not change since acquisition, it means
+                    // the user thread won the race, so it must leave a marker to tell the producer thread to release
+                    // instead of holding onto the buffer.
                     heldBuffer = HTTP2Producer.RELEASE_MARKER;
                 }
                 else
                 {
+                    // If a buffer is still held, it means the producer thread won the race and the user thread
+                    // must release the held buffer to avoid leaving a buffer at rest out of the pool.
                     held.release();
                     heldBuffer = null;
                 }
@@ -484,6 +498,10 @@ public class HTTP2Connection extends AbstractConnection implements Parser.Listen
             assert lock.isHeldByCurrentThread();
 
             RetainableByteBuffer.Mutable buffer = heldBuffer;
+            // This can happen when re-acquiring a buffer while the user thread won the release race;
+            // release is done by the re-acquisition so we can safely ignore the release marker.
+            if (buffer == RELEASE_MARKER)
+                buffer = null;
             heldBuffer = null;
             RetainableByteBuffer.Mutable held = buffer;
             if (buffer == null)

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Connection.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Connection.java
@@ -420,11 +420,12 @@ public class HTTP2Connection extends AbstractConnection implements Parser.Listen
             }
             finally
             {
-                if (networkBuffer.isRetained() && !shutdown)
-                {
-                    holdBuffer(networkBuffer);
-                }
-                else
+// TODO this keeps a buffer around when the client is at rest
+//                if (networkBuffer.isRetained() && !shutdown)
+//                {
+//                    holdBuffer(networkBuffer);
+//                }
+//                else
                 {
                     if (LOG.isDebugEnabled())
                         LOG.debug("Released after process {}", networkBuffer);

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -1011,7 +1011,7 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
                 super(wrapped.getByteBuffer(), wrapped);
                 this.size = size;
                 this.acquireInstant = Instant.now();
-                this.acquireStack = new Throwable(Thread.currentThread().getName());
+                this.acquireStack = new Throwable("Acquired by " + Thread.currentThread().getName());
             }
 
             public int getSize()
@@ -1061,7 +1061,7 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
             public void retain()
             {
                 super.retain();
-                retainStacks.add(new Throwable(Thread.currentThread().getName()));
+                retainStacks.add(new Throwable("Retained by " + Thread.currentThread().getName()));
             }
 
             @Override
@@ -1076,14 +1076,16 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
                         if (LOG.isDebugEnabled())
                             LOG.debug("released {}", this);
                     }
-                    releaseStacks.add(new Throwable());
+                    releaseStacks.add(new Throwable("Released by " + Thread.currentThread().getName()));
                     return released;
                 }
                 catch (IllegalStateException e)
                 {
                     buffers.add(this);
-                    overReleaseStacks.add(new Throwable(Thread.currentThread().getName()));
-                    throw e;
+                    overReleaseStacks.add(new Throwable("Over-released by " + Thread.currentThread().getName()));
+                    IllegalStateException ise = new IllegalStateException(Thread.currentThread().getName() + " over-released " + this);
+                    releaseStacks.forEach(ise::addSuppressed);
+                    throw ise;
                 }
             }
 

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
@@ -1461,7 +1461,10 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
         @Override
         public boolean isInputShutdown()
         {
-            return (_decryptedInput == null || !_decryptedInput.hasRemaining()) && (getEndPoint().isInputShutdown() || isInboundDone());
+            return
+                (_encryptedInput == null || !_encryptedInput.hasRemaining()) &&
+                (_decryptedInput == null || !_decryptedInput.hasRemaining()) &&
+                (getEndPoint().isInputShutdown() || isInboundDone());
         }
 
         private boolean isInboundDone()

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AbstractTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AbstractTest.java
@@ -131,8 +131,6 @@ public class AbstractTest
     @AfterEach
     public void dispose(TestInfo testInfo) throws Exception
     {
-        // Stop the client so that all connections are closed and any saved buffers are released
-        LifeCycle.stop(client);
         try
         {
             if (serverBufferPool != null && !isLeakTrackingDisabled(testInfo, "server"))
@@ -142,7 +140,7 @@ public class AbstractTest
         }
         finally
         {
-            LifeCycle.stop(server);
+            stop();
         }
     }
 


### PR DESCRIPTION
Fixes #12862

Also improve `HTTP2Connection` to make it fulfill the _hold no buffer when at rest_ doctrine.

See https://github.com/jetty/jetty.project/pull/12896 for the 10/11 version of the fix.