### PR TITLE
Tentative fix for the flaky AsyncMiddleManServletTest.testLargeChunkedGzippedBufferedDownstreamTransformation().

### DIFF
--- a/jetty-ee10/jetty-ee10-proxy/pom.xml
+++ b/jetty-ee10/jetty-ee10-proxy/pom.xml
@@ -39,6 +39,12 @@
       <artifactId>jetty-ee10-servlet</artifactId>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-http-tools</artifactId>

--- a/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/AsyncMiddleManServletTest.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/AsyncMiddleManServletTest.java
@@ -23,9 +23,11 @@ import java.io.OutputStream;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
+import java.net.InetSocketAddress;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.ByteBuffer;
+import java.nio.channels.SocketChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -68,7 +70,10 @@ import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpHeaderValue;
 import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.io.AbstractEndPoint;
 import org.eclipse.jetty.io.RuntimeIOException;
+import org.eclipse.jetty.io.WriteFlusher;
 import org.eclipse.jetty.logging.StacklessLogging;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
@@ -90,6 +95,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -680,7 +686,7 @@ public class AsyncMiddleManServletTest
 
     private void testLargeChunkedBufferedDownstreamTransformation(boolean gzipped) throws Exception
     {
-        // Tests the race between a incomplete write performed from ProxyResponseListener.onSuccess()
+        // Tests the race between an incomplete write performed from ProxyResponseListener.onSuccess()
         // and ProxyResponseListener.onComplete() being called before the write has completed.
 
         startServer(new HttpServlet()
@@ -695,11 +701,15 @@ public class AsyncMiddleManServletTest
                     response.setHeader(HttpHeader.CONTENT_ENCODING.asString(), "gzip");
                 }
 
+                // Flush to force chunked transfer.
+                response.flushBuffer();
+
+                // Large non-compressible write to make the proxy TCP congested.
                 Random random = new Random();
                 byte[] chunk = new byte[1024 * 1024];
+                random.nextBytes(chunk);
                 for (int i = 0; i < 16; ++i)
                 {
-                    random.nextBytes(chunk);
                     output.write(chunk);
                     output.flush();
                 }
@@ -716,24 +726,29 @@ public class AsyncMiddleManServletTest
                 return transformer;
             }
         });
-        startClient();
+        // Connect to the proxy, but send a request for the server.
+        try (SocketChannel client = SocketChannel.open(new InetSocketAddress("localhost", proxyConnector.getLocalPort())))
+        {
+            String request = """
+                GET http://localhost:$P/ HTTP/1.1
+                Host: localhost:$P
+                Accept-Encoding: gzip
+                
+                """.replace("$P", String.valueOf(serverConnector.getLocalPort()));
+            client.write(BufferUtil.toBuffer(request, StandardCharsets.UTF_8));
 
-        CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest("localhost", serverConnector.getLocalPort())
-            .onResponseContent((response, content) ->
-            {
-                // Slow down the reader so that the
-                // write from the proxy gets congested.
-                sleep(1);
-            })
-            .send(result ->
-            {
-                assertTrue(result.isSucceeded());
-                assertEquals(200, result.getResponse().getStatus());
-                latch.countDown();
-            });
+            // Do not read yet, wait for the proxy to become TCP congested.
+            await().atMost(15, TimeUnit.SECONDS).until(() ->
+                proxyConnector.getConnectedEndPoints().stream()
+                    .filter(endPoint -> endPoint instanceof AbstractEndPoint)
+                    .map(endPoint -> ((AbstractEndPoint)endPoint).getWriteFlusher())
+                    .anyMatch(WriteFlusher::isPending)
+            );
 
-        assertTrue(latch.await(15, TimeUnit.SECONDS));
+            client.socket().setSoTimeout(5000);
+            HttpTester.Response response = HttpTester.parseResponse(HttpTester.from(client));
+            assertEquals(HttpStatus.OK_200, response.getStatus());
+        }
     }
 
     @Test

--- a/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/AsyncMiddleManServletTest.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/AsyncMiddleManServletTest.java
@@ -726,6 +726,7 @@ public class AsyncMiddleManServletTest
                 return transformer;
             }
         });
+
         // Connect to the proxy, but send a request for the server.
         try (SocketChannel client = SocketChannel.open(new InetSocketAddress("localhost", proxyConnector.getLocalPort())))
         {

--- a/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/AsyncMiddleManServletTest.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/AsyncMiddleManServletTest.java
@@ -108,6 +108,7 @@ public class AsyncMiddleManServletTest
 {
     private static final Logger LOG = LoggerFactory.getLogger(AsyncMiddleManServletTest.class);
     private static final String PROXIED_HEADER = "X-Proxied";
+
     private HttpClient client;
     private Server proxy;
     private ServerConnector proxyConnector;
@@ -689,6 +690,17 @@ public class AsyncMiddleManServletTest
         // Tests the race between an incomplete write performed from ProxyResponseListener.onSuccess()
         // and ProxyResponseListener.onComplete() being called before the write has completed.
 
+        Random random = new Random();
+        byte[] bytes = new byte[16 * 1024 * 1024];
+        random.nextBytes(bytes);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (OutputStream gzipOutput = new GZIPOutputStream(baos))
+        {
+            gzipOutput.write(bytes);
+        }
+        byte[] gzipBytes = baos.toByteArray();
+
         startServer(new HttpServlet()
         {
             @Override
@@ -697,22 +709,19 @@ public class AsyncMiddleManServletTest
                 OutputStream output = response.getOutputStream();
                 if (gzipped)
                 {
-                    output = new GZIPOutputStream(output);
                     response.setHeader(HttpHeader.CONTENT_ENCODING.asString(), "gzip");
+                    output = new GZIPOutputStream(output);
                 }
 
                 // Flush to force chunked transfer.
-                response.flushBuffer();
+                output.flush();
 
                 // Large non-compressible write to make the proxy TCP congested.
-                Random random = new Random();
-                byte[] chunk = new byte[1024 * 1024];
-                random.nextBytes(chunk);
-                for (int i = 0; i < 16; ++i)
-                {
-                    output.write(chunk);
-                    output.flush();
-                }
+                output.write(bytes);
+
+                // Make sure the GZIPOutputStream is closed to ensure all of it is written.
+                if (gzipped)
+                    output.close();
             }
         });
         startProxy(new AsyncMiddleManServlet()
@@ -748,7 +757,23 @@ public class AsyncMiddleManServletTest
 
             client.socket().setSoTimeout(5000);
             HttpTester.Response response = HttpTester.parseResponse(HttpTester.from(client));
+            byte[] rawBytes = response.getContentBytes();
+
             assertEquals(HttpStatus.OK_200, response.getStatus());
+
+            if (gzipped)
+            {
+                assertArrayEquals(gzipBytes, rawBytes);
+                byte[] ungzipped = new GZIPInputStream(new ByteArrayInputStream(rawBytes)).readAllBytes();
+                assertArrayEquals(bytes, ungzipped);
+            }
+            else
+            {
+                assertArrayEquals(bytes, rawBytes);
+            }
+
+            byte[] result = gzipped ? new GZIPInputStream(new ByteArrayInputStream(rawBytes)).readAllBytes() : rawBytes;
+            assertArrayEquals(bytes, result);
         }
     }
 

--- a/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/AsyncMiddleManServletTest.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/AsyncMiddleManServletTest.java
@@ -771,9 +771,6 @@ public class AsyncMiddleManServletTest
             {
                 assertArrayEquals(bytes, rawBytes);
             }
-
-            byte[] result = gzipped ? new GZIPInputStream(new ByteArrayInputStream(rawBytes)).readAllBytes() : rawBytes;
-            assertArrayEquals(bytes, result);
         }
     }
 

--- a/jetty-ee8/jetty-ee8-proxy/pom.xml
+++ b/jetty-ee8/jetty-ee8-proxy/pom.xml
@@ -39,6 +39,12 @@
       <artifactId>jetty-servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-http-tools</artifactId>

--- a/jetty-ee9/jetty-ee9-proxy/pom.xml
+++ b/jetty-ee9/jetty-ee9-proxy/pom.xml
@@ -38,6 +38,12 @@
       <artifactId>jetty-jakarta-servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-http-tools</artifactId>

--- a/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/AsyncMiddleManServletTest.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/AsyncMiddleManServletTest.java
@@ -23,9 +23,11 @@ import java.io.OutputStream;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
+import java.net.InetSocketAddress;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.ByteBuffer;
+import java.nio.channels.SocketChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -68,7 +70,10 @@ import org.eclipse.jetty.ee9.servlet.ServletHolder;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpHeaderValue;
 import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.io.AbstractEndPoint;
 import org.eclipse.jetty.io.RuntimeIOException;
+import org.eclipse.jetty.io.WriteFlusher;
 import org.eclipse.jetty.logging.StacklessLogging;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
@@ -90,6 +95,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -685,7 +691,7 @@ public class AsyncMiddleManServletTest
 
     private void testLargeChunkedBufferedDownstreamTransformation(boolean gzipped) throws Exception
     {
-        // Tests the race between a incomplete write performed from ProxyResponseListener.onSuccess()
+        // Tests the race between an incomplete write performed from ProxyResponseListener.onSuccess()
         // and ProxyResponseListener.onComplete() being called before the write has completed.
 
         startServer(new HttpServlet()
@@ -700,11 +706,15 @@ public class AsyncMiddleManServletTest
                     response.setHeader(HttpHeader.CONTENT_ENCODING.asString(), "gzip");
                 }
 
+                // Flush to force chunked transfer.
+                response.flushBuffer();
+
+                // Large non-compressible write to make the proxy TCP congested.
                 Random random = new Random();
                 byte[] chunk = new byte[1024 * 1024];
+                random.nextBytes(chunk);
                 for (int i = 0; i < 16; ++i)
                 {
-                    random.nextBytes(chunk);
                     output.write(chunk);
                     output.flush();
                 }
@@ -721,24 +731,30 @@ public class AsyncMiddleManServletTest
                 return transformer;
             }
         });
-        startClient();
 
-        CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest("localhost", serverConnector.getLocalPort())
-            .onResponseContent((response, content) ->
-            {
-                // Slow down the reader so that the
-                // write from the proxy gets congested.
-                sleep(1);
-            })
-            .send(result ->
-            {
-                assertTrue(result.isSucceeded());
-                assertEquals(200, result.getResponse().getStatus());
-                latch.countDown();
-            });
+        // Connect to the proxy, but send a request for the server.
+        try (SocketChannel client = SocketChannel.open(new InetSocketAddress("localhost", proxyConnector.getLocalPort())))
+        {
+            String request = """
+                GET http://localhost:$P/ HTTP/1.1
+                Host: localhost:$P
+                Accept-Encoding: gzip
+                
+                """.replace("$P", String.valueOf(serverConnector.getLocalPort()));
+            client.write(BufferUtil.toBuffer(request, StandardCharsets.UTF_8));
 
-        assertTrue(latch.await(15, TimeUnit.SECONDS));
+            // Do not read yet, wait for the proxy to become TCP congested.
+            await().atMost(15, TimeUnit.SECONDS).until(() ->
+                proxyConnector.getConnectedEndPoints().stream()
+                    .filter(endPoint -> endPoint instanceof AbstractEndPoint)
+                    .map(endPoint -> ((AbstractEndPoint)endPoint).getWriteFlusher())
+                    .anyMatch(WriteFlusher::isPending)
+            );
+
+            client.socket().setSoTimeout(5000);
+            HttpTester.Response response = HttpTester.parseResponse(HttpTester.from(client));
+            assertEquals(HttpStatus.OK_200, response.getStatus());
+        }
     }
 
     @Test

--- a/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/AsyncMiddleManServletTest.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/AsyncMiddleManServletTest.java
@@ -694,6 +694,17 @@ public class AsyncMiddleManServletTest
         // Tests the race between an incomplete write performed from ProxyResponseListener.onSuccess()
         // and ProxyResponseListener.onComplete() being called before the write has completed.
 
+        Random random = new Random();
+        byte[] bytes = new byte[16 * 1024 * 1024];
+        random.nextBytes(bytes);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (OutputStream gzipOutput = new GZIPOutputStream(baos))
+        {
+            gzipOutput.write(bytes);
+        }
+        byte[] gzipBytes = baos.toByteArray();
+
         startServer(new HttpServlet()
         {
             @Override
@@ -702,22 +713,19 @@ public class AsyncMiddleManServletTest
                 OutputStream output = response.getOutputStream();
                 if (gzipped)
                 {
-                    output = new GZIPOutputStream(output);
                     response.setHeader(HttpHeader.CONTENT_ENCODING.asString(), "gzip");
+                    output = new GZIPOutputStream(output);
                 }
 
                 // Flush to force chunked transfer.
-                response.flushBuffer();
+                output.flush();
 
                 // Large non-compressible write to make the proxy TCP congested.
-                Random random = new Random();
-                byte[] chunk = new byte[1024 * 1024];
-                random.nextBytes(chunk);
-                for (int i = 0; i < 16; ++i)
-                {
-                    output.write(chunk);
-                    output.flush();
-                }
+                output.write(bytes);
+
+                // Make sure the GZIPOutputStream is closed to ensure all of it is written.
+                if (gzipped)
+                    output.close();
             }
         });
         startProxy(new AsyncMiddleManServlet()
@@ -753,7 +761,23 @@ public class AsyncMiddleManServletTest
 
             client.socket().setSoTimeout(5000);
             HttpTester.Response response = HttpTester.parseResponse(HttpTester.from(client));
+            byte[] rawBytes = response.getContentBytes();
+
             assertEquals(HttpStatus.OK_200, response.getStatus());
+
+            if (gzipped)
+            {
+                assertArrayEquals(gzipBytes, rawBytes);
+                byte[] ungzipped = new GZIPInputStream(new ByteArrayInputStream(rawBytes)).readAllBytes();
+                assertArrayEquals(bytes, ungzipped);
+            }
+            else
+            {
+                assertArrayEquals(bytes, rawBytes);
+            }
+
+            byte[] result = gzipped ? new GZIPInputStream(new ByteArrayInputStream(rawBytes)).readAllBytes() : rawBytes;
+            assertArrayEquals(bytes, result);
         }
     }
 

--- a/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/AsyncMiddleManServletTest.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/AsyncMiddleManServletTest.java
@@ -775,9 +775,6 @@ public class AsyncMiddleManServletTest
             {
                 assertArrayEquals(bytes, rawBytes);
             }
-
-            byte[] result = gzipped ? new GZIPInputStream(new ByteArrayInputStream(rawBytes)).readAllBytes() : rawBytes;
-            assertArrayEquals(bytes, result);
         }
     }
 


### PR DESCRIPTION
Rewrote the test client part to avoid `Thread.sleep()` and using a `SocketChannel` to control reads.