### PR TITLE
Issue #12918 NPE in AuthenticationState.ServeAs.wrap

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -1033,6 +1033,27 @@ public interface Request extends Attributes, Content.Source
         return null;
     }
 
+    /** Unwrap a Request back to the given type, ensuring that we do not cross a
+     * context boundary (as might be the case during cross-context dispatch).
+     * @param request the possibly wrapped request to unwrap
+     * @param type the type to unwrap to
+     * @param context the limiting context
+     * @return the request unwrapped back to the given type, or null if it cannot be
+     * unwrapped to that type or a context boundary is crossed.
+     */
+    static <T extends Request> T as(Request request, Class<T> type, Context context)
+    {
+        while (request != null)
+        {
+            if (type.isInstance(request))
+                return (T)request;
+            request = request instanceof Request.Wrapper wrapper ? wrapper.getWrapped() : null;
+            if (request == null || request.getContext() != context)
+                return null;
+        }
+        return null;
+    }
+
     @SuppressWarnings("unchecked")
     static <T, R> R get(Request request, Class<T> type, Function<T, R> getter)
     {

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -1039,16 +1039,23 @@ public interface Request extends Attributes, Content.Source
         return null;
     }
 
-    /** Unwrap a Request back to the given type, ensuring that we do not cross a
+    /**
+     * Unwrap a Request back to the given type, ensuring that we do not cross a
      * context boundary (as might be the case during cross-context dispatch).
+     *
      * @param request the possibly wrapped request to unwrap
      * @param type the type to unwrap to
-     * @param context the limiting context
      * @return the request unwrapped back to the given type, or null if it cannot be
      * unwrapped to that type or a context boundary is crossed.
      */
-    static <T extends Request> T as(Request request, Class<T> type, Context context)
+    static <T extends Request> T asInContext(Request request, Class<T> type)
     {
+        //the context whose boundary should not be crossed
+        Context context = request == null ? null : request.getContext();
+
+        if (context == null)
+            return Request.as(request, type);
+
         while (request != null)
         {
             if (request.getContext() != context)

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -1021,6 +1021,12 @@ public interface Request extends Attributes, Content.Source
         }
     }
 
+    /** Unwrap a Request back to the given type.
+     * @param request the possibly wrapped request to unwrap
+     * @param type the type to unwrap to
+     * @return the request unwrapped back to the given type or
+     * null if it cannot be unwrapped to the supplied type.
+     */
     @SuppressWarnings("unchecked")
     static <T> T as(Request request, Class<T> type)
     {

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -1045,11 +1045,11 @@ public interface Request extends Attributes, Content.Source
     {
         while (request != null)
         {
+            if (request.getContext() != context)
+                return null;
             if (type.isInstance(request))
                 return (T)request;
             request = request instanceof Request.Wrapper wrapper ? wrapper.getWrapped() : null;
-            if (request == null || request.getContext() != context)
-                return null;
         }
         return null;
     }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -116,7 +116,7 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
 
     public static ContextHandler getContextHandler(Request request)
     {
-        ContextRequest contextRequest = Request.as(request, ContextRequest.class);
+        ContextRequest contextRequest = Request.asInContext(request, ContextRequest.class);
         if (contextRequest == null)
             return null;
         return contextRequest.getContext() instanceof ScopedContext scoped ? scoped.getContextHandler() : null;

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/MockContext.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/MockContext.java
@@ -1,0 +1,120 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.server;
+
+import java.io.File;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.jetty.http.MimeTypes;
+import org.eclipse.jetty.util.resource.Resource;
+
+public class MockContext implements Context
+{
+    @Override
+    public <T> T decorate(T o)
+    {
+        return null;
+    }
+
+    @Override
+    public void destroy(Object o)
+    {
+
+    }
+
+    @Override
+    public String getContextPath()
+    {
+        return "";
+    }
+
+    @Override
+    public ClassLoader getClassLoader()
+    {
+        return null;
+    }
+
+    @Override
+    public Resource getBaseResource()
+    {
+        return null;
+    }
+
+    @Override
+    public Request.Handler getErrorHandler()
+    {
+        return null;
+    }
+
+    @Override
+    public List<String> getVirtualHosts()
+    {
+        return List.of();
+    }
+
+    @Override
+    public MimeTypes getMimeTypes()
+    {
+        return null;
+    }
+
+    @Override
+    public void execute(Runnable task)
+    {
+
+    }
+
+    @Override
+    public Object removeAttribute(String name)
+    {
+        return null;
+    }
+
+    @Override
+    public Object setAttribute(String name, Object attribute)
+    {
+        return null;
+    }
+
+    @Override
+    public Object getAttribute(String name)
+    {
+        return null;
+    }
+
+    @Override
+    public Set<String> getAttributeNameSet()
+    {
+        return Set.of();
+    }
+
+    @Override
+    public void run(Runnable task)
+    {
+
+    }
+
+    @Override
+    public void run(Runnable task, Request request)
+    {
+
+    }
+
+    @Override
+    public File getTempDirectory()
+    {
+        return null;
+    }
+}

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/MockRequest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/MockRequest.java
@@ -1,0 +1,200 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.server;
+
+import java.util.Set;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpURI;
+import org.eclipse.jetty.io.Content;
+
+public class MockRequest implements Request
+{
+    private final Context _context;
+
+    public static class MockWrapper extends Request.Wrapper
+    {
+        private Context _context;
+
+        public MockWrapper(Request wrapped)
+        {
+            super(wrapped);
+        }
+
+        public MockWrapper(Request request, Context context)
+        {
+            super(request);
+            _context = context;
+        }
+
+        @Override
+        public Context getContext()
+        {
+            return _context;
+        }
+    }
+
+    public MockRequest(Context context)
+    {
+        _context = context;
+    }
+
+    @Override
+    public String getId()
+    {
+        return "";
+    }
+
+    @Override
+    public Components getComponents()
+    {
+        return null;
+    }
+
+    @Override
+    public ConnectionMetaData getConnectionMetaData()
+    {
+        return null;
+    }
+
+    @Override
+    public String getMethod()
+    {
+        return "";
+    }
+
+    @Override
+    public HttpURI getHttpURI()
+    {
+        return null;
+    }
+
+    @Override
+    public Context getContext()
+    {
+        return _context;
+    }
+
+    @Override
+    public HttpFields getHeaders()
+    {
+        return null;
+    }
+
+    @Override
+    public void demand(Runnable demandCallback)
+    {
+
+    }
+
+    @Override
+    public void fail(Throwable failure)
+    {
+
+    }
+
+    @Override
+    public HttpFields getTrailers()
+    {
+        return null;
+    }
+
+    @Override
+    public long getBeginNanoTime()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getHeadersNanoTime()
+    {
+        return 0;
+    }
+
+    @Override
+    public boolean isSecure()
+    {
+        return false;
+    }
+
+    @Override
+    public Content.Chunk read()
+    {
+        return null;
+    }
+
+    @Override
+    public boolean consumeAvailable()
+    {
+        return false;
+    }
+
+    @Override
+    public void addIdleTimeoutListener(Predicate<TimeoutException> onIdleTimeout)
+    {
+
+    }
+
+    @Override
+    public void addFailureListener(Consumer<Throwable> onFailure)
+    {
+
+    }
+
+    @Override
+    public TunnelSupport getTunnelSupport()
+    {
+        return null;
+    }
+
+    @Override
+    public void addHttpStreamWrapper(Function<HttpStream, HttpStream> wrapper)
+    {
+
+    }
+
+    @Override
+    public Session getSession(boolean create)
+    {
+        return null;
+    }
+
+    @Override
+    public Object removeAttribute(String name)
+    {
+        return null;
+    }
+
+    @Override
+    public Object setAttribute(String name, Object attribute)
+    {
+        return null;
+    }
+
+    @Override
+    public Object getAttribute(String name)
+    {
+        return null;
+    }
+
+    @Override
+    public Set<String> getAttributeNameSet()
+    {
+        return Set.of();
+    }
+}

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
@@ -52,6 +52,7 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RequestTest
@@ -75,6 +76,49 @@ public class RequestTest
     {
         LifeCycle.stop(server);
         connector = null;
+    }
+
+    @Test
+    public void testAsInContext() throws Exception
+    {
+        // no request
+        assertNull(Request.asInContext(null, MockRequest.Wrapper.class));
+
+        // request with no context is the same as Request.as
+        MockRequest request = new MockRequest(new MockContext());
+        MockContext wrappedContext = new MockContext();
+        MockRequest.MockWrapper wrapperA = new MockRequest.MockWrapper(request, wrappedContext);
+        MockRequest.MockWrapper wrapperB = new MockRequest.MockWrapper(wrapperA, null);
+        Request asInContext = Request.asInContext(wrapperB, MockRequest.MockWrapper.class);
+        Request as = Request.as(wrapperB, MockRequest.MockWrapper.class);
+        assertSame(asInContext, as);
+        assertSame(wrapperB, asInContext);
+        assertSame(wrapperB, as);
+
+        // request with context must not cross boundary
+        wrapperB = new MockRequest.MockWrapper(wrapperA, new MockContext());
+        Request.Wrapper wrapperC = new Request.Wrapper(wrapperB)
+        {
+            @Override
+            public Context getContext()
+            {
+                return new MockContext();
+            }
+        };
+        assertNull(Request.asInContext(wrapperC, MockRequest.MockWrapper.class));
+
+        // request with same context in more than one wrap returns first matching class
+        wrapperB = new MockRequest.MockWrapper(wrapperA, wrapperA.getContext());
+        wrapperC = new Request.Wrapper(wrapperB)
+        {
+            @Override
+            public Context getContext()
+            {
+                return getWrapped().getContext();
+            }
+        };
+
+        assertSame(wrapperB, Request.asInContext(wrapperC, MockRequest.MockWrapper.class));
     }
 
     @Test

--- a/jetty-ee10/jetty-ee10-jaspi/src/main/java/org/eclipse/jetty/ee10/security/jaspi/JaspiAuthenticator.java
+++ b/jetty-ee10/jetty-ee10-jaspi/src/main/java/org/eclipse/jetty/ee10/security/jaspi/JaspiAuthenticator.java
@@ -248,7 +248,7 @@ public class JaspiAuthenticator extends LoginAuthenticator
     // TODO This is not longer supported by core security
     public boolean secureResponse(Request request, Response response, Callback callback, boolean mandatory, AuthenticationState.Succeeded validatedSucceeded) throws ServerAuthException
     {
-        ServletContextRequest servletContextRequest = Request.as(request, ServletContextRequest.class);
+        ServletContextRequest servletContextRequest = Request.asInContext(request, ServletContextRequest.class);
         JaspiMessageInfo info = (JaspiMessageInfo)servletContextRequest.getServletApiRequest().getAttribute("org.eclipse.jetty.ee10.security.jaspi.info");
         if (info == null)
             throw new NullPointerException("MessageInfo from request missing: " + request);

--- a/jetty-ee10/jetty-ee10-jaspi/src/main/java/org/eclipse/jetty/ee10/security/jaspi/JaspiMessageInfo.java
+++ b/jetty-ee10/jetty-ee10-jaspi/src/main/java/org/eclipse/jetty/ee10/security/jaspi/JaspiMessageInfo.java
@@ -73,7 +73,7 @@ public class JaspiMessageInfo implements MessageInfo
     {
         if (_request == null)
             return null;
-        return Request.as(_request, ServletContextRequest.class).getServletApiRequest();
+        return Request.asInContext(_request, ServletContextRequest.class).getServletApiRequest();
     }
 
     @Override
@@ -81,7 +81,7 @@ public class JaspiMessageInfo implements MessageInfo
     {
         if (_response == null)
             return null;
-        return Response.as(_response, ServletContextResponse.class).getServletApiResponse();
+        return Response.asInContext(_response, ServletContextResponse.class).getServletApiResponse();
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/EagerFormHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/EagerFormHandler.java
@@ -147,7 +147,7 @@ public class EagerFormHandler extends Handler.Wrapper
             }
         };
 
-        ServletMultiPartFormData.onParts(Request.as(request, ServletContextRequest.class).getServletApiRequest(), contentType, onParts);
+        ServletMultiPartFormData.onParts(Request.asInContext(request, ServletContextRequest.class).getServletApiRequest(), contentType, onParts);
         if (done.decrementAndGet() == 0)
             onParts.handle();
         return true;

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ErrorHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ErrorHandler.java
@@ -88,7 +88,7 @@ public class ErrorHandler implements Request.Handler
             return true;
         }
 
-        ServletContextRequest servletContextRequest = Request.as(request, ServletContextRequest.class);
+        ServletContextRequest servletContextRequest = Request.asInContext(request, ServletContextRequest.class);
         HttpServletRequest httpServletRequest = servletContextRequest.getServletApiRequest();
         HttpServletResponse httpServletResponse = servletContextRequest.getHttpServletResponse();
         ServletContextHandler contextHandler = servletContextRequest.getServletContext().getServletContextHandler();

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ResourceServlet.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ResourceServlet.java
@@ -838,7 +838,7 @@ public class ResourceServlet extends HttpServlet
 
         private HttpServletRequest getServletRequest(Request request)
         {
-            ServletCoreRequest servletCoreRequest = Request.as(request, ServletCoreRequest.class);
+            ServletCoreRequest servletCoreRequest = Request.asInContext(request, ServletCoreRequest.class);
             if (servletCoreRequest != null)
                 return servletCoreRequest.getServletRequest();
 
@@ -851,11 +851,11 @@ public class ResourceServlet extends HttpServlet
 
         private HttpServletResponse getServletResponse(Response response)
         {
-            ServletCoreResponse servletCoreResponse = Response.as(response, ServletCoreResponse.class);
+            ServletCoreResponse servletCoreResponse = Response.asInContext(response, ServletCoreResponse.class);
             if (servletCoreResponse != null)
                 return servletCoreResponse.getServletResponse();
 
-            ServletContextResponse servletContextResponse = Response.as(response, ServletContextResponse.class);
+            ServletContextResponse servletContextResponse = Response.asInContext(response, ServletContextResponse.class);
             if (servletContextResponse != null)
                 return servletContextResponse.getServletApiResponse();
 

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
@@ -143,7 +143,7 @@ public class ServletChannel
         if (_callback != null)
             throw new IllegalStateException();
 
-        if (request != _request && Request.as(request, ServletContextRequest.class) != _servletContextRequest)
+        if (request != _request && Request.asInContext(request, ServletContextRequest.class) != _servletContextRequest)
             throw new IllegalStateException();
         _request = request;
         _response = response;

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextRequest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextRequest.java
@@ -190,7 +190,7 @@ public class ServletContextRequest extends ContextRequest implements ServletCont
             decodedPathInContext,
             matchedResource
         );
-        ServletContextRequest originalServletContextRequest = Request.as(request, ServletContextRequest.class, request.getContext());
+        ServletContextRequest originalServletContextRequest = Request.asInContext(request, ServletContextRequest.class);
         if (originalServletContextRequest != null)
         {
             servletContextRequest.setRequestedSession(originalServletContextRequest.getRequestedSession());

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextRequest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextRequest.java
@@ -190,7 +190,8 @@ public class ServletContextRequest extends ContextRequest implements ServletCont
             decodedPathInContext,
             matchedResource
         );
-        if (request instanceof ServletContextRequest originalServletContextRequest)
+        ServletContextRequest originalServletContextRequest = Request.as(request, ServletContextRequest.class, request.getContext());
+        if (originalServletContextRequest != null)
         {
             servletContextRequest.setRequestedSession(originalServletContextRequest.getRequestedSession());
             servletContextRequest.setManagedSession(originalServletContextRequest.getManagedSession());

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextRequest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextRequest.java
@@ -190,6 +190,11 @@ public class ServletContextRequest extends ContextRequest implements ServletCont
             decodedPathInContext,
             matchedResource
         );
+        if (request instanceof ServletContextRequest originalServletContextRequest)
+        {
+            servletContextRequest.setRequestedSession(originalServletContextRequest.getRequestedSession());
+            servletContextRequest.setManagedSession(originalServletContextRequest.getManagedSession());
+        }
         servletChannel.associate(servletContextRequest);
         return servletContextRequest;
     }

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/SessionHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/SessionHandler.java
@@ -400,11 +400,11 @@ public class SessionHandler extends AbstractSessionManager implements Handler.Si
     @Override
     public ManagedSession getManagedSession(Request request)
     {
-        ServletContextRequest servletContextRequest = Request.as(request, ServletContextRequest.class);
+        ServletContextRequest servletContextRequest = Request.asInContext(request, ServletContextRequest.class);
         if (servletContextRequest != null)
             return servletContextRequest.getManagedSession();
 
-        NonServletSessionRequest nonServletSessionRequest = Request.as(request, NonServletSessionRequest.class);
+        NonServletSessionRequest nonServletSessionRequest = Request.asInContext(request, NonServletSessionRequest.class);
         if (nonServletSessionRequest != null)
             return nonServletSessionRequest.getManagedSession();
 

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/security/FormAuthenticatorTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/security/FormAuthenticatorTest.java
@@ -66,6 +66,7 @@ public class FormAuthenticatorTest
         @Override
         protected void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException
         {
+            req.getSession();
             PrintWriter writer = resp.getWriter();
             writer.println("contextPath: " + req.getContextPath());
             writer.println("servletPath: " + req.getServletPath());


### PR DESCRIPTION
Fixes #12918

As the `ServletContextRequest` fields `_requestedSession` and `_managedSession` are `private`, they must be explicitly set on the newly created instance in `ServletContextHandler.newServletContextRequest` when the passed-in request is itself a `ServletContextRequest`.