### PR TITLE
Fix `SessionHandlerTest.testFlushOnResponseCommit` and modify `GracefulHandler` to also track `HttpStream` wrappers

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/GracefulHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/GracefulHandler.java
@@ -15,8 +15,8 @@ package org.eclipse.jetty.server.handler;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
-
 import java.util.function.Function;
+
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpStream;

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/GracefulHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/GracefulHandler.java
@@ -120,7 +120,6 @@ public class GracefulHandler extends Handler.Wrapper implements Graceful
     {
         super.doStop();
         _shutdown.cancel();
-        _requests.set(0L);
     }
 
     @Override

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/GracefulHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/GracefulHandler.java
@@ -14,7 +14,7 @@
 package org.eclipse.jetty.server.handler;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.LongAdder;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.Handler;
@@ -34,7 +34,7 @@ public class GracefulHandler extends Handler.Wrapper implements Graceful
 {
     private static final Logger LOG = LoggerFactory.getLogger(GracefulHandler.class);
 
-    private final LongAdder _requests = new LongAdder();
+    private final AtomicLong _requests = new AtomicLong();
     private final Shutdown _shutdown;
 
     public GracefulHandler()
@@ -61,7 +61,7 @@ public class GracefulHandler extends Handler.Wrapper implements Graceful
     @ManagedAttribute("number of requests being currently handled")
     public long getCurrentRequestCount()
     {
-        return _requests.sum();
+        return _requests.longValue();
     }
 
     /**
@@ -116,6 +116,14 @@ public class GracefulHandler extends Handler.Wrapper implements Graceful
     }
 
     @Override
+    protected void doStop() throws Exception
+    {
+        super.doStop();
+        _shutdown.cancel();
+        _requests.set(0L);
+    }
+
+    @Override
     public CompletableFuture<Void> shutdown()
     {
         if (LOG.isDebugEnabled())
@@ -133,13 +141,13 @@ public class GracefulHandler extends Handler.Wrapper implements Graceful
             super(callback, 1);
             this.request = request;
             this.response = response;
-            _requests.increment();
+            _requests.incrementAndGet();
         }
 
         @Override
         public void completed()
         {
-            _requests.decrement();
+            _requests.decrementAndGet();
             if (isShutdown())
                 _shutdown.check();
         }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/GracefulHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/GracefulHandler.java
@@ -16,8 +16,10 @@ package org.eclipse.jetty.server.handler;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
 
+import java.util.function.Function;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.HttpStream;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
@@ -35,6 +37,7 @@ public class GracefulHandler extends Handler.Wrapper implements Graceful
     private static final Logger LOG = LoggerFactory.getLogger(GracefulHandler.class);
 
     private final AtomicLong _requests = new AtomicLong();
+    private final AtomicLong _streamWrappers = new AtomicLong();
     private final Shutdown _shutdown;
 
     public GracefulHandler()
@@ -50,10 +53,11 @@ public class GracefulHandler extends Handler.Wrapper implements Graceful
             @Override
             public boolean isShutdownDone()
             {
-                long count = getCurrentRequestCount();
+                long requestCount = getCurrentRequestCount();
+                long streamWrapperCount = getCurrentStreamWrapperCount();
                 if (LOG.isDebugEnabled())
-                    LOG.debug("isShutdownDone: count {}", count);
-                return count == 0;
+                    LOG.debug("isShutdownDone: requestCount {} streamWrapperCount {}", requestCount, streamWrapperCount);
+                return requestCount == 0L && streamWrapperCount == 0L;
             }
         };
     }
@@ -62,6 +66,12 @@ public class GracefulHandler extends Handler.Wrapper implements Graceful
     public long getCurrentRequestCount()
     {
         return _requests.longValue();
+    }
+
+    @ManagedAttribute("number of stream wrappers currently pending")
+    public long getCurrentStreamWrapperCount()
+    {
+        return _streamWrappers.longValue();
     }
 
     /**
@@ -79,6 +89,7 @@ public class GracefulHandler extends Handler.Wrapper implements Graceful
     @Override
     public boolean handle(Request request, Response response, Callback callback) throws Exception
     {
+        request = new ShutdownTrackingRequest(request);
         Handler handler = getHandler();
         if (handler == null || !isStarted())
         {
@@ -149,6 +160,59 @@ public class GracefulHandler extends Handler.Wrapper implements Graceful
             _requests.decrementAndGet();
             if (isShutdown())
                 _shutdown.check();
+        }
+    }
+
+    private class ShutdownTrackingRequest extends Request.Wrapper
+    {
+        public ShutdownTrackingRequest(Request wrapped)
+        {
+            super(wrapped);
+        }
+
+        @Override
+        public void addHttpStreamWrapper(Function<HttpStream, HttpStream> wrapper)
+        {
+            super.addHttpStreamWrapper(httpStream ->
+            {
+                HttpStream wrapped = wrapper.apply(httpStream);
+                _streamWrappers.incrementAndGet();
+                return new HttpStream.Wrapper(wrapped)
+                {
+                    @Override
+                    public void succeeded()
+                    {
+                        try
+                        {
+                            super.succeeded();
+                        }
+                        finally
+                        {
+                            onCompletion(null);
+                        }
+                    }
+
+                    @Override
+                    public void failed(Throwable x)
+                    {
+                        try
+                        {
+                            super.failed(x);
+                        }
+                        finally
+                        {
+                            onCompletion(x);
+                        }
+                    }
+
+                    private void onCompletion(Throwable x)
+                    {
+                        _streamWrappers.decrementAndGet();
+                        if (isShutdown())
+                            _shutdown.check();
+                    }
+                };
+            });
         }
     }
 }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/GracefulHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/GracefulHandler.java
@@ -127,10 +127,11 @@ public class GracefulHandler extends Handler.Wrapper implements Graceful
     }
 
     @Override
-    protected void doStop() throws Exception
+    protected void doStart() throws Exception
     {
-        super.doStop();
+        // Reset _shutdown in doStart instead of doStop so that the isShutdown() == true state is preserved while stopped.
         _shutdown.cancel();
+        super.doStart();
     }
 
     @Override

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/GracefulHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/GracefulHandlerTest.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.jetty.http.HttpHeader;
@@ -695,6 +696,92 @@ public class GracefulHandlerTest
         assertThat(response.getContent(), is("(Read:10) (Content-Length:10)"));
 
         client0.close();
+    }
+
+    @Test
+    public void testGracefulAlsoWaitsForStreamWrappers() throws Exception
+    {
+        GracefulHandler gracefulHandler = new GracefulHandler();
+        LatchedStreamWrappingHandler handler = new LatchedStreamWrappingHandler();
+        gracefulHandler.setHandler(handler);
+        server = createServer(gracefulHandler);
+        server.setStopTimeout(10000);
+        server.start();
+
+        // Complete request
+        String rawRequest = """
+            GET /?num=%d HTTP/1.1\r
+            Host: localhost\r
+            Content-Type: text/plain\r
+            \r
+            """;
+
+        Socket client0 = newSocketToServer("client0");
+        OutputStream output0 = client0.getOutputStream();
+        HttpTester.Response response;
+
+        // Send one normal request to server
+        output0.write(rawRequest.formatted(1).getBytes(StandardCharsets.UTF_8));
+        output0.flush();
+
+        // Verify response
+        response = HttpTester.parseResponse(client0.getInputStream());
+        assertNotNull(response);
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        assertThat(response.get(HttpHeader.CONNECTION), is(nullValue()));
+
+        // Trigger stop
+        CompletableFuture<Long> stopFuture = runAsyncServerStop();
+
+        // Verify shutdown does not happen while a stream wrapper is pending
+        await().during(1, TimeUnit.SECONDS).atMost(5, TimeUnit.SECONDS).until(() -> gracefulHandler.getCurrentStreamWrapperCount() > 0);
+
+        // Unblock shutdown
+        handler.latch.countDown();
+
+        // Verify shutdown is done
+        await().atMost(5, TimeUnit.SECONDS).until(() ->
+        {
+            long currentRequestCount = gracefulHandler.getCurrentRequestCount();
+            long currentStreamWrapperCount = gracefulHandler.getCurrentStreamWrapperCount();
+            return currentRequestCount == 0 && currentStreamWrapperCount == 0;
+        });
+
+        // Verify Stop duration
+        long stopDuration = stopFuture.get();
+        assertThat(stopDuration, lessThan(5000L));
+    }
+
+    static class LatchedStreamWrappingHandler extends Handler.Abstract
+    {
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        @Override
+        public boolean handle(Request request, Response response, Callback callback) throws Exception
+        {
+            System.out.println("Xhandle");
+            LOG.debug("process: request={}", request);
+            request.addHttpStreamWrapper(s -> new HttpStream.Wrapper(s)
+            {
+                @Override
+                public void succeeded()
+                {
+                    try
+                    {
+                        if (!latch.await(5, TimeUnit.SECONDS))
+                            throw new TimeoutException();
+                        super.succeeded();
+                    }
+                    catch (Throwable x)
+                    {
+                        super.failed(x);
+                    }
+                }
+            });
+            Integer num = Request.getParameters(request).get("num").getValueAsInt();
+            Content.Sink.write(response, true, "the body #" + num, callback);
+            return true;
+        }
     }
 
     /**

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/GracefulHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/GracefulHandlerTest.java
@@ -759,7 +759,6 @@ public class GracefulHandlerTest
         @Override
         public boolean handle(Request request, Response response, Callback callback) throws Exception
         {
-            System.out.println("Xhandle");
             LOG.debug("process: request={}", request);
             request.addHttpStreamWrapper(s -> new HttpStream.Wrapper(s)
             {

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/GracefulHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/GracefulHandlerTest.java
@@ -676,6 +676,25 @@ public class GracefulHandlerTest
         // The socket should have been closed
         assertThat(client0 + " not closed", in.read(), is(-1));
         assertThat(client0 + " close took too long", NanoTime.millisSince(beginClose), lessThan(2000L));
+
+        // Restart the server to make sure handling resumes normally
+        server.start();
+
+        client0 = newSocketToServer("client0");
+        output0 = client0.getOutputStream();
+
+        // Send one normal request to server
+        output0.write(rawRequest.formatted(1).getBytes(StandardCharsets.UTF_8));
+        output0.flush();
+
+        // Verify response
+        response = HttpTester.parseResponse(client0.getInputStream());
+        assertNotNull(response);
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        assertThat(response.get(HttpHeader.CONNECTION), is(nullValue()));
+        assertThat(response.getContent(), is("(Read:10) (Content-Length:10)"));
+
+        client0.close();
     }
 
     /**

--- a/jetty-core/jetty-session/src/main/java/org/eclipse/jetty/session/AbstractSessionManager.java
+++ b/jetty-core/jetty-session/src/main/java/org/eclipse/jetty/session/AbstractSessionManager.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -1208,15 +1209,49 @@ public abstract class AbstractSessionManager extends ContainerLifeCycle implemen
             }
         }
     }
-    
+
+    private final AtomicInteger inFlightRequestCounter = new AtomicInteger();
+
     protected void addSessionStreamWrapper(Request request)
     {
-        request.addHttpStreamWrapper(s -> new SessionStreamWrapper(s, this, request));
+        inFlightRequestCounter.incrementAndGet();
+        request.addHttpStreamWrapper(s -> new SessionStreamWrapper(s, this, request)
+        {
+            @Override
+            public void failed(Throwable x)
+            {
+                try
+                {
+                    super.failed(x);
+                }
+                finally
+                {
+                    inFlightRequestCounter.decrementAndGet();
+                }
+            }
+
+            @Override
+            public void succeeded()
+            {
+                try
+                {
+                    super.succeeded();
+                }
+                finally
+                {
+                    inFlightRequestCounter.decrementAndGet();
+                }
+            }
+        });
     }
 
     @Override
     protected void doStop() throws Exception
     {
+        // SUPER HACKY!!
+        while (inFlightRequestCounter.get() != 0)
+            Thread.onSpinWait();
+
         // Destroy sessions before destroying servlets/filters see JETTY-1266
         shutdownSessions();
         _sessionCache.stop();

--- a/jetty-core/jetty-session/src/main/java/org/eclipse/jetty/session/AbstractSessionManager.java
+++ b/jetty-core/jetty-session/src/main/java/org/eclipse/jetty/session/AbstractSessionManager.java
@@ -89,7 +89,7 @@ public abstract class AbstractSessionManager extends ContainerLifeCycle implemen
     private int _refreshCookieAge;
     private boolean _checkingRemoteSessionIdEncoding;
     private List<Session.LifeCycleListener> _sessionLifeCycleListeners = Collections.emptyList();
-    private final AtomicLong _inFlightRequestCounter = new AtomicLong();
+    private final AtomicLong _requests = new AtomicLong();
     private final Shutdown _shutdown;
 
     public AbstractSessionManager()
@@ -99,7 +99,7 @@ public abstract class AbstractSessionManager extends ContainerLifeCycle implemen
             @Override
             public boolean isShutdownDone()
             {
-                long count = _inFlightRequestCounter.get();
+                long count = _requests.get();
                 if (LOG.isDebugEnabled())
                     LOG.debug("isShutdownDone: count {}", count);
                 return count == 0;
@@ -1227,7 +1227,7 @@ public abstract class AbstractSessionManager extends ContainerLifeCycle implemen
 
     protected void addSessionStreamWrapper(Request request)
     {
-        _inFlightRequestCounter.incrementAndGet();
+        _requests.incrementAndGet();
         request.addHttpStreamWrapper(s -> new SessionStreamWrapper(s, this, request)
         {
             @Override
@@ -1258,7 +1258,7 @@ public abstract class AbstractSessionManager extends ContainerLifeCycle implemen
 
             private void complete()
             {
-                _inFlightRequestCounter.decrementAndGet();
+                _requests.decrementAndGet();
                 if (isShutdown())
                     _shutdown.check();
             }

--- a/jetty-core/jetty-session/src/main/java/org/eclipse/jetty/session/AbstractSessionManager.java
+++ b/jetty-core/jetty-session/src/main/java/org/eclipse/jetty/session/AbstractSessionManager.java
@@ -89,7 +89,7 @@ public abstract class AbstractSessionManager extends ContainerLifeCycle implemen
     private int _refreshCookieAge;
     private boolean _checkingRemoteSessionIdEncoding;
     private List<Session.LifeCycleListener> _sessionLifeCycleListeners = Collections.emptyList();
-    private final AtomicLong _requests = new AtomicLong();
+    private final AtomicLong _streamWrappers = new AtomicLong();
     private final Shutdown _shutdown;
 
     public AbstractSessionManager()
@@ -99,7 +99,7 @@ public abstract class AbstractSessionManager extends ContainerLifeCycle implemen
             @Override
             public boolean isShutdownDone()
             {
-                long count = _requests.get();
+                long count = _streamWrappers.get();
                 if (LOG.isDebugEnabled())
                     LOG.debug("isShutdownDone: count {}", count);
                 return count == 0;
@@ -1227,42 +1227,7 @@ public abstract class AbstractSessionManager extends ContainerLifeCycle implemen
 
     protected void addSessionStreamWrapper(Request request)
     {
-        _requests.incrementAndGet();
-        request.addHttpStreamWrapper(s -> new SessionStreamWrapper(s, this, request)
-        {
-            @Override
-            public void failed(Throwable x)
-            {
-                try
-                {
-                    super.failed(x);
-                }
-                finally
-                {
-                    complete();
-                }
-            }
-
-            @Override
-            public void succeeded()
-            {
-                try
-                {
-                    super.succeeded();
-                }
-                finally
-                {
-                    complete();
-                }
-            }
-
-            private void complete()
-            {
-                _requests.decrementAndGet();
-                if (isShutdown())
-                    _shutdown.check();
-            }
-        });
+        request.addHttpStreamWrapper(s -> new SessionStreamWrapper(s, this, request));
     }
 
     @Override
@@ -1534,14 +1499,22 @@ public abstract class AbstractSessionManager extends ContainerLifeCycle implemen
             _sessionManager = sessionManager;
             _request = request;
             _context = _request.getContext();
+            _streamWrappers.incrementAndGet();
         }
 
         @Override
         public void failed(Throwable x)
         {
-            //Leave session
-            _context.run(this::doComplete, _request);
-            super.failed(x);
+            try
+            {
+                // Leave session
+                _context.run(this::doComplete, _request);
+                super.failed(x);
+            }
+            finally
+            {
+                onStreamWrapperComplete();
+            }
         }
 
         @Override
@@ -1558,9 +1531,23 @@ public abstract class AbstractSessionManager extends ContainerLifeCycle implemen
         @Override
         public void succeeded()
         {
-            // Leave session
-            _context.run(this::doComplete, _request);
-            super.succeeded();
+            try
+            {
+                // Leave session
+                _context.run(this::doComplete, _request);
+                super.succeeded();
+            }
+            finally
+            {
+                onStreamWrapperComplete();
+            }
+        }
+
+        private void onStreamWrapperComplete()
+        {
+            _streamWrappers.decrementAndGet();
+            if (isShutdown())
+                _shutdown.check();
         }
 
         private void doCommit()

--- a/jetty-core/jetty-session/src/main/java/org/eclipse/jetty/session/AbstractSessionManager.java
+++ b/jetty-core/jetty-session/src/main/java/org/eclipse/jetty/session/AbstractSessionManager.java
@@ -23,9 +23,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -46,6 +47,7 @@ import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
+import org.eclipse.jetty.util.component.Graceful;
 import org.eclipse.jetty.util.statistic.CounterStatistic;
 import org.eclipse.jetty.util.statistic.SampleStatistic;
 import org.eclipse.jetty.util.thread.AutoLock;
@@ -58,7 +60,7 @@ import org.slf4j.LoggerFactory;
  * AbstractSessionHandler
  * Class to implement most non-servlet-spec specific session behaviour.
  */
-public abstract class AbstractSessionManager extends ContainerLifeCycle implements SessionManager, SessionConfig.Mutable
+public abstract class AbstractSessionManager extends ContainerLifeCycle implements SessionManager, SessionConfig.Mutable, Graceful
 {
     static final Logger LOG = LoggerFactory.getLogger(AbstractSessionManager.class);
     private final Set<String> _candidateSessionIdsForExpiry = ConcurrentHashMap.newKeySet();
@@ -87,9 +89,22 @@ public abstract class AbstractSessionManager extends ContainerLifeCycle implemen
     private int _refreshCookieAge;
     private boolean _checkingRemoteSessionIdEncoding;
     private List<Session.LifeCycleListener> _sessionLifeCycleListeners = Collections.emptyList();
+    private final AtomicLong _inFlightRequestCounter = new AtomicLong();
+    private final Shutdown _shutdown;
 
     public AbstractSessionManager()
     {
+        _shutdown = new Shutdown(this)
+        {
+            @Override
+            public boolean isShutdownDone()
+            {
+                long count = _inFlightRequestCounter.get();
+                if (LOG.isDebugEnabled())
+                    LOG.debug("isShutdownDone: count {}", count);
+                return count == 0;
+            }
+        };
     }
     
     /**
@@ -1210,11 +1225,9 @@ public abstract class AbstractSessionManager extends ContainerLifeCycle implemen
         }
     }
 
-    private final AtomicInteger inFlightRequestCounter = new AtomicInteger();
-
     protected void addSessionStreamWrapper(Request request)
     {
-        inFlightRequestCounter.incrementAndGet();
+        _inFlightRequestCounter.incrementAndGet();
         request.addHttpStreamWrapper(s -> new SessionStreamWrapper(s, this, request)
         {
             @Override
@@ -1226,7 +1239,7 @@ public abstract class AbstractSessionManager extends ContainerLifeCycle implemen
                 }
                 finally
                 {
-                    inFlightRequestCounter.decrementAndGet();
+                    complete();
                 }
             }
 
@@ -1239,19 +1252,34 @@ public abstract class AbstractSessionManager extends ContainerLifeCycle implemen
                 }
                 finally
                 {
-                    inFlightRequestCounter.decrementAndGet();
+                    complete();
                 }
+            }
+
+            private void complete()
+            {
+                _inFlightRequestCounter.decrementAndGet();
+                if (isShutdown())
+                    _shutdown.check();
             }
         });
     }
 
     @Override
+    public CompletableFuture<Void> shutdown()
+    {
+        return _shutdown.shutdown();
+    }
+
+    @Override
+    public boolean isShutdown()
+    {
+        return _shutdown.isShutdown();
+    }
+
+    @Override
     protected void doStop() throws Exception
     {
-        // SUPER HACKY!!
-        while (inFlightRequestCounter.get() != 0)
-            Thread.onSpinWait();
-
         // Destroy sessions before destroying servlets/filters see JETTY-1266
         shutdownSessions();
         _sessionCache.stop();
@@ -1262,6 +1290,7 @@ public abstract class AbstractSessionManager extends ContainerLifeCycle implemen
         _loader = null;
         removeBean(_sessionLifeCycleListeners);
         _sessionLifeCycleListeners = Collections.emptyList();
+        _shutdown.cancel();
     }
 
     /**

--- a/jetty-core/jetty-session/src/main/java/org/eclipse/jetty/session/AbstractSessionManager.java
+++ b/jetty-core/jetty-session/src/main/java/org/eclipse/jetty/session/AbstractSessionManager.java
@@ -23,10 +23,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -47,7 +45,6 @@ import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
-import org.eclipse.jetty.util.component.Graceful;
 import org.eclipse.jetty.util.statistic.CounterStatistic;
 import org.eclipse.jetty.util.statistic.SampleStatistic;
 import org.eclipse.jetty.util.thread.AutoLock;
@@ -60,7 +57,7 @@ import org.slf4j.LoggerFactory;
  * AbstractSessionHandler
  * Class to implement most non-servlet-spec specific session behaviour.
  */
-public abstract class AbstractSessionManager extends ContainerLifeCycle implements SessionManager, SessionConfig.Mutable, Graceful
+public abstract class AbstractSessionManager extends ContainerLifeCycle implements SessionManager, SessionConfig.Mutable
 {
     static final Logger LOG = LoggerFactory.getLogger(AbstractSessionManager.class);
     private final Set<String> _candidateSessionIdsForExpiry = ConcurrentHashMap.newKeySet();
@@ -89,22 +86,9 @@ public abstract class AbstractSessionManager extends ContainerLifeCycle implemen
     private int _refreshCookieAge;
     private boolean _checkingRemoteSessionIdEncoding;
     private List<Session.LifeCycleListener> _sessionLifeCycleListeners = Collections.emptyList();
-    private final AtomicLong _streamWrappers = new AtomicLong();
-    private final Shutdown _shutdown;
 
     public AbstractSessionManager()
     {
-        _shutdown = new Shutdown(this)
-        {
-            @Override
-            public boolean isShutdownDone()
-            {
-                long count = _streamWrappers.get();
-                if (LOG.isDebugEnabled())
-                    LOG.debug("isShutdownDone: count {}", count);
-                return count == 0;
-            }
-        };
     }
     
     /**
@@ -1224,22 +1208,10 @@ public abstract class AbstractSessionManager extends ContainerLifeCycle implemen
             }
         }
     }
-
+    
     protected void addSessionStreamWrapper(Request request)
     {
         request.addHttpStreamWrapper(s -> new SessionStreamWrapper(s, this, request));
-    }
-
-    @Override
-    public CompletableFuture<Void> shutdown()
-    {
-        return _shutdown.shutdown();
-    }
-
-    @Override
-    public boolean isShutdown()
-    {
-        return _shutdown.isShutdown();
     }
 
     @Override
@@ -1255,7 +1227,6 @@ public abstract class AbstractSessionManager extends ContainerLifeCycle implemen
         _loader = null;
         removeBean(_sessionLifeCycleListeners);
         _sessionLifeCycleListeners = Collections.emptyList();
-        _shutdown.cancel();
     }
 
     /**
@@ -1499,22 +1470,14 @@ public abstract class AbstractSessionManager extends ContainerLifeCycle implemen
             _sessionManager = sessionManager;
             _request = request;
             _context = _request.getContext();
-            _streamWrappers.incrementAndGet();
         }
 
         @Override
         public void failed(Throwable x)
         {
-            try
-            {
-                // Leave session
-                _context.run(this::doComplete, _request);
-                super.failed(x);
-            }
-            finally
-            {
-                onStreamWrapperComplete();
-            }
+            //Leave session
+            _context.run(this::doComplete, _request);
+            super.failed(x);
         }
 
         @Override
@@ -1531,23 +1494,9 @@ public abstract class AbstractSessionManager extends ContainerLifeCycle implemen
         @Override
         public void succeeded()
         {
-            try
-            {
-                // Leave session
-                _context.run(this::doComplete, _request);
-                super.succeeded();
-            }
-            finally
-            {
-                onStreamWrapperComplete();
-            }
-        }
-
-        private void onStreamWrapperComplete()
-        {
-            _streamWrappers.decrementAndGet();
-            if (isShutdown())
-                _shutdown.check();
+            // Leave session
+            _context.run(this::doComplete, _request);
+            super.succeeded();
         }
 
         private void doCommit()


### PR DESCRIPTION
Make sure `SessionDataStore` instances are not stopped before all in-flight session requests have not been finished.

This requires modifying `GracefulHandler` as it currently only tracks completion of the `Callback`, not of the stream wrappers that are used to update the sessions.

This also requires fixing a bug in `GracefulHandler` so that it resets its state after a stop/start cycle instead of being stuck serving 503's.

Plus another bug that involves replacing the request counter from a `LongAdder` to an `AtomicLong` as a precise value is needed for this mechanism to work reliably.

Closes #13031