### PR TITLE
Upgrade to quiche 0.23.5

### DIFF
--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-common/src/main/java/org/eclipse/jetty/quic/quiche/QuicheBinding.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-common/src/main/java/org/eclipse/jetty/quic/quiche/QuicheBinding.java
@@ -20,7 +20,7 @@ import java.nio.ByteBuffer;
 
 public interface QuicheBinding
 {
-    Throwable checkUsable();
+    Throwable initialize();
     int priority();
 
     byte[] fromPacket(ByteBuffer packet);

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-common/src/main/java/org/eclipse/jetty/quic/quiche/QuicheBinding.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-common/src/main/java/org/eclipse/jetty/quic/quiche/QuicheBinding.java
@@ -20,7 +20,7 @@ import java.nio.ByteBuffer;
 
 public interface QuicheBinding
 {
-    boolean isUsable();
+    Throwable checkUsable();
     int priority();
 
     byte[] fromPacket(ByteBuffer packet);

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-common/src/main/java/org/eclipse/jetty/quic/quiche/QuicheConnection.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-common/src/main/java/org/eclipse/jetty/quic/quiche/QuicheConnection.java
@@ -48,7 +48,7 @@ public abstract class QuicheConnection
         QUICHE_BINDING = bindings.stream()
             .filter(quicheBinding ->
             {
-                Throwable failure = quicheBinding.checkUsable();
+                Throwable failure = quicheBinding.initialize();
                 failures.add(failure);
                 return failure == null;
             })

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-common/src/main/java/org/eclipse/jetty/quic/quiche/QuicheConnection.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-common/src/main/java/org/eclipse/jetty/quic/quiche/QuicheConnection.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.ServiceLoader;
@@ -36,17 +37,28 @@ public abstract class QuicheConnection
     {
         // This code is safe even if trying to load a QuicheBinding instance throws an error,
         // as in that case a warning would be logged and the binding ignored.
+        List<QuicheBinding> bindings = TypeUtil.serviceStream(ServiceLoader.load(QuicheBinding.class))
+            .sorted(Comparator.comparingInt(QuicheBinding::priority))
+            .collect(Collectors.toList());
+
         if (LOG.isDebugEnabled())
-        {
-            List<QuicheBinding> bindings = TypeUtil.serviceStream(ServiceLoader.load(QuicheBinding.class))
-                .sorted(Comparator.comparingInt(QuicheBinding::priority))
-                .collect(Collectors.toList());
             LOG.debug("found quiche binding implementations: {}", bindings);
-        }
-        QUICHE_BINDING = TypeUtil.serviceStream(ServiceLoader.load(QuicheBinding.class))
-            .filter(QuicheBinding::isUsable)
+
+        List<Throwable> failures = new ArrayList<>();
+        QUICHE_BINDING = bindings.stream()
+            .filter(quicheBinding ->
+            {
+                Throwable failure = quicheBinding.checkUsable();
+                failures.add(failure);
+                return failure == null;
+            })
             .min(Comparator.comparingInt(QuicheBinding::priority))
-            .orElseThrow(() -> new IllegalStateException("no quiche binding implementation found"));
+            .orElseThrow(() ->
+            {
+                IllegalStateException ise = new IllegalStateException("no quiche binding implementation found");
+                failures.forEach(ise::addSuppressed);
+                return ise;
+            });
         if (LOG.isDebugEnabled())
             LOG.debug("using quiche binding implementation: {}", QUICHE_BINDING.getClass().getName());
     }

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/main/java/org/eclipse/jetty/quic/quiche/foreign/ForeignQuicheBinding.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/main/java/org/eclipse/jetty/quic/quiche/foreign/ForeignQuicheBinding.java
@@ -24,23 +24,26 @@ import org.eclipse.jetty.quic.quiche.QuicheConnection;
 
 public class ForeignQuicheBinding implements QuicheBinding
 {
+    private Throwable failure;
+
     @Override
-    public Throwable checkUsable()
+    public Throwable initialize()
     {
         try
         {
             quiche_h.initialize();
-            return null;
+            failure = null;
         }
         catch (ExceptionInInitializerError e)
         {
             Throwable cause = e.getCause();
-            return cause != null ? cause : e;
+            failure = cause != null ? cause : e;
         }
         catch (Throwable x)
         {
-            return x;
+            failure = x;
         }
+        return failure;
     }
 
     @Override
@@ -76,6 +79,6 @@ public class ForeignQuicheBinding implements QuicheBinding
     @Override
     public String toString()
     {
-        return getClass().getSimpleName() + "{p=" + priority() + " f=" + checkUsable() + "}";
+        return getClass().getSimpleName() + "{p=" + priority() + " f=" + failure + "}";
     }
 }

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/main/java/org/eclipse/jetty/quic/quiche/foreign/ForeignQuicheBinding.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/main/java/org/eclipse/jetty/quic/quiche/foreign/ForeignQuicheBinding.java
@@ -21,27 +21,25 @@ import java.nio.ByteBuffer;
 import org.eclipse.jetty.quic.quiche.QuicheBinding;
 import org.eclipse.jetty.quic.quiche.QuicheConfig;
 import org.eclipse.jetty.quic.quiche.QuicheConnection;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ForeignQuicheBinding implements QuicheBinding
 {
-    private static final Logger LOG = LoggerFactory.getLogger(ForeignQuicheBinding.class);
-
     @Override
-    public boolean isUsable()
+    public Throwable checkUsable()
     {
         try
         {
-            // Make a Quiche call to confirm.
-            quiche_h.quiche_version();
-            return true;
+            quiche_h.initialize();
+            return null;
+        }
+        catch (ExceptionInInitializerError e)
+        {
+            Throwable cause = e.getCause();
+            return cause != null ? cause : e;
         }
         catch (Throwable x)
         {
-            if (LOG.isDebugEnabled())
-                LOG.debug("java.lang.foreign quiche binding is not usable", x);
-            return false;
+            return x;
         }
     }
 
@@ -78,6 +76,6 @@ public class ForeignQuicheBinding implements QuicheBinding
     @Override
     public String toString()
     {
-        return getClass().getSimpleName() + "{p=" + priority() + " u=" + isUsable() + "}";
+        return getClass().getSimpleName() + "{p=" + priority() + " f=" + checkUsable() + "}";
     }
 }

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/main/java/org/eclipse/jetty/quic/quiche/foreign/ForeignQuicheConnection.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/main/java/org/eclipse/jetty/quic/quiche/foreign/ForeignQuicheConnection.java
@@ -44,6 +44,11 @@ public class ForeignQuicheConnection extends QuicheConnection
     private static final Logger LOG = LoggerFactory.getLogger(ForeignQuicheConnection.class);
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
+    static
+    {
+        quiche_h.versionCheck();
+    }
+
     // Quiche does not allow concurrent calls with the same connection.
     private final AutoLock lock = new AutoLock();
     private MemorySegment quicheConn;

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/main/java/org/eclipse/jetty/quic/quiche/foreign/ForeignQuicheConnection.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/main/java/org/eclipse/jetty/quic/quiche/foreign/ForeignQuicheConnection.java
@@ -44,11 +44,6 @@ public class ForeignQuicheConnection extends QuicheConnection
     private static final Logger LOG = LoggerFactory.getLogger(ForeignQuicheConnection.class);
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
-    static
-    {
-        quiche_h.versionCheck();
-    }
-
     // Quiche does not allow concurrent calls with the same connection.
     private final AutoLock lock = new AutoLock();
     private MemorySegment quicheConn;

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/main/java/org/eclipse/jetty/quic/quiche/foreign/quiche_h.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/main/java/org/eclipse/jetty/quic/quiche/foreign/quiche_h.java
@@ -30,8 +30,30 @@ import static org.eclipse.jetty.quic.quiche.foreign.NativeHelper.C_POINTER;
 
 public class quiche_h
 {
-    private static final String EXPECTED_QUICHE_VERSION = "0.23.4";
+    private static final String EXPECTED_QUICHE_VERSION = "0.23.5";
     private static final Logger LOG = LoggerFactory.getLogger(quiche_h.class);
+
+    static
+    {
+        if (LOG.isDebugEnabled())
+        {
+            String quicheVersion = quiche_version().getString(0L, StandardCharsets.UTF_8);
+            LOG.debug("Quiche version {}", quicheVersion);
+
+            MemorySegment cb = NativeHelper.upcallMemorySegment(LoggingCallback.class, "log", LoggingCallback.INSTANCE,
+                FunctionDescriptor.ofVoid(C_POINTER, C_POINTER), LoggingCallback.SCOPE);
+
+            if (quiche_enable_debug_logging(cb, MemorySegment.NULL) != 0)
+                throw new AssertionError("Cannot enable quiche debug logging");
+        }
+    }
+
+    static void versionCheck()
+    {
+        String quicheVersion = quiche_version().getString(0L, StandardCharsets.UTF_8);
+        if (!EXPECTED_QUICHE_VERSION.equals(quicheVersion))
+            throw new IllegalStateException("Native Quiche library version [" + quicheVersion + "] does not match expected version [" + EXPECTED_QUICHE_VERSION + "]");
+    }
 
     private static class LoggingCallback
     {
@@ -41,25 +63,6 @@ public class quiche_h
         public void log(MemorySegment msg, MemorySegment argp)
         {
             LOG.debug(msg.getString(0L, StandardCharsets.UTF_8));
-        }
-    }
-
-    static
-    {
-        String quicheVersion = quiche_version().getString(0L, StandardCharsets.US_ASCII);
-
-        if (!EXPECTED_QUICHE_VERSION.equals(quicheVersion))
-            throw new IllegalStateException("Native Quiche library version [" + quicheVersion + "] does not match expected version [" + EXPECTED_QUICHE_VERSION + "]");
-
-        if (LOG.isDebugEnabled())
-        {
-            LOG.debug("Quiche version {}", quicheVersion);
-
-            MemorySegment cb = NativeHelper.upcallMemorySegment(LoggingCallback.class, "log", LoggingCallback.INSTANCE,
-                FunctionDescriptor.ofVoid(C_POINTER, C_POINTER), LoggingCallback.SCOPE);
-
-            if (quiche_enable_debug_logging(cb, MemorySegment.NULL) != 0)
-                throw new AssertionError("Cannot enable quiche debug logging");
         }
     }
 

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/main/java/org/eclipse/jetty/quic/quiche/foreign/quiche_h.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/main/java/org/eclipse/jetty/quic/quiche/foreign/quiche_h.java
@@ -33,12 +33,16 @@ public class quiche_h
     private static final String EXPECTED_QUICHE_VERSION = "0.23.5";
     private static final Logger LOG = LoggerFactory.getLogger(quiche_h.class);
 
-    static
+    static void initialize()
     {
+        String quicheVersion = quiche_version().getString(0L, StandardCharsets.UTF_8);
+        if (!EXPECTED_QUICHE_VERSION.equals(quicheVersion))
+            throw new IllegalStateException("Native Quiche library version [" + quicheVersion + "] does not match expected version [" + EXPECTED_QUICHE_VERSION + "]");
+
         if (LOG.isDebugEnabled())
         {
-            String quicheVersion = quiche_version().getString(0L, StandardCharsets.UTF_8);
-            LOG.debug("Quiche version {}", quicheVersion);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Quiche version {}", quicheVersion);
 
             MemorySegment cb = NativeHelper.upcallMemorySegment(LoggingCallback.class, "log", LoggingCallback.INSTANCE,
                 FunctionDescriptor.ofVoid(C_POINTER, C_POINTER), LoggingCallback.SCOPE);
@@ -46,13 +50,6 @@ public class quiche_h
             if (quiche_enable_debug_logging(cb, MemorySegment.NULL) != 0)
                 throw new AssertionError("Cannot enable quiche debug logging");
         }
-    }
-
-    static void versionCheck()
-    {
-        String quicheVersion = quiche_version().getString(0L, StandardCharsets.UTF_8);
-        if (!EXPECTED_QUICHE_VERSION.equals(quicheVersion))
-            throw new IllegalStateException("Native Quiche library version [" + quicheVersion + "] does not match expected version [" + EXPECTED_QUICHE_VERSION + "]");
     }
 
     private static class LoggingCallback

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/pom.xml
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/pom.xml
@@ -39,4 +39,18 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>@{argLine}
+            ${jetty.surefire.argLine}
+            --enable-native-access com.sun.jna</argLine>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/JnaQuicheBinding.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/JnaQuicheBinding.java
@@ -24,23 +24,26 @@ import org.eclipse.jetty.quic.quiche.QuicheConnection;
 
 public class JnaQuicheBinding implements QuicheBinding
 {
+    private Throwable failure;
+
     @Override
-    public Throwable checkUsable()
+    public Throwable initialize()
     {
         try
         {
             LibQuiche.initialize();
-            return null;
+            failure = null;
         }
         catch (ExceptionInInitializerError e)
         {
             Throwable cause = e.getCause();
-            return cause != null ? cause : e;
+            failure = cause != null ? cause : e;
         }
         catch (Throwable x)
         {
-            return x;
+            failure = x;
         }
+        return failure;
     }
 
     @Override
@@ -76,6 +79,6 @@ public class JnaQuicheBinding implements QuicheBinding
     @Override
     public String toString()
     {
-        return getClass().getSimpleName() + "{p=" + priority() + " f=" + checkUsable() + "}";
+        return getClass().getSimpleName() + "{p=" + priority() + " f=" + failure + "}";
     }
 }

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/JnaQuicheBinding.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/JnaQuicheBinding.java
@@ -21,26 +21,25 @@ import java.nio.ByteBuffer;
 import org.eclipse.jetty.quic.quiche.QuicheBinding;
 import org.eclipse.jetty.quic.quiche.QuicheConfig;
 import org.eclipse.jetty.quic.quiche.QuicheConnection;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class JnaQuicheBinding implements QuicheBinding
 {
-    private static final Logger LOG = LoggerFactory.getLogger(JnaQuicheBinding.class);
-
     @Override
-    public boolean isUsable()
+    public Throwable checkUsable()
     {
         try
         {
-            // Make a Quiche call to confirm.
-            LibQuiche.INSTANCE.quiche_version();
-            return true;
+            LibQuiche.initialize();
+            return null;
+        }
+        catch (ExceptionInInitializerError e)
+        {
+            Throwable cause = e.getCause();
+            return cause != null ? cause : e;
         }
         catch (Throwable x)
         {
-            LOG.debug("JNA quiche binding is not usable", x);
-            return false;
+            return x;
         }
     }
 
@@ -77,6 +76,6 @@ public class JnaQuicheBinding implements QuicheBinding
     @Override
     public String toString()
     {
-        return getClass().getSimpleName() + "{p=" + priority() + " u=" + isUsable() + "}";
+        return getClass().getSimpleName() + "{p=" + priority() + " f=" + checkUsable() + "}";
     }
 }

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/JnaQuicheConnection.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/JnaQuicheConnection.java
@@ -40,11 +40,6 @@ public class JnaQuicheConnection extends QuicheConnection
     private static final Logger LOG = LoggerFactory.getLogger(JnaQuicheConnection.class);
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
-    static
-    {
-        LibQuiche.Logging.enable();
-    }
-
     // Quiche does not allow concurrent calls with the same connection.
     private final AutoLock lock = new AutoLock();
     private LibQuiche.quiche_conn quicheConn;

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/LibQuiche.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/LibQuiche.java
@@ -31,7 +31,7 @@ public interface LibQuiche extends Library
 {
     // This interface is a translation of the quiche.h header of a specific version.
     // It needs to be reviewed each time the native lib version changes.
-    String EXPECTED_QUICHE_VERSION = "0.23.4";
+    String EXPECTED_QUICHE_VERSION = "0.23.5";
 
     // The charset used to convert java.lang.String to char * and vice versa.
     Charset CHARSET = StandardCharsets.UTF_8;

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/LibQuiche.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/LibQuiche.java
@@ -17,7 +17,6 @@ import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.sun.jna.Callback;
 import com.sun.jna.Library;
@@ -39,23 +38,17 @@ public interface LibQuiche extends Library
     // Load the native lib.
     LibQuiche INSTANCE = Native.load("quiche", LibQuiche.class, Map.of(Library.OPTION_STRING_ENCODING, CHARSET.name()));
 
-    class Logging
+    static void initialize()
     {
-        private static final Logger LIB_QUICHE_LOG = LoggerFactory.getLogger(LibQuiche.class);
-        private static final LoggingCallback LIB_QUICHE_LOGGING_CALLBACK = (msg, argp) -> LIB_QUICHE_LOG.debug(msg);
-        private static final AtomicBoolean LOGGING_ENABLED = new AtomicBoolean();
+        String quicheVersion = INSTANCE.quiche_version();
+        if (!EXPECTED_QUICHE_VERSION.equals(quicheVersion))
+            throw new IllegalStateException("native quiche library version [" + quicheVersion + "] does not match expected version [" + EXPECTED_QUICHE_VERSION + "]");
 
-        public static void enable()
+        Logger logger = LoggerFactory.getLogger(LibQuiche.class);
+        if (logger.isDebugEnabled())
         {
-            String quicheVersion = INSTANCE.quiche_version();
-            if (!EXPECTED_QUICHE_VERSION.equals(quicheVersion))
-                throw new IllegalStateException("native quiche library version [" + quicheVersion + "] does not match expected version [" + EXPECTED_QUICHE_VERSION + "]");
-
-            if (LIB_QUICHE_LOG.isDebugEnabled() && LOGGING_ENABLED.compareAndSet(false, true))
-            {
-                INSTANCE.quiche_enable_debug_logging(LIB_QUICHE_LOGGING_CALLBACK, null);
-                LIB_QUICHE_LOG.debug("quiche version {}", quicheVersion);
-            }
+            INSTANCE.quiche_enable_debug_logging((msg, argp) -> logger.debug(msg), null);
+            logger.debug("quiche version {}", quicheVersion);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
     <jboss.logging.processor.version>2.2.1.Final</jboss.logging.processor.version>
     <jboss.logging.version>3.6.1.Final</jboss.logging.version>
     <jetty-assembly-descriptors.version>1.1</jetty-assembly-descriptors.version>
-    <jetty-quiche-native.version>0.23.4</jetty-quiche-native.version>
+    <jetty-quiche-native.version>0.23.5</jetty-quiche-native.version>
     <jetty-test-policy.version>1.2</jetty-test-policy.version>
     <jetty-version.maven.plugin.version>2.7</jetty-version.maven.plugin.version>
     <jetty.perf-helper.version>1.0.7</jetty.perf-helper.version>


### PR DESCRIPTION
Also fixes a minor bug in the Foreign binding: now the reported error contains the correct error message when the native version check fails.