### PR TITLE
Issue #12992 - Deployment Scanning interval is disabled by default (per documentation)

### DIFF
--- a/jetty-core/jetty-deploy/src/main/config/modules/deployment-scanner.mod
+++ b/jetty-core/jetty-deploy/src/main/config/modules/deployment-scanner.mod
@@ -29,6 +29,8 @@ etc/jetty-deployment-scanner.xml
 # jetty.deploy.deferInitialScan=false
 
 ## Monitored directory scan period (seconds)
+# value of 0 is hot-redeploy disabled
+# value of 1 or more will enable hot-redeploy
 # jetty.deploy.scanInterval=0
 
 ## Environments directory name (relative to $jetty.base)

--- a/jetty-core/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/DeploymentScanner.java
+++ b/jetty-core/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/DeploymentScanner.java
@@ -137,7 +137,7 @@ public class DeploymentScanner extends ContainerLifeCycle implements Scanner.Bul
     private Deployer deployer;
     private Comparator<DeployAction> actionComparator = new DeployActionComparator();
     private Path environmentsDir;
-    private int scanInterval = 10;
+    private int scanInterval = 0;
     private Scanner scanner;
     private boolean useRealPaths;
     private boolean deferInitialScan = false;
@@ -654,7 +654,7 @@ public class DeploymentScanner extends ContainerLifeCycle implements Scanner.Bul
         if (monitoredDirs.isEmpty())
             throw new IllegalStateException("No monitored dir specified");
 
-        LOG.info("Deployment monitor in {} at intervals {}s", monitoredDirs, getScanInterval());
+        LOG.info("Deployment monitoring {} at intervals {}s {}", monitoredDirs, getScanInterval(), getScanInterval() <= 0 ? "(hot-redeploy disabled)" : "");
 
         Predicate<Path> validDir = (path) ->
         {


### PR DESCRIPTION
Make the behavior follow the documentation.
Improve the INFO logging about the behavior.

Fixes #12992