### PR TITLE
shared blocking callback hang

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -480,6 +480,11 @@ public class HttpChannelState implements HttpChannel, Components
                 };
 
                 // Serialize all the error actions.
+
+//                Case 2
+//                if (invokeOnContentAvailable != null || invokeWriteFailure != null)
+//                    invokeOnFailureListeners = null;
+
                 task = Invocable.combine(_readInvoker.offer(invokeOnContentAvailable), _writeInvoker.offer(invokeWriteFailure), _readInvoker.offer(invokeOnFailureListeners));
             }
         }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -1219,7 +1219,7 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
                 }
 
 //                Case 1
-//                ThreadPool.executeImmediately(getServer().getThreadPool(), _httpChannel.onFailure(bad));
+                ThreadPool.executeImmediately(getServer().getThreadPool(), _httpChannel.onFailure(bad));
             }
         }
     }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -1219,7 +1219,7 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
                 }
 
 //                Case 1
-                ThreadPool.executeImmediately(getServer().getThreadPool(), _httpChannel.onFailure(bad));
+//                ThreadPool.executeImmediately(getServer().getThreadPool(), _httpChannel.onFailure(bad));
             }
         }
     }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -1218,7 +1218,8 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
                     stream._chunk = Content.Chunk.from(bad);
                 }
 
-                ThreadPool.executeImmediately(getServer().getThreadPool(), _httpChannel.onFailure(bad));
+//                Case 1
+//                ThreadPool.executeImmediately(getServer().getThreadPool(), _httpChannel.onFailure(bad));
             }
         }
     }

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannelState.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannelState.java
@@ -839,11 +839,11 @@ public class HttpChannelState
                     if (_asyncListeners == null || _asyncListeners.isEmpty())
                     {
 //                        Case 3
-//                        return false;
-                        if (committed)
-                            return true;
-                        sendError(th);
                         return false;
+//                        if (committed)
+//                            return true;
+//                        sendError(th);
+//                        return false;
                     }
                     asyncEvent = _event;
                     asyncEvent.addThrowable(th);

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannelState.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannelState.java
@@ -838,6 +838,8 @@ public class HttpChannelState
                 {
                     if (_asyncListeners == null || _asyncListeners.isEmpty())
                     {
+//                        Case 3
+//                        return false;
                         if (committed)
                             return true;
                         sendError(th);

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannelState.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannelState.java
@@ -839,11 +839,11 @@ public class HttpChannelState
                     if (_asyncListeners == null || _asyncListeners.isEmpty())
                     {
 //                        Case 3
-                        return false;
-//                        if (committed)
-//                            return true;
-//                        sendError(th);
 //                        return false;
+                        if (committed)
+                            return true;
+                        sendError(th);
+                        return false;
                     }
                     asyncEvent = _event;
                     asyncEvent.addThrowable(th);

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/pom.xml
@@ -45,11 +45,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.jetty.ee9</groupId>
+    <artifactId>jetty-ee9-tests</artifactId>
+    <version>12.1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>jetty-ee9-test-jersey</artifactId>
+  <packaging>jar</packaging>
+  <name>EE9 :: Tests :: Jersey</name>
+
+  <properties>
+    <bundle-symbolic-name>${project.groupId}.jersey.tests</bundle-symbolic-name>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.ee9</groupId>
+      <artifactId>jetty-ee9-webapp</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-test-helper</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.containers</groupId>
+      <artifactId>jersey-container-servlet</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.inject</groupId>
+      <artifactId>jersey-hk2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-binding</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-slf4j-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jul-to-slf4j</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/java/org/eclipse/jetty/ee9/jersey/tests/EmbeddedJerseyTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/java/org/eclipse/jetty/ee9/jersey/tests/EmbeddedJerseyTest.java
@@ -1,0 +1,160 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee9.jersey.tests;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.client.AsyncRequestContent;
+import org.eclipse.jetty.client.CompletableResponseListener;
+import org.eclipse.jetty.client.ContentResponse;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.Request;
+import org.eclipse.jetty.client.StringRequestContent;
+import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee9.servlet.ServletHolder;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.MimeTypes;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class EmbeddedJerseyTest
+{
+    @BeforeAll
+    public static void beforeAll()
+    {
+        // Wire up java.util.logging to slf4j.
+        org.slf4j.bridge.SLF4JBridgeHandler.removeHandlersForRootLogger();
+        org.slf4j.bridge.SLF4JBridgeHandler.install();
+    }
+
+    @AfterAll
+    public static void afterAll()
+    {
+        org.slf4j.bridge.SLF4JBridgeHandler.uninstall();
+    }
+
+    private Server server;
+    private ServerConnector connector;
+    private HttpClient httpClient;
+
+    private void start() throws Exception
+    {
+        startServer();
+        startClient();
+    }
+
+    private void startServer() throws Exception
+    {
+        server = new Server();
+        connector = new ServerConnector(server, 1, 1);
+        server.addConnector(connector);
+        ServletContextHandler context = new ServletContextHandler();
+        context.setContextPath("/");
+        server.setHandler(context);
+
+        ServletHolder servletHolder = new ServletHolder(org.glassfish.jersey.servlet.ServletContainer.class);
+        servletHolder.setInitOrder(1);
+        servletHolder.setInitParameter("jersey.config.server.provider.packages", "org.eclipse.jetty.ee9.jersey.tests.endpoints");
+        context.addServlet(servletHolder, "/webapi/*");
+
+        server.start();
+    }
+
+    private void startClient() throws Exception
+    {
+        httpClient = new HttpClient();
+        httpClient.start();
+    }
+
+    @AfterEach
+    public void tearDown()
+    {
+        LifeCycle.stop(httpClient);
+        LifeCycle.stop(server);
+    }
+
+    @Test
+    public void testPutJSON() throws Exception
+    {
+        start();
+
+        Request.Content content = new StringRequestContent("""
+            {
+                "principal" : "foo",
+                "roles" : ["admin", "user"]
+            }
+            """
+        );
+        ContentResponse response = httpClient.newRequest("localhost", connector.getLocalPort())
+            .method(HttpMethod.PUT)
+            .path("/webapi/resource/security/")
+            .headers(httpFields -> httpFields.put(HttpHeader.CONTENT_TYPE, MimeTypes.Type.APPLICATION_JSON.asString()))
+            .body(content)
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.getHeaders().get(HttpHeader.CONTENT_TYPE), is(MimeTypes.Type.APPLICATION_JSON.asString()));
+        assertThat(response.getContentAsString(), is("""
+            {
+                "response" : "ok"
+            }
+            """)
+        );
+    }
+
+    @Test
+    public void testPutNoJSONThenTimeout() throws Exception
+    {
+        start();
+        long idleTimeout = 1000;
+        connector.setIdleTimeout(idleTimeout);
+
+        AsyncRequestContent content = new AsyncRequestContent();
+
+        CountDownLatch responseLatch = new CountDownLatch(1);
+        CompletableFuture<ContentResponse> completable = new CompletableResponseListener(
+            httpClient.newRequest("localhost", connector.getLocalPort())
+                .method(HttpMethod.PUT)
+                .path("/webapi/resource/security/")
+                .timeout(3 * idleTimeout, TimeUnit.SECONDS)
+                .headers(httpFields -> httpFields.put(HttpHeader.CONTENT_TYPE, MimeTypes.Type.APPLICATION_JSON.asString()))
+                .body(content)
+                .onResponseSuccess(r -> responseLatch.countDown())
+        ).send();
+
+        // Do not add content to the request, the server should time out and send the response.
+        assertTrue(responseLatch.await(2 * idleTimeout, TimeUnit.MILLISECONDS));
+
+        // Terminate the request too.
+        content.close();
+
+        ContentResponse response = completable.get(idleTimeout, TimeUnit.MILLISECONDS);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR_500, response.getStatus());
+    }
+}

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/java/org/eclipse/jetty/ee9/jersey/tests/HungBlockingThreadsTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/java/org/eclipse/jetty/ee9/jersey/tests/HungBlockingThreadsTest.java
@@ -1,0 +1,239 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee9.jersey.tests;
+
+import java.io.InputStream;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Feature;
+import jakarta.ws.rs.core.FeatureContext;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee9.servlet.ServletHolder;
+import org.eclipse.jetty.io.EofException;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.SharedBlockingCallback;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.server.model.Resource;
+import org.glassfish.jersey.servlet.ServletContainer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class HungBlockingThreadsTest
+{
+    private static final Logger LOG = LoggerFactory.getLogger(HungBlockingThreadsTest.class);
+    private static final int THREAD_COUNT = 1000;
+    private Server server;
+    private ExecutorService executorService;
+    private HttpClient httpClient;
+
+    @BeforeAll
+    public static void beforeAll()
+    {
+        // Wire up java.util.logging to slf4j.
+        org.slf4j.bridge.SLF4JBridgeHandler.removeHandlersForRootLogger();
+        org.slf4j.bridge.SLF4JBridgeHandler.install();
+    }
+
+    @AfterAll
+    public static void afterAll()
+    {
+        org.slf4j.bridge.SLF4JBridgeHandler.uninstall();
+    }
+
+    @BeforeEach
+    public void setUp() throws Exception
+    {
+        QueuedThreadPool queuedThreadPool = new QueuedThreadPool(10, 10, (int)TimeUnit.MINUTES.toMillis(1000L));
+        queuedThreadPool.setName("jetty-queue-tp");
+        queuedThreadPool.setDaemon(true);
+        queuedThreadPool.setReservedThreads(1);
+
+        server = new Server(queuedThreadPool);
+
+        ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        context.setContextPath("/");
+
+        ResourceConfig resourceConfig = new ResourceConfig();
+        resourceConfig.registerResources(makeAsync(Resource.builder(MyResource.class).build()));
+        resourceConfig.register(CustomFeature.class);
+
+        context.addServlet(new ServletHolder(new ServletContainer(resourceConfig)), "/*");
+
+        server.setHandler(context);
+
+        ServerConnector connector = new ServerConnector(server);
+        connector.setPort(0);
+        connector.setIdleTimeout(Long.MAX_VALUE);
+        server.addConnector(connector);
+        server.start();
+
+        executorService = Executors.newCachedThreadPool();
+        httpClient = HttpClient.newHttpClient();
+    }
+
+    @AfterEach
+    public void tearDown()
+    {
+        executorService.shutdownNow();
+        LifeCycle.stop(server);
+    }
+
+    @Test
+    public void test() throws Exception
+    {
+        List<Future<?>> futures = new CopyOnWriteArrayList<>();
+        CountDownLatch latch = new CountDownLatch(THREAD_COUNT);
+        for (int i = 0; i < THREAD_COUNT; i++)
+        {
+            executorService.submit(() ->
+            {
+                HttpRequest request = HttpRequest.newBuilder()
+                    .POST(HttpRequest.BodyPublishers.ofInputStream(() -> new HangInputStream(latch)))
+                    .uri(server.getURI())
+                    .timeout(Duration.ofDays(1))
+                    .build();
+                CompletableFuture<HttpResponse<String>> future = httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString());
+                futures.add(future);
+            });
+        }
+
+        LOG.debug("awaiting for client to block on all threads");
+        assertTrue(latch.await(15, TimeUnit.SECONDS));
+
+        LOG.debug("Shutting down client");
+        // while hanging in inputstream read, close connections.
+        futures.forEach(f -> f.cancel(true));
+
+        LOG.debug("Waiting for hung threads");
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertThat(threadDump(), not(containsString(SharedBlockingCallback.class.getSimpleName()))));
+    }
+
+    private static class HangInputStream extends InputStream
+    {
+        private final CountDownLatch latch;
+        private int count = 0;
+
+        public HangInputStream(CountDownLatch latch)
+        {
+            this.latch = latch;
+        }
+
+        @Override
+        public int read()
+        {
+            if (count == 1_000_000)
+            {
+                try
+                {
+                    latch.countDown();
+                    Thread.sleep(Duration.ofDays(1).toMillis());
+                }
+                catch (InterruptedException e)
+                {
+                    throw new RuntimeException(e);
+                }
+            }
+            count++;
+            return 'A';
+        }
+    }
+
+    private static String threadDump()
+    {
+        StringBuilder threadDump = new StringBuilder(System.lineSeparator());
+        ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+        for (ThreadInfo threadInfo : threadMXBean.dumpAllThreads(true, true))
+        {
+            threadDump.append(threadInfo.toString());
+        }
+        return threadDump.toString();
+    }
+
+    private static Resource makeAsync(Resource resource)
+    {
+        Resource.Builder resourceBuilder = Resource.builder(resource);
+        resource.getResourceMethods().forEach(resourceMethod -> resourceBuilder.updateMethod(resourceMethod).managedAsync());
+        return resourceBuilder.build();
+    }
+
+    public static class CustomFeature implements Feature
+    {
+        @Override
+        public boolean configure(FeatureContext context)
+        {
+            context.register(JettyEofExceptionMapper.class);
+            return true;
+        }
+    }
+
+    /**
+     * Used to not log a stack trace for Jetty EOF exceptions
+     */
+    public static class JettyEofExceptionMapper implements ExceptionMapper<EofException>
+    {
+        @Override
+        public Response toResponse(EofException e)
+        {
+            Response.Status status = Response.Status.BAD_REQUEST;
+            return Response.status((Response.StatusType)status)
+                .type(MediaType.APPLICATION_JSON + "; " + MediaType.CHARSET_PARAMETER + "=utf-8")
+                .entity(status.getReasonPhrase()).build();
+        }
+    }
+
+    @Path("")
+    public static class MyResource
+    {
+        @POST
+        @Consumes("text/plain")
+        public Response doPost(String body)
+        {
+            return Response.ok().entity(body).build();
+        }
+    }
+}

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/java/org/eclipse/jetty/ee9/jersey/tests/endpoints/Resource.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/java/org/eclipse/jetty/ee9/jersey/tests/endpoints/Resource.java
@@ -1,0 +1,46 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee9.jersey.tests.endpoints;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.Suspended;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("resource")
+public class Resource
+{
+    @PUT
+    @Path("/security")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public void putSecurity(@Context HttpServletRequest httpRequest, Security security, @Suspended final AsyncResponse asyncResponse)
+    {
+        if (security.getPrincipal() == null)
+            throw new NullPointerException("principal must no be null");
+        if (security.getRoles() == null)
+            throw new NullPointerException("roles must no be null");
+
+        asyncResponse.resume("""
+            {
+                "response" : "ok"
+            }
+            """);
+    }
+}

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/java/org/eclipse/jetty/ee9/jersey/tests/endpoints/Security.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/java/org/eclipse/jetty/ee9/jersey/tests/endpoints/Security.java
@@ -1,0 +1,56 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee9.jersey.tests.endpoints;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Security
+{
+    private String principal;
+    private List<String> roles = new ArrayList<>();
+
+    public Security()
+    {
+    }
+
+    public String getPrincipal()
+    {
+        return principal;
+    }
+
+    public void setPrincipal(String principal)
+    {
+        this.principal = principal;
+    }
+
+    public List<String> getRoles()
+    {
+        return roles;
+    }
+
+    public void setRoles(List<String> roles)
+    {
+        this.roles = roles;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "Security{" +
+            "principal='" + principal + '\'' +
+            ", roles=" + roles +
+            '}';
+    }
+}

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/resources/jetty-logging.properties
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/resources/jetty-logging.properties
@@ -1,0 +1,2 @@
+#org.eclipse.jetty.LEVEL=DEBUG
+#org.eclipse.jetty.ee9.servlet.LEVEL=DEBUG

--- a/jetty-ee9/jetty-ee9-tests/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/pom.xml
@@ -20,6 +20,7 @@
     <module>jetty-ee9-test-felix-webapp</module>
     <module>jetty-ee9-test-http2-webapp</module>
     <module>jetty-ee9-test-integration</module>
+    <module>jetty-ee9-test-jersey</module>
     <module>jetty-ee9-test-jmx</module>
     <module>jetty-ee9-test-jndi</module>
     <module>jetty-ee9-test-loginservice</module>

--- a/jetty-ee9/pom.xml
+++ b/jetty-ee9/pom.xml
@@ -40,7 +40,6 @@
   </modules>
 
   <properties>
-
     <jakarta.activation.api.version>${ee9.jakarta.activation.api.version}</jakarta.activation.api.version>
     <jakarta.annotation.api.version>${ee9.jakarta.annotation.api.version}</jakarta.annotation.api.version>
     <jakarta.authentication.api.version>${ee9.jakarta.authentication.api.version}</jakarta.authentication.api.version>
@@ -64,6 +63,7 @@
     <!-- TODO: Remove these javax.* entries? -->
     <javax.activation.impl.version>${ee9.javax.activation.impl.version}</javax.activation.impl.version>
     <javax.mail.glassfish.version>${ee9.javax.mail.glassfish.version}</javax.mail.glassfish.version>
+    <jersey.version>${ee9.jersey.version}</jersey.version>
     <!-- FIXME we need a separate property for this one -->
     <jetty.servlet.api.version>${ee9.jetty.servlet.api.version}</jetty.servlet.api.version>
     <jsp.impl.version>${ee9.jsp.impl.version}</jsp.impl.version>
@@ -416,6 +416,27 @@
         <groupId>org.glassfish.jaxb</groupId>
         <artifactId>jaxb-runtime</artifactId>
         <version>${jakarta.xml.bind.impl.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.jersey.containers</groupId>
+        <artifactId>jersey-container-servlet</artifactId>
+        <version>${jersey.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.jersey.inject</groupId>
+        <artifactId>jersey-hk2</artifactId>
+        <version>${jersey.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.jersey.media</groupId>
+        <artifactId>jersey-media-json-binding</artifactId>
+        <version>${jersey.version}</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish.web</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,7 @@
     <!-- TODO: Remove these javax.* entries? -->
     <ee9.javax.activation.impl.version>1.1.0.v201105071233</ee9.javax.activation.impl.version>
     <ee9.javax.mail.glassfish.version>1.4.1.v201005082020</ee9.javax.mail.glassfish.version>
+    <ee9.jersey.version>3.0.17</ee9.jersey.version>
     <!-- FIXME we need a separate property for this one -->
     <ee9.jetty.servlet.api.version>5.0.2</ee9.jetty.servlet.api.version>
     <ee9.jsp.impl.version>10.0.27</ee9.jsp.impl.version>


### PR DESCRIPTION
Trying out potential fixes for #13066 :

case 1: do not call `onFailure` from earlyEOF
~~case 2: do not call the failure listeners if we have either a reader or a writer task~~ _abandoned; this is incorrect_
case 3: do not call `sendError` from `HttpChannelState.onError()`