### PR TITLE
12.0.x: Fix SSL buffer leak

### DIFF
--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
@@ -1460,7 +1460,10 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
         @Override
         public boolean isInputShutdown()
         {
-            return (_decryptedInput == null || !_decryptedInput.hasRemaining()) && (getEndPoint().isInputShutdown() || isInboundDone());
+            return
+                (_encryptedInput == null || !_encryptedInput.hasRemaining()) &&
+                (_decryptedInput == null || !_decryptedInput.hasRemaining()) &&
+                (getEndPoint().isInputShutdown() || isInboundDone());
         }
 
         private boolean isInboundDone()


### PR DESCRIPTION
Make sure `SslEndpoint.isInputShutdown()` only returns true when both input buffers have been depleted, so that when for instance `HTTP2Connection.fill()` calls `isInputShutdown()`, the latter won't return true until the encrypted buffer has been fully consumed, forcing `HTTP2Connection.fill()` to call `EndPoint.fill()` again.

See the [10.0.x](https://github.com/jetty/jetty.project/pull/12896) version of this.