### PR TITLE
Issue #13029 - clear out inflater/deflater buffers when input consumed

### DIFF
--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/PerMessageDeflateExtension.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/PerMessageDeflateExtension.java
@@ -326,6 +326,7 @@ public class PerMessageDeflateExtension extends AbstractExtension implements Dem
 
                 if (compressed == 0)
                 {
+                    deflater.setInput(BufferUtil.EMPTY_BUFFER);
                     finished = true;
                     break;
                 }
@@ -459,6 +460,7 @@ public class PerMessageDeflateExtension extends AbstractExtension implements Dem
                         continue;
                     }
 
+                    inflater.setInput(BufferUtil.EMPTY_BUFFER);
                     complete = true;
                     break;
                 }

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/PerMessageDeflateExtension.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/PerMessageDeflateExtension.java
@@ -292,6 +292,13 @@ public class PerMessageDeflateExtension extends AbstractExtension implements Dem
         {
             boolean finished = deflate(callback);
             _first = false;
+
+            if (finished)
+            {
+                _frame = null;
+                getDeflater().setInput(BufferUtil.EMPTY_BUFFER);
+            }
+
             return finished;
         }
 
@@ -326,7 +333,6 @@ public class PerMessageDeflateExtension extends AbstractExtension implements Dem
 
                 if (compressed == 0)
                 {
-                    deflater.setInput(BufferUtil.EMPTY_BUFFER);
                     finished = true;
                     break;
                 }


### PR DESCRIPTION
fixes #13029

This prevents the inflater/deflater from holding a reference to the frames buffer when it is fully consumed and awaiting the next frame/message.

I could not find a way to write a test case for this, but tested manually by accessing the `DeflaterPool`,  getting the `Deflater` used by the websocket session, and using reflection to view its internal buffer.