### PR TITLE
Issue #13004 - Warn for bounded thread pool queues

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/BlockingArrayQueue.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/BlockingArrayQueue.java
@@ -27,16 +27,16 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
- * A BlockingQueue backed by a circular array capable or growing.
+ * A BlockingQueue backed by a circular array capable of growing.
  * <p>
  * This queue is uses a variant of the two lock queue algorithm to provide an efficient queue or list backed by a growable circular array.
  * </p>
  * <p>
- * Unlike {@link java.util.concurrent.ArrayBlockingQueue}, this class is able to grow and provides a blocking put call.
+ * Unlike {@link java.util.concurrent.ArrayBlockingQueue}, this class is able to grow and provides a blocking {@link #put(Object)} call.
  * </p>
  * <p>
- * The queue has both a capacity (the size of the array currently allocated) and a max capacity (the maximum size that may be allocated), which defaults to
- * {@link Integer#MAX_VALUE}.
+ * The queue has both a capacity (the size of the array currently allocated) and a max capacity (the maximum size that may be allocated),
+ * which defaults to {@link Integer#MAX_VALUE}.
  * </p>
  *
  * @param <E> The element type
@@ -127,17 +127,14 @@ public class BlockingArrayQueue<E> extends AbstractList<E> implements BlockingQu
         _maxCapacity = maxCapacity;
     }
 
-
     /* Collection methods */
 
     @Override
     public void clear()
     {
-
         _tailLock.lock();
         try
         {
-
             _headLock.lock();
             try
             {
@@ -167,7 +164,6 @@ public class BlockingArrayQueue<E> extends AbstractList<E> implements BlockingQu
     {
         return listIterator();
     }
-
 
     /* Queue methods */
 
@@ -205,8 +201,6 @@ public class BlockingArrayQueue<E> extends AbstractList<E> implements BlockingQu
     public E poll(long time, TimeUnit unit) throws InterruptedException
     {
         long nanos = unit.toNanos(time);
-        E e = null;
-
         _headLock.lockInterruptibly(); // Size cannot shrink
         try
         {
@@ -226,18 +220,19 @@ public class BlockingArrayQueue<E> extends AbstractList<E> implements BlockingQu
             }
 
             int head = _indexes[HEAD_OFFSET];
-            e = (E)_elements[head];
+            E e = (E)_elements[head];
             _elements[head] = null;
             _indexes[HEAD_OFFSET] = (head + 1) % _elements.length;
 
             if (_size.decrementAndGet() > 0)
                 _notEmpty.signal();
+
+            return e;
         }
         finally
         {
             _headLock.unlock();
         }
-        return e;
     }
 
     @SuppressWarnings("unchecked")
@@ -275,11 +270,9 @@ public class BlockingArrayQueue<E> extends AbstractList<E> implements BlockingQu
     @Override
     public E remove(int index)
     {
-
         _tailLock.lock();
         try
         {
-
             _headLock.lock();
             try
             {
@@ -332,11 +325,9 @@ public class BlockingArrayQueue<E> extends AbstractList<E> implements BlockingQu
     @Override
     public boolean remove(Object o)
     {
-
         _tailLock.lock();
         try
         {
-
             _headLock.lock();
             try
             {
@@ -382,7 +373,6 @@ public class BlockingArrayQueue<E> extends AbstractList<E> implements BlockingQu
         return e;
     }
 
-
     /* BlockingQueue methods */
 
     @Override
@@ -390,7 +380,7 @@ public class BlockingArrayQueue<E> extends AbstractList<E> implements BlockingQu
     {
         Objects.requireNonNull(e);
 
-        boolean notEmpty = false;
+        boolean notEmpty;
         _tailLock.lock(); // Size cannot grow... only shrink
         try
         {
@@ -465,7 +455,6 @@ public class BlockingArrayQueue<E> extends AbstractList<E> implements BlockingQu
         _tailLock.lock();
         try
         {
-
             _headLock.lock();
             try
             {
@@ -535,8 +524,6 @@ public class BlockingArrayQueue<E> extends AbstractList<E> implements BlockingQu
     @Override
     public E take() throws InterruptedException
     {
-        E e = null;
-
         _headLock.lockInterruptibly(); // Size cannot shrink
         try
         {
@@ -554,32 +541,34 @@ public class BlockingArrayQueue<E> extends AbstractList<E> implements BlockingQu
             }
 
             final int head = _indexes[HEAD_OFFSET];
-            e = (E)_elements[head];
+            E e = (E)_elements[head];
             _elements[head] = null;
             _indexes[HEAD_OFFSET] = (head + 1) % _elements.length;
 
             if (_size.decrementAndGet() > 0)
                 _notEmpty.signal();
+
+            return e;
         }
         finally
         {
             _headLock.unlock();
         }
-        return e;
     }
 
     @Override
     public int remainingCapacity()
     {
-
         _tailLock.lock();
         try
         {
-
             _headLock.lock();
             try
             {
-                return getCapacity() - size();
+                int maxCapacity = getMaxCapacity();
+                if (maxCapacity == Integer.MAX_VALUE)
+                    return Integer.MAX_VALUE;
+                return maxCapacity - size();
             }
             finally
             {
@@ -652,14 +641,12 @@ public class BlockingArrayQueue<E> extends AbstractList<E> implements BlockingQu
         return elements;
     }
 
-
     /* List methods */
 
     @SuppressWarnings("unchecked")
     @Override
     public E get(int index)
     {
-
         _tailLock.lock();
         try
         {
@@ -694,7 +681,6 @@ public class BlockingArrayQueue<E> extends AbstractList<E> implements BlockingQu
         _tailLock.lock();
         try
         {
-
             _headLock.lock();
             try
             {
@@ -723,11 +709,9 @@ public class BlockingArrayQueue<E> extends AbstractList<E> implements BlockingQu
     @Override
     public ListIterator<E> listIterator(int index)
     {
-
         _tailLock.lock();
         try
         {
-
             _headLock.lock();
             try
             {
@@ -794,7 +778,6 @@ public class BlockingArrayQueue<E> extends AbstractList<E> implements BlockingQu
         _tailLock.lock();
         try
         {
-
             _headLock.lock();
             try
             {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ExecutorThreadPool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ExecutorThreadPool.java
@@ -31,6 +31,8 @@ import org.eclipse.jetty.util.annotation.ManagedObject;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
 import org.eclipse.jetty.util.component.Dumpable;
 import org.eclipse.jetty.util.component.DumpableCollection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A {@link org.eclipse.jetty.util.thread.ThreadPool.SizedThreadPool} wrapper around {@link ThreadPoolExecutor}.
@@ -38,12 +40,14 @@ import org.eclipse.jetty.util.component.DumpableCollection;
 @ManagedObject("A thread pool")
 public class ExecutorThreadPool extends ContainerLifeCycle implements ThreadPool.SizedThreadPool, TryExecutor, VirtualThreads.Configurable
 {
+    private static final Logger LOG = LoggerFactory.getLogger(ExecutorThreadPool.class);
+
     private final ThreadPoolExecutor _executor;
     private final ThreadPoolBudget _budget;
     private final ThreadGroup _group;
     private String _name = "etp" + hashCode();
     private int _minThreads;
-    private int _reservedThreads = -1;
+    private int _reservedThreads;
     private TryExecutor _tryExecutor = TryExecutor.NO_TRY;
     private int _priority = Thread.NORM_PRIORITY;
     private boolean _daemon;
@@ -93,6 +97,8 @@ public class ExecutorThreadPool extends ContainerLifeCycle implements ThreadPool
             executor.shutdownNow();
             throw new IllegalArgumentException("max threads (" + maxThreads + ") cannot be less than min threads (" + minThreads + ")");
         }
+        if (executor.getQueue().remainingCapacity() != Integer.MAX_VALUE)
+            LOG.warn("A bounded thread pool queue may lead to unexpected behavior, use an unbounded queue instead.");
         _executor = executor;
         _executor.setThreadFactory(this::newThread);
         _group = group;
@@ -102,7 +108,7 @@ public class ExecutorThreadPool extends ContainerLifeCycle implements ThreadPool
     }
 
     /**
-     * @return the name of the this thread pool
+     * @return the name of this thread pool
      */
     @ManagedAttribute("name of this thread pool")
     public String getName()
@@ -379,13 +385,13 @@ public class ExecutorThreadPool extends ContainerLifeCycle implements ThreadPool
                     public void dump(Appendable out, String indent) throws IOException
                     {
                         StringBuilder b = new StringBuilder();
-                        b.append(String.valueOf(thread.getId()))
+                        b.append(thread.getId())
                             .append(" ")
                             .append(thread.getName())
-                            .append(" p=").append(String.valueOf(thread.getPriority()))
+                            .append(" p=").append(thread.getPriority())
                             .append(" ")
                             .append(known)
-                            .append(thread.getState().toString());
+                            .append(thread.getState());
 
                         if (isDetailedDump())
                         {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ExecutorThreadPool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ExecutorThreadPool.java
@@ -99,7 +99,7 @@ public class ExecutorThreadPool extends ContainerLifeCycle implements ThreadPool
         }
         BlockingQueue<Runnable> queue = executor.getQueue();
         if (queue.remainingCapacity() != Integer.MAX_VALUE)
-            LOG.warn("Detected thread pool queue {} bounded at {} entries, which may lead to unexpected behavior. Use an unbounded queue instead.", queue, queue.remainingCapacity());
+            LOG.warn("Detected thread pool queue {} bounded at {} entries, which can lead to unexpected behavior. Use an unbounded queue instead.", queue, queue.remainingCapacity());
         _executor = executor;
         _executor.setThreadFactory(this::newThread);
         _group = group;

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ExecutorThreadPool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ExecutorThreadPool.java
@@ -97,8 +97,9 @@ public class ExecutorThreadPool extends ContainerLifeCycle implements ThreadPool
             executor.shutdownNow();
             throw new IllegalArgumentException("max threads (" + maxThreads + ") cannot be less than min threads (" + minThreads + ")");
         }
-        if (executor.getQueue().remainingCapacity() != Integer.MAX_VALUE)
-            LOG.warn("A bounded thread pool queue may lead to unexpected behavior, use an unbounded queue instead.");
+        BlockingQueue<Runnable> queue = executor.getQueue();
+        if (queue.remainingCapacity() != Integer.MAX_VALUE)
+            LOG.warn("Detected thread pool queue {} bounded at {} entries, which may lead to unexpected behavior. Use an unbounded queue instead.", queue, queue.remainingCapacity());
         _executor = executor;
         _executor.setThreadFactory(this::newThread);
         _group = group;

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
  * <p>A thread pool with a queue of jobs to execute.</p>
  * <p>The queue of jobs should be unbounded, because critical jobs that have been submitted for
  * execution cannot be rejected due to the queue bound limit.
- * The queue may be only temporarily full due to a job submission spike.
+ * The queue might be temporarily full due to a job submission spike.
  * Furthermore, the same HTTP request may be handled by different jobs, and would be non-optimal
  * to reject a job of a request that is already being handled in favor of a job for a new
  * concurrent request that is not yet handled by the application.</p>
@@ -181,7 +181,7 @@ public class QueuedThreadPool extends ContainerLifeCycle implements ThreadFactor
             queue = new BlockingArrayQueue<>(capacity, capacity);
         }
         if (queue.remainingCapacity() != Integer.MAX_VALUE)
-            LOG.warn("Detected thread pool queue {} bounded at {} entries, which may lead to unexpected behavior. Use an unbounded queue instead.", queue, queue.remainingCapacity());
+            LOG.warn("Detected thread pool queue {} bounded at {} entries, which can lead to unexpected behavior. Use an unbounded queue instead.", queue, queue.remainingCapacity());
         _jobs = queue;
         _threadGroup = threadGroup;
         setThreadPoolBudget(new ThreadPoolBudget(this));

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
@@ -45,8 +45,8 @@ import org.slf4j.LoggerFactory;
 /**
  * <p>A thread pool with a queue of jobs to execute.</p>
  * <p>The queue of jobs should be unbounded, because critical jobs that have been submitted for
- * execution cannot be rejected by the queue, which may be only temporarily full due to a job
- * submission spike.
+ * execution cannot be rejected due to the queue bound limit.
+ * The queue may be only temporarily full due to a job submission spike.
  * Furthermore, the same HTTP request may be handled by different jobs, and would be non-optimal
  * to reject a job of a request that is already being handled in favor of a job for a new
  * concurrent request that is not yet handled by the application.</p>
@@ -181,7 +181,7 @@ public class QueuedThreadPool extends ContainerLifeCycle implements ThreadFactor
             queue = new BlockingArrayQueue<>(capacity, capacity);
         }
         if (queue.remainingCapacity() != Integer.MAX_VALUE)
-            LOG.warn("A bounded thread pool queue may lead to unexpected behavior, use an unbounded queue instead.");
+            LOG.warn("Detected thread pool queue {} bounded at {} entries, which may lead to unexpected behavior. Use an unbounded queue instead.", queue, queue.remainingCapacity());
         _jobs = queue;
         _threadGroup = threadGroup;
         setThreadPoolBudget(new ThreadPoolBudget(this));

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
@@ -44,6 +44,12 @@ import org.slf4j.LoggerFactory;
 
 /**
  * <p>A thread pool with a queue of jobs to execute.</p>
+ * <p>The queue of jobs should be unbounded, because critical jobs that have been submitted for
+ * execution cannot be rejected by the queue, which may be only temporarily full due to a job
+ * submission spike.
+ * Furthermore, the same HTTP request may be handled by different jobs, and would be non-optimal
+ * to reject a job of a request that is already being handled in favor of a job for a new
+ * concurrent request that is not yet handled by the application.</p>
  * <p>Jetty components that need threads (such as network acceptors and selector) may lease threads
  * from this thread pool using a {@link ThreadPoolBudget}; these threads are "active" from the point
  * of view of the thread pool, but not available to run <em>transient</em> jobs such as processing
@@ -174,6 +180,8 @@ public class QueuedThreadPool extends ContainerLifeCycle implements ThreadFactor
             int capacity = Math.max(_minThreads, 8) * 1024;
             queue = new BlockingArrayQueue<>(capacity, capacity);
         }
+        if (queue.remainingCapacity() != Integer.MAX_VALUE)
+            LOG.warn("A bounded thread pool queue may lead to unexpected behavior, use an unbounded queue instead.");
         _jobs = queue;
         _threadGroup = threadGroup;
         setThreadPoolBudget(new ThreadPoolBudget(this));
@@ -596,11 +604,8 @@ public class QueuedThreadPool extends ContainerLifeCycle implements ThreadFactor
     public int getMaxReservedThreads()
     {
         TryExecutor tryExecutor = _tryExecutor;
-        if (tryExecutor instanceof ReservedThreadExecutor)
-        {
-            ReservedThreadExecutor reservedThreadExecutor = (ReservedThreadExecutor)tryExecutor;
-            return reservedThreadExecutor.getCapacity();
-        }
+        if (tryExecutor instanceof ReservedThreadExecutor reserved)
+            return reserved.getCapacity();
         return 0;
     }
 
@@ -612,11 +617,8 @@ public class QueuedThreadPool extends ContainerLifeCycle implements ThreadFactor
     public int getAvailableReservedThreads()
     {
         TryExecutor tryExecutor = _tryExecutor;
-        if (tryExecutor instanceof ReservedThreadExecutor)
-        {
-            ReservedThreadExecutor reservedThreadExecutor = (ReservedThreadExecutor)tryExecutor;
-            return reservedThreadExecutor.getAvailable();
-        }
+        if (tryExecutor instanceof ReservedThreadExecutor reserved)
+            return reserved.getAvailable();
         return 0;
     }
 
@@ -1099,7 +1101,7 @@ public class QueuedThreadPool extends ContainerLifeCycle implements ThreadFactor
                 buf.append(thread.getState()).append(":").append(System.lineSeparator());
                 for (StackTraceElement element : thread.getStackTrace())
                 {
-                    buf.append("  at ").append(element.toString()).append(System.lineSeparator());
+                    buf.append("  at ").append(element).append(System.lineSeparator());
                 }
                 return buf.toString();
             }


### PR DESCRIPTION
Added a warning in case the `BlockingQueue` passed to a `ThreadPool` is bounded.

Other miscellaneous cleanups.