### PR TITLE
Fix shared blocking callback hang

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -481,6 +481,11 @@ public class HttpChannelState implements HttpChannel, Components
                 };
 
                 // Serialize all the error actions.
+
+//                Case 2
+                if (invokeOnContentAvailable != null || invokeWriteFailure != null)
+                    invokeOnFailureListeners = null;
+
                 task = Invocable.combine(_readInvoker.offer(invokeOnContentAvailable), _writeInvoker.offer(invokeWriteFailure), _readInvoker.offer(invokeOnFailureListeners));
             }
         }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -476,10 +476,10 @@ public class HttpChannelState implements HttpChannel, Components
                 Consumer<Throwable> onFailure = _onFailure;
                 _onFailure = null;
 
-                boolean hasFailureConsumer = onFailure == null;
+                boolean hasNoFailureConsumer = onFailure == null;
                 boolean skipListeners = remote && !getHttpConfiguration().isNotifyRemoteAsyncErrors();
                 boolean readerOrWriterWaiting = invokeOnContentAvailable != null || invokeWriteFailure != null;
-                Runnable invokeOnFailureListeners = hasFailureConsumer || readerOrWriterWaiting || skipListeners ? null : () ->
+                Runnable invokeOnFailureListeners = hasNoFailureConsumer || readerOrWriterWaiting || skipListeners ? null : () ->
                 {
                     try
                     {

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -475,8 +475,10 @@ public class HttpChannelState implements HttpChannel, Components
                 Consumer<Throwable> onFailure = _onFailure;
                 _onFailure = null;
 
+                boolean hasFailureConsumer = onFailure == null;
                 boolean skipListeners = remote && !getHttpConfiguration().isNotifyRemoteAsyncErrors();
-                Runnable invokeOnFailureListeners = onFailure == null || skipListeners ? null : () ->
+                boolean readerOrWriterWaiting = invokeOnContentAvailable != null || invokeWriteFailure != null; // Case 2
+                Runnable invokeOnFailureListeners = hasFailureConsumer || readerOrWriterWaiting || skipListeners ? null : () ->
                 {
                     try
                     {
@@ -491,11 +493,6 @@ public class HttpChannelState implements HttpChannel, Components
                 };
 
                 // Serialize all the error actions.
-
-//                Case 2
-                if (invokeOnContentAvailable != null || invokeWriteFailure != null)
-                    invokeOnFailureListeners = null;
-
                 task = Invocable.combine(_readInvoker.offer(invokeOnContentAvailable), _writeInvoker.offer(invokeWriteFailure), _readInvoker.offer(invokeOnFailureListeners));
             }
         }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -388,19 +388,20 @@ public class HttpChannelState implements HttpChannel, Components
             {
                 return () ->
                 {
+                    boolean failure;
                     try
                     {
-                        if (onIdleTimeout.test(t))
-                        {
-                            // If the idle timeout listener(s) return true, then we call onFailure and run any task it returns.
-                            Runnable task = onFailure(t);
-                            if (task != null)
-                                task.run();
-                        }
+                        failure = onIdleTimeout.test(t);
                     }
                     catch (Throwable x)
                     {
                         ExceptionUtil.addSuppressedIfNotAssociated(t, x);
+                        failure = true;
+                    }
+                    if (failure)
+                    {
+                        // If the idle timeout listener(s) returns true or throws,
+                        // then we call onFailure and run any task it returns.
                         Runnable task = onFailure(t);
                         if (task != null)
                             task.run();

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -388,6 +388,7 @@ public class HttpChannelState implements HttpChannel, Components
             {
                 return () ->
                 {
+                    // TODO we should handle any exception thrown by the onIdleTimeout predicate by calling onFailure().
                     if (onIdleTimeout.test(t))
                     {
                         // If the idle timeout listener(s) return true, then we call onFailure and run any task it returns.

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -476,10 +476,10 @@ public class HttpChannelState implements HttpChannel, Components
                 Consumer<Throwable> onFailure = _onFailure;
                 _onFailure = null;
 
-                boolean hasNoFailureConsumer = onFailure == null;
+                boolean noFailureListener = onFailure == null;
                 boolean skipListeners = remote && !getHttpConfiguration().isNotifyRemoteAsyncErrors();
                 boolean readerOrWriterWaiting = invokeOnContentAvailable != null || invokeWriteFailure != null;
-                Runnable invokeOnFailureListeners = hasNoFailureConsumer || readerOrWriterWaiting || skipListeners ? null : () ->
+                Runnable invokeOnFailureListeners = noFailureListener || readerOrWriterWaiting || skipListeners ? null : () ->
                 {
                     try
                     {

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -388,10 +388,19 @@ public class HttpChannelState implements HttpChannel, Components
             {
                 return () ->
                 {
-                    // TODO we should handle any exception thrown by the onIdleTimeout predicate by calling onFailure().
-                    if (onIdleTimeout.test(t))
+                    try
                     {
-                        // If the idle timeout listener(s) return true, then we call onFailure and run any task it returns.
+                        if (onIdleTimeout.test(t))
+                        {
+                            // If the idle timeout listener(s) return true, then we call onFailure and run any task it returns.
+                            Runnable task = onFailure(t);
+                            if (task != null)
+                                task.run();
+                        }
+                    }
+                    catch (Throwable x)
+                    {
+                        ExceptionUtil.addSuppressedIfNotAssociated(t, x);
                         Runnable task = onFailure(t);
                         if (task != null)
                             task.run();

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -477,7 +477,7 @@ public class HttpChannelState implements HttpChannel, Components
 
                 boolean hasFailureConsumer = onFailure == null;
                 boolean skipListeners = remote && !getHttpConfiguration().isNotifyRemoteAsyncErrors();
-                boolean readerOrWriterWaiting = invokeOnContentAvailable != null || invokeWriteFailure != null; // Case 2
+                boolean readerOrWriterWaiting = invokeOnContentAvailable != null || invokeWriteFailure != null;
                 Runnable invokeOnFailureListeners = hasFailureConsumer || readerOrWriterWaiting || skipListeners ? null : () ->
                 {
                     try

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -529,6 +529,7 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
             int filled = fillRequestBuffer();
             if (filled <= 0)
             {
+                releaseRequestBuffer();
                 // If fillRequestBuffer() read -1, it may be because of an early EOF;
                 // force the parser check its state again so its handler can generate
                 // an error chunk if appropriate. Doing this saves returning a null
@@ -536,7 +537,6 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
                 // actually makes the parser generate the error chunk.
                 if (filled < 0)
                     _parser.parseNext(BufferUtil.EMPTY_BUFFER);
-                releaseRequestBuffer();
                 break;
             }
         }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -1093,7 +1093,7 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
                 }
 
 //              Case 1
-//                ThreadPool.executeImmediately(getServer().getThreadPool(), _httpChannel.onFailure(bad));
+                ThreadPool.executeImmediately(getServer().getThreadPool(), _httpChannel.onFailure(bad));
             }
         }
     }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -1098,9 +1098,6 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
                         chunk.release();
                     stream._chunk = Content.Chunk.from(bad);
                 }
-
-//              Case 1
-//                ThreadPool.executeImmediately(getServer().getThreadPool(), _httpChannel.onFailure(bad));
             }
         }
     }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -1092,7 +1092,8 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
                     stream._chunk = Content.Chunk.from(bad);
                 }
 
-                ThreadPool.executeImmediately(getServer().getThreadPool(), _httpChannel.onFailure(bad));
+//              Case 1
+//                ThreadPool.executeImmediately(getServer().getThreadPool(), _httpChannel.onFailure(bad));
             }
         }
     }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -529,12 +529,13 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
             int filled = fillRequestBuffer();
             if (filled <= 0)
             {
-                // TODO comment and write test for this change
+                // If fillRequestBuffer() read -1, it may be because of an early EOF;
+                // force the parser check its state again so its handler can generate
+                // an error chunk if appropriate. Doing this saves returning a null
+                // chunk followed by an immediately served demand where the next read()
+                // actually makes the parser generate the error chunk.
                 if (filled < 0)
-                {
-                    _parser.atEOF();
                     _parser.parseNext(BufferUtil.EMPTY_BUFFER);
-                }
                 releaseRequestBuffer();
                 break;
             }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -529,6 +529,12 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
             int filled = fillRequestBuffer();
             if (filled <= 0)
             {
+                // TODO comment and write test for this change
+                if (filled < 0)
+                {
+                    _parser.atEOF();
+                    _parser.parseNext(BufferUtil.EMPTY_BUFFER);
+                }
                 releaseRequestBuffer();
                 break;
             }
@@ -1093,7 +1099,7 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
                 }
 
 //              Case 1
-                ThreadPool.executeImmediately(getServer().getThreadPool(), _httpChannel.onFailure(bad));
+//                ThreadPool.executeImmediately(getServer().getThreadPool(), _httpChannel.onFailure(bad));
             }
         }
     }

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
@@ -1222,6 +1222,9 @@ public class HttpChannelTest
         // Demand callback was called.
         assertTrue(demand.await(5, TimeUnit.SECONDS));
 
+        // onFailure listeners were not called by the onFailure task.
+        assertThat(error.get(), nullValue());
+
         // Complete the request.
         try (StacklessLogging ignore = new StacklessLogging(Response.class))
         {
@@ -1231,7 +1234,7 @@ public class HttpChannelTest
         // Request handling was completed.
         assertTrue(stream.isComplete());
 
-        // onFailure listeners were not called.
+        // onFailure listeners were not called by the callback's failed().
         assertThat(error.get(), nullValue());
     }
 

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
@@ -1170,6 +1170,72 @@ public class HttpChannelTest
     }
 
     @Test
+    public void testOnFailureDoesNotCallFailureListenersWhenDemandIsPending() throws Exception
+    {
+        AtomicReference<Response> handling = new AtomicReference<>();
+        AtomicReference<Callback> callbackRef = new AtomicReference<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        Handler handler = new Handler.Abstract.NonBlocking()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                handling.set(response);
+                request.addFailureListener(t -> error.set(new Throwable("WRONG")));
+                callbackRef.set(callback);
+                return true;
+            }
+        };
+        _server.setHandler(handler);
+        _server.start();
+
+        ConnectionMetaData connectionMetaData = new MockConnectionMetaData(new MockConnector(_server));
+        HttpChannel channel = new HttpChannelState(connectionMetaData);
+        MockHttpStream stream = new MockHttpStream(channel, false);
+
+        HttpFields fields = HttpFields.build().add(HttpHeader.HOST, "localhost").asImmutable();
+        MetaData.Request request = new MetaData.Request("POST", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields, 10);
+        Runnable onRequest = channel.onRequest(request);
+        onRequest.run();
+
+        // Check we are handling.
+        assertNotNull(handling.get());
+        assertThat(stream.isComplete(), is(false));
+        assertThat(stream.getFailure(), nullValue());
+        assertThat(stream.getResponse(), nullValue());
+
+        // Demand.
+        CountDownLatch demand = new CountDownLatch(1);
+        handling.get().getRequest().demand(demand::countDown);
+
+        // Demand is not serviced immediately.
+        assertThat(demand.getCount(), is(1L));
+
+        // Failure happens.
+        IOException failure = new IOException("Testing");
+        Runnable onFailure = channel.onFailure(failure);
+        assertNotNull(onFailure);
+
+        // Run the onFailure task.
+        onFailure.run();
+
+        // Demand callback was called.
+        assertTrue(demand.await(5, TimeUnit.SECONDS));
+
+        // Complete the request.
+        try (StacklessLogging ignore = new StacklessLogging(Response.class))
+        {
+            callbackRef.get().failed(new Throwable("FAILED"));
+        }
+
+        // Request handling was completed.
+        assertTrue(stream.isComplete());
+
+        // onFailure listeners were not called.
+        assertThat(error.get(), nullValue());
+    }
+
+    @Test
     public void testOnFailure() throws Exception
     {
         AtomicReference<Response> handling = new AtomicReference<>();

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AsyncRequestContentTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AsyncRequestContentTest.java
@@ -64,7 +64,6 @@ public class AsyncRequestContentTest extends AbstractTest
             @Override
             public boolean handle(Request request, Response response, Callback callback) throws Exception
             {
-                serverHandleLatch.countDown();
                 request.addFailureListener(x -> failureRef.compareAndExchange(null, x).addSuppressed(x));
 
                 request.demand(new Runnable()
@@ -91,6 +90,7 @@ public class AsyncRequestContentTest extends AbstractTest
                             request.demand(this);
                     }
                 });
+                serverHandleLatch.countDown();
 
                 return true;
             }

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AsyncRequestContentTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AsyncRequestContentTest.java
@@ -38,6 +38,7 @@ import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.component.LifeCycle;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -56,6 +57,9 @@ public class AsyncRequestContentTest extends AbstractTest
     @MethodSource("transports")
     public void testEarlyEofWithDemand(Transport transport) throws Exception
     {
+        // TODO FCGI is broken, fix or file a bug
+        Assumptions.assumeTrue(transport != Transport.FCGI);
+
         CountDownLatch serverHandleLatch = new CountDownLatch(1);
         List<Content.Chunk> chunks = new CopyOnWriteArrayList<>();
         AtomicReference<Throwable> failureRef = new AtomicReference<>();

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AsyncRequestContentTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AsyncRequestContentTest.java
@@ -16,28 +16,111 @@ package org.eclipse.jetty.test.client.transport;
 import java.io.ByteArrayInputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-
+import java.util.concurrent.atomic.AtomicReference;
 import org.eclipse.jetty.client.AsyncRequestContent;
 import org.eclipse.jetty.client.InputStreamRequestContent;
 import org.eclipse.jetty.client.OutputStreamRequestContent;
+import org.eclipse.jetty.client.Result;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.io.EofException;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.component.LifeCycle;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AsyncRequestContentTest extends AbstractTest
 {
+    @ParameterizedTest
+    @MethodSource("transports")
+    public void testEarlyEofWithDemand(Transport transport) throws Exception
+    {
+        CountDownLatch serverHandleLatch = new CountDownLatch(1);
+        List<Content.Chunk> chunks = new CopyOnWriteArrayList<>();
+        AtomicReference<Throwable> failureRef = new AtomicReference<>();
+        start(transport, new Handler.Abstract() {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            {
+                serverHandleLatch.countDown();
+                request.addFailureListener(x -> failureRef.compareAndExchange(null, x).addSuppressed(x));
+
+                request.demand(new Runnable()
+                {
+                    @Override
+                    public void run()
+                    {
+                        Content.Chunk read = request.read();
+                        if (read == null)
+                        {
+                            request.demand(this);
+                            return;
+                        }
+
+                        chunks.add(read);
+
+                        if (Content.Chunk.isFailure(read, true))
+                        {
+                            callback.failed(read.getFailure());
+                            return;
+                        }
+
+                        if (!read.isLast())
+                            request.demand(this);
+                    }
+                });
+
+                return true;
+            }
+        });
+
+        AsyncRequestContent content = new AsyncRequestContent();
+        CompletableFuture<Result> clientResponseFuture = new CompletableFuture<>();
+        client.POST(newURI(transport))
+            .body(content)
+            .send(result ->
+            {
+                if (result.isFailed())
+                    clientResponseFuture.completeExceptionally(result.getFailure());
+                else
+                    clientResponseFuture.complete(result);
+            });
+
+        assertTrue(serverHandleLatch.await(5, TimeUnit.SECONDS));
+
+        // Stop the client while an upload is in progress -> abruptly closes the connection so that provokes an early EOF on the server.
+        LifeCycle.stop(client);
+
+        ExecutionException ex = assertThrows(ExecutionException.class, () -> clientResponseFuture.get(5, TimeUnit.SECONDS));
+        assertInstanceOf(ClosedChannelException.class, ex.getCause());
+
+        await().during(3, TimeUnit.SECONDS).atMost(5, TimeUnit.SECONDS).untilAsserted(() ->
+        {
+            assertThat(chunks.size(), is(1));
+            assertInstanceOf(EofException.class, chunks.get(0).getFailure());
+        });
+        assertInstanceOf(EofException.class, failureRef.get());
+    }
+
     @ParameterizedTest
     @MethodSource("transports")
     public void testEmptyAsyncContent(Transport transport) throws Exception

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AsyncRequestContentTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AsyncRequestContentTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+
 import org.eclipse.jetty.client.AsyncRequestContent;
 import org.eclipse.jetty.client.InputStreamRequestContent;
 import org.eclipse.jetty.client.OutputStreamRequestContent;
@@ -57,7 +58,8 @@ public class AsyncRequestContentTest extends AbstractTest
         CountDownLatch serverHandleLatch = new CountDownLatch(1);
         List<Content.Chunk> chunks = new CopyOnWriteArrayList<>();
         AtomicReference<Throwable> failureRef = new AtomicReference<>();
-        start(transport, new Handler.Abstract() {
+        start(transport, new Handler.Abstract()
+        {
             @Override
             public boolean handle(Request request, Response response, Callback callback) throws Exception
             {

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AsyncRequestContentTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AsyncRequestContentTest.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -120,7 +121,7 @@ public class AsyncRequestContentTest extends AbstractTest
             assertThat(chunks.size(), is(1));
             assertInstanceOf(EofException.class, chunks.get(0).getFailure());
         });
-        assertInstanceOf(EofException.class, failureRef.get());
+        assertThat(failureRef.get(), nullValue());
     }
 
     @ParameterizedTest

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AsyncRequestContentTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AsyncRequestContentTest.java
@@ -16,7 +16,6 @@ package org.eclipse.jetty.test.client.transport;
 import java.io.ByteArrayInputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
-import java.nio.channels.ClosedChannelException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -37,7 +36,6 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
-import org.eclipse.jetty.util.component.LifeCycle;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -98,7 +96,8 @@ public class AsyncRequestContentTest extends AbstractTest
 
         AsyncRequestContent content = new AsyncRequestContent();
         CompletableFuture<Result> clientResponseFuture = new CompletableFuture<>();
-        client.POST(newURI(transport))
+        org.eclipse.jetty.client.Request request = client.POST(newURI(transport));
+        request
             .body(content)
             .send(result ->
             {
@@ -110,11 +109,9 @@ public class AsyncRequestContentTest extends AbstractTest
 
         assertTrue(serverHandleLatch.await(5, TimeUnit.SECONDS));
 
-        // Stop the client while an upload is in progress -> abruptly closes the connection so that provokes an early EOF on the server.
-        LifeCycle.stop(client);
-
-        ExecutionException ex = assertThrows(ExecutionException.class, () -> clientResponseFuture.get(5, TimeUnit.SECONDS));
-        assertInstanceOf(ClosedChannelException.class, ex.getCause());
+        // Abruptly abort the request while an upload is in progress to provoke an early EOF on the server.
+        assertThat(request.abort(new Throwable("test aborts the request")).get(5, TimeUnit.SECONDS), is(Boolean.TRUE));
+        assertThrows(ExecutionException.class, () -> clientResponseFuture.get(5, TimeUnit.SECONDS));
 
         await().during(3, TimeUnit.SECONDS).atMost(5, TimeUnit.SECONDS).untilAsserted(() ->
         {

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AsyncRequestContentTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AsyncRequestContentTest.java
@@ -38,7 +38,6 @@ import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.component.LifeCycle;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -57,9 +56,6 @@ public class AsyncRequestContentTest extends AbstractTest
     @MethodSource("transports")
     public void testEarlyEofWithDemand(Transport transport) throws Exception
     {
-        // TODO FCGI is broken, fix or file a bug
-        Assumptions.assumeTrue(transport != Transport.FCGI);
-
         CountDownLatch serverHandleLatch = new CountDownLatch(1);
         List<Content.Chunk> chunks = new CopyOnWriteArrayList<>();
         AtomicReference<Throwable> failureRef = new AtomicReference<>();

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AsyncRequestContentTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AsyncRequestContentTest.java
@@ -96,7 +96,7 @@ public class AsyncRequestContentTest extends AbstractTest
 
         AsyncRequestContent content = new AsyncRequestContent();
         CompletableFuture<Result> clientResponseFuture = new CompletableFuture<>();
-        org.eclipse.jetty.client.Request request = client.POST(newURI(transport));
+        var request = client.POST(newURI(transport));
         request
             .body(content)
             .send(result ->

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannelState.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannelState.java
@@ -911,14 +911,7 @@ public class ServletChannelState
                 case ASYNC:
                 {
                     if (_asyncListeners == null || _asyncListeners.isEmpty())
-                    {
-//                      Case 3 (ee10)
                         return false;
-//                        if (committed)
-//                            return true;
-//                        sendError(th);
-//                        return false;
-                    }
                     asyncEvent = _event;
                     asyncEvent.addThrowable(th);
                     asyncListeners = _asyncListeners;

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannelState.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannelState.java
@@ -912,10 +912,12 @@ public class ServletChannelState
                 {
                     if (_asyncListeners == null || _asyncListeners.isEmpty())
                     {
-                        if (committed)
-                            return true;
-                        sendError(th);
+//                      Case 3 (ee10)
                         return false;
+//                        if (committed)
+//                            return true;
+//                        sendError(th);
+//                        return false;
                     }
                     asyncEvent = _event;
                     asyncEvent.addThrowable(th);

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncContextTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncContextTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -114,7 +115,7 @@ public class AsyncContextTest
         });
 
         String request =
-            "GET /ctx/startthrow HTTP/1.1\r\n" +
+            "GET /ctx/startthrow?timeout=100 HTTP/1.1\r\n" +
                 "Host: localhost\r\n" +
                 "Connection: close\r\n" +
                 "\r\n";
@@ -124,9 +125,10 @@ public class AsyncContextTest
 
         String responseBody = response.getContent();
 
-        assertThat(responseBody, containsString("ERROR: /error"));
-        assertThat(responseBody, containsString("PathInfo= /IOE"));
-        assertThat(responseBody, containsString("EXCEPTION: org.eclipse.jetty.ee10.servlet.QuietServletException: java.io.IOException: Test"));
+        assertThat(responseBody, containsString("HTTP ERROR 500 AsyncContext timeout"));
+        assertThat(responseBody, not(containsString("ERROR: /error")));
+        assertThat(responseBody, not(containsString("PathInfo= /IOE")));
+        assertThat(responseBody, not(containsString("EXCEPTION: org.eclipse.jetty.ee10.servlet.QuietServletException: java.io.IOException: Test")));
     }
 
     @Test
@@ -149,13 +151,15 @@ public class AsyncContextTest
                 "\r\n";
         HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse(request));
 
-        assertThat("Response.status", response.getStatus(), is(HttpServletResponse.SC_INTERNAL_SERVER_ERROR));
+        // OK b/c exception was thrown after AsyncContext.dispatch() was called
+        assertThat("Response.status", response.getStatus(), is(HttpServletResponse.SC_OK));
 
         String responseBody = response.getContent();
 
-        assertThat(responseBody, containsString("ERROR: /error"));
-        assertThat(responseBody, containsString("PathInfo= /IOE"));
-        assertThat(responseBody, containsString("EXCEPTION: org.eclipse.jetty.ee10.servlet.QuietServletException: java.io.IOException: Test"));
+        assertThat(responseBody, emptyString());
+        assertThat(responseBody, not(containsString("ERROR: /error")));
+        assertThat(responseBody, not(containsString("PathInfo= /IOE")));
+        assertThat(responseBody, not(containsString("EXCEPTION: org.eclipse.jetty.ee10.servlet.QuietServletException: java.io.IOException: Test")));
     }
 
     @Test
@@ -178,12 +182,14 @@ public class AsyncContextTest
             "\r\n";
         HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse(request));
 
-        assertThat("Response.status", response.getStatus(), is(HttpServletResponse.SC_INTERNAL_SERVER_ERROR));
+          // OK b/c exception was thrown after AsyncContext.complete() was called
+        assertThat("Response.status", response.getStatus(), is(HttpServletResponse.SC_OK));
 
         String responseBody = response.getContent();
-        assertThat(responseBody, containsString("ERROR: /error"));
-        assertThat(responseBody, containsString("PathInfo= /IOE"));
-        assertThat(responseBody, containsString("EXCEPTION: org.eclipse.jetty.ee10.servlet.QuietServletException: java.io.IOException: Test"));
+        assertThat(responseBody, containsString("completeBeforeThrow"));
+        assertThat(responseBody, not(containsString("ERROR: /error")));
+        assertThat(responseBody, not(containsString("PathInfo= /IOE")));
+        assertThat(responseBody, not(containsString("EXCEPTION: org.eclipse.jetty.ee10.servlet.QuietServletException: java.io.IOException: Test")));
     }
 
     @Test
@@ -789,7 +795,10 @@ public class AsyncContextTest
         {
             if (request.getDispatcherType() == DispatcherType.REQUEST)
             {
-                request.startAsync(request, response);
+                AsyncContext async = request.startAsync(request, response);
+                String timeoutString = request.getParameter("timeout");
+                if (timeoutString != null)
+                    async.setTimeout(Long.parseLong(timeoutString));
 
                 if (Boolean.parseBoolean(request.getParameter("dispatch")))
                 {

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncContextTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncContextTest.java
@@ -108,7 +108,8 @@ public class AsyncContextTest
         AtomicReference<AsyncContext> asyncContextRef = new AtomicReference<>();
         startServer((config) ->
         {
-            _contextHandler.addServlet(new ServletHolder(new HttpServlet() {
+            _contextHandler.addServlet(new ServletHolder(new HttpServlet()
+            {
                 @Override
                 protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
                 {
@@ -153,7 +154,8 @@ public class AsyncContextTest
     {
         startServer((config) ->
         {
-            _contextHandler.addServlet(new ServletHolder(new HttpServlet() {
+            _contextHandler.addServlet(new ServletHolder(new HttpServlet()
+            {
                 @Override
                 protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException
                 {
@@ -162,7 +164,8 @@ public class AsyncContextTest
                     throw new QuietServletException(new IOException("Test"));
                 }
             }), "/startthrow/*");
-            _contextHandler.addServlet(new ServletHolder(new HttpServlet() {
+            _contextHandler.addServlet(new ServletHolder(new HttpServlet()
+            {
                 @Override
                 protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException
                 {
@@ -199,7 +202,8 @@ public class AsyncContextTest
     {
         startServer((config) ->
         {
-            _contextHandler.addServlet(new ServletHolder(new HttpServlet() {
+            _contextHandler.addServlet(new ServletHolder(new HttpServlet()
+            {
                 @Override
                 protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
                 {
@@ -237,7 +241,8 @@ public class AsyncContextTest
     {
         startServer((config) ->
         {
-            _contextHandler.addServlet(new ServletHolder(new HttpServlet() {
+            _contextHandler.addServlet(new ServletHolder(new HttpServlet()
+            {
                 @Override
                 protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
                 {

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncContextTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncContextTest.java
@@ -14,7 +14,9 @@
 package org.eclipse.jetty.ee10.servlet;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import jakarta.servlet.AsyncContext;
@@ -30,8 +32,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpServletResponseWrapper;
 import org.eclipse.jetty.http.HttpTester;
-import org.eclipse.jetty.logging.StacklessLogging;
-import org.eclipse.jetty.server.HttpChannel;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.Server;
@@ -39,11 +39,12 @@ import org.eclipse.jetty.util.StringUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -104,9 +105,19 @@ public class AsyncContextTest
     @Test
     public void testStartThrow() throws Exception
     {
+        AtomicReference<AsyncContext> asyncContextRef = new AtomicReference<>();
         startServer((config) ->
         {
-            _contextHandler.addServlet(new ServletHolder(new TestStartThrowServlet()), "/startthrow/*");
+            _contextHandler.addServlet(new ServletHolder(new HttpServlet() {
+                @Override
+                protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+                {
+                    AsyncContext async = request.startAsync(request, response);
+                    asyncContextRef.set(async);
+                    response.getOutputStream().write("wrote text just fine".getBytes(StandardCharsets.UTF_8));
+                    throw new QuietServletException(new IOException("Test"));
+                }
+            }), "/startthrow/*");
             _contextHandler.addServlet(new ServletHolder(new ErrorServlet()), "/error/*");
             ErrorPageErrorHandler errorHandler = new ErrorPageErrorHandler();
             errorHandler.setUnwrapServletException(false);
@@ -115,20 +126,26 @@ public class AsyncContextTest
         });
 
         String request =
-            "GET /ctx/startthrow?timeout=100 HTTP/1.1\r\n" +
-                "Host: localhost\r\n" +
-                "Connection: close\r\n" +
-                "\r\n";
-        HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse(request, 10, TimeUnit.MINUTES));
+            """
+                GET /ctx/startthrow HTTP/1.1\r
+                Host: localhost\r
+                Connection: close\r
+                \r
+                """;
 
-        assertThat("Response.status", response.getStatus(), is(HttpServletResponse.SC_INTERNAL_SERVER_ERROR));
+        try (LocalConnector.LocalEndPoint localEndPoint = _connector.connect())
+        {
+            localEndPoint.addInputAndExecute(request);
+            assertThat(localEndPoint.getResponse(false, 1, TimeUnit.SECONDS), nullValue());
 
-        String responseBody = response.getContent();
+            await().atMost(5, TimeUnit.SECONDS).until(asyncContextRef::get, not(nullValue())).complete();
 
-        assertThat(responseBody, containsString("HTTP ERROR 500 AsyncContext timeout"));
-        assertThat(responseBody, not(containsString("ERROR: /error")));
-        assertThat(responseBody, not(containsString("PathInfo= /IOE")));
-        assertThat(responseBody, not(containsString("EXCEPTION: org.eclipse.jetty.ee10.servlet.QuietServletException: java.io.IOException: Test")));
+            HttpTester.Response response = HttpTester.parseResponse(localEndPoint.getResponse(false, 10, TimeUnit.SECONDS));
+            assertThat("Response.status", response.getStatus(), is(HttpServletResponse.SC_OK));
+
+            String responseBody = response.getContent();
+            assertThat(responseBody, is("wrote text just fine"));
+        }
     }
 
     @Test
@@ -136,7 +153,23 @@ public class AsyncContextTest
     {
         startServer((config) ->
         {
-            _contextHandler.addServlet(new ServletHolder(new TestStartThrowServlet()), "/startthrow/*");
+            _contextHandler.addServlet(new ServletHolder(new HttpServlet() {
+                @Override
+                protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException
+                {
+                    AsyncContext async = request.startAsync(request, response);
+                    async.dispatch("/dispatch-landing/");
+                    throw new QuietServletException(new IOException("Test"));
+                }
+            }), "/startthrow/*");
+            _contextHandler.addServlet(new ServletHolder(new HttpServlet() {
+                @Override
+                protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException
+                {
+                    response.getOutputStream().write("Landed just fine".getBytes(StandardCharsets.UTF_8));
+                }
+            }), "/dispatch-landing/*");
+
             _contextHandler.addServlet(new ServletHolder(new ErrorServlet()), "/error/*");
             ErrorPageErrorHandler errorHandler = new ErrorPageErrorHandler();
             errorHandler.setUnwrapServletException(false);
@@ -145,10 +178,12 @@ public class AsyncContextTest
         });
 
         String request =
-            "GET /ctx/startthrow?dispatch=true HTTP/1.1\r\n" +
-                "Host: localhost\r\n" +
-                "Connection: close\r\n" +
-                "\r\n";
+            """
+                GET /ctx/startthrow HTTP/1.1\r
+                Host: localhost\r
+                Connection: close\r
+                \r
+                """;
         HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse(request));
 
         // OK b/c exception was thrown after AsyncContext.dispatch() was called
@@ -156,10 +191,7 @@ public class AsyncContextTest
 
         String responseBody = response.getContent();
 
-        assertThat(responseBody, emptyString());
-        assertThat(responseBody, not(containsString("ERROR: /error")));
-        assertThat(responseBody, not(containsString("PathInfo= /IOE")));
-        assertThat(responseBody, not(containsString("EXCEPTION: org.eclipse.jetty.ee10.servlet.QuietServletException: java.io.IOException: Test")));
+        assertThat(responseBody, is("Landed just fine"));
     }
 
     @Test
@@ -167,7 +199,16 @@ public class AsyncContextTest
     {
         startServer((config) ->
         {
-            _contextHandler.addServlet(new ServletHolder(new TestStartThrowServlet()), "/startthrow/*");
+            _contextHandler.addServlet(new ServletHolder(new HttpServlet() {
+                @Override
+                protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+                {
+                    AsyncContext async = request.startAsync(request, response);
+                    response.getOutputStream().write("completeBeforeThrow".getBytes(StandardCharsets.UTF_8));
+                    async.complete();
+                    throw new QuietServletException(new IOException("Test"));
+                }
+            }), "/startthrow/*");
             _contextHandler.addServlet(new ServletHolder(new ErrorServlet()), "/error/*");
             ErrorPageErrorHandler errorHandler = new ErrorPageErrorHandler();
             errorHandler.setUnwrapServletException(false);
@@ -175,11 +216,13 @@ public class AsyncContextTest
             errorHandler.addErrorPage(IOException.class.getName(), "/error/IOE");
         });
 
-        String request = "GET /ctx/startthrow?complete=true HTTP/1.1\r\n" +
-            "Host: localhost\r\n" +
-            "Content-Type: application/x-www-form-urlencoded\r\n" +
-            "Connection: close\r\n" +
-            "\r\n";
+        String request = """
+            GET /ctx/startthrow HTTP/1.1\r
+            Host: localhost\r
+            Content-Type: application/x-www-form-urlencoded\r
+            Connection: close\r
+            \r
+            """;
         HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse(request));
 
           // OK b/c exception was thrown after AsyncContext.complete() was called
@@ -187,9 +230,6 @@ public class AsyncContextTest
 
         String responseBody = response.getContent();
         assertThat(responseBody, containsString("completeBeforeThrow"));
-        assertThat(responseBody, not(containsString("ERROR: /error")));
-        assertThat(responseBody, not(containsString("PathInfo= /IOE")));
-        assertThat(responseBody, not(containsString("EXCEPTION: org.eclipse.jetty.ee10.servlet.QuietServletException: java.io.IOException: Test")));
     }
 
     @Test
@@ -197,7 +237,17 @@ public class AsyncContextTest
     {
         startServer((config) ->
         {
-            _contextHandler.addServlet(new ServletHolder(new TestStartThrowServlet()), "/startthrow/*");
+            _contextHandler.addServlet(new ServletHolder(new HttpServlet() {
+                @Override
+                protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+                {
+                    AsyncContext async = request.startAsync(request, response);
+                    response.getOutputStream().write("completeBeforeThrow".getBytes());
+                    response.flushBuffer();
+                    async.complete();
+                    throw new QuietServletException(new IOException("Test"));
+                }
+            }), "/startthrow/*");
             _contextHandler.addServlet(new ServletHolder(new ErrorServlet()), "/error/*");
             ErrorPageErrorHandler errorHandler = new ErrorPageErrorHandler();
             errorHandler.setUnwrapServletException(false);
@@ -205,20 +255,19 @@ public class AsyncContextTest
             errorHandler.addErrorPage(IOException.class.getName(), "/error/IOE");
         });
 
-        try (StacklessLogging ignore = new StacklessLogging(HttpChannel.class))
-        {
-            String request = "GET /ctx/startthrow?flush=true&complete=true HTTP/1.1\r\n" +
-                "Host: localhost\r\n" +
-                "Content-Type: application/x-www-form-urlencoded\r\n" +
-                "Connection: close\r\n" +
-                "\r\n";
-            HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse(request));
-            assertThat("Response.status", response.getStatus(), is(HttpServletResponse.SC_OK));
+        String request = """
+            GET /ctx/startthrow HTTP/1.1\r
+            Host: localhost\r
+            Content-Type: application/x-www-form-urlencoded\r
+            Connection: close\r
+            \r
+            """;
+        HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse(request));
+        assertThat("Response.status", response.getStatus(), is(HttpServletResponse.SC_OK));
 
-            String responseBody = response.getContent();
+        String responseBody = response.getContent();
 
-            assertThat("error servlet", responseBody, containsString("completeBeforeThrow"));
-        }
+        assertThat("error servlet", responseBody, containsString("completeBeforeThrow"));
     }
 
     @Test
@@ -785,36 +834,6 @@ public class AsyncContextTest
             response.getOutputStream().print("doGet:async:getRequestURL:" + asyncRequest.getRequestURL() + "\n");
             response.getOutputStream().print("doGet:async:getPathInfo:" + asyncRequest.getPathInfo() + "\n");
             asyncContext.start(new AsyncRunnable(asyncContext));
-        }
-    }
-
-    private static class TestStartThrowServlet extends HttpServlet
-    {
-        @Override
-        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
-        {
-            if (request.getDispatcherType() == DispatcherType.REQUEST)
-            {
-                AsyncContext async = request.startAsync(request, response);
-                String timeoutString = request.getParameter("timeout");
-                if (timeoutString != null)
-                    async.setTimeout(Long.parseLong(timeoutString));
-
-                if (Boolean.parseBoolean(request.getParameter("dispatch")))
-                {
-                    request.getAsyncContext().dispatch();
-                }
-
-                if (Boolean.parseBoolean(request.getParameter("complete")))
-                {
-                    response.getOutputStream().write("completeBeforeThrow".getBytes());
-                    if (Boolean.parseBoolean(request.getParameter("flush")))
-                        response.flushBuffer();
-                    request.getAsyncContext().complete();
-                }
-
-                throw new QuietServletException(new IOException("Test"));
-            }
         }
     }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncServletIOTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncServletIOTest.java
@@ -937,15 +937,8 @@ public class AsyncServletIOTest
             {
                 try
                 {
-                    try
-                    {
-                        IO.readBytes(req.getInputStream());
-                        throw new AssertionError("expected IOException");
-                    }
-                    catch (IOException e)
-                    {
-                        exceptionRef.set(e);
-                    }
+                    IO.readBytes(req.getInputStream());
+                    throw new AssertionError("expected IOException");
                 }
                 catch (Throwable x)
                 {

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncServletIOTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncServletIOTest.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -39,13 +40,16 @@ import jakarta.servlet.WriteListener;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.concurrent.atomic.AtomicReference;
 import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.io.EofException;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.util.IO;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -53,7 +57,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -73,6 +79,7 @@ public class AsyncServletIOTest
     protected AsyncIOServlet3 _servlet3 = new AsyncIOServlet3();
     protected AsyncIOServlet4 _servlet4 = new AsyncIOServlet4();
     protected StolenAsyncReadServlet _servletStolenAsyncRead = new StolenAsyncReadServlet();
+    protected AsyncReadServlet _servletAsyncRead = new AsyncReadServlet();
     protected int _port;
     protected Server _server;
     protected ServletHandler _servletHandler;
@@ -113,6 +120,10 @@ public class AsyncServletIOTest
         ServletHolder holder5 = new ServletHolder(_servletStolenAsyncRead);
         holder5.setAsyncSupported(true);
         _servletHandler.addServletWithMapping(holder5, "/stolen/*");
+
+        ServletHolder holder6 = new ServletHolder(_servletAsyncRead);
+        holder6.setAsyncSupported(true);
+        _servletHandler.addServletWithMapping(holder6, "/asyncRead/*");
 
         _server.start();
         _port = _connector.getLocalPort();
@@ -229,6 +240,33 @@ public class AsyncServletIOTest
 
         assertEquals(list.get(0), "data");
         assertTrue(_servlet2.completed.await(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testEarlyEofDuringClientAsyncRequestBlockingRead() throws Exception
+    {
+        int port = _port;
+        try (Socket socket = new Socket("localhost", port))
+        {
+            String request =
+                "GET /ctx/asyncRead HTTP/1.1\r\n" +
+                    "Host: localhost\r\n" +
+                    "Content-Length: 10\r\n" +
+                    "\r\n" +
+                    "01234";
+
+            OutputStream output = socket.getOutputStream();
+            output.write(request.getBytes(StandardCharsets.UTF_8));
+            output.flush();
+
+            // Close.
+        }
+
+        // Assert that the blocking read throws EofException.
+        await().atMost(5, TimeUnit.SECONDS).until(() -> _servletAsyncRead.exceptionRef.get() instanceof EofException);
+
+        // Assert that no async event was generated as the blocking read got notified of the error.
+        await().during(3, TimeUnit.SECONDS).atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertThat(_servletAsyncRead.listener.events, empty()));
     }
 
     @Test
@@ -881,6 +919,67 @@ public class AsyncServletIOTest
             {
                 t.printStackTrace();
                 asyncContext.complete();
+            }
+        }
+    }
+
+    public static class AsyncReadServlet extends HttpServlet
+    {
+        final AtomicReference<Throwable> exceptionRef = new AtomicReference<>();
+        final TestAsyncListener listener = new TestAsyncListener();
+
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException
+        {
+            AsyncContext asyncContext = req.startAsync();
+            asyncContext.addListener(listener);
+            new Thread(() ->
+            {
+                try
+                {
+                    try
+                    {
+                        IO.readBytes(req.getInputStream());
+                        throw new AssertionError("expected IOException");
+                    }
+                    catch (IOException e)
+                    {
+                        exceptionRef.set(e);
+                    }
+                }
+                catch (Throwable x)
+                {
+                    exceptionRef.set(x);
+                }
+            }).start();
+        }
+
+        static class TestAsyncListener implements AsyncListener
+        {
+            final List<String> events = new CopyOnWriteArrayList<>();
+
+            @Override
+            public void onComplete(AsyncEvent event)
+            {
+                events.add("complete");
+            }
+
+            @Override
+            public void onTimeout(AsyncEvent event)
+            {
+                events.add("timeout");
+            }
+
+            @Override
+            public void onError(AsyncEvent event)
+            {
+                events.add("error");
+            }
+
+            @Override
+            public void onStartAsync(AsyncEvent event)
+            {
+                events.add("startAsync");
             }
         }
     }

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncServletIOTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncServletIOTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import jakarta.servlet.AsyncContext;
 import jakarta.servlet.AsyncEvent;
@@ -40,7 +41,6 @@ import jakarta.servlet.WriteListener;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.concurrent.atomic.AtomicReference;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.io.EofException;
 import org.eclipse.jetty.server.Connector;

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/AsyncIOServletTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/AsyncIOServletTest.java
@@ -303,7 +303,7 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testOnErrorThrows(Transport transport) throws Exception
+    public void testOnDataAvailableThrows(Transport transport) throws Exception
     {
         AtomicInteger errors = new AtomicInteger();
         start(transport, new HttpServlet()

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/AsyncIOServletTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/AsyncIOServletTest.java
@@ -318,7 +318,7 @@ public class AsyncIOServletTest extends AbstractTest
                     return;
                 }
 
-                request.startAsync(request, response);
+                AsyncContext asyncContext = request.startAsync(request, response);
                 request.getInputStream().setReadListener(new ReadListener()
                 {
                     @Override
@@ -338,13 +338,11 @@ public class AsyncIOServletTest extends AbstractTest
                     public void onError(Throwable t)
                     {
                         assertScope();
+                        assertThat(t, instanceOf(NullPointerException.class));
+                        assertThat(t.getMessage(), is("explicitly_thrown_by_test_1"));
                         errors.incrementAndGet();
-                        throw new NullPointerException("explicitly_thrown_by_test_2")
-                        {
-                            {
-                                this.initCause(t);
-                            }
-                        };
+                        response.setStatus(HttpStatus.IM_A_TEAPOT_418);
+                        asyncContext.complete();
                     }
                 });
             }
@@ -357,7 +355,7 @@ public class AsyncIOServletTest extends AbstractTest
                 .timeout(5, TimeUnit.SECONDS)
                 .send();
 
-            assertEquals(HttpStatus.INTERNAL_SERVER_ERROR_500, response.getStatus());
+            assertEquals(HttpStatus.IM_A_TEAPOT_418, response.getStatus());
             assertEquals(1, errors.get());
         }
     }

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jersey/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jersey/pom.xml
@@ -48,6 +48,7 @@
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jersey/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jersey/pom.xml
@@ -46,6 +46,10 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-client</artifactId>
       <scope>test</scope>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jersey/src/test/java/org/eclipse/jetty/ee10/jersey/tests/HungBlockingThreadsTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jersey/src/test/java/org/eclipse/jetty/ee10/jersey/tests/HungBlockingThreadsTest.java
@@ -61,7 +61,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class HungBlockingThreadsTest
 {
     private static final Logger LOG = LoggerFactory.getLogger(HungBlockingThreadsTest.class);
-    private static final int THREAD_COUNT = 1000;
+    private static final int THREAD_COUNT = 128;
     private Server server;
     private ExecutorService executorService;
     private HttpClient httpClient;

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jersey/src/test/java/org/eclipse/jetty/ee10/jersey/tests/HungBlockingThreadsTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jersey/src/test/java/org/eclipse/jetty/ee10/jersey/tests/HungBlockingThreadsTest.java
@@ -205,9 +205,6 @@ public class HungBlockingThreadsTest
         }
     }
 
-    /**
-     * Used to not log a stack trace for Jetty EOF exceptions
-     */
     public static class JettyEofExceptionMapper implements ExceptionMapper<EofException>
     {
         @Override

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jersey/src/test/java/org/eclipse/jetty/ee10/jersey/tests/HungBlockingThreadsTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jersey/src/test/java/org/eclipse/jetty/ee10/jersey/tests/HungBlockingThreadsTest.java
@@ -13,11 +13,11 @@
 
 package org.eclipse.jetty.ee10.jersey.tests;
 
-import java.io.InputStream;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
-import java.time.Duration;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -31,8 +31,9 @@ import jakarta.ws.rs.core.FeatureContext;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
+import org.eclipse.jetty.client.AsyncRequestContent;
 import org.eclipse.jetty.client.HttpClient;
-import org.eclipse.jetty.client.InputStreamRequestContent;
+import org.eclipse.jetty.client.Request;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.eclipse.jetty.io.EofException;
@@ -48,6 +49,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,7 +63,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class HungBlockingThreadsTest
 {
     private static final Logger LOG = LoggerFactory.getLogger(HungBlockingThreadsTest.class);
-    private static final int THREAD_COUNT = 128;
+    private static final int THREAD_COUNT = 512;
     private Server server;
     private ExecutorService executorService;
     private HttpClient httpClient;
@@ -128,60 +130,45 @@ public class HungBlockingThreadsTest
         LifeCycle.stop(httpClient);
     }
 
+    /**
+     * This test tries to reproduce issue #13066 by running THREAD_COUNT parallel requests
+     * in the hope of reproducing the issue statistically.
+     */
+    @Tag("stress")
     @Test
     public void test() throws Exception
     {
+        ByteBuffer data = ByteBuffer.wrap("A".repeat(1024).getBytes(StandardCharsets.UTF_8));
         CountDownLatch latch = new CountDownLatch(THREAD_COUNT);
         for (int i = 0; i < THREAD_COUNT; i++)
         {
             executorService.submit(() ->
             {
-                httpClient.POST(server.getURI())
-                    .body(new InputStreamRequestContent("text/plain", new HangInputStream(latch)))
-                    .timeout(1, TimeUnit.DAYS)
+                AsyncRequestContent content = new AsyncRequestContent("text/plain", data.slice());
+                Request request = httpClient.POST(server.getURI());
+                request
+                    .onRequestListener(new Request.Listener() {
+                        @Override
+                        public void onCommit(Request request)
+                        {
+                            latch.countDown();
+                        }
+                    })
+                    .body(content)
+                    .timeout(60, TimeUnit.SECONDS)
                     .send(result -> {});
             });
         }
 
-        LOG.debug("awaiting for client to block on all threads");
+        LOG.debug("Awaiting for client to block on all threads");
         assertTrue(latch.await(15, TimeUnit.SECONDS));
 
         LOG.debug("Shutting down client");
-        // while hanging in inputstream read, close connections.
-        LifeCycle.stop(httpClient);
+        // While the server is hanging in InputStream read, close the client's connections.
+        httpClient.stop();
 
         LOG.debug("Waiting for hung threads");
         await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertThat(threadDump(), not(containsString(Blocker.Shared.class.getName()))));
-    }
-
-    private static class HangInputStream extends InputStream
-    {
-        private final CountDownLatch latch;
-        private int count = 0;
-
-        public HangInputStream(CountDownLatch latch)
-        {
-            this.latch = latch;
-        }
-
-        @Override
-        public int read()
-        {
-            if (count == 1_000_000)
-            {
-                try
-                {
-                    latch.countDown();
-                    Thread.sleep(Duration.ofDays(1).toMillis());
-                }
-                catch (InterruptedException e)
-                {
-                    throw new RuntimeException(e);
-                }
-            }
-            count++;
-            return 'A';
-        }
     }
 
     private static String threadDump()

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jersey/src/test/java/org/eclipse/jetty/ee10/jersey/tests/HungBlockingThreadsTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jersey/src/test/java/org/eclipse/jetty/ee10/jersey/tests/HungBlockingThreadsTest.java
@@ -147,7 +147,8 @@ public class HungBlockingThreadsTest
                 AsyncRequestContent content = new AsyncRequestContent("text/plain", data.slice());
                 Request request = httpClient.POST(server.getURI());
                 request
-                    .onRequestListener(new Request.Listener() {
+                    .onRequestListener(new Request.Listener()
+                    {
                         @Override
                         public void onCommit(Request request)
                         {

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jersey/src/test/java/org/eclipse/jetty/ee10/jersey/tests/HungBlockingThreadsTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jersey/src/test/java/org/eclipse/jetty/ee10/jersey/tests/HungBlockingThreadsTest.java
@@ -1,0 +1,233 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee10.jersey.tests;
+
+import java.io.InputStream;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Feature;
+import jakarta.ws.rs.core.FeatureContext;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.InputStreamRequestContent;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.servlet.ServletHolder;
+import org.eclipse.jetty.io.EofException;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.Blocker;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.server.model.Resource;
+import org.glassfish.jersey.servlet.ServletContainer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class HungBlockingThreadsTest
+{
+    private static final Logger LOG = LoggerFactory.getLogger(HungBlockingThreadsTest.class);
+    private static final int THREAD_COUNT = 1000;
+    private Server server;
+    private ExecutorService executorService;
+    private HttpClient httpClient;
+
+    @BeforeAll
+    public static void beforeAll()
+    {
+        // Wire up java.util.logging to slf4j.
+        org.slf4j.bridge.SLF4JBridgeHandler.removeHandlersForRootLogger();
+        org.slf4j.bridge.SLF4JBridgeHandler.install();
+    }
+
+    @AfterAll
+    public static void afterAll()
+    {
+        org.slf4j.bridge.SLF4JBridgeHandler.uninstall();
+    }
+
+    @BeforeEach
+    public void setUp() throws Exception
+    {
+        QueuedThreadPool queuedThreadPool = new QueuedThreadPool(10, 10, (int)TimeUnit.MINUTES.toMillis(1000L));
+        queuedThreadPool.setName("server");
+        queuedThreadPool.setDaemon(true);
+        queuedThreadPool.setReservedThreads(1);
+
+        server = new Server(queuedThreadPool);
+
+        ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        context.setContextPath("/");
+
+        ResourceConfig resourceConfig = new ResourceConfig();
+        Resource resource = Resource.builder(PostResource.class).build();
+        Resource.Builder resourceBuilder = Resource.builder(resource);
+        resource.getResourceMethods().forEach(resourceMethod -> resourceBuilder.updateMethod(resourceMethod).managedAsync());
+        resourceConfig.registerResources(resourceBuilder.build());
+        resourceConfig.register(CustomFeature.class);
+
+        context.addServlet(new ServletHolder(new ServletContainer(resourceConfig)), "/*");
+
+        server.setHandler(context);
+
+        ServerConnector connector = new ServerConnector(server);
+        connector.setPort(0);
+        connector.setIdleTimeout(Long.MAX_VALUE);
+        server.addConnector(connector);
+        server.start();
+
+        httpClient = new HttpClient();
+        QueuedThreadPool clientQtp = new QueuedThreadPool(THREAD_COUNT * 2);
+        clientQtp.setName("client");
+        httpClient.setExecutor(clientQtp);
+        httpClient.setMaxConnectionsPerDestination(THREAD_COUNT);
+        httpClient.start();
+
+        executorService = Executors.newCachedThreadPool();
+    }
+
+    @AfterEach
+    public void tearDown()
+    {
+        executorService.shutdownNow();
+        LifeCycle.stop(server);
+        LifeCycle.stop(httpClient);
+    }
+
+    @Test
+    public void test() throws Exception
+    {
+        CountDownLatch latch = new CountDownLatch(THREAD_COUNT);
+        for (int i = 0; i < THREAD_COUNT; i++)
+        {
+            executorService.submit(() ->
+            {
+                httpClient.POST(server.getURI())
+                    .body(new InputStreamRequestContent("text/plain", new HangInputStream(latch)))
+                    .timeout(1, TimeUnit.DAYS)
+                    .send(result -> {});
+            });
+        }
+
+        LOG.debug("awaiting for client to block on all threads");
+        assertTrue(latch.await(15, TimeUnit.SECONDS));
+
+        LOG.debug("Shutting down client");
+        // while hanging in inputstream read, close connections.
+        LifeCycle.stop(httpClient);
+
+        LOG.debug("Waiting for hung threads");
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertThat(threadDump(), not(containsString(Blocker.Shared.class.getName()))));
+    }
+
+    private static class HangInputStream extends InputStream
+    {
+        private final CountDownLatch latch;
+        private int count = 0;
+
+        public HangInputStream(CountDownLatch latch)
+        {
+            this.latch = latch;
+        }
+
+        @Override
+        public int read()
+        {
+            if (count == 1_000_000)
+            {
+                try
+                {
+                    latch.countDown();
+                    Thread.sleep(Duration.ofDays(1).toMillis());
+                }
+                catch (InterruptedException e)
+                {
+                    throw new RuntimeException(e);
+                }
+            }
+            count++;
+            return 'A';
+        }
+    }
+
+    private static String threadDump()
+    {
+        StringBuilder threadDump = new StringBuilder(System.lineSeparator());
+        ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+        for (ThreadInfo threadInfo : threadMXBean.dumpAllThreads(true, true))
+        {
+            threadDump.append(threadInfo.toString());
+        }
+        return threadDump.toString();
+    }
+
+    public static class CustomFeature implements Feature
+    {
+        @Override
+        public boolean configure(FeatureContext context)
+        {
+            context.register(JettyEofExceptionMapper.class);
+            return true;
+        }
+    }
+
+    /**
+     * Used to not log a stack trace for Jetty EOF exceptions
+     */
+    public static class JettyEofExceptionMapper implements ExceptionMapper<EofException>
+    {
+        @Override
+        public Response toResponse(EofException e)
+        {
+            Response.Status status = Response.Status.BAD_REQUEST;
+            return Response.status((Response.StatusType)status)
+                .type(MediaType.APPLICATION_JSON + "; " + MediaType.CHARSET_PARAMETER + "=utf-8")
+                .entity(status.getReasonPhrase()).build();
+        }
+    }
+
+    @Path("")
+    public static class PostResource
+    {
+        @POST
+        @Consumes("text/plain")
+        public Response doPost(String body)
+        {
+            return Response.ok().entity(body).build();
+        }
+    }
+}

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannelState.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannelState.java
@@ -838,11 +838,11 @@ public class HttpChannelState
                     if (_asyncListeners == null || _asyncListeners.isEmpty())
                     {
 //                      Case 3
-//                        return false;
-                        if (committed)
-                            return true;
-                        sendError(th);
                         return false;
+//                        if (committed)
+//                            return true;
+//                        sendError(th);
+//                        return false;
                     }
                     asyncEvent = _event;
                     asyncEvent.addThrowable(th);

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannelState.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannelState.java
@@ -837,7 +837,7 @@ public class HttpChannelState
                 {
                     if (_asyncListeners == null || _asyncListeners.isEmpty())
                     {
-//                      Case 3
+//                      Case 3 (ee9)
                         return false;
 //                        if (committed)
 //                            return true;

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannelState.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannelState.java
@@ -836,14 +836,7 @@ public class HttpChannelState
                 case ASYNC:
                 {
                     if (_asyncListeners == null || _asyncListeners.isEmpty())
-                    {
-//                      Case 3 (ee9)
                         return false;
-//                        if (committed)
-//                            return true;
-//                        sendError(th);
-//                        return false;
-                    }
                     asyncEvent = _event;
                     asyncEvent.addThrowable(th);
                     asyncListeners = _asyncListeners;

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannelState.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannelState.java
@@ -837,6 +837,8 @@ public class HttpChannelState
                 {
                     if (_asyncListeners == null || _asyncListeners.isEmpty())
                     {
+//                      Case 3
+//                        return false;
                         if (committed)
                             return true;
                         sendError(th);

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/AsyncContextTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/AsyncContextTest.java
@@ -45,6 +45,7 @@ import org.slf4j.LoggerFactory;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -121,7 +122,7 @@ public class AsyncContextTest
         });
 
         String request = """
-            GET /ctx/startthrow HTTP/1.1\r
+            GET /ctx/startthrow?timeout=100 HTTP/1.1\r
             Host: localhost\r
             Connection: close\r
             \r
@@ -132,9 +133,10 @@ public class AsyncContextTest
 
         String responseBody = response.getContent();
 
-        assertThat(responseBody, containsString("ERROR: /error"));
-        assertThat(responseBody, containsString("PathInfo= /IOE"));
-        assertThat(responseBody, containsString("EXCEPTION: org.eclipse.jetty.ee9.nested.QuietServletException: java.io.IOException: Test"));
+        assertThat(responseBody, containsString("HTTP ERROR 500 AsyncContext timeout"));
+        assertThat(responseBody, not(containsString("ERROR: /error")));
+        assertThat(responseBody, not(containsString("PathInfo= /IOE")));
+        assertThat(responseBody, not(containsString("EXCEPTION: org.eclipse.jetty.ee9.nested.QuietServletException: java.io.IOException: Test")));
     }
 
     @Test
@@ -158,13 +160,15 @@ public class AsyncContextTest
             """;
         HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse(request));
 
-        assertThat("Response.status", response.getStatus(), is(HttpServletResponse.SC_INTERNAL_SERVER_ERROR));
+        // OK b/c exception was thrown after AsyncContext.dispatch() was called
+        assertThat("Response.status", response.getStatus(), is(HttpServletResponse.SC_OK));
 
         String responseBody = response.getContent();
 
-        assertThat(responseBody, containsString("ERROR: /error"));
-        assertThat(responseBody, containsString("PathInfo= /IOE"));
-        assertThat(responseBody, containsString("EXCEPTION: org.eclipse.jetty.ee9.nested.QuietServletException: java.io.IOException: Test"));
+        assertThat(responseBody, emptyString());
+        assertThat(responseBody, not(containsString("ERROR: /error")));
+        assertThat(responseBody, not(containsString("PathInfo= /IOE")));
+        assertThat(responseBody, not(containsString("EXCEPTION: org.eclipse.jetty.ee9.nested.QuietServletException: java.io.IOException: Test")));
     }
 
     @Test
@@ -189,12 +193,14 @@ public class AsyncContextTest
             """;
         HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse(request));
 
-        assertThat("Response.status", response.getStatus(), is(HttpServletResponse.SC_INTERNAL_SERVER_ERROR));
+        // OK b/c exception was thrown after AsyncContext.complete() was called
+        assertThat("Response.status", response.getStatus(), is(HttpServletResponse.SC_OK));
 
         String responseBody = response.getContent();
-        assertThat(responseBody, containsString("ERROR: /error"));
-        assertThat(responseBody, containsString("PathInfo= /IOE"));
-        assertThat(responseBody, containsString("EXCEPTION: org.eclipse.jetty.ee9.nested.QuietServletException: java.io.IOException: Test"));
+        assertThat(responseBody, containsString("completeBeforeThrow"));
+        assertThat(responseBody, not(containsString("ERROR: /error")));
+        assertThat(responseBody, not(containsString("PathInfo= /IOE")));
+        assertThat(responseBody, not(containsString("EXCEPTION: org.eclipse.jetty.ee9.nested.QuietServletException: java.io.IOException: Test")));
     }
 
     @Test
@@ -764,7 +770,10 @@ public class AsyncContextTest
         {
             if (request.getDispatcherType() == DispatcherType.REQUEST)
             {
-                request.startAsync(request, response);
+                AsyncContext async = request.startAsync(request, response);
+                String timeoutString = request.getParameter("timeout");
+                if (timeoutString != null)
+                    async.setTimeout(Long.parseLong(timeoutString));
 
                 if (Boolean.parseBoolean(request.getParameter("dispatch")))
                 {

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/AsyncContextTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/AsyncContextTest.java
@@ -14,7 +14,9 @@
 package org.eclipse.jetty.ee9.servlet;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import jakarta.servlet.AsyncContext;
@@ -29,11 +31,9 @@ import jakarta.servlet.http.HttpServletMapping;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpServletResponseWrapper;
-import org.eclipse.jetty.ee9.nested.HttpChannel;
 import org.eclipse.jetty.ee9.nested.QuietServletException;
 import org.eclipse.jetty.ee9.nested.Request;
 import org.eclipse.jetty.http.HttpTester;
-import org.eclipse.jetty.logging.StacklessLogging;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.Server;
@@ -43,11 +43,12 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 /**
@@ -111,9 +112,19 @@ public class AsyncContextTest
     @Test
     public void testStartThrow() throws Exception
     {
+        AtomicReference<AsyncContext> asyncContextRef = new AtomicReference<>();
         startServer((config) ->
         {
-            _contextHandler.addServlet(new ServletHolder(new TestStartThrowServlet()), "/startthrow/*");
+            _contextHandler.addServlet(new ServletHolder(new HttpServlet() {
+                @Override
+                protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+                {
+                    AsyncContext async = request.startAsync(request, response);
+                    asyncContextRef.set(async);
+                    response.getOutputStream().write("wrote text just fine".getBytes(StandardCharsets.UTF_8));
+                    throw new QuietServletException(new IOException("Test"));
+                }
+            }), "/startthrow/*");
             _contextHandler.addServlet(new ServletHolder(new ErrorServlet()), "/error/*");
             ErrorPageErrorHandler errorHandler = new ErrorPageErrorHandler();
             errorHandler.setUnwrapServletException(false);
@@ -121,22 +132,27 @@ public class AsyncContextTest
             errorHandler.addErrorPage(IOException.class.getName(), "/error/IOE");
         });
 
-        String request = """
-            GET /ctx/startthrow?timeout=100 HTTP/1.1\r
-            Host: localhost\r
-            Connection: close\r
-            \r
-            """;
-        HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse(request, 10, TimeUnit.MINUTES));
+        String request =
+            """
+                GET /ctx/startthrow HTTP/1.1\r
+                Host: localhost\r
+                Connection: close\r
+                \r
+                """;
 
-        assertThat("Response.status", response.getStatus(), is(HttpServletResponse.SC_INTERNAL_SERVER_ERROR));
+        try (LocalConnector.LocalEndPoint localEndPoint = _connector.connect())
+        {
+            localEndPoint.addInputAndExecute(request);
+            assertThat(localEndPoint.getResponse(false, 1, TimeUnit.SECONDS), nullValue());
 
-        String responseBody = response.getContent();
+            await().atMost(5, TimeUnit.SECONDS).until(asyncContextRef::get, not(nullValue())).complete();
 
-        assertThat(responseBody, containsString("HTTP ERROR 500 AsyncContext timeout"));
-        assertThat(responseBody, not(containsString("ERROR: /error")));
-        assertThat(responseBody, not(containsString("PathInfo= /IOE")));
-        assertThat(responseBody, not(containsString("EXCEPTION: org.eclipse.jetty.ee9.nested.QuietServletException: java.io.IOException: Test")));
+            HttpTester.Response response = HttpTester.parseResponse(localEndPoint.getResponse(false, 10, TimeUnit.SECONDS));
+            assertThat("Response.status", response.getStatus(), is(HttpServletResponse.SC_OK));
+
+            String responseBody = response.getContent();
+            assertThat(responseBody, is("wrote text just fine"));
+        }
     }
 
     @Test
@@ -144,7 +160,23 @@ public class AsyncContextTest
     {
         startServer((config) ->
         {
-            _contextHandler.addServlet(new ServletHolder(new TestStartThrowServlet()), "/startthrow/*");
+            _contextHandler.addServlet(new ServletHolder(new HttpServlet() {
+                @Override
+                protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException
+                {
+                    AsyncContext async = request.startAsync(request, response);
+                    async.dispatch("/dispatch-landing/");
+                    throw new QuietServletException(new IOException("Test"));
+                }
+            }), "/startthrow/*");
+            _contextHandler.addServlet(new ServletHolder(new HttpServlet() {
+                @Override
+                protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException
+                {
+                    response.getOutputStream().write("Landed just fine".getBytes(StandardCharsets.UTF_8));
+                }
+            }), "/dispatch-landing/*");
+
             _contextHandler.addServlet(new ServletHolder(new ErrorServlet()), "/error/*");
             ErrorPageErrorHandler errorHandler = new ErrorPageErrorHandler();
             errorHandler.setUnwrapServletException(false);
@@ -152,12 +184,13 @@ public class AsyncContextTest
             errorHandler.addErrorPage(IOException.class.getName(), "/error/IOE");
         });
 
-        String request = """
-            GET /ctx/startthrow?dispatch=true HTTP/1.1\r
-            Host: localhost\r
-            Connection: close\r
-            \r
-            """;
+        String request =
+            """
+                GET /ctx/startthrow HTTP/1.1\r
+                Host: localhost\r
+                Connection: close\r
+                \r
+                """;
         HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse(request));
 
         // OK b/c exception was thrown after AsyncContext.dispatch() was called
@@ -165,10 +198,7 @@ public class AsyncContextTest
 
         String responseBody = response.getContent();
 
-        assertThat(responseBody, emptyString());
-        assertThat(responseBody, not(containsString("ERROR: /error")));
-        assertThat(responseBody, not(containsString("PathInfo= /IOE")));
-        assertThat(responseBody, not(containsString("EXCEPTION: org.eclipse.jetty.ee9.nested.QuietServletException: java.io.IOException: Test")));
+        assertThat(responseBody, is("Landed just fine"));
     }
 
     @Test
@@ -176,7 +206,16 @@ public class AsyncContextTest
     {
         startServer((config) ->
         {
-            _contextHandler.addServlet(new ServletHolder(new TestStartThrowServlet()), "/startthrow/*");
+            _contextHandler.addServlet(new ServletHolder(new HttpServlet() {
+                @Override
+                protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+                {
+                    AsyncContext async = request.startAsync(request, response);
+                    response.getOutputStream().write("completeBeforeThrow".getBytes(StandardCharsets.UTF_8));
+                    async.complete();
+                    throw new QuietServletException(new IOException("Test"));
+                }
+            }), "/startthrow/*");
             _contextHandler.addServlet(new ServletHolder(new ErrorServlet()), "/error/*");
             ErrorPageErrorHandler errorHandler = new ErrorPageErrorHandler();
             errorHandler.setUnwrapServletException(false);
@@ -185,7 +224,7 @@ public class AsyncContextTest
         });
 
         String request = """
-            GET /ctx/startthrow?complete=true HTTP/1.1\r
+            GET /ctx/startthrow HTTP/1.1\r
             Host: localhost\r
             Content-Type: application/x-www-form-urlencoded\r
             Connection: close\r
@@ -198,9 +237,6 @@ public class AsyncContextTest
 
         String responseBody = response.getContent();
         assertThat(responseBody, containsString("completeBeforeThrow"));
-        assertThat(responseBody, not(containsString("ERROR: /error")));
-        assertThat(responseBody, not(containsString("PathInfo= /IOE")));
-        assertThat(responseBody, not(containsString("EXCEPTION: org.eclipse.jetty.ee9.nested.QuietServletException: java.io.IOException: Test")));
     }
 
     @Test
@@ -208,7 +244,17 @@ public class AsyncContextTest
     {
         startServer((config) ->
         {
-            _contextHandler.addServlet(new ServletHolder(new TestStartThrowServlet()), "/startthrow/*");
+            _contextHandler.addServlet(new ServletHolder(new HttpServlet() {
+                @Override
+                protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+                {
+                    AsyncContext async = request.startAsync(request, response);
+                    response.getOutputStream().write("completeBeforeThrow".getBytes());
+                    response.flushBuffer();
+                    async.complete();
+                    throw new QuietServletException(new IOException("Test"));
+                }
+            }), "/startthrow/*");
             _contextHandler.addServlet(new ServletHolder(new ErrorServlet()), "/error/*");
             ErrorPageErrorHandler errorHandler = new ErrorPageErrorHandler();
             errorHandler.setUnwrapServletException(false);
@@ -216,22 +262,19 @@ public class AsyncContextTest
             errorHandler.addErrorPage(IOException.class.getName(), "/error/IOE");
         });
 
-        try (StacklessLogging ignore = new StacklessLogging(HttpChannel.class))
-        {
-            String request = """
-                GET /ctx/startthrow?flush=true&complete=true HTTP/1.1\r
-                Host: localhost\r
-                Content-Type: application/x-www-form-urlencoded\r
-                Connection: close\r
-                \r
-                """;
-            HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse(request));
-            assertThat("Response.status", response.getStatus(), is(HttpServletResponse.SC_OK));
+        String request = """
+            GET /ctx/startthrow HTTP/1.1\r
+            Host: localhost\r
+            Content-Type: application/x-www-form-urlencoded\r
+            Connection: close\r
+            \r
+            """;
+        HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse(request));
+        assertThat("Response.status", response.getStatus(), is(HttpServletResponse.SC_OK));
 
-            String responseBody = response.getContent();
+        String responseBody = response.getContent();
 
-            assertThat("error servlet", responseBody, containsString("completeBeforeThrow"));
-        }
+        assertThat("error servlet", responseBody, containsString("completeBeforeThrow"));
     }
 
     @Test
@@ -760,36 +803,6 @@ public class AsyncContextTest
             response.getOutputStream().print("doGet:async:getRequestURL:" + asyncRequest.getRequestURL() + "\n");
             response.getOutputStream().print("doGet:async:getPathInfo:" + asyncRequest.getPathInfo() + "\n");
             asyncContext.start(new AsyncRunnable(asyncContext));
-        }
-    }
-
-    private static class TestStartThrowServlet extends HttpServlet
-    {
-        @Override
-        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
-        {
-            if (request.getDispatcherType() == DispatcherType.REQUEST)
-            {
-                AsyncContext async = request.startAsync(request, response);
-                String timeoutString = request.getParameter("timeout");
-                if (timeoutString != null)
-                    async.setTimeout(Long.parseLong(timeoutString));
-
-                if (Boolean.parseBoolean(request.getParameter("dispatch")))
-                {
-                    request.getAsyncContext().dispatch();
-                }
-
-                if (Boolean.parseBoolean(request.getParameter("complete")))
-                {
-                    response.getOutputStream().write("completeBeforeThrow".getBytes());
-                    if (Boolean.parseBoolean(request.getParameter("flush")))
-                        response.flushBuffer();
-                    request.getAsyncContext().complete();
-                }
-
-                throw new QuietServletException(new IOException("Test"));
-            }
         }
     }
 

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/AsyncContextTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/AsyncContextTest.java
@@ -115,7 +115,8 @@ public class AsyncContextTest
         AtomicReference<AsyncContext> asyncContextRef = new AtomicReference<>();
         startServer((config) ->
         {
-            _contextHandler.addServlet(new ServletHolder(new HttpServlet() {
+            _contextHandler.addServlet(new ServletHolder(new HttpServlet()
+            {
                 @Override
                 protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
                 {
@@ -160,7 +161,8 @@ public class AsyncContextTest
     {
         startServer((config) ->
         {
-            _contextHandler.addServlet(new ServletHolder(new HttpServlet() {
+            _contextHandler.addServlet(new ServletHolder(new HttpServlet()
+            {
                 @Override
                 protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException
                 {
@@ -169,7 +171,8 @@ public class AsyncContextTest
                     throw new QuietServletException(new IOException("Test"));
                 }
             }), "/startthrow/*");
-            _contextHandler.addServlet(new ServletHolder(new HttpServlet() {
+            _contextHandler.addServlet(new ServletHolder(new HttpServlet()
+            {
                 @Override
                 protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException
                 {
@@ -206,7 +209,8 @@ public class AsyncContextTest
     {
         startServer((config) ->
         {
-            _contextHandler.addServlet(new ServletHolder(new HttpServlet() {
+            _contextHandler.addServlet(new ServletHolder(new HttpServlet()
+            {
                 @Override
                 protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
                 {
@@ -244,7 +248,8 @@ public class AsyncContextTest
     {
         startServer((config) ->
         {
-            _contextHandler.addServlet(new ServletHolder(new HttpServlet() {
+            _contextHandler.addServlet(new ServletHolder(new HttpServlet()
+            {
                 @Override
                 protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
                 {

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/AsyncServletIOTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/AsyncServletIOTest.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -42,12 +43,14 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.ee9.nested.DebugListener;
+import org.eclipse.jetty.io.EofException;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
@@ -57,7 +60,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -76,6 +81,7 @@ public class AsyncServletIOTest
     protected AsyncIOServlet3 _servlet3 = new AsyncIOServlet3();
     protected AsyncIOServlet4 _servlet4 = new AsyncIOServlet4();
     protected StolenAsyncReadServlet _servletStolenAsyncRead = new StolenAsyncReadServlet();
+    protected AsyncReadServlet _servletAsyncRead = new AsyncReadServlet();
     protected int _port;
     protected WrappingQTP _wQTP;
     protected Server _server;
@@ -118,6 +124,10 @@ public class AsyncServletIOTest
         ServletHolder holder5 = new ServletHolder(_servletStolenAsyncRead);
         holder5.setAsyncSupported(true);
         _servletHandler.addServletWithMapping(holder5, "/stolen/*");
+
+        ServletHolder holder6 = new ServletHolder(_servletAsyncRead);
+        holder6.setAsyncSupported(true);
+        _servletHandler.addServletWithMapping(holder6, "/asyncRead/*");
 
         _server.start();
         _port = _connector.getLocalPort();
@@ -234,6 +244,33 @@ public class AsyncServletIOTest
 
         assertEquals(list.get(0), "data");
         assertTrue(_servlet2.completed.await(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testEarlyEofDuringClientAsyncRequestBlockingRead() throws Exception
+    {
+        int port = _port;
+        try (Socket socket = new Socket("localhost", port))
+        {
+            String request =
+                "GET /ctx/asyncRead HTTP/1.1\r\n" +
+                    "Host: localhost\r\n" +
+                    "Content-Length: 10\r\n" +
+                    "\r\n" +
+                    "01234";
+
+            OutputStream output = socket.getOutputStream();
+            output.write(request.getBytes(StandardCharsets.UTF_8));
+            output.flush();
+
+            // Close.
+        }
+
+        // Assert that the blocking read throws EofException.
+        await().atMost(5, TimeUnit.SECONDS).until(() -> _servletAsyncRead.exceptionRef.get() instanceof EofException);
+
+        // Assert that no async event was generated as the blocking read got notified of the error.
+        await().during(3, TimeUnit.SECONDS).atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertThat(_servletAsyncRead.listener.events, empty()));
     }
 
     @Test
@@ -957,6 +994,71 @@ public class AsyncServletIOTest
             public void onStartAsync(AsyncEvent event)
             {
             }
+        }
+    }
+
+    public static class AsyncReadServlet extends HttpServlet
+    {
+        final AtomicReference<Throwable> exceptionRef = new AtomicReference<>();
+        final TestAsyncListener listener = new TestAsyncListener();
+
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException
+        {
+            AsyncContext asyncContext = req.startAsync();
+            asyncContext.addListener(listener);
+            new Thread(() ->
+            {
+                try
+                {
+                    try
+                    {
+                        IO.readBytes(req.getInputStream());
+                        throw new AssertionError("expected IOException");
+                    }
+                    catch (IOException e)
+                    {
+                        exceptionRef.set(e);
+                    }
+                    finally
+                    {
+//                        asyncContext.complete();
+                    }
+                }
+                catch (Throwable x)
+                {
+                    exceptionRef.set(x);
+                }
+            }).start();
+        }
+    }
+
+    static class TestAsyncListener implements AsyncListener
+    {
+        final List<String> events = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void onComplete(AsyncEvent event) throws IOException
+        {
+            events.add("complete");
+        }
+
+        @Override
+        public void onTimeout(AsyncEvent event) throws IOException
+        {
+            events.add("timeout");
+        }
+
+        @Override
+        public void onError(AsyncEvent event) throws IOException
+        {
+            events.add("error");
+        }
+
+        @Override
+        public void onStartAsync(AsyncEvent event) throws IOException
+        {
+            events.add("startAsync");
         }
     }
 

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/AsyncServletIOTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/AsyncServletIOTest.java
@@ -1020,10 +1020,6 @@ public class AsyncServletIOTest
                     {
                         exceptionRef.set(e);
                     }
-                    finally
-                    {
-//                        asyncContext.complete();
-                    }
                 }
                 catch (Throwable x)
                 {
@@ -1031,34 +1027,34 @@ public class AsyncServletIOTest
                 }
             }).start();
         }
-    }
 
-    static class TestAsyncListener implements AsyncListener
-    {
-        final List<String> events = new CopyOnWriteArrayList<>();
-
-        @Override
-        public void onComplete(AsyncEvent event) throws IOException
+        static class TestAsyncListener implements AsyncListener
         {
-            events.add("complete");
-        }
+            final List<String> events = new CopyOnWriteArrayList<>();
 
-        @Override
-        public void onTimeout(AsyncEvent event) throws IOException
-        {
-            events.add("timeout");
-        }
+            @Override
+            public void onComplete(AsyncEvent event)
+            {
+                events.add("complete");
+            }
 
-        @Override
-        public void onError(AsyncEvent event) throws IOException
-        {
-            events.add("error");
-        }
+            @Override
+            public void onTimeout(AsyncEvent event)
+            {
+                events.add("timeout");
+            }
 
-        @Override
-        public void onStartAsync(AsyncEvent event) throws IOException
-        {
-            events.add("startAsync");
+            @Override
+            public void onError(AsyncEvent event)
+            {
+                events.add("error");
+            }
+
+            @Override
+            public void onStartAsync(AsyncEvent event)
+            {
+                events.add("startAsync");
+            }
         }
     }
 

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/AsyncServletIOTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/AsyncServletIOTest.java
@@ -1011,15 +1011,8 @@ public class AsyncServletIOTest
             {
                 try
                 {
-                    try
-                    {
-                        IO.readBytes(req.getInputStream());
-                        throw new AssertionError("expected IOException");
-                    }
-                    catch (IOException e)
-                    {
-                        exceptionRef.set(e);
-                    }
+                    IO.readBytes(req.getInputStream());
+                    throw new AssertionError("expected IOException");
                 }
                 catch (Throwable x)
                 {

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/AsyncIOServletTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/AsyncIOServletTest.java
@@ -305,7 +305,7 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testOnErrorThrows(Transport transport) throws Exception
+    public void testOnDataAvailableThrows(Transport transport) throws Exception
     {
         AtomicInteger errors = new AtomicInteger();
         start(transport, new HttpServlet()

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/AsyncIOServletTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/AsyncIOServletTest.java
@@ -320,7 +320,7 @@ public class AsyncIOServletTest extends AbstractTest
                     return;
                 }
 
-                request.startAsync(request, response);
+                AsyncContext asyncContext = request.startAsync(request, response);
                 request.getInputStream().setReadListener(new ReadListener()
                 {
                     @Override
@@ -340,13 +340,11 @@ public class AsyncIOServletTest extends AbstractTest
                     public void onError(Throwable t)
                     {
                         assertScope();
+                        assertThat(t, instanceOf(NullPointerException.class));
+                        assertThat(t.getMessage(), is("explicitly_thrown_by_test_1"));
                         errors.incrementAndGet();
-                        throw new NullPointerException("explicitly_thrown_by_test_2")
-                        {
-                            {
-                                this.initCause(t);
-                            }
-                        };
+                        response.setStatus(HttpStatus.IM_A_TEAPOT_418);
+                        asyncContext.complete();
                     }
                 });
             }
@@ -359,7 +357,7 @@ public class AsyncIOServletTest extends AbstractTest
                 .timeout(5, TimeUnit.SECONDS)
                 .send();
 
-            assertEquals(HttpStatus.INTERNAL_SERVER_ERROR_500, response.getStatus());
+            assertEquals(HttpStatus.IM_A_TEAPOT_418, response.getStatus());
             assertEquals(1, errors.get());
         }
     }

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty.ee9</groupId>
     <artifactId>jetty-ee9-tests</artifactId>
-    <version>12.0.21-SNAPSHOT</version>
+    <version>12.0.22-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-ee9-test-jersey</artifactId>
   <packaging>jar</packaging>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.jetty.ee9</groupId>
+    <artifactId>jetty-ee9-tests</artifactId>
+    <version>12.0.21-SNAPSHOT</version>
+  </parent>
+  <artifactId>jetty-ee9-test-jersey</artifactId>
+  <packaging>jar</packaging>
+  <name>EE9 :: Tests :: Jersey</name>
+
+  <properties>
+    <bundle-symbolic-name>${project.groupId}.jersey.tests</bundle-symbolic-name>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.jetty.ee9</groupId>
+      <artifactId>jetty-ee9-webapp</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-test-helper</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.containers</groupId>
+      <artifactId>jersey-container-servlet</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.inject</groupId>
+      <artifactId>jersey-hk2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-binding</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-slf4j-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jul-to-slf4j</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/pom.xml
@@ -17,6 +17,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty.ee9</groupId>
       <artifactId>jetty-ee9-webapp</artifactId>
     </dependency>
@@ -39,6 +43,11 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/java/org/eclipse/jetty/ee9/jersey/tests/EmbeddedJerseyTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/java/org/eclipse/jetty/ee9/jersey/tests/EmbeddedJerseyTest.java
@@ -1,0 +1,160 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee9.jersey.tests;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.client.AsyncRequestContent;
+import org.eclipse.jetty.client.CompletableResponseListener;
+import org.eclipse.jetty.client.ContentResponse;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.Request;
+import org.eclipse.jetty.client.StringRequestContent;
+import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee9.servlet.ServletHolder;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.MimeTypes;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class EmbeddedJerseyTest
+{
+    @BeforeAll
+    public static void beforeAll()
+    {
+        // Wire up java.util.logging to slf4j.
+        org.slf4j.bridge.SLF4JBridgeHandler.removeHandlersForRootLogger();
+        org.slf4j.bridge.SLF4JBridgeHandler.install();
+    }
+
+    @AfterAll
+    public static void afterAll()
+    {
+        org.slf4j.bridge.SLF4JBridgeHandler.uninstall();
+    }
+
+    private Server server;
+    private ServerConnector connector;
+    private HttpClient httpClient;
+
+    private void start() throws Exception
+    {
+        startServer();
+        startClient();
+    }
+
+    private void startServer() throws Exception
+    {
+        server = new Server();
+        connector = new ServerConnector(server, 1, 1);
+        server.addConnector(connector);
+        ServletContextHandler context = new ServletContextHandler();
+        context.setContextPath("/");
+        server.setHandler(context);
+
+        ServletHolder servletHolder = new ServletHolder(org.glassfish.jersey.servlet.ServletContainer.class);
+        servletHolder.setInitOrder(1);
+        servletHolder.setInitParameter("jersey.config.server.provider.packages", "org.eclipse.jetty.ee9.jersey.tests.endpoints");
+        context.addServlet(servletHolder, "/webapi/*");
+
+        server.start();
+    }
+
+    private void startClient() throws Exception
+    {
+        httpClient = new HttpClient();
+        httpClient.start();
+    }
+
+    @AfterEach
+    public void tearDown()
+    {
+        LifeCycle.stop(httpClient);
+        LifeCycle.stop(server);
+    }
+
+    @Test
+    public void testPutJSON() throws Exception
+    {
+        start();
+
+        Request.Content content = new StringRequestContent("""
+            {
+                "principal" : "foo",
+                "roles" : ["admin", "user"]
+            }
+            """
+        );
+        ContentResponse response = httpClient.newRequest("localhost", connector.getLocalPort())
+            .method(HttpMethod.PUT)
+            .path("/webapi/resource/security/")
+            .headers(httpFields -> httpFields.put(HttpHeader.CONTENT_TYPE, MimeTypes.Type.APPLICATION_JSON.asString()))
+            .body(content)
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.getHeaders().get(HttpHeader.CONTENT_TYPE), is(MimeTypes.Type.APPLICATION_JSON.asString()));
+        assertThat(response.getContentAsString(), is("""
+            {
+                "response" : "ok"
+            }
+            """)
+        );
+    }
+
+    @Test
+    public void testPutNoJSONThenTimeout() throws Exception
+    {
+        start();
+        long idleTimeout = 1000;
+        connector.setIdleTimeout(idleTimeout);
+
+        AsyncRequestContent content = new AsyncRequestContent();
+
+        CountDownLatch responseLatch = new CountDownLatch(1);
+        CompletableFuture<ContentResponse> completable = new CompletableResponseListener(
+            httpClient.newRequest("localhost", connector.getLocalPort())
+                .method(HttpMethod.PUT)
+                .path("/webapi/resource/security/")
+                .timeout(3 * idleTimeout, TimeUnit.SECONDS)
+                .headers(httpFields -> httpFields.put(HttpHeader.CONTENT_TYPE, MimeTypes.Type.APPLICATION_JSON.asString()))
+                .body(content)
+                .onResponseSuccess(r -> responseLatch.countDown())
+        ).send();
+
+        // Do not add content to the request, the server should time out and send the response.
+        assertTrue(responseLatch.await(2 * idleTimeout, TimeUnit.MILLISECONDS));
+
+        // Terminate the request too.
+        content.close();
+
+        ContentResponse response = completable.get(idleTimeout, TimeUnit.MILLISECONDS);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR_500, response.getStatus());
+    }
+}

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/java/org/eclipse/jetty/ee9/jersey/tests/HungBlockingThreadsTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/java/org/eclipse/jetty/ee9/jersey/tests/HungBlockingThreadsTest.java
@@ -1,0 +1,239 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee9.jersey.tests;
+
+import java.io.InputStream;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Feature;
+import jakarta.ws.rs.core.FeatureContext;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee9.servlet.ServletHolder;
+import org.eclipse.jetty.io.EofException;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.SharedBlockingCallback;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.server.model.Resource;
+import org.glassfish.jersey.servlet.ServletContainer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class HungBlockingThreadsTest
+{
+    private static final Logger LOG = LoggerFactory.getLogger(HungBlockingThreadsTest.class);
+    private static final int THREAD_COUNT = 1000;
+    private Server server;
+    private ExecutorService executorService;
+    private HttpClient httpClient;
+
+    @BeforeAll
+    public static void beforeAll()
+    {
+        // Wire up java.util.logging to slf4j.
+        org.slf4j.bridge.SLF4JBridgeHandler.removeHandlersForRootLogger();
+        org.slf4j.bridge.SLF4JBridgeHandler.install();
+    }
+
+    @AfterAll
+    public static void afterAll()
+    {
+        org.slf4j.bridge.SLF4JBridgeHandler.uninstall();
+    }
+
+    @BeforeEach
+    public void setUp() throws Exception
+    {
+        QueuedThreadPool queuedThreadPool = new QueuedThreadPool(10, 10, (int)TimeUnit.MINUTES.toMillis(1000L));
+        queuedThreadPool.setName("jetty-queue-tp");
+        queuedThreadPool.setDaemon(true);
+        queuedThreadPool.setReservedThreads(1);
+
+        server = new Server(queuedThreadPool);
+
+        ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        context.setContextPath("/");
+
+        ResourceConfig resourceConfig = new ResourceConfig();
+        resourceConfig.registerResources(makeAsync(Resource.builder(MyResource.class).build()));
+        resourceConfig.register(CustomFeature.class);
+
+        context.addServlet(new ServletHolder(new ServletContainer(resourceConfig)), "/*");
+
+        server.setHandler(context);
+
+        ServerConnector connector = new ServerConnector(server);
+        connector.setPort(0);
+        connector.setIdleTimeout(Long.MAX_VALUE);
+        server.addConnector(connector);
+        server.start();
+
+        executorService = Executors.newCachedThreadPool();
+        httpClient = HttpClient.newHttpClient();
+    }
+
+    @AfterEach
+    public void tearDown()
+    {
+        executorService.shutdownNow();
+        LifeCycle.stop(server);
+    }
+
+    @Test
+    public void test() throws Exception
+    {
+        List<Future<?>> futures = new CopyOnWriteArrayList<>();
+        CountDownLatch latch = new CountDownLatch(THREAD_COUNT);
+        for (int i = 0; i < THREAD_COUNT; i++)
+        {
+            executorService.submit(() ->
+            {
+                HttpRequest request = HttpRequest.newBuilder()
+                    .POST(HttpRequest.BodyPublishers.ofInputStream(() -> new HangInputStream(latch)))
+                    .uri(server.getURI())
+                    .timeout(Duration.ofDays(1))
+                    .build();
+                CompletableFuture<HttpResponse<String>> future = httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString());
+                futures.add(future);
+            });
+        }
+
+        LOG.debug("awaiting for client to block on all threads");
+        assertTrue(latch.await(15, TimeUnit.SECONDS));
+
+        LOG.debug("Shutting down client");
+        // while hanging in inputstream read, close connections.
+        futures.forEach(f -> f.cancel(true));
+
+        LOG.debug("Waiting for hung threads");
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertThat(threadDump(), not(containsString(SharedBlockingCallback.class.getSimpleName()))));
+    }
+
+    private static class HangInputStream extends InputStream
+    {
+        private final CountDownLatch latch;
+        private int count = 0;
+
+        public HangInputStream(CountDownLatch latch)
+        {
+            this.latch = latch;
+        }
+
+        @Override
+        public int read()
+        {
+            if (count == 1_000_000)
+            {
+                try
+                {
+                    latch.countDown();
+                    Thread.sleep(Duration.ofDays(1).toMillis());
+                }
+                catch (InterruptedException e)
+                {
+                    throw new RuntimeException(e);
+                }
+            }
+            count++;
+            return 'A';
+        }
+    }
+
+    private static String threadDump()
+    {
+        StringBuilder threadDump = new StringBuilder(System.lineSeparator());
+        ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+        for (ThreadInfo threadInfo : threadMXBean.dumpAllThreads(true, true))
+        {
+            threadDump.append(threadInfo.toString());
+        }
+        return threadDump.toString();
+    }
+
+    private static Resource makeAsync(Resource resource)
+    {
+        Resource.Builder resourceBuilder = Resource.builder(resource);
+        resource.getResourceMethods().forEach(resourceMethod -> resourceBuilder.updateMethod(resourceMethod).managedAsync());
+        return resourceBuilder.build();
+    }
+
+    public static class CustomFeature implements Feature
+    {
+        @Override
+        public boolean configure(FeatureContext context)
+        {
+            context.register(JettyEofExceptionMapper.class);
+            return true;
+        }
+    }
+
+    /**
+     * Used to not log a stack trace for Jetty EOF exceptions
+     */
+    public static class JettyEofExceptionMapper implements ExceptionMapper<EofException>
+    {
+        @Override
+        public Response toResponse(EofException e)
+        {
+            Response.Status status = Response.Status.BAD_REQUEST;
+            return Response.status((Response.StatusType)status)
+                .type(MediaType.APPLICATION_JSON + "; " + MediaType.CHARSET_PARAMETER + "=utf-8")
+                .entity(status.getReasonPhrase()).build();
+        }
+    }
+
+    @Path("")
+    public static class MyResource
+    {
+        @POST
+        @Consumes("text/plain")
+        public Response doPost(String body)
+        {
+            return Response.ok().entity(body).build();
+        }
+    }
+}

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/java/org/eclipse/jetty/ee9/jersey/tests/HungBlockingThreadsTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/java/org/eclipse/jetty/ee9/jersey/tests/HungBlockingThreadsTest.java
@@ -61,7 +61,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class HungBlockingThreadsTest
 {
     private static final Logger LOG = LoggerFactory.getLogger(HungBlockingThreadsTest.class);
-    private static final int THREAD_COUNT = 1000;
+    private static final int THREAD_COUNT = 128;
     private Server server;
     private ExecutorService executorService;
     private HttpClient httpClient;

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/java/org/eclipse/jetty/ee9/jersey/tests/HungBlockingThreadsTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/java/org/eclipse/jetty/ee9/jersey/tests/HungBlockingThreadsTest.java
@@ -205,9 +205,6 @@ public class HungBlockingThreadsTest
         }
     }
 
-    /**
-     * Used to not log a stack trace for Jetty EOF exceptions
-     */
     public static class JettyEofExceptionMapper implements ExceptionMapper<EofException>
     {
         @Override

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/java/org/eclipse/jetty/ee9/jersey/tests/HungBlockingThreadsTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/java/org/eclipse/jetty/ee9/jersey/tests/HungBlockingThreadsTest.java
@@ -17,17 +17,10 @@ import java.io.InputStream;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.time.Duration;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import jakarta.ws.rs.Consumes;
@@ -38,6 +31,8 @@ import jakarta.ws.rs.core.FeatureContext;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.InputStreamRequestContent;
 import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee9.servlet.ServletHolder;
 import org.eclipse.jetty.io.EofException;
@@ -89,7 +84,7 @@ public class HungBlockingThreadsTest
     public void setUp() throws Exception
     {
         QueuedThreadPool queuedThreadPool = new QueuedThreadPool(10, 10, (int)TimeUnit.MINUTES.toMillis(1000L));
-        queuedThreadPool.setName("jetty-queue-tp");
+        queuedThreadPool.setName("server");
         queuedThreadPool.setDaemon(true);
         queuedThreadPool.setReservedThreads(1);
 
@@ -99,7 +94,10 @@ public class HungBlockingThreadsTest
         context.setContextPath("/");
 
         ResourceConfig resourceConfig = new ResourceConfig();
-        resourceConfig.registerResources(makeAsync(Resource.builder(MyResource.class).build()));
+        Resource resource = Resource.builder(PostResource.class).build();
+        Resource.Builder resourceBuilder = Resource.builder(resource);
+        resource.getResourceMethods().forEach(resourceMethod -> resourceBuilder.updateMethod(resourceMethod).managedAsync());
+        resourceConfig.registerResources(resourceBuilder.build());
         resourceConfig.register(CustomFeature.class);
 
         context.addServlet(new ServletHolder(new ServletContainer(resourceConfig)), "/*");
@@ -112,8 +110,14 @@ public class HungBlockingThreadsTest
         server.addConnector(connector);
         server.start();
 
+        httpClient = new HttpClient();
+        QueuedThreadPool clientQtp = new QueuedThreadPool(THREAD_COUNT * 2);
+        clientQtp.setName("client");
+        httpClient.setExecutor(clientQtp);
+        httpClient.setMaxConnectionsPerDestination(THREAD_COUNT);
+        httpClient.start();
+
         executorService = Executors.newCachedThreadPool();
-        httpClient = HttpClient.newHttpClient();
     }
 
     @AfterEach
@@ -121,24 +125,21 @@ public class HungBlockingThreadsTest
     {
         executorService.shutdownNow();
         LifeCycle.stop(server);
+        LifeCycle.stop(httpClient);
     }
 
     @Test
     public void test() throws Exception
     {
-        List<Future<?>> futures = new CopyOnWriteArrayList<>();
         CountDownLatch latch = new CountDownLatch(THREAD_COUNT);
         for (int i = 0; i < THREAD_COUNT; i++)
         {
             executorService.submit(() ->
             {
-                HttpRequest request = HttpRequest.newBuilder()
-                    .POST(HttpRequest.BodyPublishers.ofInputStream(() -> new HangInputStream(latch)))
-                    .uri(server.getURI())
-                    .timeout(Duration.ofDays(1))
-                    .build();
-                CompletableFuture<HttpResponse<String>> future = httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString());
-                futures.add(future);
+                httpClient.POST(server.getURI())
+                    .body(new InputStreamRequestContent("text/plain", new HangInputStream(latch)))
+                    .timeout(1, TimeUnit.DAYS)
+                    .send(result -> {});
             });
         }
 
@@ -147,10 +148,10 @@ public class HungBlockingThreadsTest
 
         LOG.debug("Shutting down client");
         // while hanging in inputstream read, close connections.
-        futures.forEach(f -> f.cancel(true));
+        LifeCycle.stop(httpClient);
 
         LOG.debug("Waiting for hung threads");
-        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertThat(threadDump(), not(containsString(SharedBlockingCallback.class.getSimpleName()))));
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertThat(threadDump(), not(containsString(SharedBlockingCallback.class.getName()))));
     }
 
     private static class HangInputStream extends InputStream
@@ -194,13 +195,6 @@ public class HungBlockingThreadsTest
         return threadDump.toString();
     }
 
-    private static Resource makeAsync(Resource resource)
-    {
-        Resource.Builder resourceBuilder = Resource.builder(resource);
-        resource.getResourceMethods().forEach(resourceMethod -> resourceBuilder.updateMethod(resourceMethod).managedAsync());
-        return resourceBuilder.build();
-    }
-
     public static class CustomFeature implements Feature
     {
         @Override
@@ -227,7 +221,7 @@ public class HungBlockingThreadsTest
     }
 
     @Path("")
-    public static class MyResource
+    public static class PostResource
     {
         @POST
         @Consumes("text/plain")

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/java/org/eclipse/jetty/ee9/jersey/tests/HungBlockingThreadsTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/java/org/eclipse/jetty/ee9/jersey/tests/HungBlockingThreadsTest.java
@@ -147,7 +147,8 @@ public class HungBlockingThreadsTest
                 AsyncRequestContent content = new AsyncRequestContent("text/plain", data.slice());
                 Request request = httpClient.POST(server.getURI());
                 request
-                    .onRequestListener(new Request.Listener() {
+                    .onRequestListener(new Request.Listener()
+                    {
                         @Override
                         public void onCommit(Request request)
                         {

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/java/org/eclipse/jetty/ee9/jersey/tests/HungBlockingThreadsTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/java/org/eclipse/jetty/ee9/jersey/tests/HungBlockingThreadsTest.java
@@ -13,11 +13,11 @@
 
 package org.eclipse.jetty.ee9.jersey.tests;
 
-import java.io.InputStream;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
-import java.time.Duration;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -31,8 +31,9 @@ import jakarta.ws.rs.core.FeatureContext;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
+import org.eclipse.jetty.client.AsyncRequestContent;
 import org.eclipse.jetty.client.HttpClient;
-import org.eclipse.jetty.client.InputStreamRequestContent;
+import org.eclipse.jetty.client.Request;
 import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee9.servlet.ServletHolder;
 import org.eclipse.jetty.io.EofException;
@@ -48,6 +49,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,7 +63,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class HungBlockingThreadsTest
 {
     private static final Logger LOG = LoggerFactory.getLogger(HungBlockingThreadsTest.class);
-    private static final int THREAD_COUNT = 128;
+    private static final int THREAD_COUNT = 512;
     private Server server;
     private ExecutorService executorService;
     private HttpClient httpClient;
@@ -128,60 +130,45 @@ public class HungBlockingThreadsTest
         LifeCycle.stop(httpClient);
     }
 
+    /**
+     * This test tries to reproduce issue #13066 by running THREAD_COUNT parallel requests
+     * in the hope of reproducing the issue statistically.
+     */
+    @Tag("stress")
     @Test
     public void test() throws Exception
     {
+        ByteBuffer data = ByteBuffer.wrap("A".repeat(1024).getBytes(StandardCharsets.UTF_8));
         CountDownLatch latch = new CountDownLatch(THREAD_COUNT);
         for (int i = 0; i < THREAD_COUNT; i++)
         {
             executorService.submit(() ->
             {
-                httpClient.POST(server.getURI())
-                    .body(new InputStreamRequestContent("text/plain", new HangInputStream(latch)))
-                    .timeout(1, TimeUnit.DAYS)
+                AsyncRequestContent content = new AsyncRequestContent("text/plain", data.slice());
+                Request request = httpClient.POST(server.getURI());
+                request
+                    .onRequestListener(new Request.Listener() {
+                        @Override
+                        public void onCommit(Request request)
+                        {
+                            latch.countDown();
+                        }
+                    })
+                    .body(content)
+                    .timeout(60, TimeUnit.SECONDS)
                     .send(result -> {});
             });
         }
 
-        LOG.debug("awaiting for client to block on all threads");
+        LOG.debug("Awaiting for client to block on all threads");
         assertTrue(latch.await(15, TimeUnit.SECONDS));
 
         LOG.debug("Shutting down client");
-        // while hanging in inputstream read, close connections.
-        LifeCycle.stop(httpClient);
+        // While the server is hanging in InputStream read, close the client's connections.
+        httpClient.stop();
 
         LOG.debug("Waiting for hung threads");
         await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertThat(threadDump(), not(containsString(SharedBlockingCallback.class.getName()))));
-    }
-
-    private static class HangInputStream extends InputStream
-    {
-        private final CountDownLatch latch;
-        private int count = 0;
-
-        public HangInputStream(CountDownLatch latch)
-        {
-            this.latch = latch;
-        }
-
-        @Override
-        public int read()
-        {
-            if (count == 1_000_000)
-            {
-                try
-                {
-                    latch.countDown();
-                    Thread.sleep(Duration.ofDays(1).toMillis());
-                }
-                catch (InterruptedException e)
-                {
-                    throw new RuntimeException(e);
-                }
-            }
-            count++;
-            return 'A';
-        }
     }
 
     private static String threadDump()

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/java/org/eclipse/jetty/ee9/jersey/tests/endpoints/Resource.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/java/org/eclipse/jetty/ee9/jersey/tests/endpoints/Resource.java
@@ -1,0 +1,46 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee9.jersey.tests.endpoints;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.Suspended;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("resource")
+public class Resource
+{
+    @PUT
+    @Path("/security")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public void putSecurity(@Context HttpServletRequest httpRequest, Security security, @Suspended final AsyncResponse asyncResponse)
+    {
+        if (security.getPrincipal() == null)
+            throw new NullPointerException("principal must no be null");
+        if (security.getRoles() == null)
+            throw new NullPointerException("roles must no be null");
+
+        asyncResponse.resume("""
+            {
+                "response" : "ok"
+            }
+            """);
+    }
+}

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/java/org/eclipse/jetty/ee9/jersey/tests/endpoints/Security.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/java/org/eclipse/jetty/ee9/jersey/tests/endpoints/Security.java
@@ -1,0 +1,56 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee9.jersey.tests.endpoints;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Security
+{
+    private String principal;
+    private List<String> roles = new ArrayList<>();
+
+    public Security()
+    {
+    }
+
+    public String getPrincipal()
+    {
+        return principal;
+    }
+
+    public void setPrincipal(String principal)
+    {
+        this.principal = principal;
+    }
+
+    public List<String> getRoles()
+    {
+        return roles;
+    }
+
+    public void setRoles(List<String> roles)
+    {
+        this.roles = roles;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "Security{" +
+            "principal='" + principal + '\'' +
+            ", roles=" + roles +
+            '}';
+    }
+}

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/resources/jetty-logging.properties
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/resources/jetty-logging.properties
@@ -1,0 +1,2 @@
+#org.eclipse.jetty.LEVEL=DEBUG
+#org.eclipse.jetty.ee9.servlet.LEVEL=DEBUG

--- a/jetty-ee9/jetty-ee9-tests/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/pom.xml
@@ -20,6 +20,7 @@
     <module>jetty-ee9-test-felix-webapp</module>
     <module>jetty-ee9-test-http2-webapp</module>
     <module>jetty-ee9-test-integration</module>
+    <module>jetty-ee9-test-jersey</module>
     <module>jetty-ee9-test-jmx</module>
     <module>jetty-ee9-test-jndi</module>
     <module>jetty-ee9-test-loginservice</module>

--- a/jetty-ee9/pom.xml
+++ b/jetty-ee9/pom.xml
@@ -66,6 +66,7 @@
     <!-- TODO: Remove these javax.* entries? -->
     <javax.activation.impl.version>1.1.0.v201105071233</javax.activation.impl.version>
     <javax.mail.glassfish.version>1.4.1.v201005082020</javax.mail.glassfish.version>
+    <jersey.version>3.0.17</jersey.version>
     <!-- FIXME we need a separate property for this one -->
     <jetty.servlet.api.version>5.0.2</jetty.servlet.api.version>
 
@@ -420,6 +421,27 @@
         <groupId>org.glassfish.jaxb</groupId>
         <artifactId>jaxb-runtime</artifactId>
         <version>${jakarta.xml.bind.impl.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.jersey.containers</groupId>
+        <artifactId>jersey-container-servlet</artifactId>
+        <version>${jersey.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.jersey.inject</groupId>
+        <artifactId>jersey-hk2</artifactId>
+        <version>${jersey.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.jersey.media</groupId>
+        <artifactId>jersey-media-json-binding</artifactId>
+        <version>${jersey.version}</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish.web</groupId>


### PR DESCRIPTION
3 changes are needed:
 1. do not call `onFailure` from `earlyEOF()` in the H1 parser's `RequestHandler`
 2. do not call the failure listeners if we have either a reader or a writer task in `HttpChannel.onFailure()`
 3. do not call `sendError` from `HttpChannelState.onError()`, both in ee9 and ee10


Fixes #13066