### PR TITLE
Issue #8715 - Optimize RequestLog information retrieval

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/CustomRequestLog.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/CustomRequestLog.java
@@ -351,6 +351,7 @@ public class CustomRequestLog extends ContainerLifeCycle implements RequestLog
     private transient PathMappings<String> _ignorePathMap;
     private String[] _ignorePaths;
     private BiPredicate<Request, Response> _filter;
+    boolean _requiresLogDetail = false;
 
     public CustomRequestLog()
     {
@@ -381,6 +382,14 @@ public class CustomRequestLog extends ContainerLifeCycle implements RequestLog
         {
             throw new IllegalStateException(e);
         }
+    }
+
+    /**
+     * @return true if the {@link #LOG_DETAIL} request attribute is required to be set with an instance of {@link LogDetail}.
+     */
+    public boolean requiresLogDetail()
+    {
+        return _requiresLogDetail;
     }
 
     /**
@@ -771,7 +780,11 @@ public class CustomRequestLog extends ContainerLifeCycle implements RequestLog
 
                 yield lookup.findStatic(CustomRequestLog.class, "logEnvironmentVar", logTypeArg).bindTo(arg);
             }
-            case "f" -> lookup.findStatic(CustomRequestLog.class, "logFilename", logType);
+            case "f" ->
+            {
+                _requiresLogDetail = true;
+                yield lookup.findStatic(CustomRequestLog.class, "logFilename", logType);
+            }
             case "H" -> lookup.findStatic(CustomRequestLog.class, "logRequestProtocol", logType);
             case "i" ->
             {
@@ -790,7 +803,11 @@ public class CustomRequestLog extends ContainerLifeCycle implements RequestLog
             }
             case "q" -> lookup.findStatic(CustomRequestLog.class, "logQueryString", logType);
             case "r" -> lookup.findStatic(CustomRequestLog.class, "logRequestFirstLine", logType);
-            case "R" -> lookup.findStatic(CustomRequestLog.class, "logRequestHandler", logType);
+            case "R" ->
+            {
+                _requiresLogDetail = true;
+                yield lookup.findStatic(CustomRequestLog.class, "logRequestHandler", logType);
+            }
             case "s" -> lookup.findStatic(CustomRequestLog.class, "logResponseStatus", logType);
             case "t" ->
             {

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/CustomRequestLog.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/CustomRequestLog.java
@@ -351,7 +351,7 @@ public class CustomRequestLog extends ContainerLifeCycle implements RequestLog
     private transient PathMappings<String> _ignorePathMap;
     private String[] _ignorePaths;
     private BiPredicate<Request, Response> _filter;
-    boolean _requiresLogDetail = false;
+    private boolean _requiresLogDetail = false;
 
     public CustomRequestLog()
     {
@@ -387,7 +387,7 @@ public class CustomRequestLog extends ContainerLifeCycle implements RequestLog
     /**
      * @return true if the {@link #LOG_DETAIL} request attribute is required to be set with an instance of {@link LogDetail}.
      */
-    public boolean requiresLogDetail()
+    public boolean isLogDetailRequired()
     {
         return _requiresLogDetail;
     }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/CustomRequestLog.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/CustomRequestLog.java
@@ -393,6 +393,18 @@ public class CustomRequestLog extends ContainerLifeCycle implements RequestLog
     }
 
     /**
+     * Check if a {@link Server} has a {@link CustomRequestLog} with a {@link #isLogDetailRequired()} value of true.
+     *
+     * @param server the server to get the {@link RequestLog} from.
+     * @return true if the {@link #LOG_DETAIL} request attribute is required to be set with an instance of {@link LogDetail}.
+     * @see #isLogDetailRequired()
+     */
+    public static boolean isLogDetailRequired(Server server)
+    {
+        return server.getRequestLog() instanceof CustomRequestLog customRequestLog && customRequestLog.isLogDetailRequired();
+    }
+
+    /**
      * This allows you to set a custom filter to decide whether to log a request or omit it from the request log.
      * This filter is evaluated after path filtering is applied from {@link #setIgnorePaths(String[])}.
      * @param filter - a BiPredicate which returns true if this request should be logged.

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
@@ -728,7 +728,7 @@ public class ServletChannel
         if (LOG.isDebugEnabled())
             LOG.debug("onCompleted for {} written app={} net={}", apiRequest.getRequestURI(), getHttpOutput().getWritten(), getBytesWritten());
 
-        if (getServer().getRequestLog() instanceof CustomRequestLog)
+        if (getServer().getRequestLog() instanceof CustomRequestLog customRequestLog && customRequestLog.requiresLogDetail())
         {
             CustomRequestLog.LogDetail logDetail = new CustomRequestLog.LogDetail(
                 _servletContextRequest.getServletName(),

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
@@ -728,7 +728,7 @@ public class ServletChannel
         if (LOG.isDebugEnabled())
             LOG.debug("onCompleted for {} written app={} net={}", apiRequest.getRequestURI(), getHttpOutput().getWritten(), getBytesWritten());
 
-        if (getServer().getRequestLog() instanceof CustomRequestLog customRequestLog && customRequestLog.isLogDetailRequired())
+        if (CustomRequestLog.isLogDetailRequired(getServer()))
         {
             CustomRequestLog.LogDetail logDetail = new CustomRequestLog.LogDetail(
                 _servletContextRequest.getServletName(),

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
@@ -728,7 +728,7 @@ public class ServletChannel
         if (LOG.isDebugEnabled())
             LOG.debug("onCompleted for {} written app={} net={}", apiRequest.getRequestURI(), getHttpOutput().getWritten(), getBytesWritten());
 
-        if (getServer().getRequestLog() instanceof CustomRequestLog customRequestLog && customRequestLog.requiresLogDetail())
+        if (getServer().getRequestLog() instanceof CustomRequestLog customRequestLog && customRequestLog.isLogDetailRequired())
         {
             CustomRequestLog.LogDetail logDetail = new CustomRequestLog.LogDetail(
                 _servletContextRequest.getServletName(),

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletChannel.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletChannel.java
@@ -729,7 +729,7 @@ public class ServletChannel
         if (LOG.isDebugEnabled())
             LOG.debug("onCompleted for {} written app={} net={}", apiRequest.getRequestURI(), getHttpOutput().getWritten(), getBytesWritten());
 
-        if (getServer().getRequestLog() instanceof CustomRequestLog customRequestLog && customRequestLog.requiresLogDetail())
+        if (getServer().getRequestLog() instanceof CustomRequestLog customRequestLog && customRequestLog.isLogDetailRequired())
         {
             CustomRequestLog.LogDetail logDetail = new CustomRequestLog.LogDetail(
                 _servletContextRequest.getServletName(),

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletChannel.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletChannel.java
@@ -729,7 +729,7 @@ public class ServletChannel
         if (LOG.isDebugEnabled())
             LOG.debug("onCompleted for {} written app={} net={}", apiRequest.getRequestURI(), getHttpOutput().getWritten(), getBytesWritten());
 
-        if (getServer().getRequestLog() instanceof CustomRequestLog customRequestLog && customRequestLog.isLogDetailRequired())
+        if (CustomRequestLog.isLogDetailRequired(getServer()))
         {
             CustomRequestLog.LogDetail logDetail = new CustomRequestLog.LogDetail(
                 _servletContextRequest.getServletName(),

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletChannel.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletChannel.java
@@ -729,7 +729,7 @@ public class ServletChannel
         if (LOG.isDebugEnabled())
             LOG.debug("onCompleted for {} written app={} net={}", apiRequest.getRequestURI(), getHttpOutput().getWritten(), getBytesWritten());
 
-        if (getServer().getRequestLog() instanceof CustomRequestLog)
+        if (getServer().getRequestLog() instanceof CustomRequestLog customRequestLog && customRequestLog.requiresLogDetail())
         {
             CustomRequestLog.LogDetail logDetail = new CustomRequestLog.LogDetail(
                 _servletContextRequest.getServletName(),

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
@@ -915,7 +915,7 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
         if (idleTO >= 0 && getIdleTimeout() != _oldIdleTimeout)
             setIdleTimeout(_oldIdleTimeout);
 
-        if (getServer().getRequestLog() instanceof CustomRequestLog customRequestLog && customRequestLog.isLogDetailRequired())
+        if (CustomRequestLog.isLogDetailRequired(getServer()))
         {
             CustomRequestLog.LogDetail logDetail = new CustomRequestLog.LogDetail(
                 _request.getServletName(),

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
@@ -915,7 +915,7 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
         if (idleTO >= 0 && getIdleTimeout() != _oldIdleTimeout)
             setIdleTimeout(_oldIdleTimeout);
 
-        if (getServer().getRequestLog() instanceof CustomRequestLog customRequestLog && customRequestLog.requiresLogDetail())
+        if (getServer().getRequestLog() instanceof CustomRequestLog customRequestLog && customRequestLog.isLogDetailRequired())
         {
             CustomRequestLog.LogDetail logDetail = new CustomRequestLog.LogDetail(
                 _request.getServletName(),

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
@@ -915,7 +915,7 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
         if (idleTO >= 0 && getIdleTimeout() != _oldIdleTimeout)
             setIdleTimeout(_oldIdleTimeout);
 
-        if (getServer().getRequestLog() instanceof CustomRequestLog)
+        if (getServer().getRequestLog() instanceof CustomRequestLog customRequestLog && customRequestLog.requiresLogDetail())
         {
             CustomRequestLog.LogDetail logDetail = new CustomRequestLog.LogDetail(
                 _request.getServletName(),


### PR DESCRIPTION
Only create the `CustomRequestLog.LogDetail` instance if it required by the `CustomRequestLog` format string.

closes #8715