### PR TITLE
Added min/max mapped file size  to `ResourceHandler` and EE11 `ResourceServlet`

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/FileMappingHttpContentFactory.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/FileMappingHttpContentFactory.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 public class FileMappingHttpContentFactory implements HttpContent.Factory
 {
     private static final Logger LOG = LoggerFactory.getLogger(FileMappingHttpContentFactory.class);
-    private static final int DEFAULT_MIN_FILE_SIZE = 16 * 1024;
+    private static final int DEFAULT_MIN_FILE_SIZE = 1024 * 1024;
     private static final int DEFAULT_MAX_BUFFER_SIZE = Integer.MAX_VALUE;
 
     private final HttpContent.Factory _factory;
@@ -47,21 +47,23 @@ public class FileMappingHttpContentFactory implements HttpContent.Factory
      */
     public FileMappingHttpContentFactory(HttpContent.Factory factory)
     {
-        this(factory, DEFAULT_MIN_FILE_SIZE, DEFAULT_MAX_BUFFER_SIZE);
+        this(factory, -1, -1);
     }
 
     /**
      * Construct a {@link FileMappingHttpContentFactory} which can use file mapped buffers.
      *
      * @param factory the wrapped {@link HttpContent.Factory} to use.
-     * @param minFileSize the minimum size of an {@link HttpContent} before trying to use a file mapped buffer.
-     * @param maxBufferSize the maximum size of the memory mapped buffers
+     * @param minFileSize the minimum size of an {@link HttpContent} before trying to use a file mapped buffer;
+     *                    or {@code -1} for a default.
+     * @param maxBufferSize the maximum size of the memory mapped buffers;
+     *                      or {@code -1} for a default.
      */
     public FileMappingHttpContentFactory(HttpContent.Factory factory, int minFileSize, int maxBufferSize)
     {
         _factory = Objects.requireNonNull(factory);
-        _minFileSize = minFileSize;
-        _maxBufferSize = maxBufferSize;
+        _minFileSize = minFileSize == -1 ? DEFAULT_MIN_FILE_SIZE : minFileSize;
+        _maxBufferSize = maxBufferSize == -1 ? DEFAULT_MAX_BUFFER_SIZE : maxBufferSize;
     }
 
     @Override

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ResourceHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ResourceHandler.java
@@ -63,7 +63,8 @@ public class ResourceHandler extends Handler.Wrapper
     private Resource _styleSheet;
     private MimeTypes _mimeTypes;
     private List<String> _welcomes = List.of("index.html");
-    private boolean _useFileMapping = true;
+    private int _minMappedFileSize = -1;
+    private int _maxMappedFileSize = -1;
 
     public ResourceHandler()
     {
@@ -134,8 +135,8 @@ public class ResourceHandler extends Handler.Wrapper
     protected HttpContent.Factory newHttpContentFactory(ByteBufferPool.Sized byteBufferPool)
     {
         HttpContent.Factory contentFactory = new ResourceHttpContentFactory(getBaseResource(), getMimeTypes(), byteBufferPool);
-        if (isUseFileMapping())
-            contentFactory = new FileMappingHttpContentFactory(contentFactory);
+        if (getMinMappedFileSize() != 0)
+            contentFactory = new FileMappingHttpContentFactory(contentFactory, getMinMappedFileSize(), getMaxMappedFileSize());
         contentFactory = new VirtualHttpContentFactory(contentFactory, getStyleSheet(), "text/css", byteBufferPool);
         contentFactory = new PreCompressedHttpContentFactory(contentFactory, getPrecompressedFormats());
         contentFactory = new ValidatingCachingHttpContentFactory(contentFactory, Duration.ofSeconds(1).toMillis(), byteBufferPool);
@@ -248,9 +249,10 @@ public class ResourceHandler extends Handler.Wrapper
         return _resourceService.isEtags();
     }
 
+    @Deprecated(forRemoval = true, since = "12.1.0")
     public boolean isUseFileMapping()
     {
-        return _useFileMapping;
+        return _minMappedFileSize != 0;
     }
 
     /**
@@ -363,11 +365,51 @@ public class ResourceHandler extends Handler.Wrapper
         _mimeTypes = mimeTypes;
     }
 
+    /**
+     * @param useFileMapping True if mapped files should be used
+     * @deprecated use {@link #setMinMappedFileSize(int)}
+     */
+    @Deprecated(forRemoval = true, since = "12.1.0")
     public void setUseFileMapping(boolean useFileMapping)
     {
+        setMinMappedFileSize(useFileMapping ? -1 : 0);
+    }
+
+    /**
+     * @return The maximum size in bytes for a mapped file.
+     */
+    public int getMaxMappedFileSize()
+    {
+        return _maxMappedFileSize;
+    }
+
+    /**
+     * @param maxMappedFileSize The maximum size in bytes for a mapped file
+     */
+    public void setMaxMappedFileSize(int maxMappedFileSize)
+    {
         if (isRunning())
-            throw new IllegalStateException("Unable to set useFileMapping on started " + this);
-        _useFileMapping = useFileMapping;
+            throw new IllegalStateException("Unable to set when started " + this);
+        _maxMappedFileSize = maxMappedFileSize;
+    }
+
+    /**
+     * @return the minimum size in bytes for a mapped file; or {@code 0} for no mapping; or {@code -1} for a default.
+     */
+    public int getMinMappedFileSize()
+    {
+        return _minMappedFileSize;
+    }
+
+    /**
+     * @param minMappedFileSize the minimum size in bytes for a mapped file; or {@code 0} for no mapping;
+     *                          or {@code -1} for a default.
+     */
+    public void setMinMappedFileSize(int minMappedFileSize)
+    {
+        if (isRunning())
+            throw new IllegalStateException("Unable to set when started " + this);
+        _minMappedFileSize = minMappedFileSize;
     }
 
     public void setWelcomeMode(ResourceService.WelcomeMode welcomeMode)

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ResourceHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ResourceHandlerTest.java
@@ -664,7 +664,7 @@ public class ResourceHandlerTest
             protected HttpContent.Factory newHttpContentFactory(ByteBufferPool.Sized byteBufferPool)
             {
                 HttpContent.Factory contentFactory = new ResourceHttpContentFactory(getBaseResource(), getMimeTypes(), byteBufferPool);
-                contentFactory = new FileMappingHttpContentFactory(contentFactory, -1, -1);
+                contentFactory = new FileMappingHttpContentFactory(contentFactory);
                 contentFactory = new VirtualHttpContentFactory(contentFactory, getStyleSheet(), "text/css", byteBufferPool);
                 contentFactory = new PreCompressedHttpContentFactory(contentFactory, getPrecompressedFormats());
                 contentFactory = new ValidatingCachingHttpContentFactory(contentFactory, 0, byteBufferPool);

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ResourceHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ResourceHandlerTest.java
@@ -664,7 +664,7 @@ public class ResourceHandlerTest
             protected HttpContent.Factory newHttpContentFactory(ByteBufferPool.Sized byteBufferPool)
             {
                 HttpContent.Factory contentFactory = new ResourceHttpContentFactory(getBaseResource(), getMimeTypes(), byteBufferPool);
-                contentFactory = new FileMappingHttpContentFactory(contentFactory);
+                contentFactory = new FileMappingHttpContentFactory(contentFactory, -1, -1);
                 contentFactory = new VirtualHttpContentFactory(contentFactory, getStyleSheet(), "text/css", byteBufferPool);
                 contentFactory = new PreCompressedHttpContentFactory(contentFactory, getPrecompressedFormats());
                 contentFactory = new ValidatingCachingHttpContentFactory(contentFactory, 0, byteBufferPool);

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ResourceServlet.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ResourceServlet.java
@@ -167,11 +167,14 @@ import org.slf4j.LoggerFactory;
  *     Use {@code true} to use direct byte buffers to serve static resources.
  *     Defaults to {@code true}.
  *   </dd>
- *   <dt>useFileMappedBuffer</dt>
+ *   <dt>minMappedFileSize</dt>
  *   <dd>
- *     Use {@code true} to use file mapping to serve static resources instead of
- *     buffers configured with the above two settings.
- *     Defaults to {@code false}.
+ *     The minimum size in bytes of a file that will used with file mapping, or {@code 0} for
+ *     no file mapping or {@code null} for a default size.
+ *   </dd>
+ *   <dt>maxMappedFileSize</dt>
+ *   <dd>
+ *     The maximum size in bytes of a file that will used with file mapping, or {@code null} for a default size.
  *   </dd>
  *   <dt>welcomeServlets</dt>
  *   <dd>
@@ -277,8 +280,15 @@ public class ResourceServlet extends HttpServlet
                 }
             }
 
-            if (getInitBoolean("useFileMappedBuffer", false))
-                contentFactory = new FileMappingHttpContentFactory(contentFactory);
+            int minMappedFileSize = getInitInt("minMappedFileSize", -1);
+            String useFileMappedBuffer = getInitParameter("useFileMappedBuffer");
+            if (useFileMappedBuffer != null)
+                LOG.warn("{} Deprecated useFileMappedBuffer used. Use minMappedFileSize instead", this);
+            
+            if (minMappedFileSize > 0)
+                contentFactory = new FileMappingHttpContentFactory(contentFactory, minMappedFileSize, getInitInt("maxMappedFileSize", Integer.MAX_VALUE));
+            else if (minMappedFileSize == -1 || getInitBoolean("useFileMappedBuffer", true))
+                contentFactory = new FileMappingHttpContentFactory(contentFactory, -1, -1);
 
             contentFactory = new VirtualHttpContentFactory(contentFactory, styleSheet, "text/css", bufferPool);
             contentFactory = new PreCompressedHttpContentFactory(contentFactory, precompressedFormats);

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ResourceServlet.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ResourceServlet.java
@@ -169,12 +169,13 @@ import org.slf4j.LoggerFactory;
  *   </dd>
  *   <dt>minMappedFileSize</dt>
  *   <dd>
- *     The minimum size in bytes of a file that will used with file mapping, or {@code 0} for
- *     no file mapping or {@code null} for a default size.
+ *     The minimum size in bytes of a file that will used with file mapping; or {@code 0} for
+ *     no file mapping; or {@code -1} (or net set) for a default size of 1MB.
  *   </dd>
  *   <dt>maxMappedFileSize</dt>
  *   <dd>
- *     The maximum size in bytes of a file that will used with file mapping, or {@code null} for a default size.
+ *     The maximum size in bytes of a file that will used with file mapping;
+ *     or {@code -1} (or not set) for a default size of {@link Integer#MAX_VALUE}.
  *   </dd>
  *   <dt>welcomeServlets</dt>
  *   <dd>

--- a/jetty-ee11/jetty-ee11-webapp/src/main/config/etc/webdefault-ee11.xml
+++ b/jetty-ee11/jetty-ee11-webapp/src/main/config/etc/webdefault-ee11.xml
@@ -114,9 +114,9 @@
  *  maxCachedFiles    The maximum number of files to cache
  *
  *  minMappedFileSize The minimum size in bytes of a file that will be used with file mapping;
- *                    or 0 for no file mapping; or not set for a default size.
+ *                    or 0 for no file mapping; or -1 (or not set) for a default size of 1MB.
  *  maxMappedFileSize The maximum size in bytes of a file that will be used with file mapping;
- *                    or not set for a default size.
+ *                    or -1 (or not set) for a default size of MAX_VALUE.
  *
  *  cacheControl      If set, all static content will have this value set as the cache-control
  *                    header.

--- a/jetty-ee11/jetty-ee11-webapp/src/main/config/etc/webdefault-ee11.xml
+++ b/jetty-ee11/jetty-ee11-webapp/src/main/config/etc/webdefault-ee11.xml
@@ -113,11 +113,10 @@
  *  maxCachedFileSize The maximum size of a file to cache
  *  maxCachedFiles    The maximum number of files to cache
  *
- *  useFileMappedBuffer
- *                    If set to true, it will use mapped file buffers to serve static content
- *                    when using an NIO connector. Setting this value to false means that
- *                    a direct buffer will be used instead of a mapped file buffer.
- *                    This file sets the value to true.
+ *  minMappedFileSize The minimum size in bytes of a file that will be used with file mapping;
+ *                    or 0 for no file mapping; or not set for a default size.
+ *  maxMappedFileSize The maximum size in bytes of a file that will be used with file mapping;
+ *                    or not set for a default size.
  *
  *  cacheControl      If set, all static content will have this value set as the cache-control
  *                    header.
@@ -166,8 +165,12 @@
       <param-value>false</param-value>
     </init-param>
     <init-param>
-      <param-name>useFileMappedBuffer</param-name>
-      <param-value>true</param-value>
+      <param-name>minMappedFileSize</param-name>
+      <param-value>-1</param-value>
+    </init-param>
+    <init-param>
+      <param-name>maxMappedFileSize</param-name>
+      <param-value>-1</param-value>
     </init-param>
     <load-on-startup>0</load-on-startup>
   </servlet>


### PR DESCRIPTION
Fix #12700 by adding `maxMappedFileSize` and `maxMappedFileSize` to `ResourceHandler` and EE11 `ResourceServlet`. 
Increased default min size to 1MB