### PR TITLE
Workstation wide cache and RRF

### DIFF
--- a/.github/ci-mimir-daemon.properties
+++ b/.github/ci-mimir-daemon.properties
@@ -1,0 +1,4 @@
+# Mimir Daemon properties
+
+# Disable JGroups; we don't want/use LAN cache sharing
+mimir.jgroups.enabled=false

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -69,6 +69,14 @@ jobs:
           # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
           # queries: security-extended,security-and-quality
 
+      - name: Handle Maven Build Cache caches
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/build-cache
+          key: mbc-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            mbc-
+
       - name: Prepare Mimir
         shell: bash
         run: |
@@ -86,7 +94,7 @@ jobs:
 
       - name: Set up Maven
         run:
-          mvn -e -B -V org.apache.maven.plugins:maven-wrapper-plugin:3.1.0:wrapper "-Dmaven=3.9.9"
+          mvn -e -B -V org.apache.maven.plugins:maven-wrapper-plugin:3.3.2:wrapper "-Dmaven=3.9.9"
 
       - name: Clean install dependencies and build
         env:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -71,6 +71,20 @@ jobs:
           # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
           # queries: security-extended,security-and-quality
 
+      - name: Prepare Mimir
+        shell: bash
+        run: |
+          mkdir -p ~/.mimir
+          cp .github/ci-mimir-daemon.properties ~/.mimir/daemon.properties
+
+      - name: Handle Mimir caches
+        uses: actions/cache@v4
+        with:
+          path: ~/.mimir/local
+          key: mimir-codeql-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            mimir-codeql-
+            mimir-
 
       - name: Set up Maven
         run:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,7 +45,6 @@ jobs:
         with:
           distribution: temurin
           java-version: 11
-          cache: maven
 
       # Install and setup JDK 17
       - name: Setup JDK 17
@@ -57,7 +56,6 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
-          cache: maven
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -69,15 +69,6 @@ jobs:
           # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
           # queries: security-extended,security-and-quality
 
-      # MBC cache
-      - name: Handle Maven Build Cache caches
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/build-cache
-          key: mbc-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            mbc-
-
       - name: Prepare Mimir
         shell: bash
         run: |
@@ -101,7 +92,7 @@ jobs:
         env:
           MAVEN_OPTS: "-Djava.awt.headless=true -client -Xmx4G -Xms4G"
         run:
-          ./mvnw clean install -DskipTests -B -V
+          ./mvnw clean install -P fast -B -V
 
 
       # ℹ️ Command-line programs to run using the OS shell.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -69,6 +69,7 @@ jobs:
           # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
           # queries: security-extended,security-and-quality
 
+      # MBC cache
       - name: Handle Maven Build Cache caches
         uses: actions/cache@v4
         with:

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <!-- Workstation wide caching: just nuke your local repository and rebuild -->
+    <extension>
+        <groupId>eu.maveniverse.maven.mimir</groupId>
+        <artifactId>extension</artifactId>
+        <version>0.7.1</version>
+    </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,5 @@
 -Daether.dependencyCollector.impl=bf
+-Daether.remoteRepositoryFilter.prefixes=true
+-Daether.remoteRepositoryFilter.prefixes.basedir=${session.rootDirectory}/.mvn/rrf/
+-Daether.remoteRepositoryFilter.groupId=true
+-Daether.remoteRepositoryFilter.groupId.basedir=${session.rootDirectory}/.mvn/rrf/

--- a/.mvn/rrf/groupId-confluent.txt
+++ b/.mvn/rrf/groupId-confluent.txt
@@ -1,0 +1,1 @@
+# Allowed groupIDs (each on newline)

--- a/.mvn/rrf/groupId-google-maven-central-copy.txt
+++ b/.mvn/rrf/groupId-google-maven-central-copy.txt
@@ -1,0 +1,1 @@
+# Allowed groupIDs (each on newline)

--- a/.mvn/rrf/groupId-hazelcast-security.txt
+++ b/.mvn/rrf/groupId-hazelcast-security.txt
@@ -1,0 +1,1 @@
+# Allowed groupIDs (each on newline)

--- a/.mvn/rrf/groupId-maven-central.txt
+++ b/.mvn/rrf/groupId-maven-central.txt
@@ -1,0 +1,1 @@
+# Allowed groupIDs (each on newline)

--- a/.mvn/rrf/groupId-redhat-ga.txt
+++ b/.mvn/rrf/groupId-redhat-ga.txt
@@ -1,0 +1,1 @@
+# Allowed groupIDs (each on newline)


### PR DESCRIPTION
The build (especially with empty local repo) shows how Maven "wanders around" to multiple remote repositories to take stuff that is available from Central proper.

Also, some dependencies introduce new remote repositories making this even more painful (time consuming).

This PR adds two things:
* Mimir Cache: `~/.mimir/local` is a "pure" cache, unlike Maven Local Repo that is "mixed bag" of installed/cached artifacts.
* Maven RRF (3.9+ feature): limiting where Maven can go (currently all allowed groupIDs are empty, as Central has all)

These two now makes "-P fast" build below 20 seconds on my workstation **with empty local repository** (and Mimir caches primed).

Moreover, CI caching now becomes trivial, as between jobs it is only `~/.mimir/local` that needs to be saved and restored before next run. This way even Central is interacted minimally (only new deps are pulled, once).