### PR TITLE
`InputStreamContentSource` should always acquire indirect buffers from its buffer pool

### DIFF
--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferPool.java
@@ -156,6 +156,24 @@ public interface ByteBufferPool
         {
             return getWrapped().acquire(_size, _direct);
         }
+
+        /**
+         * @return A {@link RetainableByteBuffer} suitable for the specified preconfigured type.
+         * @param size The specified size in bytes of the buffer
+         */
+        public RetainableByteBuffer acquire(int size)
+        {
+            return getWrapped().acquire(size, _direct);
+        }
+
+        /**
+         * @return A {@link RetainableByteBuffer} suitable for the specified preconfigured size.
+         * @param direct true for a direct byte buffer, false otherwise
+         */
+        public RetainableByteBuffer acquire(boolean direct)
+        {
+            return getWrapped().acquire(_size, direct);
+        }
     }
 
     /**

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/IOResources.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/IOResources.java
@@ -21,7 +21,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.eclipse.jetty.io.content.ByteBufferContentSource;
-import org.eclipse.jetty.io.content.InputStreamContentSource;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.IO;
@@ -136,7 +135,7 @@ public class IOResources
         Path path = resource.getPath();
         if (path != null)
         {
-            return Content.Source.from(new ByteBufferPool.Sized(bufferPool, direct, bufferSize), path, 0, -1);
+            return Content.Source.from(new ByteBufferPool.Sized(bufferPool, direct, bufferSize), path);
         }
         if (resource instanceof MemoryResource memoryResource)
         {
@@ -150,7 +149,7 @@ public class IOResources
             InputStream inputStream = resource.newInputStream();
             if (inputStream == null)
                 throw new IllegalArgumentException("Resource does not support InputStream: " + resource);
-            return new InputStreamContentSource(inputStream, new ByteBufferPool.Sized(bufferPool, direct, bufferSize));
+            return Content.Source.from(new ByteBufferPool.Sized(bufferPool, direct, bufferSize), inputStream);
         }
         catch (IOException e)
         {

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/IOResources.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/IOResources.java
@@ -147,7 +147,10 @@ public class IOResources
         // Fallback to wrapping InputStream.
         try
         {
-            return new InputStreamContentSource(resource.newInputStream(), new ByteBufferPool.Sized(bufferPool, false, bufferSize));
+            InputStream inputStream = resource.newInputStream();
+            if (inputStream == null)
+                throw new IllegalArgumentException("Resource does not support InputStream: " + resource);
+            return new InputStreamContentSource(inputStream, new ByteBufferPool.Sized(bufferPool, direct, bufferSize));
         }
         catch (IOException e)
         {

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/InputStreamContentSource.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/InputStreamContentSource.java
@@ -58,7 +58,10 @@ public class InputStreamContentSource implements Content.Source
     public InputStreamContentSource(InputStream inputStream, ByteBufferPool.Sized bufferPool)
     {
         this.inputStream = Objects.requireNonNull(inputStream);
-        this.bufferPool = Objects.requireNonNullElse(bufferPool, ByteBufferPool.SIZED_NON_POOLING);
+        bufferPool = Objects.requireNonNullElse(bufferPool, ByteBufferPool.SIZED_NON_POOLING);
+        if (bufferPool.isDirect())
+            bufferPool = new ByteBufferPool.Sized(bufferPool.getWrapped(), false, bufferPool.getSize());
+        this.bufferPool = bufferPool;
     }
 
     public int getBufferSize()
@@ -86,17 +89,13 @@ public class InputStreamContentSource implements Content.Source
     }
 
     /**
+     * This method does nothing as {@code InputStreamContentSource} cannot use direct byte buffers.
      * @param useDirectByteBuffers {@code true} if direct buffers will be used.
      * @deprecated Use {@link InputStreamContentSource#InputStreamContentSource(InputStream, ByteBufferPool.Sized)}
      */
     @Deprecated(forRemoval = true, since = "12.0.11")
     public void setUseDirectByteBuffers(boolean useDirectByteBuffers)
     {
-        try (AutoLock ignored = lock.lock())
-        {
-            if (useDirectByteBuffers != bufferPool.isDirect())
-                bufferPool = new ByteBufferPool.Sized(bufferPool.getWrapped(), useDirectByteBuffers, bufferPool.getSize());
-        }
     }
     
     @Override

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/InputStreamContentSource.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/InputStreamContentSource.java
@@ -58,10 +58,7 @@ public class InputStreamContentSource implements Content.Source
     public InputStreamContentSource(InputStream inputStream, ByteBufferPool.Sized bufferPool)
     {
         this.inputStream = Objects.requireNonNull(inputStream);
-        bufferPool = Objects.requireNonNullElse(bufferPool, ByteBufferPool.SIZED_NON_POOLING);
-        if (bufferPool.isDirect())
-            bufferPool = new ByteBufferPool.Sized(bufferPool.getWrapped(), false, bufferPool.getSize());
-        this.bufferPool = bufferPool;
+        this.bufferPool = Objects.requireNonNullElse(bufferPool, ByteBufferPool.SIZED_NON_POOLING);
     }
 
     public int getBufferSize()
@@ -89,13 +86,17 @@ public class InputStreamContentSource implements Content.Source
     }
 
     /**
-     * This method does nothing as {@code InputStreamContentSource} cannot use direct byte buffers.
      * @param useDirectByteBuffers {@code true} if direct buffers will be used.
      * @deprecated Use {@link InputStreamContentSource#InputStreamContentSource(InputStream, ByteBufferPool.Sized)}
      */
     @Deprecated(forRemoval = true, since = "12.0.11")
     public void setUseDirectByteBuffers(boolean useDirectByteBuffers)
     {
+        try (AutoLock ignored = lock.lock())
+        {
+            if (useDirectByteBuffers != bufferPool.isDirect())
+                bufferPool = new ByteBufferPool.Sized(bufferPool.getWrapped(), useDirectByteBuffers, bufferPool.getSize());
+        }
     }
     
     @Override
@@ -109,7 +110,7 @@ public class InputStreamContentSource implements Content.Source
                 return Content.Chunk.EOF;
         }
 
-        RetainableByteBuffer streamBuffer = bufferPool.acquire();
+        RetainableByteBuffer streamBuffer = bufferPool.acquire(false);
         try
         {
             ByteBuffer buffer = streamBuffer.getByteBuffer();


### PR DESCRIPTION
Re-aligns with 12.1.x after fixing #12963 