### PR TITLE
Use provided buffer size when serving non-Path Resources

### DIFF
--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/IOResources.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/IOResources.java
@@ -147,7 +147,7 @@ public class IOResources
         // Fallback to wrapping InputStream.
         try
         {
-            return new InputStreamContentSource(resource.newInputStream());
+            return new InputStreamContentSource(resource.newInputStream(), new ByteBufferPool.Sized(bufferPool, false, bufferSize));
         }
         catch (IOException e)
         {


### PR DESCRIPTION
The helper IOResources.asContentSource wraps a given Resource to be served as a Content.Source. Unless a resource had a Path component, InputStreamContentSource is used as a fallback.

Previously, we were using a hardcoded buffer size of 4096, even if the request size was larger (e.g., 32768).

This severely limited throughput when serving content via non-Path-bearing Resource implementations.

Use the provided buffer pool and size instead.

Fixes #12963