### PR TITLE
Improve reliability of WebAppContextTest

### DIFF
--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppContextTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppContextTest.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
@@ -24,12 +25,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -99,6 +100,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -216,21 +218,17 @@ public class WebAppContextTest
     public void testDefaultContextPath() throws Exception
     {
         Server server = newServer();
-        File webXml = MavenTestingUtils.getTestResourceFile("web-with-default-context-path.xml");
-        File webXmlEmptyPath = MavenTestingUtils.getTestResourceFile("web-with-empty-default-context-path.xml");
-        File webDefaultXml = MavenTestingUtils.getTestResourceFile("web-default-with-default-context-path.xml");
-        File overrideWebXml = MavenTestingUtils.getTestResourceFile("override-web-with-default-context-path.xml");
-        assertNotNull(webXml);
-        assertNotNull(webDefaultXml);
-        assertNotNull(overrideWebXml);
-        assertNotNull(webXmlEmptyPath);
+        Path webXml = MavenPaths.findTestResourceFile("web-with-default-context-path.xml");
+        Path webXmlEmptyPath = MavenPaths.findTestResourceFile("web-with-empty-default-context-path.xml");
+        Path webDefaultXml = MavenPaths.findTestResourceFile("web-default-with-default-context-path.xml");
+        Path overrideWebXml = MavenPaths.findTestResourceFile("override-web-with-default-context-path.xml");
 
         WebAppContext wac = new WebAppContext();
-        wac.setBaseResourceAsPath(MavenTestingUtils.getTargetTestingDir().getAbsoluteFile().toPath());
+        wac.setBaseResourceAsPath(MavenPaths.targetTests());
         server.setHandler(wac);
 
         //test that an empty default-context-path defaults to root
-        wac.setDescriptor(webXmlEmptyPath.getAbsolutePath());
+        wac.setDescriptor(webXmlEmptyPath.toString());
         server.start();
         assertEquals("/", wac.getContextPath());
 
@@ -238,21 +236,21 @@ public class WebAppContextTest
 
         //test web-default.xml value is used
         wac.setDescriptor(null);
-        wac.setDefaultsDescriptor(webDefaultXml.getAbsolutePath());
+        wac.setDefaultsDescriptor(webDefaultXml.toString());
         server.start();
         assertEquals("/one", wac.getContextPath());
 
         server.stop();
 
         //test web.xml value is used
-        wac.setDescriptor(webXml.getAbsolutePath());
+        wac.setDescriptor(webXml.toString());
         server.start();
         assertEquals("/two", wac.getContextPath());
 
         server.stop();
 
         //test override-web.xml value is used
-        wac.setOverrideDescriptor(overrideWebXml.getAbsolutePath());
+        wac.setOverrideDescriptor(overrideWebXml.toString());
         server.start();
         assertEquals("/three", wac.getContextPath());
 
@@ -286,7 +284,7 @@ public class WebAppContextTest
 
         // test if no classname set, and none from server its the defaults
         wac.setServer(server);
-        assertTrue(Arrays.equals(classNames, wac.getConfigurationClasses()));
+        assertArrayEquals(classNames, wac.getConfigurationClasses());
     }
 
     @Test
@@ -321,14 +319,14 @@ public class WebAppContextTest
         Configuration[] configs = {new WebInfConfiguration()};
         WebAppContext wac = new WebAppContext();
         wac.setConfigurations(configs);
-        assertThat(wac.getConfigurations(), Matchers.contains(configs));
+        assertThat(wac.getConfigurations(), contains(configs));
 
         //test that explicit config instances override any from server
         String[] classNames = {"x.y.z"};
         Server server = newServer();
         server.setAttribute(Configurations.SERVER_DEFAULT_ATTR, classNames);
         wac.setServer(server);
-        assertThat(wac.getConfigurations(), Matchers.contains(configs));
+        assertThat(wac.getConfigurations(), contains(configs));
     }
 
     @Test
@@ -429,7 +427,7 @@ public class WebAppContextTest
 
         ContextHandlerCollection contexts = new ContextHandlerCollection();
         WebAppContext context = new WebAppContext();
-        Path testWebapp = MavenTestingUtils.getProjectDirPath("src/test/webapp");
+        Path testWebapp = MavenPaths.projectBase().resolve("src/test/webapp");
         context.setBaseResourceAsPath(testWebapp);
         context.setContextPath("/");
         server.setHandler(contexts);
@@ -502,7 +500,7 @@ public class WebAppContextTest
 
         ContextHandlerCollection contexts = new ContextHandlerCollection();
         WebAppContext context = new WebAppContext();
-        Path testWebapp = MavenTestingUtils.getProjectDirPath("src/test/webapp");
+        Path testWebapp = MavenPaths.projectBase().resolve("src/test/webapp");
         context.setBaseResourceAsPath(testWebapp);
         context.setContextPath("/");
         server.setHandler(contexts);
@@ -510,7 +508,13 @@ public class WebAppContextTest
 
         server.start();
 
-        assertThat(HttpTester.parseResponse(connector.getResponse("GET " + path + " HTTP/1.1\r\nHost: localhost:8080\r\nConnection: close\r\n\r\n")).getStatus(),
+        assertThat(HttpTester.parseResponse(connector.getResponse(
+                """
+                    GET %s HTTP/1.1\r
+                    Host: localhost:8080\r
+                    Connection: close\r
+                    \r
+                    """.formatted(path))).getStatus(),
             Matchers.anyOf(is(HttpStatus.BAD_REQUEST_400)));
     }
 
@@ -521,7 +525,7 @@ public class WebAppContextTest
 
         ContextHandlerCollection contexts = new ContextHandlerCollection();
         WebAppContext context = new WebAppContext();
-        Path testWebapp = MavenTestingUtils.getProjectDirPath("src/test/webapp");
+        Path testWebapp = MavenPaths.projectBase().resolve("src/test/webapp");
         context.setBaseResourceAsPath(testWebapp);
         context.setContextPath("/");
         server.setHandler(contexts);
@@ -532,7 +536,12 @@ public class WebAppContextTest
 
         server.start();
 
-        String rawResponse = connector.getResponse("GET http://localhost:8080 HTTP/1.1\r\nHost: localhost:8080\r\nConnection: close\r\n\r\n");
+        String rawResponse = connector.getResponse("""
+            GET http://localhost:8080 HTTP/1.1\r
+            Host: localhost:8080\r
+            Connection: close\r
+            \r
+            """);
         HttpTester.Response response = HttpTester.parseResponse(rawResponse);
         assertThat(response.getStatus(), is(HttpStatus.OK_200));
     }
@@ -547,7 +556,7 @@ public class WebAppContextTest
             ServletContextHandler.NO_SESSIONS | ServletContextHandler.NO_SECURITY);
         context.setContextPath("/");
 
-        Path testWebapp = MavenTestingUtils.getProjectDirPath("src/test/webapp");
+        Path testWebapp = MavenPaths.projectBase().resolve("src/test/webapp");
         context.setBaseResourceAsPath(testWebapp);
         server.setHandler(contexts);
         contexts.addHandler(context);
@@ -577,7 +586,7 @@ public class WebAppContextTest
         }
     }
 
- public static class ErrorDumpServlet extends HttpServlet
+    public static class ErrorDumpServlet extends HttpServlet
     {
         @Override
         protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
@@ -694,8 +703,8 @@ public class WebAppContextTest
         WebAppContext context = new WebAppContext();
         context.setContextPath("/");
         context.setBaseResource(ResourceFactory.combine(
-            context.getResourceFactory().newResource(MavenTestingUtils.getTestResourcePath("wars/layer0/")),
-            context.getResourceFactory().newResource(MavenTestingUtils.getTestResourcePath("wars/layer1/"))));
+            context.getResourceFactory().newResource(MavenPaths.findTestResourceDir("wars/layer0/")),
+            context.getResourceFactory().newResource(MavenPaths.findTestResourceDir("wars/layer1/"))));
         server.setHandler(context);
         server.start();
 
@@ -712,8 +721,8 @@ public class WebAppContextTest
         WebAppContext context = new WebAppContext();
         context.setContextPath("/");
         context.setBaseResource(ResourceFactory.combine(
-            context.getResourceFactory().newResource(MavenTestingUtils.getTestResourcePath("wars/layer0/")),
-            context.getResourceFactory().newResource(MavenTestingUtils.getTestResourcePath("wars/layer1/"))));
+            context.getResourceFactory().newResource(MavenPaths.findTestResourceDir("wars/layer0/")),
+            context.getResourceFactory().newResource(MavenPaths.findTestResourceDir("wars/layer1/"))));
         server.setHandler(context);
         server.start();
 
@@ -729,10 +738,10 @@ public class WebAppContextTest
         WebAppContext context = new WebAppContext();
         context.setContextPath("/");
         context.setBaseResource(ResourceFactory.combine(
-            context.getResourceFactory().newResource(MavenTestingUtils.getTestResourcePath("wars/layer0/")),
-            context.getResourceFactory().newResource(MavenTestingUtils.getTestResourcePath("wars/layer1/")),
-            context.getResourceFactory().newResource(MavenTestingUtils.getTestResourcePath("wars/with_dirs/"))
-            ));
+            context.getResourceFactory().newResource(MavenPaths.findTestResourceDir("wars/layer0/")),
+            context.getResourceFactory().newResource(MavenPaths.findTestResourceDir("wars/layer1/")),
+            context.getResourceFactory().newResource(MavenPaths.findTestResourceDir("wars/with_dirs/"))
+        ));
         server.setHandler(context);
         server.start();
 
@@ -794,7 +803,10 @@ public class WebAppContextTest
         LocalConnector connector = new LocalConnector(server);
         server.addConnector(connector);
 
-        WebAppContext context = new WebAppContext(MavenTestingUtils.getBasePath().resolve("src/test/webapp-with-resources").toString(), "/");
+        Path warRoot = MavenPaths.projectBase().resolve("src/test/webapp-with-resources");
+        WebAppContext context = new WebAppContext();
+        context.setBaseResourceAsPath(warRoot);
+        context.setContextPath("/");
         server.setHandler(context);
         server.start();
 
@@ -851,7 +863,7 @@ public class WebAppContextTest
     {
         List<Arguments> references = new ArrayList<>();
 
-        Path extLibs = MavenTestingUtils.getTestResourcePathDir("ext");
+        Path extLibs = MavenPaths.findTestResourceDir("ext");
         extLibs = extLibs.toAbsolutePath();
 
         // Absolute reference with trailing slash and glob
@@ -895,7 +907,7 @@ public class WebAppContextTest
         ClassLoader contextClassLoader = context.getClassLoader();
         assertThat(contextClassLoader, instanceOf(WebAppClassLoader.class));
         WebAppClassLoader webAppClassLoader = (WebAppClassLoader)contextClassLoader;
-        Path extLibsDir = MavenTestingUtils.getTestResourcePathDir("ext");
+        Path extLibsDir = MavenPaths.findTestResourceDir("ext");
         extLibsDir = extLibsDir.toAbsolutePath();
         List<URI> expectedUris;
         try (Stream<Path> s = Files.list(extLibsDir))
@@ -905,14 +917,14 @@ public class WebAppContextTest
                 .filter(FileID::isJavaArchive)
                 .sorted(Comparator.naturalOrder())
                 .map(Path::toUri)
+                .filter(notInTempDirectory(context))
                 .map(URIUtil::toJarFileUri)
-                .collect(Collectors.toList());
+                .toList();
         }
-        List<URI> actualURIs = new ArrayList<>();
-        for (URL url : webAppClassLoader.getURLs())
-        {
-            actualURIs.add(url.toURI());
-        }
+        List<URI> actualURIs = Stream.of(webAppClassLoader.getURLs())
+            .map(WebAppContextTest::toURI)
+            .filter(notInTempDirectory(context))
+            .toList();
         assertThat("[" + description + "] WebAppClassLoader.urls.length", actualURIs.size(), is(expectedUris.size()));
 
         assertThat(actualURIs, contains(expectedUris.toArray()));
@@ -922,7 +934,7 @@ public class WebAppContextTest
     {
         List<Arguments> references = new ArrayList<>();
 
-        Path extLibs = MavenTestingUtils.getTestResourcePathDir("ext");
+        Path extLibs = MavenPaths.findTestResourceDir("ext");
         extLibs = extLibs.toAbsolutePath();
 
         // Absolute reference with trailing slash
@@ -973,11 +985,14 @@ public class WebAppContextTest
         ClassLoader contextClassLoader = context.getClassLoader();
         assertThat(contextClassLoader, instanceOf(WebAppClassLoader.class));
         WebAppClassLoader webAppClassLoader = (WebAppClassLoader)contextClassLoader;
-        URL[] urls = webAppClassLoader.getURLs();
-        assertThat("URLs", urls.length, is(1));
-        Path extLibs = MavenTestingUtils.getTestResourcePathDir("ext");
+        List<URI> urls = Stream.of(webAppClassLoader.getURLs())
+            .map(WebAppContextTest::toURI)
+            .filter(notInTempDirectory(context))
+            .toList();
+        assertThat("URLs", urls.size(), is(1));
+        Path extLibs = MavenPaths.findTestResourceDir("ext");
         extLibs = extLibs.toAbsolutePath();
-        assertThat("URL[0]", urls[0].toURI(), is(extLibs.toUri()));
+        assertThat("URL[0]", urls.get(0), is(extLibs.toUri()));
     }
 
     @Test
@@ -1168,5 +1183,29 @@ public class WebAppContextTest
         {
             resp.setStatus(200);
         }
+    }
+
+    private static URI toURI(URL url)
+    {
+        try
+        {
+            return url.toURI();
+        }
+        catch (URISyntaxException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Predicate<URI> notInTempDirectory(WebAppContext context)
+    {
+        String tempDirUri = context.getTempDirectory().toURI().toASCIIString();
+        return (uri) ->
+        {
+            // we don't want to see entries that are in the webapp temp dir
+            // Such as <temp-dir>/WEB-INF/classes
+            //      or <temp-dir>/WEB-INF/lib/*.jar
+            return !uri.toASCIIString().startsWith(tempDirUri);
+        };
     }
 }

--- a/jetty-ee11/jetty-ee11-webapp/src/test/java/org/eclipse/jetty/ee11/webapp/WebAppContextTest.java
+++ b/jetty-ee11/jetty-ee11-webapp/src/test/java/org/eclipse/jetty/ee11/webapp/WebAppContextTest.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
@@ -24,12 +25,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -99,6 +100,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -166,7 +168,7 @@ public class WebAppContextTest
         return warFile;
     }
 
-   @Test
+    @Test
     public void testProtectedTargetErrorPage() throws Exception
     {
         WebAppContext contextHandler = new WebAppContext();
@@ -192,13 +194,14 @@ public class WebAppContextTest
 
         try (StacklessLogging stackless = new StacklessLogging(ServletChannel.class))
         {
-            StringBuilder rawRequest = new StringBuilder();
-            rawRequest.append("GET /foo/WEB-INF/classes/this/does/not/exist").append(" HTTP/1.1\r\n");
-            rawRequest.append("Host: test\r\n");
-            rawRequest.append("Connection: close\r\n");
-            rawRequest.append("\r\n");
+            String rawRequest = """
+                GET /foo/WEB-INF/classes/this/does/not/exist HTTP/1.1\r
+                Host: test\r
+                Connection: close\r
+                \r
+                """;
 
-            String rawResponse = connector.getResponse(rawRequest.toString());
+            String rawResponse = connector.getResponse(rawRequest);
 
             HttpTester.Response response = HttpTester.parseResponse(rawResponse);
             assertThat(response.getStatus(), is(404));
@@ -215,21 +218,17 @@ public class WebAppContextTest
     public void testDefaultContextPath() throws Exception
     {
         Server server = newServer();
-        File webXml = MavenTestingUtils.getTestResourceFile("web-with-default-context-path.xml");
-        File webXmlEmptyPath = MavenTestingUtils.getTestResourceFile("web-with-empty-default-context-path.xml");
-        File webDefaultXml = MavenTestingUtils.getTestResourceFile("web-default-with-default-context-path.xml");
-        File overrideWebXml = MavenTestingUtils.getTestResourceFile("override-web-with-default-context-path.xml");
-        assertNotNull(webXml);
-        assertNotNull(webDefaultXml);
-        assertNotNull(overrideWebXml);
-        assertNotNull(webXmlEmptyPath);
+        Path webXml = MavenPaths.findTestResourceFile("web-with-default-context-path.xml");
+        Path webXmlEmptyPath = MavenPaths.findTestResourceFile("web-with-empty-default-context-path.xml");
+        Path webDefaultXml = MavenPaths.findTestResourceFile("web-default-with-default-context-path.xml");
+        Path overrideWebXml = MavenPaths.findTestResourceFile("override-web-with-default-context-path.xml");
 
         WebAppContext wac = new WebAppContext();
-        wac.setBaseResourceAsPath(MavenTestingUtils.getTargetTestingDir().getAbsoluteFile().toPath());
+        wac.setBaseResourceAsPath(MavenPaths.targetTests());
         server.setHandler(wac);
 
         //test that an empty default-context-path defaults to root
-        wac.setDescriptor(webXmlEmptyPath.getAbsolutePath());
+        wac.setDescriptor(webXmlEmptyPath.toString());
         server.start();
         assertEquals("/", wac.getContextPath());
 
@@ -237,21 +236,21 @@ public class WebAppContextTest
 
         //test web-default.xml value is used
         wac.setDescriptor(null);
-        wac.setDefaultsDescriptor(webDefaultXml.getAbsolutePath());
+        wac.setDefaultsDescriptor(webDefaultXml.toString());
         server.start();
         assertEquals("/one", wac.getContextPath());
 
         server.stop();
 
         //test web.xml value is used
-        wac.setDescriptor(webXml.getAbsolutePath());
+        wac.setDescriptor(webXml.toString());
         server.start();
         assertEquals("/two", wac.getContextPath());
 
         server.stop();
 
         //test override-web.xml value is used
-        wac.setOverrideDescriptor(overrideWebXml.getAbsolutePath());
+        wac.setOverrideDescriptor(overrideWebXml.toString());
         server.start();
         assertEquals("/three", wac.getContextPath());
 
@@ -285,7 +284,7 @@ public class WebAppContextTest
 
         // test if no classname set, and none from server its the defaults
         wac.setServer(server);
-        assertTrue(Arrays.equals(classNames, wac.getConfigurationClasses()));
+        assertArrayEquals(classNames, wac.getConfigurationClasses());
     }
 
     @Test
@@ -320,14 +319,14 @@ public class WebAppContextTest
         Configuration[] configs = {new WebInfConfiguration()};
         WebAppContext wac = new WebAppContext();
         wac.setConfigurations(configs);
-        assertThat(wac.getConfigurations(), Matchers.contains(configs));
+        assertThat(wac.getConfigurations(), contains(configs));
 
         //test that explicit config instances override any from server
         String[] classNames = {"x.y.z"};
         Server server = newServer();
         server.setAttribute(Configurations.SERVER_DEFAULT_ATTR, classNames);
         wac.setServer(server);
-        assertThat(wac.getConfigurations(), Matchers.contains(configs));
+        assertThat(wac.getConfigurations(), contains(configs));
     }
 
     @Test
@@ -428,7 +427,7 @@ public class WebAppContextTest
 
         ContextHandlerCollection contexts = new ContextHandlerCollection();
         WebAppContext context = new WebAppContext();
-        Path testWebapp = MavenTestingUtils.getProjectDirPath("src/test/webapp");
+        Path testWebapp = MavenPaths.projectBase().resolve("src/test/webapp");
         context.setBaseResourceAsPath(testWebapp);
         context.setContextPath("/");
         server.setHandler(contexts);
@@ -501,7 +500,7 @@ public class WebAppContextTest
 
         ContextHandlerCollection contexts = new ContextHandlerCollection();
         WebAppContext context = new WebAppContext();
-        Path testWebapp = MavenTestingUtils.getProjectDirPath("src/test/webapp");
+        Path testWebapp = MavenPaths.projectBase().resolve("src/test/webapp");
         context.setBaseResourceAsPath(testWebapp);
         context.setContextPath("/");
         server.setHandler(contexts);
@@ -509,7 +508,13 @@ public class WebAppContextTest
 
         server.start();
 
-        assertThat(HttpTester.parseResponse(connector.getResponse("GET " + path + " HTTP/1.1\r\nHost: localhost:8080\r\nConnection: close\r\n\r\n")).getStatus(),
+        assertThat(HttpTester.parseResponse(connector.getResponse(
+                """
+                    GET %s HTTP/1.1\r
+                    Host: localhost:8080\r
+                    Connection: close\r
+                    \r
+                    """.formatted(path))).getStatus(),
             Matchers.anyOf(is(HttpStatus.BAD_REQUEST_400)));
     }
 
@@ -520,7 +525,7 @@ public class WebAppContextTest
 
         ContextHandlerCollection contexts = new ContextHandlerCollection();
         WebAppContext context = new WebAppContext();
-        Path testWebapp = MavenTestingUtils.getProjectDirPath("src/test/webapp");
+        Path testWebapp = MavenPaths.projectBase().resolve("src/test/webapp");
         context.setBaseResourceAsPath(testWebapp);
         context.setContextPath("/");
         server.setHandler(contexts);
@@ -531,7 +536,12 @@ public class WebAppContextTest
 
         server.start();
 
-        String rawResponse = connector.getResponse("GET http://localhost:8080 HTTP/1.1\r\nHost: localhost:8080\r\nConnection: close\r\n\r\n");
+        String rawResponse = connector.getResponse("""
+            GET http://localhost:8080 HTTP/1.1\r
+            Host: localhost:8080\r
+            Connection: close\r
+            \r
+            """);
         HttpTester.Response response = HttpTester.parseResponse(rawResponse);
         assertThat(response.getStatus(), is(HttpStatus.OK_200));
     }
@@ -546,7 +556,7 @@ public class WebAppContextTest
             ServletContextHandler.NO_SESSIONS | ServletContextHandler.NO_SECURITY);
         context.setContextPath("/");
 
-        Path testWebapp = MavenTestingUtils.getProjectDirPath("src/test/webapp");
+        Path testWebapp = MavenPaths.projectBase().resolve("src/test/webapp");
         context.setBaseResourceAsPath(testWebapp);
         server.setHandler(contexts);
         contexts.addHandler(context);
@@ -695,8 +705,8 @@ public class WebAppContextTest
         WebAppContext context = new WebAppContext();
         context.setContextPath("/");
         context.setBaseResource(ResourceFactory.combine(
-            context.getResourceFactory().newResource(MavenTestingUtils.getTestResourcePath("wars/layer0/")),
-            context.getResourceFactory().newResource(MavenTestingUtils.getTestResourcePath("wars/layer1/"))));
+            context.getResourceFactory().newResource(MavenPaths.findTestResourceDir("wars/layer0/")),
+            context.getResourceFactory().newResource(MavenPaths.findTestResourceDir("wars/layer1/"))));
         server.setHandler(context);
         server.start();
 
@@ -713,8 +723,8 @@ public class WebAppContextTest
         WebAppContext context = new WebAppContext();
         context.setContextPath("/");
         context.setBaseResource(ResourceFactory.combine(
-            context.getResourceFactory().newResource(MavenTestingUtils.getTestResourcePath("wars/layer0/")),
-            context.getResourceFactory().newResource(MavenTestingUtils.getTestResourcePath("wars/layer1/"))));
+            context.getResourceFactory().newResource(MavenPaths.findTestResourceDir("wars/layer0/")),
+            context.getResourceFactory().newResource(MavenPaths.findTestResourceDir("wars/layer1/"))));
         server.setHandler(context);
         server.start();
 
@@ -730,10 +740,10 @@ public class WebAppContextTest
         WebAppContext context = new WebAppContext();
         context.setContextPath("/");
         context.setBaseResource(ResourceFactory.combine(
-            context.getResourceFactory().newResource(MavenTestingUtils.getTestResourcePath("wars/layer0/")),
-            context.getResourceFactory().newResource(MavenTestingUtils.getTestResourcePath("wars/layer1/")),
-            context.getResourceFactory().newResource(MavenTestingUtils.getTestResourcePath("wars/with_dirs/"))
-            ));
+            context.getResourceFactory().newResource(MavenPaths.findTestResourceDir("wars/layer0/")),
+            context.getResourceFactory().newResource(MavenPaths.findTestResourceDir("wars/layer1/")),
+            context.getResourceFactory().newResource(MavenPaths.findTestResourceDir("wars/with_dirs/"))
+        ));
         server.setHandler(context);
         server.start();
 
@@ -795,7 +805,10 @@ public class WebAppContextTest
         LocalConnector connector = new LocalConnector(server);
         server.addConnector(connector);
 
-        WebAppContext context = new WebAppContext(MavenTestingUtils.getBasePath().resolve("src/test/webapp-with-resources").toString(), "/");
+        Path warRoot = MavenPaths.projectBase().resolve("src/test/webapp-with-resources");
+        WebAppContext context = new WebAppContext();
+        context.setBaseResourceAsPath(warRoot);
+        context.setContextPath("/");
         server.setHandler(context);
         server.start();
 
@@ -852,7 +865,7 @@ public class WebAppContextTest
     {
         List<Arguments> references = new ArrayList<>();
 
-        Path extLibs = MavenTestingUtils.getTestResourcePathDir("ext");
+        Path extLibs = MavenPaths.findTestResourceDir("ext");
         extLibs = extLibs.toAbsolutePath();
 
         // Absolute reference with trailing slash and glob
@@ -896,7 +909,7 @@ public class WebAppContextTest
         ClassLoader contextClassLoader = context.getClassLoader();
         assertThat(contextClassLoader, instanceOf(WebAppClassLoader.class));
         WebAppClassLoader webAppClassLoader = (WebAppClassLoader)contextClassLoader;
-        Path extLibsDir = MavenTestingUtils.getTestResourcePathDir("ext");
+        Path extLibsDir = MavenPaths.findTestResourceDir("ext");
         extLibsDir = extLibsDir.toAbsolutePath();
         List<URI> expectedUris;
         try (Stream<Path> s = Files.list(extLibsDir))
@@ -906,14 +919,14 @@ public class WebAppContextTest
                 .filter(FileID::isJavaArchive)
                 .sorted(Comparator.naturalOrder())
                 .map(Path::toUri)
+                .filter(notInTempDirectory(context))
                 .map(URIUtil::toJarFileUri)
-                .collect(Collectors.toList());
+                .toList();
         }
-        List<URI> actualURIs = new ArrayList<>();
-        for (URL url : webAppClassLoader.getURLs())
-        {
-            actualURIs.add(url.toURI());
-        }
+        List<URI> actualURIs = Stream.of(webAppClassLoader.getURLs())
+            .map(WebAppContextTest::toURI)
+            .filter(notInTempDirectory(context))
+            .toList();
         assertThat("[" + description + "] WebAppClassLoader.urls.length", actualURIs.size(), is(expectedUris.size()));
 
         assertThat(actualURIs, contains(expectedUris.toArray()));
@@ -923,7 +936,7 @@ public class WebAppContextTest
     {
         List<Arguments> references = new ArrayList<>();
 
-        Path extLibs = MavenTestingUtils.getTestResourcePathDir("ext");
+        Path extLibs = MavenPaths.findTestResourceDir("ext");
         extLibs = extLibs.toAbsolutePath();
 
         // Absolute reference with trailing slash
@@ -974,11 +987,14 @@ public class WebAppContextTest
         ClassLoader contextClassLoader = context.getClassLoader();
         assertThat(contextClassLoader, instanceOf(WebAppClassLoader.class));
         WebAppClassLoader webAppClassLoader = (WebAppClassLoader)contextClassLoader;
-        URL[] urls = webAppClassLoader.getURLs();
-        assertThat("URLs", urls.length, is(1));
-        Path extLibs = MavenTestingUtils.getTestResourcePathDir("ext");
+        List<URI> urls = Stream.of(webAppClassLoader.getURLs())
+            .map(WebAppContextTest::toURI)
+            .filter(notInTempDirectory(context))
+            .toList();
+        assertThat("URLs", urls.size(), is(1));
+        Path extLibs = MavenPaths.findTestResourceDir("ext");
         extLibs = extLibs.toAbsolutePath();
-        assertThat("URL[0]", urls[0].toURI(), is(extLibs.toUri()));
+        assertThat("URL[0]", urls.get(0), is(extLibs.toUri()));
     }
 
     @Test
@@ -1098,7 +1114,7 @@ public class WebAppContextTest
         WebAppContext context = new WebAppContext();
         context.setContextPath("/");
 
-        Path testPath = MavenPaths.targetTestDir("testAddHiddenClasses");
+        Path testPath = MavenPaths.targetTestDir("testAddServerClasses");
         FS.ensureDirExists(testPath);
         FS.ensureEmpty(testPath);
         Path warPath = createWar(testPath, "test.war");
@@ -1131,7 +1147,7 @@ public class WebAppContextTest
 
         WebAppContext context = new WebAppContext();
         context.setContextPath("/");
-        Path testPath = MavenPaths.targetTestDir("testAddHiddenClasses");
+        Path testPath = MavenPaths.targetTestDir("testAddServerClasses");
         FS.ensureDirExists(testPath);
         FS.ensureEmpty(testPath);
         Path warPath = createWar(testPath, "test.war");
@@ -1161,5 +1177,29 @@ public class WebAppContextTest
         {
             resp.setStatus(200);
         }
+    }
+
+    private static URI toURI(URL url)
+    {
+        try
+        {
+            return url.toURI();
+        }
+        catch (URISyntaxException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Predicate<URI> notInTempDirectory(WebAppContext context)
+    {
+        String tempDirUri = context.getTempDirectory().toURI().toASCIIString();
+        return (uri) ->
+        {
+            // we don't want to see entries that are in the webapp temp dir
+            // Such as <temp-dir>/WEB-INF/classes
+            //      or <temp-dir>/WEB-INF/lib/*.jar
+            return !uri.toASCIIString().startsWith(tempDirUri);
+        };
     }
 }

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppContextTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppContextTest.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
@@ -29,6 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -69,9 +71,7 @@ import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.resource.FileSystemPool;
-import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
-import org.eclipse.jetty.util.resource.Resources;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -134,8 +134,7 @@ public class WebAppContextTest
     private Path createWar(Path tempDir, String name) throws Exception
     {
         // Create war on the fly
-        Path testWebappDir = MavenTestingUtils.getTargetPath("test-classes/webapp");
-        assertTrue(Files.exists(testWebappDir));
+        Path testWebappDir = MavenPaths.findTestResourceDir("webapp");
         Path warFile = tempDir.resolve(name);
 
         Map<String, String> env = new HashMap<>();
@@ -166,21 +165,17 @@ public class WebAppContextTest
     public void testDefaultContextPath() throws Exception
     {
         Server server = newServer();
-        File webXml = MavenTestingUtils.getTargetFile("test-classes/web-with-default-context-path.xml");
-        File webXmlEmptyPath = MavenTestingUtils.getTargetFile("test-classes/web-with-empty-default-context-path.xml");
-        File webDefaultXml = MavenTestingUtils.getTargetFile("test-classes/web-default-with-default-context-path.xml");
-        File overrideWebXml = MavenTestingUtils.getTargetFile("test-classes/override-web-with-default-context-path.xml");
-        assertNotNull(webXml);
-        assertNotNull(webDefaultXml);
-        assertNotNull(overrideWebXml);
-        assertNotNull(webXmlEmptyPath);
+        Path webXml = MavenPaths.findTestResourceFile("web-with-default-context-path.xml");
+        Path webXmlEmptyPath = MavenPaths.findTestResourceFile("web-with-empty-default-context-path.xml");
+        Path webDefaultXml = MavenPaths.findTestResourceFile("web-default-with-default-context-path.xml");
+        Path overrideWebXml = MavenPaths.findTestResourceFile("override-web-with-default-context-path.xml");
 
         WebAppContext wac = new WebAppContext();
-        wac.setResourceBase(MavenTestingUtils.getTargetTestingDir().getAbsolutePath());
+        wac.setBaseResourceAsPath(MavenPaths.targetTests());
         server.setHandler(wac);
 
         //test that an empty default-context-path defaults to root
-        wac.setDescriptor(webXmlEmptyPath.getAbsolutePath());
+        wac.setDescriptor(webXmlEmptyPath.toString());
         server.start();
         assertEquals("/", wac.getContextPath());
 
@@ -188,21 +183,21 @@ public class WebAppContextTest
 
         //test web-default.xml value is used
         wac.setDescriptor(null);
-        wac.setDefaultsDescriptor(webDefaultXml.getAbsolutePath());
+        wac.setDefaultsDescriptor(webDefaultXml.toString());
         server.start();
         assertEquals("/one", wac.getContextPath());
 
         server.stop();
 
         //test web.xml value is used
-        wac.setDescriptor(webXml.getAbsolutePath());
+        wac.setDescriptor(webXml.toString());
         server.start();
         assertEquals("/two", wac.getContextPath());
 
         server.stop();
 
         //test override-web.xml value is used
-        wac.setOverrideDescriptor(overrideWebXml.getAbsolutePath());
+        wac.setOverrideDescriptor(overrideWebXml.toString());
         server.start();
         assertEquals("/three", wac.getContextPath());
 
@@ -218,17 +213,13 @@ public class WebAppContextTest
     public void nestedContextHandlerTest() throws Exception
     {
         Server server = newServer();
-        File webXml = MavenTestingUtils.getTargetFile("test-classes/web-with-default-context-path.xml");
-        File webXmlEmptyPath = MavenTestingUtils.getTargetFile("test-classes/web-with-empty-default-context-path.xml");
-        File webDefaultXml = MavenTestingUtils.getTargetFile("test-classes/web-default-with-default-context-path.xml");
-        File overrideWebXml = MavenTestingUtils.getTargetFile("test-classes/override-web-with-default-context-path.xml");
-        assertNotNull(webXml);
-        assertNotNull(webDefaultXml);
-        assertNotNull(overrideWebXml);
-        assertNotNull(webXmlEmptyPath);
+        Path webXml = MavenPaths.findTestResourceFile("web-with-default-context-path.xml");
+        Path webXmlEmptyPath = MavenPaths.findTestResourceFile("web-with-empty-default-context-path.xml");
+        Path webDefaultXml = MavenPaths.findTestResourceFile("web-default-with-default-context-path.xml");
+        Path overrideWebXml = MavenPaths.findTestResourceFile("override-web-with-default-context-path.xml");
 
         WebAppContext wac = new WebAppContext();
-        wac.setResourceBase(MavenTestingUtils.getTargetTestingDir().getAbsolutePath());
+        wac.setBaseResourceAsPath(MavenPaths.targetTests());
 
         // Put WebAppContext inside another nested ContextHandler.
         ContextHandler contextHandler = new ContextHandler("/", wac);
@@ -241,7 +232,7 @@ public class WebAppContextTest
         assertNotNull(wac.getCoreContextHandler().getServer());
 
         //test that an empty default-context-path defaults to root
-        wac.setDescriptor(webXmlEmptyPath.getAbsolutePath());
+        wac.setDescriptor(webXmlEmptyPath.toString());
         server.start();
         assertEquals("/", wac.getContextPath());
 
@@ -249,21 +240,21 @@ public class WebAppContextTest
 
         //test web-default.xml value is used
         wac.setDescriptor(null);
-        wac.setDefaultsDescriptor(webDefaultXml.getAbsolutePath());
+        wac.setDefaultsDescriptor(webDefaultXml.toString());
         server.start();
         assertEquals("/one", wac.getContextPath());
 
         server.stop();
 
         //test web.xml value is used
-        wac.setDescriptor(webXml.getAbsolutePath());
+        wac.setDescriptor(webXml.toString());
         server.start();
         assertEquals("/two", wac.getContextPath());
 
         server.stop();
 
         //test override-web.xml value is used
-        wac.setOverrideDescriptor(overrideWebXml.getAbsolutePath());
+        wac.setOverrideDescriptor(overrideWebXml.toString());
         server.start();
         assertEquals("/three", wac.getContextPath());
 
@@ -322,7 +313,7 @@ public class WebAppContextTest
         expectedConfigurations.add("org.eclipse.jetty.ee9.webapp.WebAppConfiguration");
         expectedConfigurations.add("org.eclipse.jetty.ee9.webapp.JettyWebXmlConfiguration");
 
-        assertThat(actualConfigurations, Matchers.contains(expectedConfigurations.toArray()));
+        assertThat(actualConfigurations, contains(expectedConfigurations.toArray()));
     }
 
     @Test
@@ -332,14 +323,14 @@ public class WebAppContextTest
         Configuration[] configs = {new WebInfConfiguration()};
         WebAppContext wac = new WebAppContext();
         wac.setConfigurations(configs);
-        assertThat(wac.getConfigurations(), Matchers.contains(configs));
+        assertThat(wac.getConfigurations(), contains(configs));
 
         //test that explicit config instances override any from server
         String[] classNames = {"x.y.z"};
         Server server = newServer();
         server.setAttribute(Configurations.class.getName(), classNames);
         wac.setServer(server);
-        assertThat(wac.getConfigurations(), Matchers.contains(configs));
+        assertThat(wac.getConfigurations(), contains(configs));
     }
 
     @Test
@@ -434,8 +425,8 @@ public class WebAppContextTest
         server.setHandler(contexts);
 
         WebAppContext context = new WebAppContext();
-        Path testWebapp = MavenTestingUtils.getTargetPath("test-classes/webapp");
-        context.setBaseResource(context.getResourceFactory().newResource(testWebapp));
+        Path testWebapp = MavenPaths.findTestResourceDir("webapp");
+        context.setBaseResourceAsPath(testWebapp);
         context.setContextPath("/");
 
         contexts.addHandler(context);
@@ -495,8 +486,8 @@ public class WebAppContextTest
         server.setHandler(contexts);
 
         WebAppContext context = new WebAppContext();
-        Path testWebapp = MavenTestingUtils.getTargetPath("test-classes/webapp");
-        context.setBaseResource(context.getResourceFactory().newResource(testWebapp));
+        Path testWebapp = MavenPaths.findTestResourceDir("webapp");
+        context.setBaseResourceAsPath(testWebapp);
         context.setContextPath("/");
         contexts.addHandler(context);
 
@@ -516,9 +507,7 @@ public class WebAppContextTest
 
         WebAppContext context = new WebAppContext();
         Path testWebapp = MavenPaths.findTestResourceDir("webapp");
-        Resource testWebappResource = context.getResourceFactory().newResource(testWebapp);
-        assertTrue(Resources.isReadableDirectory(testWebappResource));
-        context.setBaseResource(testWebappResource);
+        context.setBaseResourceAsPath(testWebapp);
         context.setContextPath("/");
 
         contexts.addHandler(context);
@@ -549,8 +538,8 @@ public class WebAppContextTest
         WebAppContext context = new WebAppContext(null, null, null, null, null, new ErrorPageErrorHandler(),
             ServletContextHandler.NO_SESSIONS | ServletContextHandler.NO_SECURITY);
         context.setContextPath("/");
-        Path testWebapp = MavenTestingUtils.getTargetPath("test-classes/webapp");
-        context.setBaseResource(context.getResourceFactory().newResource(testWebapp));
+        Path testWebapp = MavenPaths.findTestResourceDir("webapp");
+        context.setBaseResourceAsPath(testWebapp);
         contexts.addHandler(context);
 
         LocalConnector connector = new LocalConnector(server);
@@ -726,7 +715,7 @@ public class WebAppContextTest
         // On Unix / Linux this should have no issue.
         // On Windows with fully qualified paths such as "E:\mybase\webapps\test.war" the
         // resolution of the Resource can trigger various URI issues with the "E:" portion of the provided String.
-        context.setBaseResourceAsString(warPath.toString());
+        context.setBaseResourceAsPath(warPath);
 
         server.setHandler(context);
         server.start();
@@ -802,12 +791,9 @@ public class WebAppContextTest
         LocalConnector connector = new LocalConnector(server);
         server.addConnector(connector);
 
-
-        Path warRoot = MavenTestingUtils.getTargetPath("test-classes/webapp-with-resources");
-        assertTrue(Files.isDirectory(warRoot), "Unable to find directory: " + warRoot);
+        Path warRoot = MavenPaths.findTestResourceDir("webapp-with-resources");
         WebAppContext context = new WebAppContext();
-        Resource warResource = context.getResourceFactory().newResource(warRoot);
-        context.setWarResource(warResource);
+        context.setBaseResourceAsPath(warRoot);
         context.setContextPath("/");
         server.setHandler(context);
         server.start();
@@ -862,7 +848,7 @@ public class WebAppContextTest
     {
         List<Arguments> references = new ArrayList<>();
 
-        Path extLibs = MavenTestingUtils.getTargetPath("test-classes/ext");
+        Path extLibs = MavenPaths.findTestResourceDir("ext");
         extLibs = extLibs.toAbsolutePath();
 
         // Absolute reference with trailing slash and glob
@@ -893,7 +879,7 @@ public class WebAppContextTest
         WebAppContext context = new WebAppContext();
         context.setContextPath("/");
         Path warPath = createWar(testPath, "test.war");
-        context.setBaseResource(context.getResourceFactory().newResource(warPath));
+        context.setBaseResourceAsPath(warPath);
         context.setExtraClasspath(extraClasspathGlobReference);
 
         server.setHandler(context);
@@ -906,7 +892,7 @@ public class WebAppContextTest
         ClassLoader contextClassLoader = context.getClassLoader();
         assertThat(contextClassLoader, instanceOf(WebAppClassLoader.class));
         WebAppClassLoader webAppClassLoader = (WebAppClassLoader)contextClassLoader;
-        Path extLibsDir = MavenTestingUtils.getTargetPath("test-classes/ext");
+        Path extLibsDir = MavenPaths.findTestResourceDir("ext");
         extLibsDir = extLibsDir.toAbsolutePath();
 
         List<URI> expectedUris;
@@ -917,14 +903,14 @@ public class WebAppContextTest
                 .filter(FileID::isLibArchive)
                 .sorted(Comparator.naturalOrder())
                 .map(Path::toUri)
+                .filter(notInTempDirectory(context))
                 .map(URIUtil::toJarFileUri)
-                .collect(Collectors.toList());
+                .toList();
         }
-        List<URI> actualURIs = new ArrayList<>();
-        for (URL url : webAppClassLoader.getURLs())
-        {
-            actualURIs.add(url.toURI());
-        }
+        List<URI> actualURIs = Stream.of(webAppClassLoader.getURLs())
+            .map(WebAppContextTest::toURI)
+            .filter(notInTempDirectory(context))
+            .toList();
         assertThat("[" + description + "] WebAppClassLoader.urls.length", actualURIs.size(), is(expectedUris.size()));
 
         assertThat(actualURIs, contains(expectedUris.toArray()));
@@ -971,7 +957,7 @@ public class WebAppContextTest
         WebAppContext context = new WebAppContext();
         context.setContextPath("/");
         Path warPath = createWar(testPath, "test.war");
-        context.setBaseResource(context.getResourceFactory().newResource(warPath));
+        context.setBaseResourceAsPath(warPath);
 
         context.setExtraClasspath(extraClassPathReference);
 
@@ -985,11 +971,14 @@ public class WebAppContextTest
         ClassLoader contextClassLoader = context.getClassLoader();
         assertThat(contextClassLoader, instanceOf(WebAppClassLoader.class));
         WebAppClassLoader webAppClassLoader = (WebAppClassLoader)contextClassLoader;
-        URL[] urls = webAppClassLoader.getURLs();
-        assertThat("URLs", urls.length, is(1));
+        List<URI> urls = Stream.of(webAppClassLoader.getURLs())
+            .map(WebAppContextTest::toURI)
+            .filter(notInTempDirectory(context))
+            .toList();
+        assertThat("URLs", urls.size(), is(1));
         Path extLibs = MavenPaths.findTestResourceDir("ext");
         extLibs = extLibs.toAbsolutePath();
-        assertThat("URL[0]", urls[0].toURI(), is(extLibs.toUri()));
+        assertThat("URL[0]", urls.get(0), is(extLibs.toUri()));
     }
 
     @Test
@@ -1059,5 +1048,29 @@ public class WebAppContextTest
             assertThat("Should have default patterns", systemClasses, hasItem(defaultSystemClass));
         }
         assertThat("deprecated API", systemClasses, hasItem("org.deprecated.api."));
+    }
+
+    private static URI toURI(URL url)
+    {
+        try
+        {
+            return url.toURI();
+        }
+        catch (URISyntaxException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Predicate<URI> notInTempDirectory(WebAppContext context)
+    {
+        String tempDirUri = context.getTempDirectory().toURI().toASCIIString();
+        return (uri) ->
+        {
+            // we don't want to see entries that are in the webapp temp dir
+            // Such as <temp-dir>/WEB-INF/classes
+            //      or <temp-dir>/WEB-INF/lib/*.jar
+            return !uri.toASCIIString().startsWith(tempDirUri);
+        };
     }
 }


### PR DESCRIPTION
* Don't use deprecated methods/classes
* Introduce notInTempDirectory predicate
* Use notInTempDirectory when testing extraClassPath behaviors
* Improve test resource discovery for ee9 -> ee8 layer.