### PR TITLE
Fix to EE8/EE9 StandardDescriptorProcessor to allow duplicate ServletMappings

### DIFF
--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/StandardDescriptorProcessor.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/StandardDescriptorProcessor.java
@@ -1271,10 +1271,6 @@ public class StandardDescriptorProcessor extends IterativeDescriptorProcessor
                         }
                         case DESCRIPTOR ->
                         {
-                            //if the descriptor of the original mapping and the new mapping are the same, that is an error
-                            if (originalMapping.getSource().getResource().equals(descriptor.getResource()))
-                                throw new IllegalStateException("Duplicate mappings for " + path);
-
                             //if the original mapping came from the defaults descriptor it can be overridden by any other descriptor
                             if (originalMapping.isFromDefaultDescriptor())
                             {


### PR DESCRIPTION
Allow duplicate servlet path mappings in the EE8/EE9 `StandardDescriptorProcessor`.

This is an issue with the GAE migration to Jetty 12, where I was provided with a stacktrace of an application which was throwing `IllegalStateException` on Jetty 12 which was not previously throwing on Jetty 9.4

In this case the mappings are being found from `quickstart-web.xml`.