### PR TITLE
Allow onSuccess to abort Iterating Callback

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/IteratingCallback.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/IteratingCallback.java
@@ -232,7 +232,7 @@ public abstract class IteratingCallback implements Callback
             processing(true);
     }
 
-    private void processing(boolean processing)
+    private void processing(boolean processFirst)
     {
         // This should only ever be called when in processing state, however a failed or close call
         // may happen concurrently, so state is not assumed.
@@ -246,7 +246,7 @@ public abstract class IteratingCallback implements Callback
         {
             // Call process to get the action that we have to take.
             Action action = null;
-            if (processing)
+            if (processFirst)
             {
                 try
                 {
@@ -340,10 +340,7 @@ public abstract class IteratingCallback implements Callback
                 if (callOnSuccess)
                 {
                     onSuccess();
-                    try (AutoLock ignored = _lock.lock())
-                    {
-                        processing = _state == State.PROCESSING;
-                    }
+                    processFirst = isProcessing();
                 }
             }
         }
@@ -398,12 +395,7 @@ public abstract class IteratingCallback implements Callback
         if (process)
         {
             onSuccess();
-            boolean processing;
-            try (AutoLock ignored = _lock.lock())
-            {
-                processing = _state == State.PROCESSING;
-            }
-            processing(processing);
+            processing(isProcessing());
         }
     }
 
@@ -599,6 +591,17 @@ public abstract class IteratingCallback implements Callback
         try (AutoLock ignored = _lock.lock())
         {
             return _state == State.SUCCEEDED;
+        }
+    }
+
+    /**
+     * @return {@code true} if the iterating callback is processing
+     */
+    private boolean isProcessing()
+    {
+        try (AutoLock ignored = _lock.lock())
+        {
+            return _state == State.PROCESSING;
         }
     }
 

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/IteratingCallback.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/IteratingCallback.java
@@ -245,15 +245,24 @@ public abstract class IteratingCallback implements Callback
         while (true)
         {
             // Call process to get the action that we have to take.
-            Action action = null;
-            try
+            boolean processing;
+            try (AutoLock ignored = _lock.lock())
             {
-                action = process();
+                processing = _state == State.PROCESSING;
             }
-            catch (Throwable x)
+
+            Action action = null;
+            if (processing)
             {
-                failed(x);
-                // Fall through to possibly invoke onCompleteFailure().
+                try
+                {
+                    action = process();
+                }
+                catch (Throwable x)
+                {
+                    failed(x);
+                    // Fall through to possibly invoke onCompleteFailure().
+                }
             }
 
             boolean callOnSuccess = false;

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/IteratingCallback.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/IteratingCallback.java
@@ -229,10 +229,10 @@ public abstract class IteratingCallback implements Callback
             }
         }
         if (process)
-            processing();
+            processing(true);
     }
 
-    private void processing()
+    private void processing(boolean processing)
     {
         // This should only ever be called when in processing state, however a failed or close call
         // may happen concurrently, so state is not assumed.
@@ -245,12 +245,6 @@ public abstract class IteratingCallback implements Callback
         while (true)
         {
             // Call process to get the action that we have to take.
-            boolean processing;
-            try (AutoLock ignored = _lock.lock())
-            {
-                processing = _state == State.PROCESSING;
-            }
-
             Action action = null;
             if (processing)
             {
@@ -344,7 +338,13 @@ public abstract class IteratingCallback implements Callback
             finally
             {
                 if (callOnSuccess)
+                {
                     onSuccess();
+                    try (AutoLock ignored = _lock.lock())
+                    {
+                        processing = _state == State.PROCESSING;
+                    }
+                }
             }
         }
 
@@ -398,7 +398,12 @@ public abstract class IteratingCallback implements Callback
         if (process)
         {
             onSuccess();
-            processing();
+            boolean processing;
+            try (AutoLock ignored = _lock.lock())
+            {
+                processing = _state == State.PROCESSING;
+            }
+            processing(processing);
         }
     }
 

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/IteratingCallbackTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/IteratingCallbackTest.java
@@ -506,7 +506,7 @@ public class IteratingCallbackTest
     }
 
     @Test
-    public void testAbortFromOnSuccess() throws Exception
+    public void testAbortFromOnSuccessInProcess() throws Exception
     {
         AtomicInteger count = new AtomicInteger();
         AtomicReference<Throwable> failure = new AtomicReference<>();
@@ -534,6 +534,40 @@ public class IteratingCallbackTest
         };
 
         icb.iterate();
+        assertEquals(1, count.get());
+        assertTrue(icb.isAborted());
+    }
+
+    @Test
+    public void testAbortFromOnSuccessAfterProcess() throws Exception
+    {
+        AtomicInteger count = new AtomicInteger();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        IteratingCallback icb = new IteratingCallback()
+        {
+            @Override
+            protected Action process()
+            {
+                count.incrementAndGet();
+                return Action.SCHEDULED;
+            }
+
+            @Override
+            protected void onSuccess()
+            {
+                abort(new IllegalStateException("abortFromOnSuccess"));
+            }
+
+            @Override
+            protected void onCompleteFailure(Throwable cause)
+            {
+                failure.set(cause);
+            }
+        };
+
+        icb.iterate();
+        assertEquals(1, count.get());
+        icb.succeeded();
         assertEquals(1, count.get());
         assertTrue(icb.isAborted());
     }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/IteratingCallbackTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/IteratingCallbackTest.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.util;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.jetty.util.thread.ScheduledExecutorScheduler;
 import org.eclipse.jetty.util.thread.Scheduler;
@@ -502,5 +503,38 @@ public class IteratingCallbackTest
 
         assertThrows(IllegalStateException.class, icb::iterate);
         assertTrue(latch.await(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testAbortFromOnSuccess() throws Exception
+    {
+        AtomicInteger count = new AtomicInteger();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        IteratingCallback icb = new IteratingCallback()
+        {
+            @Override
+            protected Action process()
+            {
+                count.incrementAndGet();
+                succeeded();
+                return Action.SCHEDULED;
+            }
+
+            @Override
+            protected void onSuccess()
+            {
+                abort(new IllegalStateException("abortFromOnSuccess"));
+            }
+
+            @Override
+            protected void onCompleteFailure(Throwable cause)
+            {
+                failure.set(cause);
+            }
+        };
+
+        icb.iterate();
+        assertEquals(1, count.get());
+        assertTrue(icb.isAborted());
     }
 }


### PR DESCRIPTION
Fix an issue with `IteratingCallback` that process is always called after success, even if `onSuccess` calls abort