### PR TITLE
Allow EE8/EE9 HttpServletResponse.addHeader to accept null header values

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -1786,7 +1786,9 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
                     i = _fields.listIterator(put);
                     HttpField old = i.next();
                     field = onReplaceField(old, field);
-                    if (field != null)
+                    if (field == null)
+                        i.remove();
+                    else if (field != old)
                         i.set(field);
                 }
 
@@ -1870,7 +1872,12 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
                             if (last != null)
                             {
                                 field = onReplaceField(last, field);
-                                if (field != null)
+                                if (field == null)
+                                {
+                                    last = null;
+                                    i.remove();
+                                }
+                                else if (field != last)
                                 {
                                     last = null;
                                     i.set(field);

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -1698,6 +1698,11 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
                 _fields = fields;
             }
 
+            public Mutable getWrapped()
+            {
+                return _fields;
+            }
+
             /**
              * Called when a field is added (including as part of a put).
              *

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -961,15 +961,16 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
          * <p>Adds a new {@link HttpField} with the given name and string value.</p>
          * <p>The new {@link HttpField} is added even if a field with the
          * same name is already present.</p>
+         * <p>This method has no effect if null is passed for either the name or value parameters.</p>
          *
-         * @param name the non-{@code null} name of the field
-         * @param value the non-{@code null} value of the field
+         * @param name the name of the field
+         * @param value the value of the field
          * @return this instance
          */
         default Mutable add(String name, String value)
         {
-            Objects.requireNonNull(name);
-            Objects.requireNonNull(value);
+            if (name == null || value == null)
+                return this;
             return add(new HttpField(name, value));
         }
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -969,7 +969,8 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
          */
         default Mutable add(String name, String value)
         {
-            if (name == null || value == null)
+            Objects.requireNonNull(name);
+            if (value == null)
                 return this;
             return add(new HttpField(name, value));
         }
@@ -985,8 +986,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
          */
         default Mutable add(String name, long value)
         {
-            if (name == null)
-                return this;
+            Objects.requireNonNull(name);
             return add(new HttpField.LongValueHttpField(name, value));
         }
 
@@ -1002,7 +1002,8 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
         default Mutable add(HttpHeader header, HttpHeaderValue value)
         {
             Objects.requireNonNull(header);
-            Objects.requireNonNull(value);
+            if (value == null)
+                return this;
             return add(header, value.toString());
         }
 
@@ -1018,7 +1019,8 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
         default Mutable add(HttpHeader header, String value)
         {
             Objects.requireNonNull(header);
-            Objects.requireNonNull(value);
+            if (value == null)
+                return this;
             return add(new HttpField(header, value));
         }
 
@@ -1060,6 +1062,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
          */
         default Mutable add(HttpFields fields)
         {
+            Objects.requireNonNull(fields);
             for (HttpField field : fields)
             {
                 add(field);
@@ -1076,7 +1079,8 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
          */
         default Mutable add(String name, List<String> list)
         {
-            if (name == null || list == null || list.isEmpty())
+            Objects.requireNonNull(name);
+            if (list == null || list.isEmpty())
                 return this;
             if (list.size() == 1)
             {

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -985,7 +985,8 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
          */
         default Mutable add(String name, long value)
         {
-            Objects.requireNonNull(name);
+            if (name == null)
+                return this;
             return add(new HttpField.LongValueHttpField(name, value));
         }
 
@@ -1075,9 +1076,7 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
          */
         default Mutable add(String name, List<String> list)
         {
-            Objects.requireNonNull(name);
-            Objects.requireNonNull(list);
-            if (list.isEmpty())
+            if (name == null || list == null || list.isEmpty())
                 return this;
             if (list.size() == 1)
             {

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
@@ -1019,9 +1019,7 @@ public class HttpFieldsTest
     public void testAddNullName()
     {
         HttpFields.Mutable fields = HttpFields.build();
-        fields.add((String)null, "bogus");
-        assertThat(fields.size(), is(0));
-
+        assertThrows(NullPointerException.class, () -> fields.add((String)null, "bogus"));
         assertThrows(NullPointerException.class, () -> fields.add((HttpHeader)null, "bogus"));
         assertThat(fields.size(), is(0));
     }

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
@@ -1460,6 +1460,12 @@ public class HttpFieldsTest
             @Override
             public HttpField onReplaceField(HttpField oldField, HttpField newField)
             {
+                if (newField.getValueList().contains("removeOnReplace"))
+                {
+                    actions.add("onReplaceFieldRemove");
+                    return null;
+                }
+
                 actions.add("onReplaceField");
                 return super.onReplaceField(oldField, newField);
             }
@@ -1490,5 +1496,8 @@ public class HttpFieldsTest
         wrapper.ensureField(new HttpField("ensure", "value0"));
         wrapper.ensureField(new HttpField("ensure", "value1"));
         assertThat(wrapper.actions, is(List.of("onAddField", "onReplaceField")));
+        wrapper.ensureField(new HttpField("ensure", "removeOnReplace"));
+        assertThat(wrapper.actions, is(List.of("onAddField", "onReplaceField", "onReplaceFieldRemove")));
+        assertThat(wrapper.getField("ensure"), nullValue());
     }
 }

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
@@ -1019,7 +1019,7 @@ public class HttpFieldsTest
     public void testAddNullName()
     {
         HttpFields.Mutable fields = HttpFields.build();
-        assertThrows(NullPointerException.class, () -> fields.add((String)null, "bogus"));
+        fields.add((String)null, "bogus");
         assertThat(fields.size(), is(0));
 
         assertThrows(NullPointerException.class, () -> fields.add((HttpHeader)null, "bogus"));

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
@@ -1067,7 +1067,7 @@ public class HttpFieldsTest
     public void testAddNullValueList()
     {
         HttpFields.Mutable fields = HttpFields.build();
-        assertThrows(NullPointerException.class, () -> fields.add("name", (List<String>)null));
+        fields.add("name", (List<String>)null);
         assertThat(fields.size(), is(0));
         List<String> list = new ArrayList<>();
         fields.add("name", list);

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
@@ -1486,5 +1486,9 @@ public class HttpFieldsTest
         assertThat(wrapper.size(), is(0));
         assertThat(wrapper.actions, is(List.of("onAddField", "onReplaceField", "onRemoveField")));
         wrapper.actions.clear();
+
+        wrapper.ensureField(new HttpField("ensure", "value0"));
+        wrapper.ensureField(new HttpField("ensure", "value1"));
+        assertThat(wrapper.actions, is(List.of("onAddField", "onReplaceField")));
     }
 }

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpGeneratorClientTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpGeneratorClientTest.java
@@ -21,9 +21,9 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HttpGeneratorClientTest
@@ -99,8 +99,9 @@ public class HttpGeneratorClientTest
 
         HttpFields.Mutable fields = HttpFields.build();
         fields.add("Host", "something");
-        assertThrows(NullPointerException.class, () -> fields.add("Null", (String)null));
-        assertThrows(NullPointerException.class, () -> fields.add("Null", (List<String>)null));
+        fields.add("Null", (String)null);
+        fields.add("Null", (List<String>)null);
+        assertThat(fields.size(), equalTo(1));
         fields.add("Empty", "");
         RequestInfo info = new RequestInfo("GET", "/index.html", fields);
         assertFalse(gen.isChunking());

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/ResponseHttpFields.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/ResponseHttpFields.java
@@ -150,7 +150,7 @@ public class ResponseHttpFields implements HttpFields.Mutable
             public void remove()
             {
                 if (_committed.get())
-                    throw new UnsupportedOperationException("Read Only");
+                    return;
                 if (isPersistent(_current))
                     throw new UnsupportedOperationException("Persistent field");
                 if (_current == null)
@@ -211,7 +211,7 @@ public class ResponseHttpFields implements HttpFields.Mutable
             public void remove()
             {
                 if (_committed.get())
-                    throw new UnsupportedOperationException("Read Only");
+                    return;
                 if (isPersistent(_current))
                     throw new UnsupportedOperationException("Persistent field");
                 if (_current == null)
@@ -224,7 +224,7 @@ public class ResponseHttpFields implements HttpFields.Mutable
             public void set(HttpField field)
             {
                 if (_committed.get())
-                    throw new UnsupportedOperationException("Read Only");
+                    return;
                 if (_current instanceof Persistent persistent)
                 {
                     // cannot change the field name
@@ -248,9 +248,7 @@ public class ResponseHttpFields implements HttpFields.Mutable
             @Override
             public void add(HttpField field)
             {
-                if (_committed.get())
-                    throw new UnsupportedOperationException("Read Only");
-                if (field != null)
+                if (field != null && !_committed.get())
                     i.add(field);
             }
         };

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/ResponseHttpFields.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/ResponseHttpFields.java
@@ -64,16 +64,18 @@ public class ResponseHttpFields extends HttpFields.Mutable.Wrapper
     @Override
     public boolean onRemoveField(HttpField field)
     {
+        if (isCommitted())
+            return false;
         if (isPersistent(field))
             throw new UnsupportedOperationException("Persistent field");
-        return !isCommitted();
+        return true;
     }
 
     @Override
     public HttpField onReplaceField(HttpField oldField, HttpField newField)
     {
         if (isCommitted())
-            return null;
+            return oldField;
 
         if (oldField instanceof Persistent persistent)
         {

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/ResponseHttpFields.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/ResponseHttpFields.java
@@ -13,10 +13,8 @@
 
 package org.eclipse.jetty.server.internal;
 
-import java.util.Iterator;
 import java.util.ListIterator;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Stream;
 
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
@@ -27,15 +25,19 @@ import org.slf4j.LoggerFactory;
 
 import static org.eclipse.jetty.server.internal.ResponseHttpFields.Persistent.isPersistent;
 
-public class ResponseHttpFields implements HttpFields.Mutable
+public class ResponseHttpFields extends HttpFields.Mutable.Wrapper
 {
     private static final Logger LOG = LoggerFactory.getLogger(ResponseHttpFields.class);
-    private final Mutable _fields = HttpFields.build();
     private final AtomicBoolean _committed = new AtomicBoolean();
+
+    public ResponseHttpFields()
+    {
+        super(HttpFields.build());
+    }
 
     public HttpFields.Mutable getMutableHttpFields()
     {
-        return _fields;
+        return getWrapped();
     }
 
     public boolean commit()
@@ -51,54 +53,53 @@ public class ResponseHttpFields implements HttpFields.Mutable
         return _committed.get();
     }
 
+    @Override
+    public HttpField onAddField(HttpField field)
+    {
+        if (isCommitted())
+            return null;
+        return super.onAddField(field);
+    }
+
+    @Override
+    public boolean onRemoveField(HttpField field)
+    {
+        if (isPersistent(field))
+            throw new UnsupportedOperationException("Persistent field");
+        return !isCommitted();
+    }
+
+    @Override
+    public HttpField onReplaceField(HttpField oldField, HttpField newField)
+    {
+        if (isCommitted())
+            return null;
+
+        if (oldField instanceof Persistent persistent)
+        {
+            // cannot change the field name
+            if (newField == null || !newField.isSameName(oldField))
+                throw new UnsupportedOperationException("Persistent field");
+
+            // new field must also be persistent and clear back to the previous value
+            newField = (newField instanceof PreEncodedHttpField)
+                ? new PersistentPreEncodedHttpField(oldField.getHeader(), newField.getValue(), persistent.getOriginal())
+                : new PersistentHttpField(newField, persistent.getOriginal());
+        }
+
+        return newField;
+    }
+
     public void recycle()
     {
         _committed.set(false);
-        _fields.clear();
-    }
-
-    @Override
-    public HttpField getField(String name)
-    {
-        return _fields.getField(name);
-    }
-
-    @Override
-    public HttpField getField(HttpHeader header)
-    {
-        return _fields.getField(header);
-    }
-
-    @Override
-    public HttpField getField(int index)
-    {
-        return _fields.getField(index);
-    }
-
-    @Override
-    public int size()
-    {
-        return _fields.size();
-    }
-
-    @Override
-    public Stream<HttpField> stream()
-    {
-        return _fields.stream();
-    }
-
-    @Override
-    public Mutable add(HttpField field)
-    {
-        if (field != null && !_committed.get())
-            _fields.add(field);
-        return this;
+        super.clear();
     }
 
     @Override
     public HttpFields asImmutable()
     {
-        return _committed.get() ? this : _fields.asImmutable();
+        return _committed.get() ? this : getMutableHttpFields().asImmutable();
     }
 
     @Override
@@ -106,7 +107,7 @@ public class ResponseHttpFields implements HttpFields.Mutable
     {
         if (!_committed.get())
         {
-            for (ListIterator<HttpField> iterator = _fields.listIterator(_fields.size()); iterator.hasPrevious();)
+            for (ListIterator<HttpField> iterator = getMutableHttpFields().listIterator(size()); iterator.hasPrevious();)
             {
                 HttpField field = iterator.previous();
                 if (field instanceof Persistent persistent)
@@ -116,148 +117,6 @@ public class ResponseHttpFields implements HttpFields.Mutable
             }
         }
         return this;
-    }
-
-    @Override
-    public void ensureField(HttpField field)
-    {
-        if (!_committed.get())
-            _fields.ensureField(field);
-    }
-
-    @Override
-    public Iterator<HttpField> iterator()
-    {
-        return new Iterator<>()
-        {
-            private final Iterator<HttpField> i = _fields.iterator();
-            private HttpField _current;
-
-            @Override
-            public boolean hasNext()
-            {
-                return i.hasNext();
-            }
-
-            @Override
-            public HttpField next()
-            {
-                _current = i.next();
-                return _current;
-            }
-
-            @Override
-            public void remove()
-            {
-                if (_committed.get())
-                    return;
-                if (isPersistent(_current))
-                    throw new UnsupportedOperationException("Persistent field");
-                if (_current == null)
-                    throw new IllegalStateException("No current field");
-                i.remove();
-                _current = null;
-            }
-        };
-    }
-
-    @Override
-    public ListIterator<HttpField> listIterator(int index)
-    {
-        ListIterator<HttpField> i = _fields.listIterator(index);
-        return new ListIterator<>()
-        {
-            private HttpField _current;
-
-            @Override
-            public boolean hasNext()
-            {
-                return i.hasNext();
-            }
-
-            @Override
-            public HttpField next()
-            {
-                _current = i.next();
-                return _current;
-            }
-
-            @Override
-            public boolean hasPrevious()
-            {
-                return i.hasPrevious();
-            }
-
-            @Override
-            public HttpField previous()
-            {
-                _current = i.previous();
-                return _current;
-            }
-
-            @Override
-            public int nextIndex()
-            {
-                return i.nextIndex();
-            }
-
-            @Override
-            public int previousIndex()
-            {
-                return i.previousIndex();
-            }
-
-            @Override
-            public void remove()
-            {
-                if (_committed.get())
-                    return;
-                if (isPersistent(_current))
-                    throw new UnsupportedOperationException("Persistent field");
-                if (_current == null)
-                    throw new IllegalStateException("No current field");
-                i.remove();
-                _current = null;
-            }
-
-            @Override
-            public void set(HttpField field)
-            {
-                if (_committed.get())
-                    return;
-                if (_current instanceof Persistent persistent)
-                {
-                    // cannot change the field name
-                    if (field == null || !field.isSameName(_current))
-                        throw new UnsupportedOperationException("Persistent field");
-
-                    // new field must also be persistent and clear back to the previous value
-                    field = (field instanceof PreEncodedHttpField)
-                        ? new PersistentPreEncodedHttpField(_current.getHeader(), field.getValue(), persistent.getOriginal())
-                        : new PersistentHttpField(field, persistent.getOriginal());
-                }
-                if (_current == null)
-                    throw new IllegalStateException("No current field");
-                if (field == null)
-                    i.remove();
-                else
-                    i.set(field);
-                _current = field;
-            }
-
-            @Override
-            public void add(HttpField field)
-            {
-                if (field != null && !_committed.get())
-                    i.add(field);
-            }
-        };
-    }
-
-    @Override
-    public String toString()
-    {
-        return _fields.toString();
     }
 
     /**

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiResponse.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiResponse.java
@@ -226,7 +226,7 @@ public class ServletApiResponse implements HttpServletResponse
     @Override
     public void addHeader(String name, String value)
     {
-        if (name == null || value == null)
+        if (name == null)
             return; // Spec is to do nothing
 
         getResponse().getHeaders().add(name, value);

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextResponse.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextResponse.java
@@ -609,7 +609,7 @@ public class ServletContextResponse extends ContextResponse implements ServletCo
             assert oldField != null && newField != null;
 
             if (isCommitted())
-                return null;
+                return oldField;
 
             if (newField.getHeader() == null)
                 return newField;

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ResponseHeadersTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ResponseHeadersTest.java
@@ -92,6 +92,7 @@ public class ResponseHeadersTest
 
                 response.setHeader("SetAfterCommit", "ignored");
                 response.addHeader("AddAfterCommit", "ignored");
+                response.setHeader("AddHeaderTwice", "ignored");
 
                 response.getOutputStream().print("OK");
             }

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Response.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Response.java
@@ -726,7 +726,8 @@ public class Response implements HttpServletResponse
             return;
         }
 
-        _fields.add(name, value);
+        if (value != null)
+            _fields.add(name, value);
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Response.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Response.java
@@ -708,7 +708,7 @@ public class Response implements HttpServletResponse
         {
             boolean errorSent = AtomicBiInteger.getHi(biInt) != 0;
             boolean including = AtomicBiInteger.getLo(biInt) > 0;
-            if (!errorSent && including && name.startsWith(SET_INCLUDE_HEADER_PREFIX))
+            if (!errorSent && including && name != null && name.startsWith(SET_INCLUDE_HEADER_PREFIX))
                 name = name.substring(SET_INCLUDE_HEADER_PREFIX.length());
             else
                 return;
@@ -726,8 +726,7 @@ public class Response implements HttpServletResponse
             return;
         }
 
-        if (value != null)
-            _fields.add(name, value);
+        _fields.add(name, value);
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ResponseHeadersTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ResponseHeadersTest.java
@@ -189,6 +189,7 @@ public class ResponseHeadersTest
 
             response.setHeader("SetAfterCommit", "ignored");
             response.addHeader("AddAfterCommit", "ignored");
+            response.setHeader("AddHeaderTwice", "ignored");
 
             response.getOutputStream().print("OK");
         }


### PR DESCRIPTION
In Jetty 9.4 you can add null header values on the response with no error. 
However in Jetty 12 EE8 this will throw NPE.

This was causing issues with the GAE migration to Jetty 12.
