### PR TITLE
Addendum to #12900 - Make JPMS work with new Environments features.

### DIFF
--- a/documentation/jetty/antora.yml
+++ b/documentation/jetty/antora.yml
@@ -11,6 +11,8 @@ asciidoc:
     ee-all: ee{8,9,10,11}
     ee-current: ee11
     ee-current-caps: EE 11
+    ee-prev: ee10
+    ee-prev-caps: EE 10
     run-jetty-classpath: ${settings.localRepository}/org/eclipse/jetty/tests/jetty-testers/${project.version}/jetty-testers-${project.version}.jar${path.separator}${run.jetty.classpath}
 nav:
 - modules/operations-guide/nav.adoc

--- a/documentation/jetty/modules/operations-guide/pages/security/jaas-support.adoc
+++ b/documentation/jetty/modules/operations-guide/pages/security/jaas-support.adoc
@@ -42,7 +42,7 @@ Enable the `jaas` module.
 include::{jetty-home}/modules/jaas.mod[]
 ----
 
-The configurable items in the resulting `$jetty.base/start.d/jaas.ini` file are:
+The configurable items in the resulting `$JETTY_BASE/start.d/jaas.ini` file are:
 
 jetty.jaas.login.conf::
 This is the location of the file that will be referenced by the system property `java.security.auth.login.config`: Jetty sets this system property for you based on the value of this property.
@@ -89,7 +89,7 @@ The `org.eclipse.jetty.security.jaas.JAASLoginService` can be declared in a coup
 
 * If you have more than one webapp that you would like to use the same security infrastructure, then you can declare your `org.eclipse.jetty.security.jaas.JAASLoginService` as a bean that is added to the `org.eclipse.jetty.server.Server`.
 The file in which you declare this needs to be on Jetty's execution path.
-The recommended procedure is to create a file in your `$jetty.base/etc` directory and then ensure it is on the classpath either by adding it to the Jetty xref:start/index.adoc[start command line], or more conveniently to a xref:modules/custom.adoc[custom module].
+The recommended procedure is to create a file in your `$JETTY_BASE/etc` directory and then ensure it is on the classpath either by adding it to the Jetty xref:start/index.adoc[start command line], or more conveniently to a xref:modules/custom.adoc[custom module].
 +
 Here's an example of this type of XML file:
 +
@@ -135,7 +135,7 @@ Here's an example of this type of XML file:
 We now need to setup the contents of the file we specified as the `jetty.jaas.login.conf` property when we <<module,configured the `jaas` module>>.
 Refer to the https://docs.oracle.com/javase/7/docs/api/javax/security/auth/login/Configuration.html[syntax rules] of this file for a full description.
 
-Remembering the example we set up <<webapp,previously>>, the contents of the `$jetty.base/etc/login.conf` file could look as follows:
+Remembering the example we set up <<webapp,previously>>, the contents of the `$JETTY_BASE/etc/login.conf` file could look as follows:
 
 [source]
 ----

--- a/documentation/jetty/modules/operations-guide/pages/start/index.adoc
+++ b/documentation/jetty/modules/operations-guide/pages/start/index.adoc
@@ -449,7 +449,7 @@ The Jetty start mechanism performs these steps:
 In this way, a Jetty module graph can be built in memory, where the module dependencies form the edges of the graph and each node contains the metadata information declared by each module (for example, the libraries that it needs, the XML files to process, and so on), in preparation for the next step.
 . Reads the Jetty module configuration files (that have extension `+*.ini+`) from the `start.d/` subdirectory of each configuration source directory and from the command line.
 This step produces a list of _enabled_ modules; for each enabled module all its dependencies are transitively resolved by navigating the graph built in the previous steps.
-. Processes the list of enabled (explicitly and transitively) modules, gathering the list of libraries to add to the class-path, the JPMS directives to add to the command line, the properties and XML files to add as program arguments, etc., so that a full JVM command line can be generated.
+. Processes the list of enabled (explicitly and transitively) modules, gathering the list of libraries to add to the class-path or module-path, the JPMS directives to add to the command line if necessary, the properties and XML files to add as program arguments, etc., so that a full JVM command line can be generated.
 . Executes the command line, either in-JVM or by forking a second JVM (if the `--exec` option is present or implied by other options such as `--jpms`), and waits for the JVM, or the forked JVM, to exit.
 
 [[start-class-path]]
@@ -471,7 +471,7 @@ rectangle "Jetty Start JVM" {
   note right of system: start.jar
   note right of start: jetty-server.jar\njetty-http.jar\njetty-io.jar\njetty-util.jar\njetty-xml.jar\netc.
 
-  system <-- start
+  system <.. start
 }
 ----
 
@@ -507,7 +507,7 @@ It is worth mentioning that there are two standard Jetty modules that allow you 
 * The xref:modules/standard.adoc#resources[`resources` module], which adds the `$JETTY_BASE/resources` directory to the server class-path.
 This is useful if you have third party libraries that lookup resources from the class-path: just put those resources in the `$JETTY_BASE/resources/` directory. +
 Logging libraries often perform class-path lookup of their configuration files (for example, `log4j.properties`, `log4j.xml`, `logging.properties`, and `logback.xml`), so `$JETTY_BASE/resources/` is the ideal place to add those files. +
-* The the `ext` module, that adds all the `+*.jar+` files under the `$JETTY_BASE/lib/ext/` directory, and subdirectories recursively, to the server class-path. +
+* The `ext` module, that adds all the `+*.jar+` files under the `$JETTY_BASE/lib/ext/` directory, and subdirectories recursively, to the server class-path. +
 +
 [CAUTION]
 ====
@@ -515,6 +515,61 @@ On one hand, the `ext` module provides a handy place to put third party librarie
 
 Prefer to group third party libraries and their dependencies into their own directories using xref:modules/custom.adoc[custom modules], or at least group them into `$JETTY_BASE/lib/ext/` subdirectories such as `$JETTY_BASE/lib/ext/util/` or `$JETTY_BASE/lib/ext/acme/`.
 ====
+
+[[start-class-path-environments]]
+==== Server Jakarta EE Environment Class-Path
+
+When a Jakarta EE Jetty module is enabled, for example the `{ee-current}-webapp` and/or the `{ee-current}-deploy` module, the server ClassLoader hierarchy is modified as follows:
+
+[plantuml,subs=+attributes]
+----
+skinparam backgroundColor transparent
+skinparam monochrome true
+skinparam shadowing false
+skinparam roundCorner 10
+
+rectangle "Jetty Start JVM" {
+  rectangle "System ClassLoader" as system
+  rectangle "Jetty Start ClassLoader" as start
+  rectangle "Jetty {ee-current-caps} ClassLoader" as env
+
+  note right of system: start.jar
+  note right of start: jetty-server.jar\njetty-http.jar\njetty-io.jar\njetty-util.jar\njetty-xml.jar\netc.
+  note right of env: jakarta.servlet-api.jar\njetty-{ee-current}-servlet.jar\njetty-{ee-current}-deploy.jar\netc.
+
+  system <.. start
+  start <.. env
+}
+----
+
+When different versions of the Jakarta EE Jetty deploy or webapp modules are enabled, the server ClassLoader hierarchy is the following:
+
+[plantuml,subs=+attributes]
+----
+skinparam backgroundColor transparent
+skinparam monochrome true
+skinparam shadowing false
+skinparam roundCorner 10
+
+rectangle "Jetty Start JVM" {
+  rectangle "System ClassLoader" as system
+  rectangle "Jetty Start ClassLoader" as start
+  rectangle "Jetty {ee-prev-caps} ClassLoader" as env1
+  rectangle "Jetty {ee-current-caps} ClassLoader" as env2
+
+  note right of system: start.jar
+  note right of start: jetty-server.jar\njetty-http.jar\njetty-io.jar\njetty-util.jar\njetty-xml.jar\netc.
+  note left of env1: jakarta.servlet-api.jar ({ee-prev})\njetty-{ee-prev}-servlet.jar\njetty-{ee-prev}-deploy.jar\netc.
+  note right of env2: jakarta.servlet-api.jar ({ee-current})\njetty-{ee-current}-servlet.jar\njetty-{ee-current}-deploy.jar\netc.
+
+  system <.. start
+  start <.. env1
+  start <.. env2
+}
+----
+
+Note how the Jetty {ee-prev-caps} ClassLoader and the Jetty {ee-current-caps} ClassLoader are siblings.
+In this way, they can load independently their own version of the Jakarta EE APIs `+*.jar+` files, and the Jetty implementation of the Jakarta EE APIs, without conflicts.
 
 [[start-xml]]
 === Assembling Jetty Components
@@ -528,7 +583,7 @@ The components are then assembled together to provide the configured Jetty featu
 
 The Jetty XML files are parametrized using properties, and a property is just a name/value pair.
 
-This parametrization of the XML files allows an XML file that resides in `$JETTY_HOME/etc/` to _declare_ a property such as `jetty.http.port`, and allow this property to be set in a `$JETTY_BASE/start.d/http.ini` file, so that you don't need to change the XML files in `$JETTY_HOME`, but only change files in your `$JETTY_BASE`.
+This parametrization of the XML files allows an XML file that resides in `$JETTY_HOME/etc/` to _declare_ a property such as `jetty.http.port`, and allow this property to be set in a `$JETTY_BASE/start.d/http.ini` file, so that you don't need to change the XML files in `$JETTY_HOME`, but only change `+*.ini+` files in your `$JETTY_BASE`.
 
 You can write your own xref:modules/custom.adoc[custom modules] with your own Jetty XML files, and your own properties, to further customize Jetty.
 

--- a/documentation/jetty/modules/operations-guide/pages/start/start-jpms.adoc
+++ b/documentation/jetty/modules/operations-guide/pages/start/start-jpms.adoc
@@ -18,6 +18,7 @@ This makes possible to run Jetty from the module-path, rather than the class-pat
 
 To start Jetty on the module-path rather than the class-path, it is enough to add the `--jpms` option to the command line, for example:
 
+[source,bash]
 ----
 $ java -jar $JETTY_HOME/start.jar --jpms
 ----
@@ -33,11 +34,11 @@ Therefore, you will have two JVMs running: one that runs `start.jar` and one tha
 Forking a second JVM may be avoided as explained in xref:start/index.adoc#configure-dry-run[this section].
 ====
 
-When Jetty is started in JPMS mode, all JPMS modules in the module-path are added to the set of JPMS _root modules_ through the JVM option `--add-modules ALL_MODULE_PATH`.
+When Jetty is started in JPMS mode, all JPMS modules in the module-path are added to the set of JPMS _root modules_ through the JVM option `--add-modules=ALL-MODULE-PATH`.
 
 For a `+*.jar+` file that is not a JPMS module, but is on the module-path, the JVM will assume internally it is an automatic JPMS module, with a JPMS module name derived from the `+*.jar+` file name.
 
-Rather than adding the `--jpms` option to the command line, you can use a custom Jetty module to centralize your JPMS configuration, where you can specify additional JPMS directives.
+As an alternative to adding the `--jpms` option to the command line, you can use a custom Jetty module to centralize your JPMS configuration, where you can specify additional JPMS directives.
 
 Create the `$JETTY_BASE/modules/jpms.mod` file:
 
@@ -52,11 +53,126 @@ The `[jpms]` section allows you to specify additional JPMS configuration, for ex
 
 Then enable it:
 
+[source,bash]
 ----
 $ java -jar $JETTY_HOME/start.jar --add-modules=jpms
 ----
 
 Now you can start Jetty without extra command line options, and it will start in JPMS mode because you have enabled the `jpms` module.
+
+[[advantages]]
+== Advantages of JPMS
+
+The main advantage of running Jetty in JPMS mode is that it provides early error reporting if a dependency is missing, especially in case of custom Jetty modules.
+
+If a Jetty module requires a specific library `+*.jar+` file, and the `+*.jar+` file is missing, this will be detected early when running in JPMS mode, since the `+*.jar+` file would be a JPMS module, and the JPMS module graph resolution would detect this problem as the JVM starts up.
+When running in class-path mode, this problem can only be detected when the library classes are loaded, therefore much later at run-time, when an HTTP request arrives and its processing requires to load the library classes.
+
+Similarly, duplicate `+*.jar+` files, of possibly different versions, are not allowed by JPMS.
+This is again detected early, at JVM startup, when running in JPMS mode, rather than passing completely unnoticed when running in class-path mode, where classes may be loaded from either of those `+*.jar+` files, possibly from the wrong version.
+
+Another advantage of running Jetty in JPMS mode is that JPMS provides strong encapsulation.
+This means that it is not possible to use reflection to access non-exported classes in JPMS modules within the `ModuleLayer` hierarchy.
+This is enforced at the JVM level, not at the application level through, for example, a custom `ClassLoader` that performs class loading filtering.
+
+It also means that it is not possible to use reflection to access sibling ``ModuleLayer``s.
+For example a Jakarta {ee-prev-caps} web application would not be able to use reflection to access a sibling Jakarta {ee-current-caps} web application.
+
+[[hierarchy]]
+== Server Module-Path and ModuleLayers
+
+When the Jetty server is started in JPMS mode, there will be two JVMs: one started by you with `java -jar $JETTY_HOME/start.jar` and one forked by the Jetty start mechanism.
+
+NOTE: Remember that you can avoid to fork a second JVM, as described in xref:start/index.adoc#configure-dry-run[this section].
+
+The forked JVM is started with `+java --module-path $JETTY_HOME/lib/jetty-server-<version>.jar:...+`, and therefore has the server libraries in its module-path, loaded by the System ClassLoader, in the boot `ModuleLayer`:
+
+[plantuml]
+----
+skinparam backgroundColor transparent
+skinparam monochrome true
+skinparam shadowing false
+skinparam roundCorner 10
+
+rectangle "Jetty Start JVM" as startJVM {
+  rectangle "System ClassLoader" as system1
+  note right of system1: start.jar
+}
+
+rectangle "Forked JVM" as forkedJVM {
+  rectangle "Boot ModuleLayer" as bootLayer {
+    rectangle "System ClassLoader" as system2
+
+    note right of system2: jetty-server.jar\njetty-http.jar\njetty-io.jar\njetty-util.jar\njetty-xml.jar\netc.
+  }
+}
+
+startJVM --> forkedJVM: " waits for"
+----
+
+When a Jakarta EE Jetty module is enabled, for example the `{ee-current}-webapp` and/or the `{ee-current}-deploy` module, the forked JVM is configured as follows:
+
+[plantuml,subs=+attributes]
+----
+skinparam backgroundColor transparent
+skinparam monochrome true
+skinparam shadowing false
+skinparam roundCorner 10
+
+rectangle "Forked JVM" as forkedJVM {
+  rectangle "Boot ModuleLayer" as bootLayer {
+    rectangle "System ClassLoader" as systemCL
+
+    note right of systemCL: jetty-server.jar\njetty-http.jar\njetty-io.jar\njetty-util.jar\njetty-xml.jar\netc.
+  }
+  rectangle "Jetty {ee-current-caps} ModuleLayer" as envLayer {
+    rectangle "Jetty {ee-current-caps} ClassLoader" as envCL
+
+    note right of envCL: jakarta.servlet-api.jar\njetty-{ee-current}-servlet.jar\njetty-{ee-current}-deploy.jar\netc.
+  }
+}
+
+bootLayer <-- envLayer
+systemCL <.. envCL
+----
+
+Note how the parent of the Jetty {ee-current-caps} `ClassLoader` is the System `ClassLoader`, and how the parent of the Jetty {ee-current-caps} `ModuleLayer` is the Boot `ModuleLayer`.
+
+When different versions of the Jakarta EE Jetty modules are enabled, the forked JVM is configured as follows:
+
+[plantuml,subs=+attributes]
+----
+skinparam backgroundColor transparent
+skinparam monochrome true
+skinparam shadowing false
+skinparam roundCorner 10
+
+rectangle "Forked JVM" as forkedJVM {
+  rectangle "Boot ModuleLayer" as bootLayer {
+    rectangle "System ClassLoader" as systemCL
+
+    note right of systemCL: jetty-server.jar\njetty-http.jar\njetty-io.jar\njetty-util.jar\njetty-xml.jar\netc.
+  }
+  rectangle "Jetty {ee-prev-caps} ModuleLayer" as envLayer1 {
+    rectangle "Jetty {ee-prev-caps} ClassLoader" as envCL1
+
+    note left of envCL1: jakarta.servlet-api.jar ({ee-prev})\njetty-{ee-prev}-servlet.jar\njetty-{ee-prev}-deploy.jar\netc.
+  }
+  rectangle "Jetty {ee-current-caps} ModuleLayer" as envLayer2 {
+    rectangle "Jetty {ee-current-caps} ClassLoader" as envCL2
+
+    note right of envCL2: jakarta.servlet-api.jar ({ee-current})\njetty-{ee-current}-servlet.jar\njetty-{ee-current}-deploy.jar\netc.
+  }
+}
+
+bootLayer <-- envLayer1
+bootLayer <-- envLayer2
+systemCL <.. envCL1
+systemCL <.. envCL2
+----
+
+Note how the Jetty EE ``ClassLoaders``s are siblings, and both have the System `ClassLoader` as parent.
+Note also how the Jetty EE ``ModuleLayer``s are siblings, and both have the Boot `ModuleLayer` as parent.
 
 [[advanced]]
 == Advanced JPMS Configuration
@@ -73,24 +189,24 @@ However, when running on the module-path, things are quite different.
 When Jetty tries to load, for example, class `org.postgresql.ds.PGConnectionPoolDataSource`, it must be in a JPMS module that is resolved in the run-time module graph.
 Furthermore, any dependency, for example classes from the `java.sql` JPMS module, must also be in a module present in the resolved module graph.
 
-Thanks to the fact that when Jetty starts in JPMS mode the `--add-modules ALL_MODULE_PATH` option is added to the JVM command line, every `+*.jar+` file in the module-path is also present in the module graph.
+Thanks to the fact that when Jetty starts in JPMS mode the `--add-modules=ALL-MODULE-PATH` option is added to the JVM command line, every `+*.jar+` file in the module-path is also present in the module graph.
 
 There are now two cases for the `postgresql-<version>.jar` file: either it is a proper JPMS module, or it is an automatic JPMS module (either an explicit automatic JPMS module with the `Automatic-Module-Name` attribute in the manifest, or an implicit automatic JPMS module whose name is derived from the `+*.jar+` file name).
 
 If the `postgresql-<version>.jar` file is a proper JPMS module, then there is nothing more that you should do: the `postgresql-<version>.jar` file is in the module-path, and all the modules in the module-path are in the module graph, and any dependency declared in the `module-info.class` will be added to the module graph.
 
 Otherwise, `postgresql-<version>.jar` file is an automatic module, and will likely have a dependency on the JDK-bundled `java.sql` JPMS module.
-However, the `java.sql` JPMS module is not in the module graph, because automatic modules do not have a way to declare their dependencies.
+Fortunately, when Jetty starts in JPMS mode, the `--add-modules=ALL-DEFAULT` option is also added to the JVM command line, so that all the Java JPMS modules are added to the module graph, and this would include the `java.sql` JPMS module.
 
-For this reason, you have to manually add the `java.sql` dependency to the module graph.
-Using the `postgresql.mod` introduced in xref:start/index.adoc#configure-custom-module[this section] as an example, modify your custom module in the following way:
+In case you need to add a custom library JPMS module to the module graph, you have to manually add it to the module graph.
+Using the `postgresql.mod` introduced in xref:start/index.adoc#configure-custom-module[this section] as an example, modify your custom module and add the dependency to the custom library JPMS module, say `com.acme.pgutils`, in the following way:
 
 .postgresql.mod
 ----
 ...
 
 [jpms]
-add-modules: java.sql
+add-modules: com.acme.pgutils
 ----
 
 The `[jpms]` section is only used when Jetty is started on the module-path.

--- a/jetty-core/jetty-deploy/src/main/config/modules/deployment-scanner.mod
+++ b/jetty-core/jetty-deploy/src/main/config/modules/deployment-scanner.mod
@@ -19,7 +19,7 @@ environments/
 etc/jetty-deployment-scanner.xml
 
 [ini-template]
-## Monitored directory name (relative to $jetty.base)
+## Monitored directory name (relative to $JETTY_BASE)
 # jetty.deploy.monitoredDir=webapps
 
 # Defer Initial Scan
@@ -33,6 +33,6 @@ etc/jetty-deployment-scanner.xml
 # value of 1 or more will enable hot-redeploy
 # jetty.deploy.scanInterval=0
 
-## Environments directory name (relative to $jetty.base)
+## Environments directory name (relative to $JETTY_BASE)
 # This is where environment specific configurations are stored.
 # jetty.deploy.environmentsDir=environments

--- a/jetty-core/jetty-server/src/main/config/modules/debuglog.mod
+++ b/jetty-core/jetty-server/src/main/config/modules/debuglog.mod
@@ -19,7 +19,7 @@ etc/jetty-debuglog.xml
 
 [ini-template]
 #tag::documentation[]
-## Logging directory (relative to $jetty.base)
+## Logging directory (relative to $JETTY_BASE)
 # jetty.debuglog.dir=logs
 
 ## Whether to append to existing file

--- a/jetty-core/jetty-server/src/main/config/modules/jaas.mod
+++ b/jetty-core/jetty-server/src/main/config/modules/jaas.mod
@@ -13,6 +13,6 @@ deployment-scanner
 etc/jetty-jaas.xml
 
 [ini-template]
-## The file location (relative to $jetty.base) for the
+## The file location (relative to $JETTY_BASE) for the
 ## JAAS "java.security.auth.login.config" system property
 # jetty.jaas.login.conf=etc/login.conf

--- a/jetty-core/jetty-server/src/main/config/modules/requestlog.mod
+++ b/jetty-core/jetty-server/src/main/config/modules/requestlog.mod
@@ -24,7 +24,7 @@ jetty.requestlog.dir?=logs
 ## Format string
 # jetty.requestlog.formatString=%{client}a - %u %{dd/MMM/yyyy:HH:mm:ss ZZZ|GMT}t "%r" %s %O "%{Referer}i" "%{User-Agent}i"
 
-## Logging directory (relative to $jetty.base)
+## Logging directory (relative to $JETTY_BASE)
 # jetty.requestlog.dir=logs
 
 ## File path


### PR DESCRIPTION
* Added documentation about ClassLoader and ModuleLayer hierarchies in case of Jakarta EE environments.
* Removed remaining references to $jetty.base, replaced by $JETTY_BASE (used now everywhere).