### PR TITLE
Fix flaky `StatisticsHandlerTest`

### DIFF
--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/StatisticsHandlerTest.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/StatisticsHandlerTest.java
@@ -22,6 +22,7 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.tests.testers.JettyHomeTester;
 import org.eclipse.jetty.tests.testers.Tester;
 import org.eclipse.jetty.toolchain.test.FS;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -29,6 +30,7 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Isolated
 public class StatisticsHandlerTest extends AbstractJettyHomeTest
 {
     @ParameterizedTest


### PR DESCRIPTION
As explained [here](https://github.com/jetty/jetty.project/issues/13094#issuecomment-2850786583), `StatisticsHandlerTest` currently can run in parallel with `DistributionTests`.

Fixes https://github.com/jetty/jetty.project/issues/13094