### PR TITLE
`IteratingCallback.iterate()` should be a no-op when closed or aborted

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/IteratingCallback.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/IteratingCallback.java
@@ -215,11 +215,6 @@ public abstract class IteratingCallback implements Callback
         {
             switch (_state)
             {
-                case PENDING:
-                case CALLED:
-                    // process will be called when callback is handled
-                    break;
-
                 case IDLE:
                     _state = State.PROCESSING;
                     process = true;
@@ -229,14 +224,8 @@ public abstract class IteratingCallback implements Callback
                     _iterate = true;
                     break;
 
-                case FAILED:
-                case SUCCEEDED:
-                    break;
-
-                case CLOSED:
-                case ABORTED:
                 default:
-                    throw new IllegalStateException(toString());
+                    break;
             }
         }
         if (process)


### PR DESCRIPTION
Aligns with the changes done in 12.1.x.

Fixes #12943