### PR TITLE
Fixes #11320 - Review callers of HttpChannelState.onIdleTimeout().

### DIFF
--- a/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/HttpStreamOverFCGI.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/HttpStreamOverFCGI.java
@@ -351,8 +351,11 @@ public class HttpStreamOverFCGI implements HttpStream
 
     public boolean onIdleTimeout(TimeoutException timeout)
     {
-        ThreadPool.executeImmediately(_connection.getConnector().getExecutor(), _httpChannel.onIdleTimeout(timeout));
-        return false;
+        HttpChannel.IdleTimeoutTask task = _httpChannel.onIdleTimeout(timeout);
+        boolean handlingRequest = task.handlingRequest();
+        if (handlingRequest)
+            ThreadPool.executeImmediately(_connection.getConnector().getExecutor(), task.action());
+        return !handlingRequest;
     }
 
     private void execute(Runnable task)

--- a/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/ServerFCGIConnection.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/ServerFCGIConnection.java
@@ -279,14 +279,6 @@ public class ServerFCGIConnection extends AbstractMetaDataConnection implements 
         }
     }
 
-    @Override
-    protected boolean onReadTimeout(TimeoutException timeout)
-    {
-        if (stream != null)
-            return stream.onIdleTimeout(timeout);
-        return true;
-    }
-
     private boolean parse(ByteBuffer buffer)
     {
         while (buffer.hasRemaining())
@@ -318,8 +310,11 @@ public class ServerFCGIConnection extends AbstractMetaDataConnection implements 
         HttpStreamOverFCGI stream = this.stream;
         if (stream == null)
             return true;
-        ThreadPool.executeImmediately(getExecutor(), stream.getHttpChannel().onIdleTimeout(timeoutException));
-        return false;
+        HttpChannel.IdleTimeoutTask task = stream.getHttpChannel().onIdleTimeout(timeoutException);
+        boolean handlingRequest = task.handlingRequest();
+        if (handlingRequest)
+            ThreadPool.executeImmediately(getExecutor(), task.action());
+        return !handlingRequest;
     }
 
     private class ServerListener implements ServerParser.Listener

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
@@ -601,9 +601,8 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
     @Override
     public void onTimeout(TimeoutException timeout, BiConsumer<Runnable, Boolean> consumer)
     {
-        Runnable task = _httpChannel.onIdleTimeout(timeout);
-        boolean idle = !_httpChannel.isRequestHandled();
-        consumer.accept(task, idle);
+        HttpChannel.IdleTimeoutTask task = _httpChannel.onIdleTimeout(timeout);
+        consumer.accept(task.action(), !task.handlingRequest());
     }
 
     @Override

--- a/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HttpStreamOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HttpStreamOverHTTP3.java
@@ -546,9 +546,8 @@ public class HttpStreamOverHTTP3 implements HttpStream
 
     public void onIdleTimeout(TimeoutException failure, BiConsumer<Runnable, Boolean> consumer)
     {
-        Runnable runnable = httpChannel.onIdleTimeout(failure);
-        boolean idle = !httpChannel.isRequestHandled();
-        consumer.accept(runnable, idle);
+        HttpChannel.IdleTimeoutTask task = httpChannel.onIdleTimeout(failure);
+        consumer.accept(task.action(), !task.handlingRequest());
     }
 
     public Runnable onFailure(Throwable failure)

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
@@ -44,11 +44,6 @@ public interface HttpChannel extends Invocable
     void setHttpStream(HttpStream httpStream);
 
     /**
-     * @return whether the request has been passed to the root {@link Handler}.
-     */
-    boolean isRequestHandled();
-
-    /**
      * <p>{@link HttpStream} invokes this method when the metadata of an HTTP
      * request (method, URI and headers, but not content) has been parsed.</p>
      * <p>The returned {@code Runnable} invokes the root {@link Handler}.</p>
@@ -84,7 +79,7 @@ public interface HttpChannel extends Invocable
      * if no action need be performed by the calling thread
      * @see Request#addIdleTimeoutListener(Predicate)
      */
-    Runnable onIdleTimeout(TimeoutException idleTimeout);
+    IdleTimeoutTask onIdleTimeout(TimeoutException idleTimeout);
 
     /**
      * <p>Notifies this {@code HttpChannel} that an asynchronous failure happened.</p>
@@ -174,5 +169,17 @@ public interface HttpChannel extends Invocable
         {
             return new HttpChannelState(connectionMetaData);
         }
+    }
+
+    /**
+     * <p>Holds the action to perform in case of idle timeout,
+     * and whether the HTTP request is being handled when the
+     * idle timeout occurs.</p>
+     *
+     * @param action the idle timeout action to perform
+     * @param handlingRequest whether the request is being handled
+     */
+    record IdleTimeoutTask(Runnable action, boolean handlingRequest)
+    {
     }
 }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
@@ -75,9 +75,10 @@ public interface HttpChannel extends Invocable
      * <p>Notifies this {@code HttpChannel} that an idle timeout happened.</p>
      *
      * @param idleTimeout the timeout.
-     * @return a {@link IdleTimeoutTask} that contains the timeout action,
-     * or {@code null} if no action need be performed by the calling thread,
-     * and whether this {@code HttpChannel} is handling an HTTP request.
+     * @return a non-{@code null}{@link IdleTimeoutTask} that contains the timeout action,
+     * which may be {@code null} if no action needs be performed by the calling thread,
+     * and a {@code boolean} indicating whether this {@code HttpChannel} is currently
+     * handling an HTTP request.
      * @see Request#addIdleTimeoutListener(Predicate)
      */
     IdleTimeoutTask onIdleTimeout(TimeoutException idleTimeout);

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java
@@ -75,8 +75,9 @@ public interface HttpChannel extends Invocable
      * <p>Notifies this {@code HttpChannel} that an idle timeout happened.</p>
      *
      * @param idleTimeout the timeout.
-     * @return a {@code Runnable} that performs the timeout action, or {@code null}
-     * if no action need be performed by the calling thread
+     * @return a {@link IdleTimeoutTask} that contains the timeout action,
+     * or {@code null} if no action need be performed by the calling thread,
+     * and whether this {@code HttpChannel} is handling an HTTP request.
      * @see Request#addIdleTimeoutListener(Predicate)
      */
     IdleTimeoutTask onIdleTimeout(TimeoutException idleTimeout);

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -320,14 +320,6 @@ public class HttpChannelState implements HttpChannel, Components
         }
     }
 
-    public boolean isRequestHandled()
-    {
-        try (AutoLock ignored = _lock.lock())
-        {
-            return _handling != null || _handled;
-        }
-    }
-
     public Runnable onContentAvailable()
     {
         Runnable onContent;
@@ -353,8 +345,9 @@ public class HttpChannelState implements HttpChannel, Components
     }
 
     @Override
-    public Runnable onIdleTimeout(TimeoutException t)
+    public IdleTimeoutTask onIdleTimeout(TimeoutException t)
     {
+        boolean requestHandled;
         try (AutoLock ignored = _lock.lock())
         {
             if (LOG.isDebugEnabled())
@@ -363,6 +356,8 @@ public class HttpChannelState implements HttpChannel, Components
             // too late?
             if (_stream == null)
                 return null;
+
+            requestHandled = _handling != null || _handled;
 
             Runnable invokeOnContentAvailable = null;
             if (_readFailure == null)
@@ -381,13 +376,13 @@ public class HttpChannelState implements HttpChannel, Components
 
             // If there was a pending IO operation, deliver the idle timeout via them.
             if (invokeOnContentAvailable != null || invokeWriteFailure != null)
-                return Invocable.combine(_readInvoker.offer(invokeOnContentAvailable), _writeInvoker.offer(invokeWriteFailure));
+                return new IdleTimeoutTask(Invocable.combine(_readInvoker.offer(invokeOnContentAvailable), _writeInvoker.offer(invokeWriteFailure)), requestHandled);
 
             // Otherwise, if there are idle timeout listeners, ask them whether we should call onFailure.
             Predicate<TimeoutException> onIdleTimeout = _onIdleTimeout;
             if (onIdleTimeout != null)
             {
-                return () ->
+                return new IdleTimeoutTask(() ->
                 {
                     if (onIdleTimeout.test(t))
                     {
@@ -396,12 +391,12 @@ public class HttpChannelState implements HttpChannel, Components
                         if (task != null)
                             task.run();
                     }
-                };
+                }, requestHandled);
             }
         }
 
         // Otherwise treat as a failure.
-        return onFailure(t);
+        return new IdleTimeoutTask(onFailure(t), requestHandled);
     }
 
     @Override

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -355,7 +355,7 @@ public class HttpChannelState implements HttpChannel, Components
 
             // too late?
             if (_stream == null)
-                return null;
+                return new IdleTimeoutTask(null, false);
 
             requestHandled = _handling != null || _handled;
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -517,7 +517,7 @@ public class HttpChannelState implements HttpChannel, Components
             {
                 stream = _stream;
             }
-            if (_stream == null)
+            if (stream == null)
                 throw new IllegalStateException("No active stream");
             HttpStream combined = onStreamEvent.apply(stream);
             if (combined == null)

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -353,8 +353,8 @@ public class HttpChannelState implements HttpChannel, Components
             if (LOG.isDebugEnabled())
                 LOG.debug("onIdleTimeout {}", this, t);
 
-            // too late?
-            if (_stream == null)
+            // Either too early or too late.
+            if (_stream == null || _request == null)
                 return new IdleTimeoutTask(null, false);
 
             requestHandled = _handling != null || _handled;

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -627,10 +627,11 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
     @Override
     public boolean onIdleExpired(TimeoutException timeout)
     {
-        if (_httpChannel.getRequest() == null)
-            return true;
-        ThreadPool.executeImmediately(getExecutor(), _httpChannel.onIdleTimeout(timeout));
-        return false;
+        HttpChannel.IdleTimeoutTask task = _httpChannel.onIdleTimeout(timeout);
+        boolean handlingRequest = task.handlingRequest();
+        if (handlingRequest)
+            ThreadPool.executeImmediately(getExecutor(), task.action());
+        return !handlingRequest;
     }
 
     @Override


### PR DESCRIPTION
Normalized code across HTTP/1/2/3.

Introduced HttpChannel.IdleTimeoutTask and removed HttpChannel.isRequestHandled() that was only used for idle timeout handling.