### PR TITLE
Improve `EagerContentHandler`

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/EagerContentHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/EagerContentHandler.java
@@ -437,18 +437,25 @@ public class EagerContentHandler extends ConditionalHandler.ElseNext
         private final int _framingOverhead;
         private final boolean _reject;
 
+        /**
+         * Creates a {@code RetainedContentLoaderFactory} with heuristically determined values for the maximum number
+         * bytes to retain and the number of bytes to include in the estimated size per {@link Content.Chunk} to allow
+         * for framing overheads in the transport and no rejection of the request when the maximum number bytes to
+         * retain is exceeded.
+         */
         public RetainedContentLoaderFactory()
         {
-            this(-1, -1, true);
+            this(-1, -1, false);
         }
 
         /**
+         * Creates a {@code RetainedContentLoaderFactory}.
          * @param maxRetainedBytes the maximum number bytes to retain whilst eagerly loading, which
          *                         includes the content bytes and any {@code framingOverhead} per chunk;
          *                         or -1 for a heuristically determined value that will not increase memory commitment.
          * @param framingOverhead the number of bytes to include in the estimated size per {@link Content.Chunk} to allow
          *                      for framing overheads in the transport. Since the content is retained rather than copied, any
-         *                      framing data is also retained in the IO buffer.
+         *                      framing data is also retained in the IO buffer; or -1 for a heuristically determined value.
          * @param reject if {@code true}, then if {@code maxRetainBytes} is exceeded, the request is rejected with a
          *               {@link HttpStatus#PAYLOAD_TOO_LARGE_413} response.
          */

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/HugeResourceTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/HugeResourceTest.java
@@ -219,11 +219,7 @@ public class HugeResourceTest
         ServletHolder holder = context.addServlet(MultipartServlet.class, "/multipart");
         holder.getRegistration().setMultipartConfig(multipartConfig);
 
-        EagerContentHandler eagerContentHandler = new EagerContentHandler(
-            new EagerContentHandler.FormContentLoaderFactory(),
-            new EagerContentHandler.MultiPartContentLoaderFactory(),
-            new EagerContentHandler.RetainedContentLoaderFactory(-1, -1, false)
-        );
+        EagerContentHandler eagerContentHandler = new EagerContentHandler();
         server.setHandler(eagerContentHandler);
         httpConfig.setDelayDispatchUntilContent(false);
 

--- a/jetty-ee11/jetty-ee11-webapp/src/test/java/org/eclipse/jetty/ee11/webapp/HugeResourceTest.java
+++ b/jetty-ee11/jetty-ee11-webapp/src/test/java/org/eclipse/jetty/ee11/webapp/HugeResourceTest.java
@@ -219,11 +219,7 @@ public class HugeResourceTest
         ServletHolder holder = context.addServlet(MultipartServlet.class, "/multipart");
         holder.getRegistration().setMultipartConfig(multipartConfig);
 
-        EagerContentHandler eagerContentHandler = new EagerContentHandler(
-            new EagerContentHandler.FormContentLoaderFactory(),
-            new EagerContentHandler.MultiPartContentLoaderFactory(),
-            new EagerContentHandler.RetainedContentLoaderFactory(-1, -1, false)
-        );
+        EagerContentHandler eagerContentHandler = new EagerContentHandler();
         server.setHandler(eagerContentHandler);
         httpConfig.setDelayDispatchUntilContent(false);
 


### PR DESCRIPTION
Change the default to not reject requests, as the `EagerContentHandler` javadoc does not speak about this (only the `RetainedContentLoaderFactory` constructor does) and I find it to be an overly restrictive and surprising (as in: breaks your code in non-obvious way) default value.

I've also slightly improved the `RetainedContentLoaderFactory` javadoc.

Fixes #13002