### PR TITLE
Fixes #13008 - Introduce HttpClient's Request.onResponseListener().

### DIFF
--- a/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/client/http/HTTPClientDocs.java
+++ b/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/client/http/HTTPClientDocs.java
@@ -309,6 +309,7 @@ public class HTTPClientDocs
             .onRequestContent((request, content) -> { /* ... */ })
             .onRequestFailure((request, failure) -> { /* ... */ })
             .onRequestSuccess(request -> { /* ... */ })
+            .onRequestListener(new Request.Listener() {}) // For all request events.
             // Add response hooks.
             .onResponseBegin(response -> { /* ... */ })
             .onResponseHeader((response, field) -> true)
@@ -316,6 +317,7 @@ public class HTTPClientDocs
             .onResponseContentAsync((response, chunk, demander) -> demander.run())
             .onResponseFailure((response, failure) -> { /* ... */ })
             .onResponseSuccess(response -> { /* ... */ })
+            .onResponseListener(new Response.Listener() {}) // For all response events.
             // Result hook.
             .send(result -> { /* ... */ });
         // end::listeners[]

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/Request.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/Request.java
@@ -355,8 +355,22 @@ public interface Request
     /**
      * @param listener a listener for request events
      * @return this request object
+     * @deprecated use {@link #onRequestListener} instead.
      */
-    Request listener(Listener listener);
+    @Deprecated(since = "12.0.20", forRemoval = true)
+    default Request listener(Listener listener)
+    {
+        return onRequestListener(listener);
+    }
+
+    /**
+     * @param listener a listener for all request events
+     * @return this request object
+     */
+    default Request onRequestListener(Request.Listener listener)
+    {
+        return this;
+    }
 
     /**
      * @param listener a listener for request queued event
@@ -399,6 +413,15 @@ public interface Request
      * @return this request object
      */
     Request onRequestFailure(FailureListener listener);
+
+    /**
+     * @param listener a listener for all response events
+     * @return this request object
+     */
+    default Request onResponseListener(Response.Listener listener)
+    {
+        return this;
+    }
 
     /**
      * @param listener a listener for response begin event

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpRequest.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpRequest.java
@@ -453,7 +453,7 @@ public class HttpRequest implements Request
     }
 
     @Override
-    public Request listener(Request.Listener listener)
+    public Request onRequestListener(Listener listener)
     {
         requestListeners().addListener(listener);
         return this;
@@ -555,6 +555,13 @@ public class HttpRequest implements Request
         if (requestListeners != null)
             requestListeners.notifyFailure(this, failure);
         getHttpClientRequestListeners().notifyFailure(this, failure);
+    }
+
+    @Override
+    public Request onResponseListener(Response.Listener listener)
+    {
+        responseListeners.addCompleteListener(listener, true);
+        return this;
     }
 
     @Override

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
@@ -1117,6 +1117,7 @@ public class HttpClientTest extends AbstractHttpClientServerTest
                 responseNanoTime = NanoTime.since(queuedNanoTime);
             }
         }
+
         MetricsListener metricsListener = new MetricsListener();
 
         Request request = client.newRequest("localhost", connector.getLocalPort())

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
@@ -87,7 +87,9 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -999,7 +1001,7 @@ public class HttpClientTest extends AbstractHttpClientServerTest
             .onRequestContent(listener)
             .onRequestSuccess(listener)
             .onRequestFailure(listener)
-            .listener(listener)
+            .onRequestListener(listener)
             .send();
 
         assertEquals(200, response.getStatus());
@@ -1090,6 +1092,43 @@ public class HttpClientTest extends AbstractHttpClientServerTest
         int expectedEventsTriggeredBySendListener = 4;
         int expected = expectedEventsTriggeredByResponseListeners + expectedEventsTriggeredBySendListener;
         assertEquals(expected, counter.get());
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testRequestListenerResponseListener(Scenario scenario) throws Exception
+    {
+        start(scenario, new EmptyServerHandler());
+
+        class MetricsListener implements Request.Listener, Response.Listener
+        {
+            private long responseNanoTime;
+
+            @Override
+            public void onQueued(Request request)
+            {
+                request.attribute("queued", NanoTime.now());
+            }
+
+            @Override
+            public void onComplete(Result result)
+            {
+                long queuedNanoTime = (Long)result.getRequest().getAttributes().get("queued");
+                responseNanoTime = NanoTime.since(queuedNanoTime);
+            }
+        }
+        MetricsListener metricsListener = new MetricsListener();
+
+        Request request = client.newRequest("localhost", connector.getLocalPort())
+            .scheme(scenario.getScheme())
+            // Separate orthogonal concerns such as metrics (e.g. responseTime)
+            // from the handling of the response (e.g. accumulate response content).
+            .onRequestListener(metricsListener)
+            .onResponseListener(metricsListener);
+        ContentResponse response = new CompletableResponseListener(request).send().get(5, TimeUnit.SECONDS);
+
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        assertThat(metricsListener.responseNanoTime, greaterThan(0L));
     }
 
     @ParameterizedTest

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpConnectionLifecycleTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpConnectionLifecycleTest.java
@@ -111,7 +111,7 @@ public class HttpConnectionLifecycleTest extends AbstractHttpClientServerTest
         assertEquals(0, connectionPool.getIdleConnections().size());
         assertEquals(0, connectionPool.getActiveConnections().size());
 
-        request.listener(new Request.Listener()
+        request.onRequestListener(new Request.Listener()
         {
             @Override
             public void onBegin(Request request)
@@ -163,7 +163,7 @@ public class HttpConnectionLifecycleTest extends AbstractHttpClientServerTest
         Collection<Connection> activeConnections = connectionPool.getActiveConnections();
         assertEquals(0, activeConnections.size());
 
-        request.listener(new Request.Listener()
+        request.onRequestListener(new Request.Listener()
         {
             @Override
             public void onBegin(Request request)
@@ -223,7 +223,7 @@ public class HttpConnectionLifecycleTest extends AbstractHttpClientServerTest
         assertEquals(0, activeConnections.size());
 
         long delay = 1000;
-        request.listener(new Request.Listener()
+        request.onRequestListener(new Request.Listener()
         {
             @Override
             public void onBegin(Request request)

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpRequestAbortTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpRequestAbortTest.java
@@ -80,7 +80,7 @@ public class HttpRequestAbortTest extends AbstractHttpClientServerTest
         Request request = client.newRequest("localhost", connector.getLocalPort()).scheme(scenario.getScheme());
         ExecutionException x = assertThrows(ExecutionException.class, () ->
         {
-            request.listener(new Request.Listener()
+            request.onRequestListener(new Request.Listener()
             {
                 @Override
                 public void onQueued(Request request)
@@ -126,7 +126,7 @@ public class HttpRequestAbortTest extends AbstractHttpClientServerTest
         Request request = client.newRequest("localhost", connector.getLocalPort()).scheme(scenario.getScheme());
         ExecutionException x = assertThrows(ExecutionException.class, () ->
         {
-            request.listener(new Request.Listener()
+            request.onRequestListener(new Request.Listener()
             {
                 @Override
                 public void onBegin(Request request)
@@ -171,7 +171,7 @@ public class HttpRequestAbortTest extends AbstractHttpClientServerTest
         Request request = client.newRequest("localhost", connector.getLocalPort()).scheme(scenario.getScheme());
         ExecutionException x = assertThrows(ExecutionException.class, () ->
         {
-            request.listener(new Request.Listener()
+            request.onRequestListener(new Request.Listener()
             {
                 @Override
                 public void onHeaders(Request request)

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/http/HttpSenderOverHTTPTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/http/HttpSenderOverHTTPTest.java
@@ -67,7 +67,7 @@ public class HttpSenderOverHTTPTest
         Request request = client.newRequest(URI.create("http://localhost/"));
         final CountDownLatch headersLatch = new CountDownLatch(1);
         final CountDownLatch successLatch = new CountDownLatch(1);
-        request.listener(new Request.Listener()
+        request.onRequestListener(new Request.Listener()
         {
             @Override
             public void onHeaders(Request request)
@@ -129,7 +129,7 @@ public class HttpSenderOverHTTPTest
         HttpConnectionOverHTTP connection = new HttpConnectionOverHTTP(endPoint, destination, new Promise.Adapter<Connection>());
         Request request = client.newRequest(URI.create("http://localhost/"));
         final CountDownLatch failureLatch = new CountDownLatch(2);
-        request.listener(new Request.Listener()
+        request.onRequestListener(new Request.Listener()
         {
             @Override
             public void onFailure(Request request, Throwable x)
@@ -159,7 +159,7 @@ public class HttpSenderOverHTTPTest
         HttpConnectionOverHTTP connection = new HttpConnectionOverHTTP(endPoint, destination, new Promise.Adapter<Connection>());
         Request request = client.newRequest(URI.create("http://localhost/"));
         final CountDownLatch failureLatch = new CountDownLatch(2);
-        request.listener(new Request.Listener()
+        request.onRequestListener(new Request.Listener()
         {
             @Override
             public void onFailure(Request request, Throwable x)
@@ -198,7 +198,7 @@ public class HttpSenderOverHTTPTest
         request.body(new ByteBufferRequestContent(ByteBuffer.wrap(content.getBytes(StandardCharsets.UTF_8))));
         final CountDownLatch headersLatch = new CountDownLatch(1);
         final CountDownLatch successLatch = new CountDownLatch(1);
-        request.listener(new Request.Listener()
+        request.onRequestListener(new Request.Listener()
         {
             @Override
             public void onHeaders(Request request)
@@ -234,7 +234,7 @@ public class HttpSenderOverHTTPTest
         request.body(new ByteBufferRequestContent(ByteBuffer.wrap(content1.getBytes(StandardCharsets.UTF_8)), ByteBuffer.wrap(content2.getBytes(StandardCharsets.UTF_8))));
         final CountDownLatch headersLatch = new CountDownLatch(1);
         final CountDownLatch successLatch = new CountDownLatch(1);
-        request.listener(new Request.Listener()
+        request.onRequestListener(new Request.Listener()
         {
             @Override
             public void onHeaders(Request request)
@@ -277,7 +277,7 @@ public class HttpSenderOverHTTPTest
         });
         final CountDownLatch headersLatch = new CountDownLatch(1);
         final CountDownLatch successLatch = new CountDownLatch(1);
-        request.listener(new Request.Listener()
+        request.onRequestListener(new Request.Listener()
         {
             @Override
             public void onHeaders(Request request)

--- a/jetty-core/jetty-websocket/jetty-websocket-core-client/src/main/java/org/eclipse/jetty/websocket/core/client/CoreClientUpgradeRequest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-client/src/main/java/org/eclipse/jetty/websocket/core/client/CoreClientUpgradeRequest.java
@@ -131,7 +131,7 @@ public abstract class CoreClientUpgradeRequest implements Response.CompleteListe
 
     public void listener(Request.Listener listener)
     {
-        request.listener(listener);
+        request.onRequestListener(listener);
     }
 
     public void headers(Consumer<HttpFields.Mutable> consumer)


### PR DESCRIPTION
Introduced `Request.onResponseListener(Response.Listener)`. 
Introduced `Request.onRequestListener(Request.Listener)` as a replacement for `Request.listener()`, which is now deprecated.