### PR TITLE
Issue #12361 - Fix ee# ErrorHandler showMessageInTitle flag

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ErrorHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ErrorHandler.java
@@ -380,10 +380,9 @@ public class ErrorHandler implements Request.Handler
             writer.write("\"/>\n");
         }
         writer.write("<title>Error ");
-        // TODO this code is duplicated in writeErrorPageMessage
         String status = Integer.toString(code);
         writer.write(status);
-        if (message != null && !message.equals(status))
+        if (isShowMessageInTitle() && message != null && !message.equals(status))
         {
             writer.write(' ');
             writer.write(StringUtil.sanitizeXmlString(message));
@@ -596,7 +595,16 @@ public class ErrorHandler implements Request.Handler
         _showMessageInTitle = showMessageInTitle;
     }
 
+    /**
+     * @deprecated use {@link #isShowMessageInTitle()} instead
+     */
+    @Deprecated
     public boolean getShowMessageInTitle()
+    {
+        return _showMessageInTitle;
+    }
+
+    public boolean isShowMessageInTitle()
     {
         return _showMessageInTitle;
     }

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ErrorHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ErrorHandler.java
@@ -366,10 +366,9 @@ public class ErrorHandler extends AbstractHandler
             writer.write("\"/>\n");
         }
         writer.write("<title>Error ");
-        // TODO this code is duplicated in writeErrorPageMessage
         String status = Integer.toString(code);
         writer.write(status);
-        if (message != null && !message.equals(status))
+        if (isShowMessageInTitle() && message != null && !message.equals(status))
         {
             writer.write(' ');
             writer.write(StringUtil.sanitizeXmlString(message));
@@ -586,7 +585,16 @@ public class ErrorHandler extends AbstractHandler
         _showMessageInTitle = showMessageInTitle;
     }
 
+    /**
+     * @deprecated use {@link #isShowMessageInTitle()} instead
+     */
+    @Deprecated
     public boolean getShowMessageInTitle()
+    {
+        return _showMessageInTitle;
+    }
+
+    public boolean isShowMessageInTitle()
     {
         return _showMessageInTitle;
     }


### PR DESCRIPTION
Ensure that the `ee#` implementations of `ErrorHandler` use the flag `showMessageInTitle` correctly.

Fixes #12361