### PR TITLE
Issue #12906 - URIUtil.correctURI() should be able to handle `file:/`

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -1779,6 +1779,9 @@ public final class URIUtil
         if (colon < 0)
             return uri; // path portion not found
 
+        if ((colon + 2) == rawURI.length())
+            return URI.create("file:///");
+
         int end = -1;
         if (rawURI.charAt(colon + 2) != '/')
             end = colon + 2;

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
@@ -640,10 +640,12 @@ public class URIUtilTest
     {
         return Stream.of(
             // Already valid URIs
+            Arguments.of("file:///", "file:///"),
             Arguments.of("file:///foo.jar", "file:///foo.jar"),
             Arguments.of("jar:file:///foo.jar!/", "jar:file:///foo.jar!/"),
             Arguments.of("jar:file:///foo.jar!/zed.txt", "jar:file:///foo.jar!/zed.txt"),
             // Badly created File.toURL.toURI URIs
+            Arguments.of("file:/", "file:///"),
             Arguments.of("file:/foo.jar", "file:///foo.jar"),
             Arguments.of("jar:file:/foo.jar", "jar:file:///foo.jar"),
             Arguments.of("jar:file:/foo.jar!/", "jar:file:///foo.jar!/"),


### PR DESCRIPTION
Fixing bad corner case of bad input `file:/`.

Note: the URIs `file://` and `file:` are not able to be created, so do not suffer from issues.

```
|  Welcome to JShell -- Version 17.0.11
|  For an introduction type: /help intro

jshell> var u = URI.create("file://")
|  Exception java.lang.IllegalArgumentException: Expected authority at index 7: file://
|        at URI.create (URI.java:906)
|        at do_it$Aux (#1:1)
|        at (#1:1)
|  Caused by: java.net.URISyntaxException: Expected authority at index 7: file://
|        at URI$Parser.fail (URI.java:2976)
|        at URI$Parser.failExpecting (URI.java:2982)
|        at URI$Parser.parseHierarchical (URI.java:3226)
|        at URI$Parser.parse (URI.java:3177)
|        at URI.<init> (URI.java:623)
|        at URI.create (URI.java:904)
|        ...

jshell> var u2 = URI.create("file:")
|  Exception java.lang.IllegalArgumentException: Expected scheme-specific part at index 5: file:
|        at URI.create (URI.java:906)
|        at do_it$Aux (#2:1)
|        at (#2:1)
|  Caused by: java.net.URISyntaxException: Expected scheme-specific part at index 5: file:
|        at URI$Parser.fail (URI.java:2976)
|        at URI$Parser.failExpecting (URI.java:2982)
|        at URI$Parser.parse (URI.java:3182)
|        at URI.<init> (URI.java:623)
|        at URI.create (URI.java:904)
|        ...
```

Fixes #12906