### PR TITLE
Do not abort response in nested HttpChannelState.onError if sendError

### DIFF
--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannelState.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannelState.java
@@ -817,7 +817,7 @@ public class HttpChannelState
             if (_sendError)
             {
                 LOG.warn("onError not handled due to prior sendError() {}", getStatusStringLocked(), th);
-                return true;
+                return false;
             }
 
             // Check async state to determine type of handling


### PR DESCRIPTION
Return false from `HttpChannelState.onError` to avoid aborting the response in the case that `sendError` has already been called. 

This is to prevent a regression in GAE, because in Jetty 9.4 the abort was not done for this case.