### PR TITLE
Issue #13000 - remove old jetty.deploy.environmentXml=<path> feature

### DIFF
--- a/jetty-core/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/ContextHandlerFactory.java
+++ b/jetty-core/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/ContextHandlerFactory.java
@@ -40,16 +40,7 @@ public interface ContextHandlerFactory
      * The attribute name for the environment name.
      */
     String ENVIRONMENT_ATTRIBUTE = "environment";
-    /**
-     * Attributes that start with this name return a String pointing to XML on the filesystem that should be used for Environment based
-     * modifications to the ContextHandler that was created.
-     *
-     * <pre>
-     * jetty.deploy.environmentXml=config/base-ee8.xml
-     * jetty.deploy.environmentXml.auditing=config/auditing-ee8.xml
-     * </pre>
-     */
-    String ENVIRONMENT_XML_ATTRIBUTE = "jetty.deploy.environmentXml";
+
     /**
      * Attribute name that stores the {@code List<Path>} pointing to XML files that represent
      * the Environment XML files to apply to the ContextHandler has been created.
@@ -67,7 +58,6 @@ public interface ContextHandlerFactory
      *                             <li>{@link #CONTEXT_HANDLER_CLASS_ATTRIBUTE}</li>
      *                             <li>{@link #CONTEXT_HANDLER_CLASS_DEFAULT_ATTRIBUTE}</li>
      *                             <li>{@link #ENVIRONMENT_ATTRIBUTE}</li>
-     *                             <li>{@link #ENVIRONMENT_XML_ATTRIBUTE}</li>
      *                             <li>{@link #ENVIRONMENT_XML_PATHS_ATTRIBUTE}</li>
      *                         </ul>
      * @return The created {@link ContextHandler}

--- a/jetty-core/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/DeploymentScanner.java
+++ b/jetty-core/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/DeploymentScanner.java
@@ -822,11 +822,6 @@ public class DeploymentScanner extends ContainerLifeCycle implements Scanner.Bul
                         Attributes envAttributes = environmentAttributesMap.get(appEnvironment);
                         Attributes deployAttributes = envAttributes == null ? app.getAttributes() : new Attributes.Layer(envAttributes, app.getAttributes());
 
-                        // Ensure that Environment configuration XMLs are listed in deployAttributes
-                        List<Path> envXmlPaths = findEnvironmentXmlPaths(deployAttributes);
-                        envXmlPaths.sort(PathCollators.byName(true));
-                        StandardContextHandlerFactory.setEnvironmentXmlPaths(deployAttributes, envXmlPaths);
-
                         // Create the Context Handler
                         Path mainPath = app.getMainPath();
                         if (mainPath == null)
@@ -857,11 +852,6 @@ public class DeploymentScanner extends ContainerLifeCycle implements Scanner.Bul
                         // combination of layered Environment Attributes with app Attributes overlaying them.
                         Attributes envAttributes = environmentAttributesMap.get(appEnvironment);
                         Attributes deployAttributes = envAttributes == null ? app.getAttributes() : new Attributes.Layer(envAttributes, app.getAttributes());
-
-                        // Ensure that Environment configuration XMLs are listed in deployAttributes
-                        List<Path> envXmlPaths = findEnvironmentXmlPaths(deployAttributes);
-                        envXmlPaths.sort(PathCollators.byName(true));
-                        StandardContextHandlerFactory.setEnvironmentXmlPaths(deployAttributes, envXmlPaths);
 
                         // Create the Context Handler
                         Path mainPath = app.getMainPath();
@@ -902,68 +892,6 @@ public class DeploymentScanner extends ContainerLifeCycle implements Scanner.Bul
         return actions;
     }
 
-    private List<Path> findEnvironmentXmlPaths(Attributes deployAttributes)
-    {
-        List<Path> rawEnvXmlPaths = deployAttributes.getAttributeNameSet()
-            .stream()
-            .filter(k -> k.startsWith(ContextHandlerFactory.ENVIRONMENT_XML_ATTRIBUTE))
-            .map(k -> Path.of((String)deployAttributes.getAttribute(k)))
-            .toList();
-
-        List<Path> ret = new ArrayList<>();
-        for (Path rawPath : rawEnvXmlPaths)
-        {
-            if (Files.exists(rawPath))
-            {
-                if (Files.isRegularFile(rawPath))
-                {
-                    // just add it, nothing else to do.
-                    if (rawPath.isAbsolute())
-                        ret.add(rawPath);
-                    else
-                        ret.add(rawPath.toAbsolutePath());
-                }
-                else
-                {
-                    if (LOG.isDebugEnabled())
-                        LOG.debug("Ignoring non-file reference to environment xml: {}", rawPath);
-                }
-            }
-            else if (!rawPath.isAbsolute())
-            {
-                // we have a relative defined path, try to resolve it from known locations
-                if (LOG.isDebugEnabled())
-                    LOG.debug("Resolving environment xml path relative reference: {}", rawPath);
-                boolean found = false;
-                for (Path monitoredDir : getMonitoredDirectories())
-                {
-                    Path resolved = monitoredDir.resolve(rawPath);
-                    if (Files.isRegularFile(resolved))
-                    {
-                        found = true;
-                        // add resolved path
-                        ret.add(resolved);
-                    }
-                    else
-                    {
-                        // try resolve from parent (this is backward compatible with 12.0.0)
-                        resolved = monitoredDir.getParent().resolve(rawPath);
-                        if (Files.isRegularFile(resolved))
-                        {
-                            found = true;
-                            // add resolved path
-                            ret.add(resolved);
-                        }
-                    }
-                }
-                if (!found && LOG.isDebugEnabled())
-                    LOG.debug("Ignoring relative environment xml path that doesn't exist: {}", rawPath);
-            }
-        }
-
-        return ret;
-    }
-
     /**
      * Load all of the {@link Environment} specific {@code <env-name>[-<name>].properties} files
      * found in the directory provided.
@@ -997,27 +925,40 @@ public class DeploymentScanner extends ContainerLifeCycle implements Scanner.Bul
             return envAttributes;
         }
 
-        List<Path> envPropertyFiles;
+        List<Path> envPropertyFiles = new ArrayList<>();
+        List<Path> envXmlFiles = new ArrayList<>();
 
-        // Get all environment specific properties files for this environment,
+        // Get all environment specific xml and properties files for this environment,
         // order them according to the lexical ordering of the filenames
         try (Stream<Path> paths = Files.list(dir))
         {
-            envPropertyFiles = paths.filter(Files::isRegularFile)
-                .filter(p -> FileID.isExtension(p, "properties"))
+            paths.filter(Files::isRegularFile)
+                .filter(p -> FileID.isExtension(p, "properties", "xml"))
                 .filter(p ->
                 {
                     String name = p.getFileName().toString();
                     return name.startsWith(env);
                 })
                 .sorted(PathCollators.byName(true))
-                .toList();
+                .forEach(file ->
+                {
+                    if (FileID.isExtension(file, "properties"))
+                        envPropertyFiles.add(file);
+                    else if (FileID.isExtension(file, "xml"))
+                        envXmlFiles.add(file);
+                });
         }
 
         if (LOG.isDebugEnabled())
+        {
             LOG.debug("Environment property files {}", envPropertyFiles);
+            LOG.debug("Environment XML files {}", envXmlFiles);
+        }
 
-        Attributes attributesLayer = envAttributes;
+        Attributes envLayer = new Attributes.Layer(envAttributes);
+
+        // Add the XML to the env layer
+        envLayer.setAttribute(ContextHandlerFactory.ENVIRONMENT_XML_PATHS_ATTRIBUTE, envXmlFiles);
 
         // Load each *.properties file
         for (Path file : envPropertyFiles)
@@ -1027,19 +968,17 @@ public class DeploymentScanner extends ContainerLifeCycle implements Scanner.Bul
                 Properties tmp = new Properties();
                 tmp.load(stream);
 
-                Attributes.Layer layer = new Attributes.Layer(attributesLayer);
                 //put each property into our substitution pool
                 tmp.stringPropertyNames().forEach(name ->
                 {
                     String value = tmp.getProperty(name);
                     String key = stripOldAttributePrefix(name);
-                    layer.setAttribute(key, value);
+                    envLayer.setAttribute(key, value);
                 });
-                attributesLayer = layer;
             }
         }
 
-        return attributesLayer;
+        return envLayer;
     }
 
     private void startTracking(PathsApp app)

--- a/jetty-core/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/StandardContextHandlerFactory.java
+++ b/jetty-core/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/StandardContextHandlerFactory.java
@@ -72,17 +72,6 @@ public class StandardContextHandlerFactory implements ContextHandlerFactory
         return Objects.toString(obj);
     }
 
-    public static List<Path> getEnvironmentXmlPaths(Attributes attributes)
-    {
-        //noinspection unchecked
-        return (List<Path>)attributes.getAttribute(ContextHandlerFactory.ENVIRONMENT_XML_PATHS_ATTRIBUTE);
-    }
-
-    public static void setEnvironmentXmlPaths(Attributes attributes, List<Path> paths)
-    {
-        attributes.setAttribute(ContextHandlerFactory.ENVIRONMENT_XML_PATHS_ATTRIBUTE, paths);
-    }
-
     @Override
     public ContextHandler newContextHandler(Server server, Environment environment, Path mainPath, Set<Path> otherPaths, Attributes deployAttributes) throws Exception
     {
@@ -301,7 +290,8 @@ public class StandardContextHandlerFactory implements ContextHandlerFactory
     {
         // Collect the optional environment context xml files.
         // Order them according to the name of their property key names.
-        List<Path> sortedEnvXmlPaths = getEnvironmentXmlPaths(attributes);
+        @SuppressWarnings("unchecked")
+        List<Path> sortedEnvXmlPaths = (List<Path>)attributes.getAttribute(ContextHandlerFactory.ENVIRONMENT_XML_PATHS_ATTRIBUTE);
 
         if (sortedEnvXmlPaths == null || sortedEnvXmlPaths.isEmpty())
             // nothing to do here

--- a/jetty-core/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/DeploymentScannerStartupTest.java
+++ b/jetty-core/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/DeploymentScannerStartupTest.java
@@ -23,6 +23,7 @@ import java.nio.file.StandardOpenOption;
 import org.eclipse.jetty.deploy.test.XmlConfiguredJetty;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.toolchain.test.FS;
+import org.eclipse.jetty.toolchain.test.IO;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
@@ -100,11 +101,8 @@ public class DeploymentScannerStartupTest extends AbstractCleanEnvironmentTest
         Path environments = jettyBase.resolve("environments");
         FS.ensureDirExists(environments);
 
-        Files.writeString(environments.resolve("core.properties"), ContextHandlerFactory.ENVIRONMENT_XML_ATTRIBUTE + "=etc/core-context.xml", StandardOpenOption.CREATE_NEW);
-        Files.writeString(environments.resolve("core-other.properties"), ContextHandlerFactory.ENVIRONMENT_XML_ATTRIBUTE + ".other=etc/core-context-other.xml", StandardOpenOption.CREATE_NEW);
-
-        Files.copy(MavenPaths.findTestResourceFile("etc/core-context.xml"), jettyBase.resolve("etc/core-context.xml"), StandardCopyOption.REPLACE_EXISTING);
-        Files.copy(MavenPaths.findTestResourceFile("etc/core-context-other.xml"), jettyBase.resolve("etc/core-context-other.xml"), StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(MavenPaths.findTestResourceFile("etc/core-context.xml"), environments.resolve("core-context.xml"), StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(MavenPaths.findTestResourceFile("etc/core-context-other.xml"), environments.resolve("core-context-other.xml"), StandardCopyOption.REPLACE_EXISTING);
 
         jetty.copyWebapp("bar-core-context.properties", "bar.properties");
         startJetty();
@@ -128,12 +126,8 @@ public class DeploymentScannerStartupTest extends AbstractCleanEnvironmentTest
         Path environments = jettyBase.resolve("environments");
         FS.ensureDirExists(environments);
 
-        Files.writeString(environments.resolve("core.properties"),
-            String.format("%s=%s%n", ContextHandlerFactory.ENVIRONMENT_XML_ATTRIBUTE, MavenPaths.findTestResourceFile("etc/core-context.xml")),
-            StandardOpenOption.CREATE_NEW);
-        Files.writeString(environments.resolve("core-other.properties"),
-            String.format("%s=%s%n", (ContextHandlerFactory.ENVIRONMENT_XML_ATTRIBUTE + ".other"), MavenPaths.findTestResourceFile("etc/core-context-other.xml")),
-            StandardOpenOption.CREATE_NEW);
+        IO.copy(MavenPaths.findTestResourceFile("etc/core-context.xml"), environments.resolve("core-context.xml"));
+        IO.copy(MavenPaths.findTestResourceFile("etc/core-context-other.xml"), environments.resolve("core-context-other.xml"));
 
         jetty.copyWebapp("bar-core-context.properties", "bar.properties");
         startJetty();
@@ -158,11 +152,11 @@ public class DeploymentScannerStartupTest extends AbstractCleanEnvironmentTest
         Path environments = jettyBase.resolve("environments");
         FS.ensureDirExists(environments);
 
-        Files.writeString(environments.resolve("non-env.properties"), ContextHandlerFactory.ENVIRONMENT_XML_ATTRIBUTE + "=some/file/that/should/be/ignored.txt");
-        Files.writeString(environments.resolve("ee8.properties"), ContextHandlerFactory.ENVIRONMENT_XML_ATTRIBUTE + "=some/file/that/should/be/ignored.txt");
-        Files.writeString(environments.resolve("ee9.properties"), ContextHandlerFactory.ENVIRONMENT_XML_ATTRIBUTE + "=some/file/that/should/be/ignored.txt");
-        Files.writeString(environments.resolve("ee10.properties"), ContextHandlerFactory.ENVIRONMENT_XML_ATTRIBUTE + "=some/file/that/should/be/ignored.txt");
-        Files.writeString(environments.resolve("not-core.properties"), ContextHandlerFactory.ENVIRONMENT_XML_ATTRIBUTE + "=some/file/that/should/be/ignored.txt");
+        Files.writeString(environments.resolve("non-env.properties"), "data.path=some/file/that/should/be/ignored.txt");
+        Files.writeString(environments.resolve("ee8.properties"), "data.path=some/file/that/should/be/ignored.txt");
+        Files.writeString(environments.resolve("ee9.properties"), "data.path=some/file/that/should/be/ignored.txt");
+        Files.writeString(environments.resolve("ee10.properties"), "data.path=some/file/that/should/be/ignored.txt");
+        Files.writeString(environments.resolve("not-core.properties"), "data.path=some/file/that/should/be/ignored.txt");
 
         jetty.copyWebapp("bar-core-context.properties", "bar.properties");
         startJetty();
@@ -184,21 +178,13 @@ public class DeploymentScannerStartupTest extends AbstractCleanEnvironmentTest
         Path environments = jettyBase.resolve("environments");
         FS.ensureDirExists(environments);
 
-        Files.writeString(environments.resolve("core-a.properties"), ContextHandlerFactory.ENVIRONMENT_XML_ATTRIBUTE + "=etc/a.xml");
-        Files.writeString(environments.resolve("core-b.properties"), ContextHandlerFactory.ENVIRONMENT_XML_ATTRIBUTE + "=etc/b.xml");
-        Files.writeString(environments.resolve("core-c.properties"), ContextHandlerFactory.ENVIRONMENT_XML_ATTRIBUTE + "=etc/c.xml");
-        Files.writeString(environments.resolve("core-d.properties"), ContextHandlerFactory.ENVIRONMENT_XML_ATTRIBUTE + "=etc/d.xml");
-
-        Path etc = jettyBase.resolve("etc");
-        FS.ensureDirExists(etc);
-
-        Path aPath = etc.resolve("a.xml");
+        Path aPath = environments.resolve("core-a.xml");
         writeXmlDisplayName(aPath, "A WebApp");
-        Path bPath = etc.resolve("b.xml");
+        Path bPath = environments.resolve("core-b.xml");
         writeXmlDisplayName(bPath, "B WebApp");
-        Path cPath = etc.resolve("c.xml");
+        Path cPath = environments.resolve("core-c.xml");
         writeXmlDisplayName(cPath, "C WebApp");
-        Path dPath = etc.resolve("d.xml");
+        Path dPath = environments.resolve("core-d.xml");
         writeXmlDisplayName(dPath, "D WebApp");
 
         jetty.copyWebapp("bar-core-context.properties", "bar.properties");
@@ -223,12 +209,11 @@ public class DeploymentScannerStartupTest extends AbstractCleanEnvironmentTest
 
         Files.writeString(environments.resolve("core.properties"),
             """
-                jetty.deploy.environmentXml=etc/core-context-sub.xml
                 test.displayName=DisplayName Set By Property
                 """);
 
         Files.copy(MavenPaths.findTestResourceFile("etc/core-context-sub.xml"),
-            jettyBase.resolve("etc/core-context-sub.xml"),
+            environments.resolve("core-context-sub.xml"),
             StandardCopyOption.REPLACE_EXISTING);
 
         jetty.copyWebapp("bar-core-context.properties", "bar.properties");


### PR DESCRIPTION
+ Using new `${jetty-base}/environments/<env-name>-<description>.xml` is preferred

Fixes #13000