### PR TITLE
Allow the HttpClient in AbstractProxyServlet to configure additional attributes

### DIFF
--- a/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/AbstractProxyServlet.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/AbstractProxyServlet.java
@@ -309,6 +309,14 @@ public abstract class AbstractProxyServlet extends HttpServlet
             value = "256";
         client.setMaxConnectionsPerDestination(Integer.parseInt(value));
 
+        value = getInitParameter("maxRequestHeadersSize");
+        if (value != null)
+            client.setMaxRequestHeadersSize(Integer.parseInt(value));
+
+        value = getInitParameter("maxResponseHeadersSize");
+        if (value != null)
+            client.setMaxResponseHeadersSize(Integer.parseInt(value));
+
         value = config.getInitParameter("idleTimeout");
         if (value == null)
             value = "30000";

--- a/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/AbstractProxyServlet.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/AbstractProxyServlet.java
@@ -307,6 +307,14 @@ public abstract class AbstractProxyServlet extends HttpServlet
             value = "256";
         client.setMaxConnectionsPerDestination(Integer.parseInt(value));
 
+        value = getInitParameter("maxRequestHeadersSize");
+        if (value != null)
+            client.setMaxRequestHeadersSize(Integer.parseInt(value));
+
+        value = getInitParameter("maxResponseHeadersSize");
+        if (value != null)
+            client.setMaxResponseHeadersSize(Integer.parseInt(value));
+
         value = config.getInitParameter("idleTimeout");
         if (value == null)
             value = "30000";


### PR DESCRIPTION
Allow the `HttpClient` in `AbstractProxyServlet` to configure additional attributes

- Configure `HttpClient` `maxRequestHeadersSize` if present
- Configure `HttpClient` `maxResponseHeadersSize` if present
- For EE9 `AbstractProxyServlet`
- For EE10 `AbstractProxyServlet`
- Note that the EE8 `AbstractProxyServlet` class is generated
- This is needed to avoid adding code in a custom subclass after porting our app from 12.0.16 to 12.0.19