### PR TITLE
Introduce `Content.Source.Factory` to allow 3rd parties benefitting from a fast codepath in `IOResources`

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPart.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPart.java
@@ -226,7 +226,7 @@ public class MultiPart
             try (AutoLock ignored = lock.lock())
             {
                 if (contentSource == null)
-                    contentSource = newContentSource();
+                    contentSource = newContentSource(bufferPool, first, length);
                 return contentSource;
             }
         }
@@ -243,18 +243,18 @@ public class MultiPart
          *
          * @return the content of this part as a new {@link Content.Source} or null if the content cannot be consumed multiple times.
          * @see #getContentSource()
+         * @deprecated override {@link #newContentSource(ByteBufferPool.Sized, long, long)} instead.
          */
+        @Deprecated
         public Content.Source newContentSource()
         {
-            return newContentSource(bufferPool, first, length);
+            return null;
         }
 
-        // This method is implemented for backward compatibility reasons: if a pre-existing subclass only
-        // overrides newContentSource(), then it won't fail to compile.
         @Override
         public Content.Source newContentSource(ByteBufferPool.Sized bufferPool, long first, long length)
         {
-            return null;
+            return newContentSource();
         }
 
         public long getLength()
@@ -287,7 +287,7 @@ public class MultiPart
                 Charset charset = defaultCharset != null ? defaultCharset : UTF_8;
                 if (charsetName != null)
                     charset = Charset.forName(charsetName);
-                return Content.Source.asString(newContentSource(), charset);
+                return Content.Source.asString(newContentSource(bufferPool, first, length), charset);
             }
             catch (IOException x)
             {
@@ -317,7 +317,7 @@ public class MultiPart
             {
                 try (OutputStream out = Files.newOutputStream(path))
                 {
-                    IO.copy(Content.Source.asInputStream(newContentSource()), out);
+                    IO.copy(Content.Source.asInputStream(newContentSource(bufferPool, first, length)), out);
                 }
                 newPath = path;
             }
@@ -400,7 +400,7 @@ public class MultiPart
         }
 
         @Override
-        public Content.Source newContentSource()
+        public Content.Source newContentSource(ByteBufferPool.Sized bufferPool, long first, long length)
         {
             return new ByteBufferContentSource(content);
         }
@@ -436,7 +436,7 @@ public class MultiPart
         }
 
         @Override
-        public Content.Source newContentSource()
+        public Content.Source newContentSource(ByteBufferPool.Sized bufferPool, long first, long length)
         {
             try (AutoLock ignored = lock.lock())
             {
@@ -546,7 +546,7 @@ public class MultiPart
         }
 
         @Override
-        public Content.Source newContentSource()
+        public Content.Source newContentSource(ByteBufferPool.Sized bufferPool, long first, long length)
         {
             Content.Source c = content;
             content = null;

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPart.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPart.java
@@ -34,6 +34,7 @@ import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.ThreadLocalRandom;
 
+import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.content.ByteBufferContentSource;
 import org.eclipse.jetty.io.content.ChunksContentSource;
@@ -127,11 +128,14 @@ public class MultiPart
      * <p>A part has an optional name, an optional fileName,
      * optional headers and an optional content.</p>
      */
-    public abstract static class Part implements Closeable
+    public abstract static class Part implements Content.Source.Factory, Closeable
     {
         static final Throwable CLOSE_EXCEPTION = new StaticException("Closed");
 
         private final AutoLock lock = new AutoLock();
+        private final ByteBufferPool.Sized bufferPool;
+        private final long first;
+        private final long length;
         private final String name;
         private final String fileName;
         private final HttpFields fields;
@@ -139,13 +143,30 @@ public class MultiPart
         private Content.Source contentSource;
         private boolean temporary;
 
+        /**
+         * @deprecated use {@link #Part(ByteBufferPool.Sized, String, String, HttpFields)} instead.
+         */
+        @Deprecated
         public Part(String name, String fileName, HttpFields fields)
         {
-            this(name, fileName, fields, null);
+            this(null, 0L, -1L, name, fileName, fields, null);
         }
 
-        private Part(String name, String fileName, HttpFields fields, Path path)
+        public Part(ByteBufferPool.Sized bufferPool, String name, String fileName, HttpFields fields)
         {
+            this(bufferPool, 0L, -1L, name, fileName, fields, null);
+        }
+
+        public Part(ByteBufferPool.Sized bufferPool, long first, long length, String name, String fileName, HttpFields fields)
+        {
+            this(bufferPool, first, length, name, fileName, fields, null);
+        }
+
+        private Part(ByteBufferPool.Sized bufferPool, long first, long length, String name, String fileName, HttpFields fields, Path path)
+        {
+            this.bufferPool = bufferPool;
+            this.first = first;
+            this.length = length;
             this.name = name;
             this.fileName = fileName;
             this.fields = fields != null ? fields : HttpFields.EMPTY;
@@ -223,7 +244,18 @@ public class MultiPart
          * @return the content of this part as a new {@link Content.Source} or null if the content cannot be consumed multiple times.
          * @see #getContentSource()
          */
-        public abstract Content.Source newContentSource();
+        public Content.Source newContentSource()
+        {
+            return newContentSource(bufferPool, first, length);
+        }
+
+        // This method is implemented for backward compatibility reasons: if a pre-existing subclass only
+        // overrides newContentSource(), then it won't fail to compile.
+        @Override
+        public Content.Source newContentSource(ByteBufferPool.Sized bufferPool, long first, long length)
+        {
+            return null;
+        }
 
         public long getLength()
         {
@@ -363,7 +395,7 @@ public class MultiPart
 
         public ByteBufferPart(String name, String fileName, HttpFields fields, List<ByteBuffer> content)
         {
-            super(name, fileName, fields);
+            super(null, name, fileName, fields);
             this.content = content;
         }
 
@@ -398,7 +430,7 @@ public class MultiPart
 
         public ChunksPart(String name, String fileName, HttpFields fields, List<Content.Chunk> content)
         {
-            super(name, fileName, fields);
+            super(null, name, fileName, fields);
             this.content.addAll(content);
             content.forEach(Content.Chunk::retain);
         }
@@ -462,9 +494,18 @@ public class MultiPart
      */
     public static class PathPart extends Part
     {
+        /**
+         * @deprecated use {@link #PathPart(ByteBufferPool.Sized, String, String, HttpFields, Path)} instead.
+         */
+        @Deprecated
         public PathPart(String name, String fileName, HttpFields fields, Path path)
         {
-            super(name, fileName, fields, path);
+            super(null, 0L, -1L, name, fileName, fields, path);
+        }
+
+        public PathPart(ByteBufferPool.Sized bufferPool, String name, String fileName, HttpFields fields, Path path)
+        {
+            super(bufferPool, 0L, -1L, name, fileName, fields, path);
         }
 
         public Path getPath()
@@ -473,10 +514,9 @@ public class MultiPart
         }
 
         @Override
-        public Content.Source newContentSource()
+        public Content.Source newContentSource(ByteBufferPool.Sized bufferPool, long first, long length)
         {
-            // TODO: use a ByteBuffer pool and direct ByteBuffers?
-            return Content.Source.from(getPath());
+            return Content.Source.from(bufferPool, getPath(), first, length);
         }
 
         @Override
@@ -501,7 +541,7 @@ public class MultiPart
 
         public ContentSourcePart(String name, String fileName, HttpFields fields, Content.Source content)
         {
-            super(name, fileName, fields);
+            super(null, name, fileName, fields);
             this.content = Objects.requireNonNull(content);
         }
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPart.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPart.java
@@ -146,7 +146,7 @@ public class MultiPart
         /**
          * @deprecated use {@link #Part(ByteBufferPool.Sized, String, String, HttpFields)} instead.
          */
-        @Deprecated
+        @Deprecated(since = "12.0.20", forRemoval = true)
         public Part(String name, String fileName, HttpFields fields)
         {
             this(null, 0L, -1L, name, fileName, fields, null);
@@ -245,12 +245,26 @@ public class MultiPart
          * @see #getContentSource()
          * @deprecated override {@link #newContentSource(ByteBufferPool.Sized, long, long)} instead.
          */
-        @Deprecated
+        @Deprecated(since = "12.0.20", forRemoval = true)
         public Content.Source newContentSource()
         {
             return null;
         }
 
+        /**
+         * {@inheritDoc}
+         *
+         * <p>Returns the content of this part as a new {@link Content.Source}</p>
+         * <p>If the content is reproducible, invoking this method multiple times will return
+         * a different independent instance for every invocation.</p>
+         * <p>If the content is not reproducible, subsequent calls to this method will return null.</p>
+         * <p>The content type and content encoding are specified in this part's {@link #getHeaders() headers}.</p>
+         * <p>The content encoding may be specified by the part named {@code _charset_},
+         * as specified in
+         * <a href="https://datatracker.ietf.org/doc/html/rfc7578#section-4.6">RFC 7578, section 4.6</a>.</p>
+         *
+         * @see #getContentSource()
+         */
         @Override
         public Content.Source newContentSource(ByteBufferPool.Sized bufferPool, long first, long length)
         {
@@ -497,7 +511,7 @@ public class MultiPart
         /**
          * @deprecated use {@link #PathPart(ByteBufferPool.Sized, String, String, HttpFields, Path)} instead.
          */
-        @Deprecated
+        @Deprecated(since = "12.0.20", forRemoval = true)
         public PathPart(String name, String fileName, HttpFields fields, Path path)
         {
             super(null, 0L, -1L, name, fileName, fields, path);

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartByteRanges.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartByteRanges.java
@@ -232,7 +232,7 @@ public class MultiPartByteRanges
         /**
          * @deprecated use {@link #Part(String, Resource, ByteRange, long, ByteBufferPool.Sized)} instead.
          */
-        @Deprecated
+        @Deprecated(since = "12.0.20", forRemoval = true)
         public Part(String contentType, Resource resource, ByteRange byteRange, long contentLength, ByteBufferPool bufferPool)
         {
             this(HttpFields.build().put(HttpHeader.CONTENT_TYPE, contentType)
@@ -253,7 +253,7 @@ public class MultiPartByteRanges
         /**
          * @deprecated use {@link #Part(HttpFields, Resource, ByteRange, ByteBufferPool.Sized)} instead.
          */
-        @Deprecated
+        @Deprecated(since = "12.0.20", forRemoval = true)
         public Part(HttpFields headers, Resource resource, ByteRange byteRange, ByteBufferPool bufferPool)
         {
             this(headers, resource, byteRange, new ByteBufferPool.Sized(bufferPool));

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartByteRanges.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartByteRanges.java
@@ -19,6 +19,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.jetty.io.ByteBufferPool;
@@ -221,8 +222,6 @@ public class MultiPartByteRanges
     public static class Part extends MultiPart.Part
     {
         private final Resource resource;
-        private final ByteRange byteRange;
-        private final ByteBufferPool bufferPool;
 
         public Part(String contentType, Resource resource, ByteRange byteRange, long contentLength)
         {
@@ -230,7 +229,17 @@ public class MultiPartByteRanges
                 .put(HttpHeader.CONTENT_RANGE, byteRange.toHeaderValue(contentLength)), resource, byteRange, null);
         }
 
+        /**
+         * @deprecated use {@link #Part(String, Resource, ByteRange, long, ByteBufferPool.Sized)} instead.
+         */
+        @Deprecated
         public Part(String contentType, Resource resource, ByteRange byteRange, long contentLength, ByteBufferPool bufferPool)
+        {
+            this(HttpFields.build().put(HttpHeader.CONTENT_TYPE, contentType)
+                .put(HttpHeader.CONTENT_RANGE, byteRange.toHeaderValue(contentLength)), resource, byteRange, new ByteBufferPool.Sized(bufferPool));
+        }
+
+        public Part(String contentType, Resource resource, ByteRange byteRange, long contentLength, ByteBufferPool.Sized bufferPool)
         {
             this(HttpFields.build().put(HttpHeader.CONTENT_TYPE, contentType)
                 .put(HttpHeader.CONTENT_RANGE, byteRange.toHeaderValue(contentLength)), resource, byteRange, bufferPool);
@@ -241,18 +250,25 @@ public class MultiPartByteRanges
             this(headers, resource, byteRange, null);
         }
 
+        /**
+         * @deprecated use {@link #Part(HttpFields, Resource, ByteRange, ByteBufferPool.Sized)} instead.
+         */
+        @Deprecated
         public Part(HttpFields headers, Resource resource, ByteRange byteRange, ByteBufferPool bufferPool)
         {
-            super(null, null, headers);
+            this(headers, resource, byteRange, new ByteBufferPool.Sized(bufferPool));
+        }
+
+        public Part(HttpFields headers, Resource resource, ByteRange byteRange, ByteBufferPool.Sized bufferPool)
+        {
+            super(Objects.requireNonNullElse(bufferPool, ByteBufferPool.SIZED_NON_POOLING), byteRange.first(), byteRange.getLength(), null, null, headers);
             this.resource = resource;
-            this.byteRange = byteRange;
-            this.bufferPool = bufferPool == null ? ByteBufferPool.NON_POOLING : bufferPool;
         }
 
         @Override
-        public Content.Source newContentSource()
+        public Content.Source newContentSource(ByteBufferPool.Sized bufferPool, long first, long length)
         {
-            return IOResources.asContentSource(resource, bufferPool, 0, false, byteRange.first(), byteRange.getLength());
+            return IOResources.asContentSource(resource, bufferPool.getWrapped(), bufferPool.getSize(), bufferPool.isDirect(), first, length);
         }
     }
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartFormData.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartFormData.java
@@ -855,7 +855,7 @@ public class MultiPartFormData
 
                     MultiPart.Part part;
                     if (fileChannel != null)
-                        part = new MultiPart.PathPart(name, fileName, headers, filePath);
+                        part = new MultiPart.PathPart(null, name, fileName, headers, filePath); // TODO use a pool
                     else
                         part = new MultiPart.ChunksPart(name, fileName, headers, List.copyOf(partChunks));
                     // Reset part-related state.

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/MultiPartCaptureTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/MultiPartCaptureTest.java
@@ -139,16 +139,16 @@ public class MultiPartCaptureTest
         @Override
         public ByteBuffer asByteBuffer() throws IOException
         {
-            return Content.Source.asByteBuffer(namedPart.newContentSource());
+            return Content.Source.asByteBuffer(namedPart.newContentSource(null, 0, -1));
         }
 
         @Override
         public String asString(Charset charset) throws IOException
         {
             if (charset == null)
-                return Content.Source.asString(namedPart.newContentSource());
+                return Content.Source.asString(namedPart.newContentSource(null, 0, -1));
             else
-                return Content.Source.asString(namedPart.newContentSource(), charset);
+                return Content.Source.asString(namedPart.newContentSource(null, 0, -1), charset);
         }
 
         @Override
@@ -160,7 +160,7 @@ public class MultiPartCaptureTest
         @Override
         public InputStream asInputStream()
         {
-            return Content.Source.asInputStream(namedPart.newContentSource());
+            return Content.Source.asInputStream(namedPart.newContentSource(null, 0, -1));
         }
     }
 

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferPool.java
@@ -156,6 +156,24 @@ public interface ByteBufferPool
         {
             return getWrapped().acquire(_size, _direct);
         }
+
+        /**
+         * @return A {@link RetainableByteBuffer} suitable for the specified preconfigured type.
+         * @param size The specified size in bytes of the buffer
+         */
+        public RetainableByteBuffer acquire(int size)
+        {
+            return getWrapped().acquire(size, _direct);
+        }
+
+        /**
+         * @return A {@link RetainableByteBuffer} suitable for the specified preconfigured size.
+         * @param direct true for a direct byte buffer, false otherwise
+         */
+        public RetainableByteBuffer acquire(boolean direct)
+        {
+            return getWrapped().acquire(_size, direct);
+        }
     }
 
     /**

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferPool.java
@@ -130,7 +130,7 @@ public interface ByteBufferPool
          * Create a sized pool for a give directness and size from a wrapped pool.
          * @param wrapped The actual {@link ByteBufferPool}
          * @param direct {@code true} for direct buffers.
-         * @param size The specified size in bytes of the buffer, or -1 for a default
+         * @param size The specified size in bytes of the buffer, any value &lt; 1 means use a default value.
          */
         public Sized(ByteBufferPool wrapped, boolean direct, int size)
         {

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferPool.java
@@ -130,7 +130,7 @@ public interface ByteBufferPool
          * Create a sized pool for a give directness and size from a wrapped pool.
          * @param wrapped The actual {@link ByteBufferPool}
          * @param direct {@code true} for direct buffers.
-         * @param size The specified size in bytes of the buffer, any value &lt; 1 means use a default value.
+         * @param size The specified size in bytes of the buffer, any value less than 1 means use a default value.
          */
         public Sized(ByteBufferPool wrapped, boolean direct, int size)
         {

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Content.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Content.java
@@ -163,12 +163,12 @@ public class Content
             /**
              * Creates a new {@link Content.Source}.
              *
-             * @param sizedBufferPool the {@link ByteBufferPool.Sized} to get buffers from. {@code null} means allocate new buffers as needed.
+             * @param bufferPool the {@link ByteBufferPool.Sized} to get buffers from. {@code null} means allocate new buffers as needed.
              * @param first the first byte of the resource to start from.
              * @param length the length of the content to make available, -1 for the full length.
              * @return a {@link Content.Source}.
              */
-            Content.Source newContentSource(ByteBufferPool.Sized sizedBufferPool, long first, long length);
+            Content.Source newContentSource(ByteBufferPool.Sized bufferPool, long first, long length);
         }
 
         /**

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Content.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Content.java
@@ -163,14 +163,12 @@ public class Content
             /**
              * Creates a new {@link Content.Source}.
              *
-             * @param bufferPool the {@link ByteBufferPool} to get buffers from. null means allocate new buffers as needed.
-             * @param bufferSize the size of the buffer to be used for the copy. Any value &lt; 1 means use a default value.
-             * @param direct the directness of the buffers, this parameter is ignored if {@code bufferSize} is &lt; 1.
+             * @param sizedBufferPool the {@link ByteBufferPool.Sized} to get buffers from. {@code null} means allocate new buffers as needed.
              * @param first the first byte of the resource to start from.
-             * @param length the length of the resource's contents to copy.
+             * @param length the length of the content to make available, -1 for the full length.
              * @return a {@link Content.Source}.
              */
-            Content.Source newContentSource(ByteBufferPool bufferPool, int bufferSize, boolean direct, long first, long length);
+            Content.Source newContentSource(ByteBufferPool.Sized sizedBufferPool, long first, long length);
         }
 
         /**

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Content.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Content.java
@@ -156,6 +156,24 @@ public class Content
     public interface Source
     {
         /**
+         * Factory of {@link Content.Source}.
+         */
+        interface Factory
+        {
+            /**
+             * Creates a new {@link Content.Source}.
+             *
+             * @param bufferPool the {@link ByteBufferPool} to get buffers from. null means allocate new buffers as needed.
+             * @param bufferSize the size of the buffer to be used for the copy. Any value &lt; 1 means use a default value.
+             * @param direct the directness of the buffers, this parameter is ignored if {@code bufferSize} is &lt; 1.
+             * @param first the first byte of the resource to start from.
+             * @param length the length of the resource's contents to copy.
+             * @return a {@link Content.Source}.
+             */
+            Content.Source newContentSource(ByteBufferPool bufferPool, int bufferSize, boolean direct, long first, long length);
+        }
+
+        /**
          * Create a {@code Content.Source} from zero or more {@link ByteBuffer}s
          * @param byteBuffers The {@link ByteBuffer}s to use as the source.
          * @return A {@code Content.Source}

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/IOResources.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/IOResources.java
@@ -90,12 +90,12 @@ public class IOResources
             }
         }
 
-        // Optimize for ContentSourceResource.
-        if (resource instanceof ContentSourceResource contentSourceResource)
+        // Optimize for Content.Source.Factory.
+        if (resource instanceof Content.Source.Factory factory)
         {
             try
             {
-                ByteBuffer buffer = Content.Source.asByteBuffer(contentSourceResource.newContentSource(bufferPool, 4096, direct, 0L, -1L));
+                ByteBuffer buffer = Content.Source.asByteBuffer(factory.newContentSource(bufferPool, 4096, direct, 0L, -1L));
                 return RetainableByteBuffer.wrap(buffer);
             }
             catch (IOException e)
@@ -157,9 +157,9 @@ public class IOResources
             byte[] bytes = memoryResource.getBytes();
             return new ByteBufferContentSource(ByteBuffer.wrap(bytes));
         }
-        if (resource instanceof ContentSourceResource contentSourceResource)
+        if (resource instanceof Content.Source.Factory factory)
         {
-            return contentSourceResource.newContentSource(bufferPool, bufferSize, direct, 0, -1);
+            return factory.newContentSource(bufferPool, bufferSize, direct, 0, -1);
         }
 
         // Fallback to wrapping InputStream.
@@ -205,9 +205,9 @@ public class IOResources
         if (resource instanceof MemoryResource memoryResource)
             return Content.Source.from(BufferUtil.slice(ByteBuffer.wrap(memoryResource.getBytes()), (int)first, (int)length));
 
-        // Try ContentSourceSupplier.
-        if (resource instanceof ContentSourceResource contentSourceResource)
-            return contentSourceResource.newContentSource(bufferPool, bufferSize, direct, first, length);
+        // Try Content.Source.Factory.
+        if (resource instanceof Content.Source.Factory factory)
+            return factory.newContentSource(bufferPool, bufferSize, direct, first, length);
 
         // Fallback to InputStream.
         try
@@ -431,26 +431,5 @@ public class IOResources
             IO.close(channel);
             super.onCompleteFailure(x);
         }
-    }
-
-    /**
-     * {@link Resource} capable of exposing itself as a {@link Content.Source} such as
-     * {@link IOResources} can use the more efficient {@link Content.Source} contract instead of
-     * relying on the much slower {@link InputStream} contract to perform the IO operations.
-     */
-    public abstract static class ContentSourceResource extends Resource
-    {
-        /**
-         * Creates a new {@link Content.Source} for this resource.
-         *
-         * @param bufferPool the {@link ByteBufferPool} to get buffers from. null means allocate new buffers as needed.
-         * @param bufferSize the size of the buffer to be used for the copy. Any value &lt; 1 means use a default value.
-         * @param direct the directness of the buffers, this parameter is ignored if {@code bufferSize} is &lt; 1.
-         * @param first the first byte of the resource to start from.
-         * @param length the length of the resource's contents to copy.
-         * @return a {@link Content.Source}.
-         * @throws IllegalArgumentException if the resource is a directory or does not exist or there is no way to access its contents.
-         */
-        public abstract Content.Source newContentSource(ByteBufferPool bufferPool, int bufferSize, boolean direct, long first, long length) throws IllegalArgumentException;
     }
 }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/IOResources.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/IOResources.java
@@ -287,6 +287,7 @@ public class IOResources
             InputStream inputStream = resource.newInputStream();
             if (inputStream == null)
                 throw new IllegalArgumentException("Resource does not support InputStream: " + resource);
+            // TODO set the directness coming from the parameter once InputStreamContentSource is fixed (#12972)
             Content.Source source = Content.Source.from(new ByteBufferPool.Sized(bufferPool, false, bufferSize), inputStream, 0, -1);
             Content.copy(source, sink, callback);
         }
@@ -346,6 +347,7 @@ public class IOResources
             InputStream inputStream = resource.newInputStream();
             if (inputStream == null)
                 throw new IllegalArgumentException("Resource does not support InputStream: " + resource);
+            // TODO set the directness coming from the parameter once InputStreamContentSource is fixed (#12972)
             Content.Source source = Content.Source.from(new ByteBufferPool.Sized(bufferPool, false, bufferSize), inputStream, first, length);
             Content.copy(source, sink, callback);
         }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/IOResources.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/IOResources.java
@@ -90,6 +90,20 @@ public class IOResources
             }
         }
 
+        // Optimize for ContentSourceResource.
+        if (resource instanceof ContentSourceResource contentSourceResource)
+        {
+            try
+            {
+                ByteBuffer buffer = Content.Source.asByteBuffer(contentSourceResource.newContentSource(bufferPool, 4096, direct, 0L, -1L));
+                return RetainableByteBuffer.wrap(buffer);
+            }
+            catch (IOException e)
+            {
+                throw new RuntimeIOException(e);
+            }
+        }
+
         // Fallback to InputStream.
         try (InputStream inputStream = resource.newInputStream())
         {
@@ -143,6 +157,10 @@ public class IOResources
             byte[] bytes = memoryResource.getBytes();
             return new ByteBufferContentSource(ByteBuffer.wrap(bytes));
         }
+        if (resource instanceof ContentSourceResource contentSourceResource)
+        {
+            return contentSourceResource.newContentSource(bufferPool, bufferSize, direct, 0, -1);
+        }
 
         // Fallback to wrapping InputStream.
         try
@@ -185,7 +203,11 @@ public class IOResources
 
         // Try an optimization for MemoryResource.
         if (resource instanceof MemoryResource memoryResource)
-            return Content.Source.from(ByteBuffer.wrap(memoryResource.getBytes()));
+            return Content.Source.from(BufferUtil.slice(ByteBuffer.wrap(memoryResource.getBytes()), (int)first, (int)length));
+
+        // Try ContentSourceSupplier.
+        if (resource instanceof ContentSourceResource contentSourceResource)
+            return contentSourceResource.newContentSource(bufferPool, bufferSize, direct, first, length);
 
         // Fallback to InputStream.
         try
@@ -409,5 +431,26 @@ public class IOResources
             IO.close(channel);
             super.onCompleteFailure(x);
         }
+    }
+
+    /**
+     * {@link Resource} capable of exposing itself as a {@link Content.Source} such as
+     * {@link IOResources} can use the more efficient {@link Content.Source} contract instead of
+     * relying on the much slower {@link InputStream} contract to perform the IO operations.
+     */
+    public static abstract class ContentSourceResource extends Resource
+    {
+        /**
+         * Creates a new {@link Content.Source} for this resource.
+         *
+         * @param bufferPool the {@link ByteBufferPool} to get buffers from. null means allocate new buffers as needed.
+         * @param bufferSize the size of the buffer to be used for the copy. Any value &lt; 1 means use a default value.
+         * @param direct the directness of the buffers, this parameter is ignored if {@code bufferSize} is &lt; 1.
+         * @param first the first byte of the resource to start from.
+         * @param length the length of the resource's contents to copy.
+         * @return a {@link Content.Source}.
+         * @throws IllegalArgumentException if the resource is a directory or does not exist or there is no way to access its contents.
+         */
+        public abstract Content.Source newContentSource(ByteBufferPool bufferPool, int bufferSize, boolean direct, long first, long length) throws IllegalArgumentException;
     }
 }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/IOResources.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/IOResources.java
@@ -295,7 +295,7 @@ public class IOResources
             InputStream inputStream = resource.newInputStream();
             if (inputStream == null)
                 throw new IllegalArgumentException("Resource does not support InputStream: " + resource);
-            Content.Source source = Content.Source.from(new ByteBufferPool.Sized(bufferPool, direct, bufferSize), inputStream, 0, -1);
+            Content.Source source = Content.Source.from(new ByteBufferPool.Sized(bufferPool, false, bufferSize), inputStream, 0, -1);
             Content.copy(source, sink, callback);
         }
         catch (IOException e)
@@ -362,7 +362,7 @@ public class IOResources
             InputStream inputStream = resource.newInputStream();
             if (inputStream == null)
                 throw new IllegalArgumentException("Resource does not support InputStream: " + resource);
-            Content.Source source = Content.Source.from(new ByteBufferPool.Sized(bufferPool, direct, bufferSize), inputStream, first, length);
+            Content.Source source = Content.Source.from(new ByteBufferPool.Sized(bufferPool, false, bufferSize), inputStream, first, length);
             Content.copy(source, sink, callback);
         }
         catch (IOException e)

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/IOResources.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/IOResources.java
@@ -21,7 +21,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.eclipse.jetty.io.content.ByteBufferContentSource;
-import org.eclipse.jetty.io.content.InputStreamContentSource;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.IO;
@@ -151,14 +150,17 @@ public class IOResources
             return factory.newContentSource(new ByteBufferPool.Sized(bufferPool, direct, bufferSize), 0, -1);
         Path path = resource.getPath();
         if (path != null)
-            return Content.Source.from(new ByteBufferPool.Sized(bufferPool, direct, bufferSize), path, 0, -1);
+            return Content.Source.from(new ByteBufferPool.Sized(bufferPool, direct, bufferSize), path);
         if (resource instanceof MemoryResource memoryResource)
             return new ByteBufferContentSource(ByteBuffer.wrap(memoryResource.getBytes()));
 
         // Fallback to wrapping InputStream.
         try
         {
-            return new InputStreamContentSource(resource.newInputStream(), new ByteBufferPool.Sized(bufferPool, false, bufferSize));
+            InputStream inputStream = resource.newInputStream();
+            if (inputStream == null)
+                throw new IllegalArgumentException("Resource does not support InputStream: " + resource);
+            return Content.Source.from(new ByteBufferPool.Sized(bufferPool, direct, bufferSize), inputStream);
         }
         catch (IOException e)
         {
@@ -287,8 +289,7 @@ public class IOResources
             InputStream inputStream = resource.newInputStream();
             if (inputStream == null)
                 throw new IllegalArgumentException("Resource does not support InputStream: " + resource);
-            // TODO set the directness coming from the parameter once InputStreamContentSource is fixed (#12972)
-            Content.Source source = Content.Source.from(new ByteBufferPool.Sized(bufferPool, false, bufferSize), inputStream, 0, -1);
+            Content.Source source = Content.Source.from(new ByteBufferPool.Sized(bufferPool, direct, bufferSize), inputStream, 0, -1);
             Content.copy(source, sink, callback);
         }
         catch (Throwable x)
@@ -347,8 +348,7 @@ public class IOResources
             InputStream inputStream = resource.newInputStream();
             if (inputStream == null)
                 throw new IllegalArgumentException("Resource does not support InputStream: " + resource);
-            // TODO set the directness coming from the parameter once InputStreamContentSource is fixed (#12972)
-            Content.Source source = Content.Source.from(new ByteBufferPool.Sized(bufferPool, false, bufferSize), inputStream, first, length);
+            Content.Source source = Content.Source.from(new ByteBufferPool.Sized(bufferPool, direct, bufferSize), inputStream, first, length);
             Content.copy(source, sink, callback);
         }
         catch (Throwable x)

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/IOResources.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/IOResources.java
@@ -438,7 +438,7 @@ public class IOResources
      * {@link IOResources} can use the more efficient {@link Content.Source} contract instead of
      * relying on the much slower {@link InputStream} contract to perform the IO operations.
      */
-    public static abstract class ContentSourceResource extends Resource
+    public abstract static class ContentSourceResource extends Resource
     {
         /**
          * Creates a new {@link Content.Source} for this resource.

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/IOResources.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/IOResources.java
@@ -289,10 +289,13 @@ public class IOResources
             return;
         }
 
-        // Fallback to InputStreamContentSource.
+        // Fallback to Content.Source.
         try
         {
-            InputStreamContentSource source = new InputStreamContentSource(resource.newInputStream(), new ByteBufferPool.Sized(bufferPool, false, bufferSize));
+            InputStream inputStream = resource.newInputStream();
+            if (inputStream == null)
+                throw new IllegalArgumentException("Resource does not support InputStream: " + resource);
+            Content.Source source = Content.Source.from(new ByteBufferPool.Sized(bufferPool, direct, bufferSize), inputStream, 0, -1);
             Content.copy(source, sink, callback);
         }
         catch (IOException e)
@@ -323,6 +326,14 @@ public class IOResources
         if (resource.isDirectory() || !resource.exists())
             throw new IllegalArgumentException("Resource must exist and cannot be a directory: " + resource);
 
+        // Check if the resource is a Content.Source.Factory as the first step.
+        if (resource instanceof Content.Source.Factory factory)
+        {
+            Content.Source source = factory.newContentSource(new ByteBufferPool.Sized(bufferPool, direct, bufferSize), first, length);
+            Content.copy(source, sink, callback);
+            return;
+        }
+
         // Save a Content.Source allocation for resources with a Path.
         Path path = resource.getPath();
         if (path != null)
@@ -346,8 +357,18 @@ public class IOResources
         }
 
         // Fallback to Content.Source.
-        Content.Source source = asContentSource(resource, bufferPool, bufferSize, direct, first, length);
-        Content.copy(source, sink, callback);
+        try
+        {
+            InputStream inputStream = resource.newInputStream();
+            if (inputStream == null)
+                throw new IllegalArgumentException("Resource does not support InputStream: " + resource);
+            Content.Source source = Content.Source.from(new ByteBufferPool.Sized(bufferPool, direct, bufferSize), inputStream, first, length);
+            Content.copy(source, sink, callback);
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeIOException(e);
+        }
     }
 
     private static class PathToSinkCopier extends IteratingNestedCallback

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/IOResources.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/IOResources.java
@@ -149,18 +149,11 @@ public class IOResources
         // Try to find an optimized content source.
         Path path = resource.getPath();
         if (path != null)
-        {
             return Content.Source.from(new ByteBufferPool.Sized(bufferPool, direct, bufferSize), path, 0, -1);
-        }
         if (resource instanceof MemoryResource memoryResource)
-        {
-            byte[] bytes = memoryResource.getBytes();
-            return new ByteBufferContentSource(ByteBuffer.wrap(bytes));
-        }
+            return new ByteBufferContentSource(ByteBuffer.wrap(memoryResource.getBytes()));
         if (resource instanceof Content.Source.Factory factory)
-        {
             return factory.newContentSource(bufferPool, bufferSize, direct, 0, -1);
-        }
 
         // Fallback to wrapping InputStream.
         try
@@ -197,13 +190,11 @@ public class IOResources
         // Try using the resource's path if possible, as the nio API is async and helps to avoid buffer copies.
         Path path = resource.getPath();
         if (path != null)
-        {
             return Content.Source.from(new ByteBufferPool.Sized(bufferPool, direct, bufferSize), path, first, length);
-        }
 
         // Try an optimization for MemoryResource.
         if (resource instanceof MemoryResource memoryResource)
-            return Content.Source.from(BufferUtil.slice(ByteBuffer.wrap(memoryResource.getBytes()), (int)first, (int)length));
+            return Content.Source.from(BufferUtil.slice(ByteBuffer.wrap(memoryResource.getBytes()), Math.toIntExact(first), Math.toIntExact(length)));
 
         // Try Content.Source.Factory.
         if (resource instanceof Content.Source.Factory factory)
@@ -286,8 +277,7 @@ public class IOResources
         // Directly write the byte array if the resource is a MemoryResource.
         if (resource instanceof MemoryResource memoryResource)
         {
-            byte[] bytes = memoryResource.getBytes();
-            sink.write(true, ByteBuffer.wrap(bytes), callback);
+            sink.write(false, ByteBuffer.wrap(memoryResource.getBytes()), callback);
             return;
         }
 
@@ -336,13 +326,7 @@ public class IOResources
         // Directly write the byte array if the resource is a MemoryResource.
         if (resource instanceof MemoryResource memoryResource)
         {
-            byte[] bytes = memoryResource.getBytes();
-            ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
-            if (first >= 0)
-                byteBuffer.position((int)first);
-            if (length >= 0)
-                byteBuffer.limit((int)(byteBuffer.position() + length));
-            sink.write(true, byteBuffer, callback);
+            sink.write(false, BufferUtil.slice(ByteBuffer.wrap(memoryResource.getBytes()), Math.toIntExact(first), Math.toIntExact(length)), callback);
             return;
         }
 
@@ -410,7 +394,7 @@ public class IOResources
             }
             BufferUtil.flipToFlush(byteBuffer, 0);
             terminated = eof || remainingLength == 0;
-            sink.write(terminated, byteBuffer, this);
+            sink.write(false, byteBuffer, this);
             return Action.SCHEDULED;
         }
 

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/IOResources.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/IOResources.java
@@ -255,45 +255,35 @@ public class IOResources
      */
     public static void copy(Resource resource, Content.Sink sink, ByteBufferPool bufferPool, int bufferSize, boolean direct, Callback callback)
     {
-        if (resource.isDirectory() || !resource.exists())
-        {
-            callback.failed(new IllegalArgumentException("Resource must exist and cannot be a directory: " + resource));
-            return;
-        }
-
-        // Check if the resource is a Content.Source.Factory as the first step.
-        if (resource instanceof Content.Source.Factory factory)
-        {
-            Content.Source source = factory.newContentSource(new ByteBufferPool.Sized(bufferPool, direct, bufferSize), 0, -1);
-            Content.copy(source, sink, callback);
-            return;
-        }
-
-        // Save a Content.Source allocation for resources with a Path.
-        Path path = resource.getPath();
-        if (path != null)
-        {
-            try
-            {
-                new PathToSinkCopier(path, sink, bufferPool, bufferSize, direct, callback).iterate();
-            }
-            catch (Throwable x)
-            {
-                callback.failed(x);
-            }
-            return;
-        }
-
-        // Directly write the byte array if the resource is a MemoryResource.
-        if (resource instanceof MemoryResource memoryResource)
-        {
-            sink.write(true, ByteBuffer.wrap(memoryResource.getBytes()), callback);
-            return;
-        }
-
-        // Fallback to Content.Source.
         try
         {
+            if (resource.isDirectory() || !resource.exists())
+                throw new IllegalArgumentException("Resource must exist and cannot be a directory: " + resource);
+
+            // Check if the resource is a Content.Source.Factory as the first step.
+            if (resource instanceof Content.Source.Factory factory)
+            {
+                Content.Source source = factory.newContentSource(new ByteBufferPool.Sized(bufferPool, direct, bufferSize), 0, -1);
+                Content.copy(source, sink, callback);
+                return;
+            }
+
+            // Save a Content.Source allocation for resources with a Path.
+            Path path = resource.getPath();
+            if (path != null)
+            {
+                new PathToSinkCopier(path, sink, bufferPool, bufferSize, direct, callback).iterate();
+                return;
+            }
+
+            // Directly write the byte array if the resource is a MemoryResource.
+            if (resource instanceof MemoryResource memoryResource)
+            {
+                sink.write(true, ByteBuffer.wrap(memoryResource.getBytes()), callback);
+                return;
+            }
+
+            // Fallback to Content.Source.
             InputStream inputStream = resource.newInputStream();
             if (inputStream == null)
                 throw new IllegalArgumentException("Resource does not support InputStream: " + resource);
@@ -324,45 +314,35 @@ public class IOResources
      */
     public static void copy(Resource resource, Content.Sink sink, ByteBufferPool bufferPool, int bufferSize, boolean direct, long first, long length, Callback callback)
     {
-        if (resource.isDirectory() || !resource.exists())
-        {
-            callback.failed(new IllegalArgumentException("Resource must exist and cannot be a directory: " + resource));
-            return;
-        }
-
-        // Check if the resource is a Content.Source.Factory as the first step.
-        if (resource instanceof Content.Source.Factory factory)
-        {
-            Content.Source source = factory.newContentSource(new ByteBufferPool.Sized(bufferPool, direct, bufferSize), first, length);
-            Content.copy(source, sink, callback);
-            return;
-        }
-
-        // Save a Content.Source allocation for resources with a Path.
-        Path path = resource.getPath();
-        if (path != null)
-        {
-            try
-            {
-                new PathToSinkCopier(path, sink, bufferPool, bufferSize, direct, first, length, callback).iterate();
-            }
-            catch (Throwable x)
-            {
-                callback.failed(x);
-            }
-            return;
-        }
-
-        // Directly write the byte array if the resource is a MemoryResource.
-        if (resource instanceof MemoryResource memoryResource)
-        {
-            sink.write(true, BufferUtil.slice(ByteBuffer.wrap(memoryResource.getBytes()), Math.toIntExact(first), Math.toIntExact(length)), callback);
-            return;
-        }
-
-        // Fallback to Content.Source.
         try
         {
+            if (resource.isDirectory() || !resource.exists())
+                throw new IllegalArgumentException("Resource must exist and cannot be a directory: " + resource);
+
+            // Check if the resource is a Content.Source.Factory as the first step.
+            if (resource instanceof Content.Source.Factory factory)
+            {
+                Content.Source source = factory.newContentSource(new ByteBufferPool.Sized(bufferPool, direct, bufferSize), first, length);
+                Content.copy(source, sink, callback);
+                return;
+            }
+
+            // Save a Content.Source allocation for resources with a Path.
+            Path path = resource.getPath();
+            if (path != null)
+            {
+                new PathToSinkCopier(path, sink, bufferPool, bufferSize, direct, first, length, callback).iterate();
+                return;
+            }
+
+            // Directly write the byte array if the resource is a MemoryResource.
+            if (resource instanceof MemoryResource memoryResource)
+            {
+                sink.write(true, BufferUtil.slice(ByteBuffer.wrap(memoryResource.getBytes()), Math.toIntExact(first), Math.toIntExact(length)), callback);
+                return;
+            }
+
+            // Fallback to Content.Source.
             InputStream inputStream = resource.newInputStream();
             if (inputStream == null)
                 throw new IllegalArgumentException("Resource does not support InputStream: " + resource);

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/IOResources.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/IOResources.java
@@ -42,7 +42,7 @@ public class IOResources
      * {@link Resource#newInputStream()} is used as a fallback.</p>
      *
      * @param resource the resource to be read.
-     * @param bufferPool the {@link ByteBufferPool} to get buffers from. null means allocate new buffers as needed.
+     * @param bufferPool the {@link ByteBufferPool} to get buffers from. {@code null} means allocate new buffers as needed.
      * @param direct the directness of the buffers.
      * @return a {@link RetainableByteBuffer} containing the resource's contents.
      * @throws IllegalArgumentException if the resource is a directory or does not exist or there is no way to access its contents.
@@ -51,6 +51,20 @@ public class IOResources
     {
         if (resource.isDirectory() || !resource.exists())
             throw new IllegalArgumentException("Resource must exist and cannot be a directory: " + resource);
+
+        // Optimize for Content.Source.Factory.
+        if (resource instanceof Content.Source.Factory factory)
+        {
+            try
+            {
+                ByteBuffer buffer = Content.Source.asByteBuffer(factory.newContentSource(new ByteBufferPool.Sized(bufferPool, direct, 0), 0L, -1L));
+                return RetainableByteBuffer.wrap(buffer);
+            }
+            catch (IOException e)
+            {
+                throw new RuntimeIOException(e);
+            }
+        }
 
         // Optimize for MemoryResource.
         if (resource instanceof MemoryResource memoryResource)
@@ -90,20 +104,6 @@ public class IOResources
             }
         }
 
-        // Optimize for Content.Source.Factory.
-        if (resource instanceof Content.Source.Factory factory)
-        {
-            try
-            {
-                ByteBuffer buffer = Content.Source.asByteBuffer(factory.newContentSource(bufferPool, 4096, direct, 0L, -1L));
-                return RetainableByteBuffer.wrap(buffer);
-            }
-            catch (IOException e)
-            {
-                throw new RuntimeIOException(e);
-            }
-        }
-
         // Fallback to InputStream.
         try (InputStream inputStream = resource.newInputStream())
         {
@@ -135,7 +135,7 @@ public class IOResources
      * {@link Resource#newInputStream()} is used as a fallback.</p>
      *
      * @param resource the resource from which to get a {@link Content.Source}.
-     * @param bufferPool the {@link ByteBufferPool} to get buffers from. null means allocate new buffers as needed.
+     * @param bufferPool the {@link ByteBufferPool} to get buffers from. {@code null} means allocate new buffers as needed.
      * @param bufferSize the size of the buffer to be used for the copy. Any value &lt; 1 means use a default value.
      * @param direct the directness of the buffers, this parameter is ignored if {@code bufferSize} is &lt; 1.
      * @return the {@link Content.Source}.
@@ -147,13 +147,13 @@ public class IOResources
             throw new IllegalArgumentException("Resource must exist and cannot be a directory: " + resource);
 
         // Try to find an optimized content source.
+        if (resource instanceof Content.Source.Factory factory)
+            return factory.newContentSource(new ByteBufferPool.Sized(bufferPool, direct, bufferSize), 0, -1);
         Path path = resource.getPath();
         if (path != null)
             return Content.Source.from(new ByteBufferPool.Sized(bufferPool, direct, bufferSize), path, 0, -1);
         if (resource instanceof MemoryResource memoryResource)
             return new ByteBufferContentSource(ByteBuffer.wrap(memoryResource.getBytes()));
-        if (resource instanceof Content.Source.Factory factory)
-            return factory.newContentSource(bufferPool, bufferSize, direct, 0, -1);
 
         // Fallback to wrapping InputStream.
         try
@@ -174,11 +174,11 @@ public class IOResources
      * {@link Resource#newInputStream()} is used as a fallback.</p>
      *
      * @param resource the resource from which to get a {@link Content.Source}.
-     * @param bufferPool the {@link ByteBufferPool} to get buffers from. null means allocate new buffers as needed.
+     * @param bufferPool the {@link ByteBufferPool} to get buffers from. {@code null} means allocate new buffers as needed.
      * @param bufferSize the size of the buffer to be used for the copy. Any value &lt; 1 means use a default value.
      * @param direct the directness of the buffers, this parameter is ignored if {@code bufferSize} is &lt; 1.
      * @param first the first byte from which to read from.
-     * @param length the length of the content to read.
+     * @param length the length of the content to read, -1 for the full length.
      * @return the {@link Content.Source}.
      * @throws IllegalArgumentException if the resource is a directory or does not exist or there is no way to access its contents.
      */
@@ -186,6 +186,10 @@ public class IOResources
     {
         if (resource.isDirectory() || !resource.exists())
             throw new IllegalArgumentException("Resource must exist and cannot be a directory: " + resource);
+
+        // Try Content.Source.Factory.
+        if (resource instanceof Content.Source.Factory factory)
+            return factory.newContentSource(new ByteBufferPool.Sized(bufferPool, direct, bufferSize), first, length);
 
         // Try using the resource's path if possible, as the nio API is async and helps to avoid buffer copies.
         Path path = resource.getPath();
@@ -195,10 +199,6 @@ public class IOResources
         // Try an optimization for MemoryResource.
         if (resource instanceof MemoryResource memoryResource)
             return Content.Source.from(BufferUtil.slice(ByteBuffer.wrap(memoryResource.getBytes()), Math.toIntExact(first), Math.toIntExact(length)));
-
-        // Try Content.Source.Factory.
-        if (resource instanceof Content.Source.Factory factory)
-            return factory.newContentSource(bufferPool, bufferSize, direct, first, length);
 
         // Fallback to InputStream.
         try
@@ -248,7 +248,7 @@ public class IOResources
      *
      * @param resource the resource to copy from.
      * @param sink the sink to copy to.
-     * @param bufferPool the {@link ByteBufferPool} to get buffers from. null means allocate new buffers as needed.
+     * @param bufferPool the {@link ByteBufferPool} to get buffers from. {@code null} means allocate new buffers as needed.
      * @param bufferSize the size of the buffer to be used for the copy. Any value &lt; 1 means use a default value.
      * @param direct the directness of the buffers, this parameter is ignored if {@code bufferSize} is &lt; 1.
      * @param callback the callback to notify when the copy is done.
@@ -258,6 +258,14 @@ public class IOResources
     {
         if (resource.isDirectory() || !resource.exists())
             throw new IllegalArgumentException("Resource must exist and cannot be a directory: " + resource);
+
+        // Check if the resource is a Content.Source.Factory as the first step.
+        if (resource instanceof Content.Source.Factory factory)
+        {
+            Content.Source source = factory.newContentSource(new ByteBufferPool.Sized(bufferPool, direct, bufferSize), 0, -1);
+            Content.copy(source, sink, callback);
+            return;
+        }
 
         // Save a Content.Source allocation for resources with a Path.
         Path path = resource.getPath();
@@ -281,9 +289,16 @@ public class IOResources
             return;
         }
 
-        // Fallback to Content.Source.
-        Content.Source source = asContentSource(resource, bufferPool, bufferSize, direct);
-        Content.copy(source, sink, callback);
+        // Fallback to InputStreamContentSource.
+        try
+        {
+            InputStreamContentSource source = new InputStreamContentSource(resource.newInputStream(), new ByteBufferPool.Sized(bufferPool, false, bufferSize));
+            Content.copy(source, sink, callback);
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeIOException(e);
+        }
     }
 
     /**
@@ -295,7 +310,7 @@ public class IOResources
      *
      * @param resource the resource to copy from.
      * @param sink the sink to copy to.
-     * @param bufferPool the {@link ByteBufferPool} to get buffers from. null means allocate new buffers as needed.
+     * @param bufferPool the {@link ByteBufferPool} to get buffers from. {@code null} means allocate new buffers as needed.
      * @param bufferSize the size of the buffer to be used for the copy. Any value &lt; 1 means use a default value.
      * @param direct the directness of the buffers, this parameter is ignored if {@code bufferSize} is &lt; 1.
      * @param first the first byte of the resource to start from.

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/IOResources.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/IOResources.java
@@ -136,7 +136,7 @@ public class IOResources
      *
      * @param resource the resource from which to get a {@link Content.Source}.
      * @param bufferPool the {@link ByteBufferPool} to get buffers from. {@code null} means allocate new buffers as needed.
-     * @param bufferSize the size of the buffer to be used for the copy. Any value &lt; 1 means use a default value.
+     * @param bufferSize the size of the buffer to be used for the copy. Any value less than 1 means use a default value.
      * @param direct the directness of the buffers, this parameter is ignored if {@code bufferSize} is &lt; 1.
      * @return the {@link Content.Source}.
      * @throws IllegalArgumentException if the resource is a directory or does not exist or there is no way to access its contents.
@@ -175,7 +175,7 @@ public class IOResources
      *
      * @param resource the resource from which to get a {@link Content.Source}.
      * @param bufferPool the {@link ByteBufferPool} to get buffers from. {@code null} means allocate new buffers as needed.
-     * @param bufferSize the size of the buffer to be used for the copy. Any value &lt; 1 means use a default value.
+     * @param bufferSize the size of the buffer to be used for the copy. Any value less than 1 means use a default value.
      * @param direct the directness of the buffers, this parameter is ignored if {@code bufferSize} is &lt; 1.
      * @param first the first byte from which to read from.
      * @param length the length of the content to read, -1 for the full length.
@@ -249,15 +249,17 @@ public class IOResources
      * @param resource the resource to copy from.
      * @param sink the sink to copy to.
      * @param bufferPool the {@link ByteBufferPool} to get buffers from. {@code null} means allocate new buffers as needed.
-     * @param bufferSize the size of the buffer to be used for the copy. Any value &lt; 1 means use a default value.
+     * @param bufferSize the size of the buffer to be used for the copy. Any value less than 1 means use a default value.
      * @param direct the directness of the buffers, this parameter is ignored if {@code bufferSize} is &lt; 1.
      * @param callback the callback to notify when the copy is done.
-     * @throws IllegalArgumentException if the resource is a directory or does not exist or there is no way to access its contents.
      */
-    public static void copy(Resource resource, Content.Sink sink, ByteBufferPool bufferPool, int bufferSize, boolean direct, Callback callback) throws IllegalArgumentException
+    public static void copy(Resource resource, Content.Sink sink, ByteBufferPool bufferPool, int bufferSize, boolean direct, Callback callback)
     {
         if (resource.isDirectory() || !resource.exists())
-            throw new IllegalArgumentException("Resource must exist and cannot be a directory: " + resource);
+        {
+            callback.failed(new IllegalArgumentException("Resource must exist and cannot be a directory: " + resource));
+            return;
+        }
 
         // Check if the resource is a Content.Source.Factory as the first step.
         if (resource instanceof Content.Source.Factory factory)
@@ -298,9 +300,9 @@ public class IOResources
             Content.Source source = Content.Source.from(new ByteBufferPool.Sized(bufferPool, false, bufferSize), inputStream, 0, -1);
             Content.copy(source, sink, callback);
         }
-        catch (IOException e)
+        catch (Throwable x)
         {
-            throw new RuntimeIOException(e);
+            callback.failed(x);
         }
     }
 
@@ -314,17 +316,19 @@ public class IOResources
      * @param resource the resource to copy from.
      * @param sink the sink to copy to.
      * @param bufferPool the {@link ByteBufferPool} to get buffers from. {@code null} means allocate new buffers as needed.
-     * @param bufferSize the size of the buffer to be used for the copy. Any value &lt; 1 means use a default value.
+     * @param bufferSize the size of the buffer to be used for the copy. Any value less than 1 means use a default value.
      * @param direct the directness of the buffers, this parameter is ignored if {@code bufferSize} is &lt; 1.
      * @param first the first byte of the resource to start from.
      * @param length the length of the resource's contents to copy.
      * @param callback the callback to notify when the copy is done.
-     * @throws IllegalArgumentException if the resource is a directory or does not exist or there is no way to access its contents.
      */
-    public static void copy(Resource resource, Content.Sink sink, ByteBufferPool bufferPool, int bufferSize, boolean direct, long first, long length, Callback callback) throws IllegalArgumentException
+    public static void copy(Resource resource, Content.Sink sink, ByteBufferPool bufferPool, int bufferSize, boolean direct, long first, long length, Callback callback)
     {
         if (resource.isDirectory() || !resource.exists())
-            throw new IllegalArgumentException("Resource must exist and cannot be a directory: " + resource);
+        {
+            callback.failed(new IllegalArgumentException("Resource must exist and cannot be a directory: " + resource));
+            return;
+        }
 
         // Check if the resource is a Content.Source.Factory as the first step.
         if (resource instanceof Content.Source.Factory factory)
@@ -365,9 +369,9 @@ public class IOResources
             Content.Source source = Content.Source.from(new ByteBufferPool.Sized(bufferPool, false, bufferSize), inputStream, first, length);
             Content.copy(source, sink, callback);
         }
-        catch (IOException e)
+        catch (Throwable x)
         {
-            throw new RuntimeIOException(e);
+            callback.failed(x);
         }
     }
 

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/IOResources.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/IOResources.java
@@ -277,7 +277,7 @@ public class IOResources
         // Directly write the byte array if the resource is a MemoryResource.
         if (resource instanceof MemoryResource memoryResource)
         {
-            sink.write(false, ByteBuffer.wrap(memoryResource.getBytes()), callback);
+            sink.write(true, ByteBuffer.wrap(memoryResource.getBytes()), callback);
             return;
         }
 
@@ -326,7 +326,7 @@ public class IOResources
         // Directly write the byte array if the resource is a MemoryResource.
         if (resource instanceof MemoryResource memoryResource)
         {
-            sink.write(false, BufferUtil.slice(ByteBuffer.wrap(memoryResource.getBytes()), Math.toIntExact(first), Math.toIntExact(length)), callback);
+            sink.write(true, BufferUtil.slice(ByteBuffer.wrap(memoryResource.getBytes()), Math.toIntExact(first), Math.toIntExact(length)), callback);
             return;
         }
 
@@ -394,7 +394,7 @@ public class IOResources
             }
             BufferUtil.flipToFlush(byteBuffer, 0);
             terminated = eof || remainingLength == 0;
-            sink.write(false, byteBuffer, this);
+            sink.write(terminated, byteBuffer, this);
             return Action.SCHEDULED;
         }
 

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/InputStreamContentSource.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/InputStreamContentSource.java
@@ -110,7 +110,7 @@ public class InputStreamContentSource implements Content.Source
                 return Content.Chunk.EOF;
         }
 
-        RetainableByteBuffer streamBuffer = bufferPool.acquire();
+        RetainableByteBuffer streamBuffer = bufferPool.acquire(false);
         try
         {
             ByteBuffer buffer = streamBuffer.getByteBuffer();

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOResourcesTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOResourcesTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -276,19 +277,23 @@ public class IOResourcesTest
     public void testCopyDirectory()
     {
         Resource resource = ResourceFactory.root().newResource(MavenTestingUtils.getTestResourcesPath());
+        TestSink sink = new TestSink();
         Callback.Completable callback = new Callback.Completable();
-        IOResources.copy(resource, (last, byteBuffer, cb) -> {}, null, 4096, false, callback);
+        IOResources.copy(resource, sink, bufferPool, 1, false, callback);
         Throwable cause = assertThrows(ExecutionException.class, callback::get).getCause();
         assertThat(cause, instanceOf(IllegalArgumentException.class));
+        assertThat(sink.takeAccumulatedChunks(), empty());
     }
 
     @Test
     public void testCopyWithRangeDirectory()
     {
         Resource resource = ResourceFactory.root().newResource(MavenTestingUtils.getTestResourcesPath());
+        TestSink sink = new TestSink();
         Callback.Completable callback = new Callback.Completable();
-        IOResources.copy(resource, (last, byteBuffer, cb) -> {}, null, 4096, false, 0, -1, callback);
+        IOResources.copy(resource, sink, bufferPool, 1, false, 0, -1, callback);
         Throwable cause = assertThrows(ExecutionException.class, callback::get).getCause();
         assertThat(cause, instanceOf(IllegalArgumentException.class));
+        assertThat(sink.takeAccumulatedChunks(), empty());
     }
 }

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOResourcesTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOResourcesTest.java
@@ -130,7 +130,7 @@ public class IOResourcesTest
         }
 
         @Override
-        public Content.Source newContentSource(ByteBufferPool.Sized bufferPool, long first, long length) throws IllegalArgumentException
+        public Content.Source newContentSource(ByteBufferPool.Sized bufferPool, long first, long length)
         {
             return Content.Source.from(BufferUtil.slice(buffer, Math.toIntExact(first), Math.toIntExact(length)));
         }

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOResourcesTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOResourcesTest.java
@@ -118,20 +118,19 @@ public class IOResourcesTest
         @Override
         public Content.Source newContentSource(ByteBufferPool bufferPool, int bufferSize, boolean direct, long first, long length) throws IllegalArgumentException
         {
-            return Content.Source.from(BufferUtil.slice(buffer, (int)first, (int)length));
+            return Content.Source.from(BufferUtil.slice(buffer, Math.toIntExact(first), Math.toIntExact(length)));
         }
     }
 
     public static Stream<Resource> all() throws Exception
     {
         Path testResourcePath = MavenTestingUtils.getTestResourcePath("keystore.p12");
-        byte[] bytes = Files.readAllBytes(testResourcePath);
         URI resourceUri = testResourcePath.toUri();
         return Stream.of(
             ResourceFactory.root().newResource(resourceUri),
             ResourceFactory.root().newMemoryResource(resourceUri.toURL()),
             new URLResourceFactory().newResource(resourceUri),
-            new TestContentSourceFactoryResource(resourceUri, bytes)
+            new TestContentSourceFactoryResource(resourceUri, Files.readAllBytes(testResourcePath))
         );
     }
 

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOResourcesTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOResourcesTest.java
@@ -50,12 +50,12 @@ public class IOResourcesTest
         assertThat("Leaks: " + bufferPool.dumpLeaks(), bufferPool.getLeaks().size(), is(0));
     }
 
-    private static class TestResource extends Resource implements Content.Source.Factory
+    private static class TestContentSourceFactoryResource extends Resource implements Content.Source.Factory
     {
         private final URI uri;
         private final ByteBuffer buffer;
 
-        public TestResource(URI uri, byte[] bytes)
+        public TestContentSourceFactoryResource(URI uri, byte[] bytes)
         {
             this.uri = uri;
             this.buffer = ByteBuffer.wrap(bytes);
@@ -131,7 +131,7 @@ public class IOResourcesTest
             ResourceFactory.root().newResource(resourceUri),
             ResourceFactory.root().newMemoryResource(resourceUri.toURL()),
             new URLResourceFactory().newResource(resourceUri),
-            new TestResource(resourceUri, bytes)
+            new TestContentSourceFactoryResource(resourceUri, bytes)
         );
     }
 

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOResourcesTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOResourcesTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.io;
 
+import java.io.InputStream;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
@@ -50,6 +51,8 @@ public class IOResourcesTest
         assertThat("Leaks: " + bufferPool.dumpLeaks(), bufferPool.getLeaks().size(), is(0));
     }
 
+    // This Resource impl has getPath() and newInputStream() return null so the only way for IOResources
+    // to read its contents is to call newContentSource().
     private static class TestContentSourceFactoryResource extends Resource implements Content.Source.Factory
     {
         private final URI uri;
@@ -76,7 +79,13 @@ public class IOResourcesTest
         @Override
         public Path getPath()
         {
-            throw new UnsupportedOperationException();
+            return null;
+        }
+
+        @Override
+        public InputStream newInputStream()
+        {
+            return null;
         }
 
         @Override

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOResourcesTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOResourcesTest.java
@@ -214,6 +214,7 @@ public class IOResourcesTest
         List<Content.Chunk> chunks = sink.takeAccumulatedChunks();
         long sum = chunks.stream().mapToLong(Content.Chunk::remaining).sum();
         assertThat(sum, is(resource.length()));
+        assertThat(chunks.get(chunks.size() - 1).isLast(), is(true));
     }
 
     @ParameterizedTest
@@ -227,6 +228,7 @@ public class IOResourcesTest
         List<Content.Chunk> chunks = sink.takeAccumulatedChunks();
         long sum = chunks.stream().mapToLong(Content.Chunk::remaining).sum();
         assertThat(sum, is(resource.length() - 100L));
+        assertThat(chunks.get(chunks.size() - 1).isLast(), is(true));
     }
 
     @ParameterizedTest
@@ -240,6 +242,7 @@ public class IOResourcesTest
         List<Content.Chunk> chunks = sink.takeAccumulatedChunks();
         long sum = chunks.stream().mapToLong(Content.Chunk::remaining).sum();
         assertThat(sum, is(500L));
+        assertThat(chunks.get(chunks.size() - 1).isLast(), is(true));
     }
 
     @ParameterizedTest
@@ -253,5 +256,6 @@ public class IOResourcesTest
         List<Content.Chunk> chunks = sink.takeAccumulatedChunks();
         long sum = chunks.stream().mapToLong(Content.Chunk::remaining).sum();
         assertThat(sum, is(500L));
+        assertThat(chunks.get(chunks.size() - 1).isLast(), is(true));
     }
 }

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOResourcesTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOResourcesTest.java
@@ -14,10 +14,14 @@
 package org.eclipse.jetty.io;
 
 import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Stream;
 
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
@@ -46,12 +50,88 @@ public class IOResourcesTest
         assertThat("Leaks: " + bufferPool.dumpLeaks(), bufferPool.getLeaks().size(), is(0));
     }
 
-    public static Stream<Resource> all()
+    private static class TestResource extends IOResources.ContentSourceResource
     {
-        URI resourceUri = MavenTestingUtils.getTestResourcePath("keystore.p12").toUri();
+        private final URI uri;
+        private final ByteBuffer buffer;
+
+        public TestResource(URI uri, byte[] bytes)
+        {
+            this.uri = uri;
+            this.buffer = ByteBuffer.wrap(bytes);
+        }
+
+        @Override
+        public boolean exists()
+        {
+            return true;
+        }
+
+        @Override
+        public long length()
+        {
+            return buffer.remaining();
+        }
+
+        @Override
+        public Path getPath()
+        {
+            return null;
+        }
+
+        @Override
+        public boolean isDirectory()
+        {
+            return false;
+        }
+
+        @Override
+        public boolean isReadable()
+        {
+            return true;
+        }
+
+        @Override
+        public URI getURI()
+        {
+            return uri;
+        }
+
+        @Override
+        public String getName()
+        {
+            return uri.getPath();
+        }
+
+        @Override
+        public String getFileName()
+        {
+            return uri.getPath();
+        }
+
+        @Override
+        public Resource resolve(String subUriPath)
+        {
+            return null;
+        }
+
+        @Override
+        public Content.Source newContentSource(ByteBufferPool bufferPool, int bufferSize, boolean direct, long first, long length) throws IllegalArgumentException
+        {
+            return Content.Source.from(BufferUtil.slice(buffer, (int)first, (int)length));
+        }
+    }
+
+    public static Stream<Resource> all() throws Exception
+    {
+        Path testResourcePath = MavenTestingUtils.getTestResourcePath("keystore.p12");
+        byte[] bytes = Files.readAllBytes(testResourcePath);
+        URI resourceUri = testResourcePath.toUri();
         return Stream.of(
             ResourceFactory.root().newResource(resourceUri),
-            new URLResourceFactory().newResource(resourceUri)
+            ResourceFactory.root().newMemoryResource(resourceUri.toURL()),
+            new URLResourceFactory().newResource(resourceUri),
+            new TestResource(resourceUri, bytes)
         );
     }
 

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOResourcesTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOResourcesTest.java
@@ -51,7 +51,7 @@ public class IOResourcesTest
         assertThat("Leaks: " + bufferPool.dumpLeaks(), bufferPool.getLeaks().size(), is(0));
     }
 
-    // This Resource impl has getPath() and newInputStream() return null so the only way for IOResources
+    // This Resource impl has getPath() and newInputStream() throw so the only way for IOResources
     // to read its contents is to call newContentSource().
     private static class TestContentSourceFactoryResource extends Resource implements Content.Source.Factory
     {
@@ -79,13 +79,13 @@ public class IOResourcesTest
         @Override
         public Path getPath()
         {
-            return null;
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public InputStream newInputStream()
         {
-            return null;
+            throw new UnsupportedOperationException();
         }
 
         @Override

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOResourcesTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOResourcesTest.java
@@ -129,7 +129,7 @@ public class IOResourcesTest
         }
 
         @Override
-        public Content.Source newContentSource(ByteBufferPool.Sized sizedBufferPool, long first, long length) throws IllegalArgumentException
+        public Content.Source newContentSource(ByteBufferPool.Sized bufferPool, long first, long length) throws IllegalArgumentException
         {
             return Content.Source.from(BufferUtil.slice(buffer, Math.toIntExact(first), Math.toIntExact(length)));
         }

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOResourcesTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOResourcesTest.java
@@ -76,7 +76,7 @@ public class IOResourcesTest
         @Override
         public Path getPath()
         {
-            return null;
+            throw new UnsupportedOperationException();
         }
 
         @Override
@@ -179,7 +179,7 @@ public class IOResourcesTest
     {
         TestSink sink = new TestSink();
         Callback.Completable callback = new Callback.Completable();
-        Content.Source contentSource = IOResources.asContentSource(resource, bufferPool, 1, false, -1, 500);
+        Content.Source contentSource = IOResources.asContentSource(resource, bufferPool, 1, false, 0, 500);
         Content.copy(contentSource, sink, callback);
         callback.get();
         List<Content.Chunk> chunks = sink.takeAccumulatedChunks();
@@ -237,7 +237,7 @@ public class IOResourcesTest
     {
         TestSink sink = new TestSink();
         Callback.Completable callback = new Callback.Completable();
-        IOResources.copy(resource, sink, bufferPool, 1, false, -1, 500, callback);
+        IOResources.copy(resource, sink, bufferPool, 1, false, 0, 500, callback);
         callback.get();
         List<Content.Chunk> chunks = sink.takeAccumulatedChunks();
         long sum = chunks.stream().mapToLong(Content.Chunk::remaining).sum();

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOResourcesTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOResourcesTest.java
@@ -19,6 +19,7 @@ import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Stream;
 
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
@@ -29,11 +30,14 @@ import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.resource.URLResourceFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class IOResourcesTest
 {
@@ -266,5 +270,25 @@ public class IOResourcesTest
         long sum = chunks.stream().mapToLong(Content.Chunk::remaining).sum();
         assertThat(sum, is(500L));
         assertThat(chunks.get(chunks.size() - 1).isLast(), is(true));
+    }
+
+    @Test
+    public void testCopyDirectory()
+    {
+        Resource resource = ResourceFactory.root().newResource(MavenTestingUtils.getTestResourcesPath());
+        Callback.Completable callback = new Callback.Completable();
+        IOResources.copy(resource, (last, byteBuffer, cb) -> {}, null, 4096, false, callback);
+        Throwable cause = assertThrows(ExecutionException.class, callback::get).getCause();
+        assertThat(cause, instanceOf(IllegalArgumentException.class));
+    }
+
+    @Test
+    public void testCopyWithRangeDirectory()
+    {
+        Resource resource = ResourceFactory.root().newResource(MavenTestingUtils.getTestResourcesPath());
+        Callback.Completable callback = new Callback.Completable();
+        IOResources.copy(resource, (last, byteBuffer, cb) -> {}, null, 4096, false, 0, -1, callback);
+        Throwable cause = assertThrows(ExecutionException.class, callback::get).getCause();
+        assertThat(cause, instanceOf(IllegalArgumentException.class));
     }
 }

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOResourcesTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOResourcesTest.java
@@ -116,7 +116,7 @@ public class IOResourcesTest
         }
 
         @Override
-        public Content.Source newContentSource(ByteBufferPool bufferPool, int bufferSize, boolean direct, long first, long length) throws IllegalArgumentException
+        public Content.Source newContentSource(ByteBufferPool.Sized sizedBufferPool, long first, long length) throws IllegalArgumentException
         {
             return Content.Source.from(BufferUtil.slice(buffer, Math.toIntExact(first), Math.toIntExact(length)));
         }

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOResourcesTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOResourcesTest.java
@@ -215,7 +215,6 @@ public class IOResourcesTest
         List<Content.Chunk> chunks = sink.takeAccumulatedChunks();
         long sum = chunks.stream().mapToLong(Content.Chunk::remaining).sum();
         assertThat(sum, is(resource.length()));
-        assertThat(chunks.get(chunks.size() - 1).isLast(), is(true));
     }
 
     @ParameterizedTest
@@ -229,7 +228,6 @@ public class IOResourcesTest
         List<Content.Chunk> chunks = sink.takeAccumulatedChunks();
         long sum = chunks.stream().mapToLong(Content.Chunk::remaining).sum();
         assertThat(sum, is(resource.length() - 100L));
-        assertThat(chunks.get(chunks.size() - 1).isLast(), is(true));
     }
 
     @ParameterizedTest
@@ -243,7 +241,6 @@ public class IOResourcesTest
         List<Content.Chunk> chunks = sink.takeAccumulatedChunks();
         long sum = chunks.stream().mapToLong(Content.Chunk::remaining).sum();
         assertThat(sum, is(500L));
-        assertThat(chunks.get(chunks.size() - 1).isLast(), is(true));
     }
 
     @ParameterizedTest
@@ -257,6 +254,5 @@ public class IOResourcesTest
         List<Content.Chunk> chunks = sink.takeAccumulatedChunks();
         long sum = chunks.stream().mapToLong(Content.Chunk::remaining).sum();
         assertThat(sum, is(500L));
-        assertThat(chunks.get(chunks.size() - 1).isLast(), is(true));
     }
 }

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOResourcesTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOResourcesTest.java
@@ -50,7 +50,7 @@ public class IOResourcesTest
         assertThat("Leaks: " + bufferPool.dumpLeaks(), bufferPool.getLeaks().size(), is(0));
     }
 
-    private static class TestResource extends IOResources.ContentSourceResource
+    private static class TestResource extends Resource implements Content.Source.Factory
     {
         private final URI uri;
         private final ByteBuffer buffer;

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceService.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ResourceService.java
@@ -700,7 +700,7 @@ public class ResourceService
         String contentType = "multipart/byteranges; boundary=";
         String boundary = MultiPart.generateBoundary(null, 24);
         MultiPartByteRanges.ContentSource byteRanges = new MultiPartByteRanges.ContentSource(boundary);
-        ranges.forEach(range -> byteRanges.addPart(new MultiPartByteRanges.Part(content.getContentTypeValue(), content.getResource(), range, contentLength, request.getComponents().getByteBufferPool())));
+        ranges.forEach(range -> byteRanges.addPart(new MultiPartByteRanges.Part(content.getContentTypeValue(), content.getResource(), range, contentLength, request.getComponents().getByteBufferPool()))); // TODO use a sized pool
         byteRanges.close();
         long partsContentLength = byteRanges.getLength();
         putHeaders(response, content, partsContentLength);

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/BufferUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/BufferUtil.java
@@ -287,9 +287,9 @@ public class BufferUtil
     }
 
     /**
-     * Slice a buffer given an offset and a length.
+     * Slice a buffer given an offset and a length, similar to RFC 7233 ranges.
      * @param buffer the buffer to slice
-     * @param offset the offset
+     * @param offset the offset, relative to the current position of the buffer, must be positive
      * @param length the length, -1 meaning use the current limit
      * @return the sliced buffer
      */

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/BufferUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/BufferUtil.java
@@ -287,6 +287,29 @@ public class BufferUtil
     }
 
     /**
+     * Slice a buffer given an offset and a length.
+     * @param buffer the buffer to slice
+     * @param offset the offset
+     * @param length the length, -1 meaning use the current limit
+     * @return the sliced buffer
+     */
+    public static ByteBuffer slice(ByteBuffer buffer, int offset, int length)
+    {
+        ByteBuffer slice = buffer.slice();
+        if (offset > 0)
+        {
+            int newPosition = slice.position() + offset;
+            if (newPosition > slice.limit() && length == 0)
+                slice.position(slice.limit());
+            else
+                slice.position(newPosition);
+        }
+        if (length > -1)
+            slice.limit(slice.position() + length);
+        return slice;
+    }
+
+    /**
      * Convert a ByteBuffer to a byte array.
      *
      * @param buffer The buffer to convert in flush mode. The buffer is not altered.

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/BufferUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/BufferUtil.java
@@ -295,6 +295,8 @@ public class BufferUtil
      */
     public static ByteBuffer slice(ByteBuffer buffer, int offset, int length)
     {
+        if (offset < 0)
+            throw new IllegalArgumentException("Invalid offset: " + offset);
         ByteBuffer slice = buffer.slice();
         if (offset > 0)
         {

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/BufferUtilTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/BufferUtilTest.java
@@ -17,6 +17,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.concurrent.ThreadLocalRandom;
@@ -55,6 +56,23 @@ public class BufferUtilTest
     public void afterEach()
     {
         assertThat(FileSystemPool.INSTANCE.mounts(), empty());
+    }
+
+    @Test
+    public void testSlice()
+    {
+        ByteBuffer byteBuffer = ByteBuffer.wrap("0123456789".getBytes(StandardCharsets.UTF_8));
+        assertEquals("0123456789", BufferUtil.toString(BufferUtil.slice(byteBuffer, 0, -1)));
+        assertEquals("3456789", BufferUtil.toString(BufferUtil.slice(byteBuffer, 3, -1)));
+        assertEquals("01234567", BufferUtil.toString(BufferUtil.slice(byteBuffer, 0, 8)));
+        assertEquals("5678", BufferUtil.toString(BufferUtil.slice(byteBuffer, 5, 4)));
+        assertEquals("", BufferUtil.toString(BufferUtil.slice(byteBuffer, 1, 0)));
+        assertEquals("", BufferUtil.toString(BufferUtil.slice(byteBuffer, 10, -1)));
+        assertEquals("", BufferUtil.toString(BufferUtil.slice(byteBuffer, 1000, 0)));
+
+        assertThrows(IllegalArgumentException.class, () -> BufferUtil.slice(byteBuffer, 0, 11));
+        assertThrows(IllegalArgumentException.class, () -> BufferUtil.slice(byteBuffer, 11, -1));
+        assertThrows(IllegalArgumentException.class, () -> BufferUtil.slice(byteBuffer, 1, 10));
     }
 
     @Test

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/BufferUtilTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/BufferUtilTest.java
@@ -73,6 +73,7 @@ public class BufferUtilTest
         assertThrows(IllegalArgumentException.class, () -> BufferUtil.slice(byteBuffer, 0, 11));
         assertThrows(IllegalArgumentException.class, () -> BufferUtil.slice(byteBuffer, 11, -1));
         assertThrows(IllegalArgumentException.class, () -> BufferUtil.slice(byteBuffer, 1, 10));
+        assertThrows(IllegalArgumentException.class, () -> BufferUtil.slice(byteBuffer, -1, 1));
     }
 
     @Test

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletMultiPartFormData.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletMultiPartFormData.java
@@ -278,7 +278,7 @@ public class ServletMultiPartFormData
         @Override
         public InputStream getInputStream() throws IOException
         {
-            return Content.Source.asInputStream(_part.newContentSource());
+            return Content.Source.asInputStream(_part.newContentSource(null, 0L, -1L)); // TODO use a pool
         }
 
         @Override

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/HugeResourceTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/HugeResourceTest.java
@@ -444,7 +444,7 @@ public class HugeResourceTest
         MultiPartRequestContent multipart = new MultiPartRequestContent();
         Path inputFile = staticBase.resolve(filename);
         String name = String.format("file-%d", expectedSize);
-        multipart.addPart(new MultiPart.PathPart(name, filename, HttpFields.EMPTY, inputFile));
+        multipart.addPart(new MultiPart.PathPart(null, name, filename, HttpFields.EMPTY, inputFile));
         multipart.close();
 
         URI destUri = server.getURI().resolve("/multipart");
@@ -487,7 +487,7 @@ public class HugeResourceTest
         };
         Path inputFile = staticBase.resolve(filename);
         String name = String.format("file-%d", expectedSize);
-        multipart.addPart(new MultiPart.PathPart(name, filename, HttpFields.EMPTY, inputFile));
+        multipart.addPart(new MultiPart.PathPart(null, name, filename, HttpFields.EMPTY, inputFile));
         multipart.close();
 
         URI destUri = server.getURI().resolve("/multipart");

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/HugeResourceTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/HugeResourceTest.java
@@ -362,7 +362,7 @@ public class HugeResourceTest
         MultiPartRequestContent multipart = new MultiPartRequestContent();
         Path inputFile = staticBase.resolve(filename);
         String name = String.format("file-%d", expectedSize);
-        multipart.addPart(new MultiPart.PathPart(name, filename, HttpFields.EMPTY, inputFile));
+        multipart.addPart(new MultiPart.PathPart(null, name, filename, HttpFields.EMPTY, inputFile));
         multipart.close();
 
         URI destUri = server.getURI().resolve("/multipart");

--- a/tests/test-integration/src/test/java/org/eclipse/jetty/test/CoreMultiPartTest.java
+++ b/tests/test-integration/src/test/java/org/eclipse/jetty/test/CoreMultiPartTest.java
@@ -537,7 +537,7 @@ public class CoreMultiPartTest
                     writer.println("Part: name=" + part.getName() + ", size=" + part.getLength() + ", content=" + partContent);
 
                     // We can only consume the getContentSource() once so we must use newContentSource().
-                    partContent = IO.toString(Content.Source.asInputStream(part.newContentSource()));
+                    partContent = IO.toString(Content.Source.asInputStream(part.newContentSource(null, 0, -1)));
                     writer.println("Part: name=" + part.getName() + ", size=" + part.getLength() + ", content=" + partContent);
                 }
 


### PR DESCRIPTION
So 3rd party `Resource`s for which `IOResources` can use the fast `Content.Source` codepath can be created.

Also modify `MultiPart` and related classes to use the new contract.

Closes #12965
