### PR TITLE
Avoid direct cast to ServletScopedContext

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/BaseHolder.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/BaseHolder.java
@@ -166,7 +166,7 @@ public abstract class BaseHolder<T> extends AbstractLifeCycle implements Dumpabl
         if (_servletHandler != null)
         {
             ServletContext context = _servletHandler.getServletContext();
-            if ((context instanceof ContextHandler.ScopedContext) && ((ContextHandler.ScopedContext)context).getContextHandler().isStarted())
+            if (context instanceof ContextHandler.ScopedContext scopedContext && scopedContext.getContextHandler().isStarted())
                 throw new IllegalStateException("Started");
         }
     }

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
@@ -472,8 +472,8 @@ public class ServletChannel
                             if (!_httpInput.consumeAvailable())
                                 ResponseUtils.ensureNotPersistent(_servletContextRequest, _servletContextRequest.getServletContextResponse());
 
-                            ContextHandler.ScopedContext context = (ContextHandler.ScopedContext)_servletContextRequest.getAttribute(ErrorHandler.ERROR_CONTEXT);
-                            Request.Handler errorHandler = ErrorHandler.getErrorHandler(getServer(), context == null ? null : context.getContextHandler());
+                            Request.Handler errorHandler = _servletContextRequest.getAttribute(ErrorHandler.ERROR_CONTEXT) instanceof ContextHandler.ScopedContext scopedContext
+                                ? ErrorHandler.getErrorHandler(getServer(), scopedContext.getContextHandler()) : null;
 
                             // If we can't have a body or have no ErrorHandler, then create a minimal error response.
                             if (HttpStatus.hasNoBody(getServletContextResponse().getStatus()) || errorHandler == null)

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContainerInitializerHolder.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContainerInitializerHolder.java
@@ -127,8 +127,8 @@ public class ServletContainerInitializerHolder extends BaseHolder<ServletContain
         if (ctx == null)
         {
             Context currentContext = ContextHandler.getCurrentContext();
-            if (currentContext instanceof ServletContextHandler.ServletScopedContext)
-                ctx = (ServletContextHandler.ServletScopedContext)currentContext;
+            if (currentContext instanceof ServletContextHandler.ServletScopedContext servletScopedContext)
+                ctx = servletScopedContext;
         }
         if (ctx == null)
             throw new IllegalStateException("No Context");

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
@@ -193,16 +193,16 @@ public class ServletContextHandler extends ContextHandler
 
     public static jakarta.servlet.ServletContext getServletContext(Context context)
     {
-        if (context instanceof ServletScopedContext)
-            return ((ServletScopedContext)context).getServletContext();
+        if (context instanceof ServletScopedContext servletScopedContext)
+            return servletScopedContext.getServletContext();
         return null;
     }
 
     public static ServletContextHandler getCurrentServletContextHandler()
     {
         Context context = ContextHandler.getCurrentContext();
-        if (context instanceof ServletScopedContext)
-            return ((ServletScopedContext)context).getServletContextHandler();
+        if (context instanceof ServletScopedContext servletScopedContext)
+            return servletScopedContext.getServletContextHandler();
         return null;
     }
 
@@ -869,7 +869,9 @@ public class ServletContextHandler extends ContextHandler
     @Override
     public ServletScopedContext getContext()
     {
-        return (ServletScopedContext)super.getContext();
+        if (super.getContext() instanceof ServletScopedContext servletScopedContext)
+            return servletScopedContext;
+        throw new IllegalStateException("Context is not ServletScopedContext");
     }
 
     /**

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextRequest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextRequest.java
@@ -282,7 +282,9 @@ public class ServletContextRequest extends ContextRequest implements ServletCont
     @Override
     public ServletContextHandler.ServletScopedContext getServletContext()
     {
-        return (ServletContextHandler.ServletScopedContext)super.getContext();
+        if (super.getContext() instanceof ServletContextHandler.ServletScopedContext servletScopedContext)
+            return servletScopedContext;
+        return null;
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletHandler.java
@@ -181,10 +181,11 @@ public class ServletHandler extends Handler.Wrapper
         try (AutoLock ignored = lock())
         {
             Context context = ContextHandler.getCurrentContext();
-            if (!(context instanceof ServletContextHandler.ServletScopedContext))
+
+            if (!(context instanceof ServletContextHandler.ServletScopedContext servletScopedContext))
                 throw new IllegalStateException("Cannot use ServletHandler without ServletContextHandler");
-            _servletContext = ((ServletContextHandler.ServletScopedContext)context).getServletContext();
-            _servletContextHandler = ((ServletContextHandler.ServletScopedContext)context).getServletContextHandler();
+            _servletContext = servletScopedContext.getServletContext();
+            _servletContextHandler = servletScopedContext.getServletContextHandler();
 
             if (_servletContextHandler != null)
             {


### PR DESCRIPTION
For #12937 cleanup direct cast of servlet scoped context.