### PR TITLE
Fixes #13098 - HTTP2 Server Error Handling is different than HTTP1

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpSenderOverHTTP.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpSenderOverHTTP.java
@@ -69,7 +69,7 @@ public class HttpSenderOverHTTP extends HttpSender
             Content.Source requestContent = request.getBody();
             long contentLength = requestContent == null ? -1 : requestContent.getLength();
             // URI validations already performed by using the java.net.URI class.
-            HttpURI uri = new HttpURI.Unsafe(null, null, -1, request.getPath(), request.getQuery(), null);
+            HttpURI uri = HttpURI.from(null, null, -1, request.getPath(), request.getQuery(), null);
             metaData = new MetaData.Request(request.getMethod(), uri, request.getVersion(), request.getHeaders(), contentLength, request.getTrailersSupplier());
             if (LOG.isDebugEnabled())
                 LOG.debug("Sending headers with content {} last={} for {}", BufferUtil.toDetailString(contentBuffer), lastContent, exchange.getRequest());

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpSenderOverHTTP.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpSenderOverHTTP.java
@@ -69,7 +69,7 @@ public class HttpSenderOverHTTP extends HttpSender
             Content.Source requestContent = request.getBody();
             long contentLength = requestContent == null ? -1 : requestContent.getLength();
             // URI validations already performed by using the java.net.URI class.
-            HttpURI uri = new HttpURI.Unsafe(request.getScheme(), request.getHost(), request.getPort(), request.getPath(), request.getQuery(), null);
+            HttpURI uri = new HttpURI.Unsafe(null, null, -1, request.getPath(), request.getQuery(), null);
             metaData = new MetaData.Request(request.getMethod(), uri, request.getVersion(), request.getHeaders(), contentLength, request.getTrailersSupplier());
             if (LOG.isDebugEnabled())
                 LOG.debug("Sending headers with content {} last={} for {}", BufferUtil.toDetailString(contentBuffer), lastContent, exchange.getRequest());

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpSenderOverHTTP.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpSenderOverHTTP.java
@@ -68,11 +68,9 @@ public class HttpSenderOverHTTP extends HttpSender
             HttpRequest request = exchange.getRequest();
             Content.Source requestContent = request.getBody();
             long contentLength = requestContent == null ? -1 : requestContent.getLength();
-            String path = request.getPath();
-            String query = request.getQuery();
-            if (query != null)
-                path += "?" + query;
-            metaData = new MetaData.Request(request.getMethod(), HttpURI.from(path), request.getVersion(), request.getHeaders(), contentLength, request.getTrailersSupplier());
+            // URI validations already performed by using the java.net.URI class.
+            HttpURI uri = new HttpURI.Unsafe(request.getScheme(), request.getHost(), request.getPort(), request.getPath(), request.getQuery(), null);
+            metaData = new MetaData.Request(request.getMethod(), uri, request.getVersion(), request.getHeaders(), contentLength, request.getTrailersSupplier());
             if (LOG.isDebugEnabled())
                 LOG.debug("Sending headers with content {} last={} for {}", BufferUtil.toDetailString(contentBuffer), lastContent, exchange.getRequest());
             headersCallback.iterate();

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
@@ -307,10 +307,10 @@ public interface HttpURI
         private Immutable(String scheme, String host, int port, String path, String query, String fragment)
         {
             _uri = null;
-            _scheme = URIUtil.normalizeScheme(scheme);
+            _scheme = scheme;
             _user = null;
             _host = host;
-            _port = (port > 0) ? port : URIUtil.UNDEFINED_PORT;
+            _port = port;
             _path = path;
             _canonicalPath = path;
             _param = null;

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
@@ -509,6 +509,8 @@ public interface HttpURI
 
     /**
      * <p>An unsafe {@link HttpURI} that accepts URI parts without checking whether they are valid.</p>
+     * <p>This class should be primarily used for testing, since possibly invalid URI may break
+     * arbitrary code.</p>
      */
     class Unsafe extends Immutable
     {

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
@@ -152,9 +152,21 @@ public interface HttpURI
         return new Mutable(scheme, host, port, pathQuery).asImmutable();
     }
 
+    /**
+     *
+     * @param scheme
+     * @param host
+     * @param port
+     * @param path
+     * @param query
+     * @param fragment
+     * @return
+     * @deprecated use {@link Unsafe} instead
+     */
+    @Deprecated(since = "12.0.21", forRemoval = true)
     static Immutable from(String scheme, String host, int port, String path, String query, String fragment)
     {
-        return new Immutable(scheme, host, port, path, query, fragment);
+        return new Unsafe(scheme, host, port, path, query, fragment);
     }
 
     Immutable asImmutable();
@@ -503,6 +515,14 @@ public interface HttpURI
         public String toString()
         {
             return asString();
+        }
+    }
+
+    class Unsafe extends Immutable
+    {
+        public Unsafe(String scheme, String host, int port, String path, String query, String fragment)
+        {
+            super(scheme, host, port, path, query, fragment);
         }
     }
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
@@ -144,21 +144,19 @@ public interface HttpURI
     }
 
     /**
-     * <p>Creates a new unsafe {@code HttpURI} with the given arguments.</p>
+     * <p>Creates a new {@code HttpURI} with the given arguments.</p>
      *
-     * @param scheme the URI scheme
+     * @param scheme the URI scheme (normalized to lower-case)
      * @param host the URI host
      * @param port the URI port, or {@code -1} for no port
      * @param path the URI path
      * @param query the URI query
      * @param fragment the URI fragment
-     * @return a new unsafe {@code HttpURI}
-     * @deprecated use {@link Unsafe} instead
+     * @return a new {@code HttpURI}
      */
-    @Deprecated(since = "12.0.21", forRemoval = true)
     static Immutable from(String scheme, String host, int port, String path, String query, String fragment)
     {
-        return new Unsafe(scheme, host, port, path, query, fragment);
+        return new Immutable(scheme, host, port, path, query, fragment, false);
     }
 
     Immutable asImmutable();
@@ -304,15 +302,15 @@ public interface HttpURI
                 _violations = Collections.unmodifiableSet(EnumSet.copyOf(builder._violations));
         }
 
-        private Immutable(String scheme, String host, int port, String path, String query, String fragment)
+        private Immutable(String scheme, String host, int port, String path, String query, String fragment, boolean unsafe)
         {
             _uri = null;
-            _scheme = scheme;
+            _scheme = unsafe ? scheme : URIUtil.normalizeScheme(scheme);
             _user = null;
             _host = host;
-            _port = port;
+            _port = unsafe || port > 0 ? port : URIUtil.UNDEFINED_PORT;
             _path = path;
-            _canonicalPath = path;
+            _canonicalPath = unsafe || path == null ? path : URIUtil.canonicalPath(path);
             _param = null;
             _query = query;
             _fragment = fragment;
@@ -526,7 +524,7 @@ public interface HttpURI
          */
         public Unsafe(String scheme, String host, int port, String path, String query, String fragment)
         {
-            super(scheme, host, port, path, query, fragment);
+            super(scheme, host, port, path, query, fragment, true);
         }
     }
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
@@ -29,14 +29,14 @@ import org.eclipse.jetty.util.TypeUtil;
 import org.eclipse.jetty.util.URIUtil;
 
 /**
- * Http URI.
- *
- * Both {@link Mutable} and {@link Immutable} implementations are available
- * via the static methods such as {@link #build()} and {@link #from(String)}.
- *
- * A URI such as
+ * <p>Representation of HTTP URIs.</p>
+ * <p>Both {@link Mutable} and {@link Immutable} implementations are available
+ * via the static methods such as {@link #build()} and {@link #from(String)},
+ * and {@link Unsafe} can be used for tests or invalid URIs.</p>
+ * <p>An HTTP URI such as
  * {@code http://user@host:port/path;param1/%2e/f%6fo%2fbar%20bob;param2?query#fragment}
- * is split into the following optional elements:<ul>
+ * is split into the following optional elements:</p>
+ * <ul>
  * <li>{@link #getScheme()} - http:</li>
  * <li>{@link #getAuthority()} - //name@host:port</li>
  * <li>{@link #getHost()} - host</li>
@@ -58,26 +58,17 @@ import org.eclipse.jetty.util.URIUtil;
  * expansion. A literal interpretation of the RFC can result in URI paths with ambiguities
  * when viewed as strings. For example, a URI of {@code /foo%2f..%2fbar} is technically a single
  * segment of "/foo/../bar", but could easily be misinterpreted as 3 segments resolving to "/bar"
- * by a file system.
- * </p>
- * <p>
- * Thus this class avoid and/or detects such ambiguities. Furthermore, by decoding characters and
+ * by a file system.</p>
+ * <p>Thus this class avoid and/or detects such ambiguities. Furthermore, by decoding characters and
  * removing parameters before relative path normalization, ambiguous paths will be resolved in such
- * a way to be non-standard-but-non-ambiguous to down stream interpretation of the decoded path string.
- * </p>
- * <p>
- * This class collates any {@link UriCompliance.Violation violations} against the specification
+ * a way to be non-standard-but-non-ambiguous to down stream interpretation of the decoded path string.</p>
+ * <p>This class collates any {@link UriCompliance.Violation violations} against the specification
  * and/or best practises in the {@link #getViolations()}.  Users of this class should check against a
  * configured {@link UriCompliance} mode if the {@code HttpURI} is suitable for use
- * (see {@link UriCompliance#checkUriCompliance(UriCompliance, HttpURI, ComplianceViolation.Listener)}).
- * </p>
- * <p>
- * For example, implementations that wish to process ambiguous URI paths must configure the compliance modes
- * to accept them and then perform their own decoding of {@link #getPath()}.
- * </p>
- * <p>
- * If there are multiple path parameters, only the last one is returned by {@link #getParam()}.
- * </p>
+ * (see {@link UriCompliance#checkUriCompliance(UriCompliance, HttpURI, ComplianceViolation.Listener)}).</p>
+ * <p>For example, implementations that wish to process ambiguous URI paths must configure the compliance
+ * modes to accept them and then perform their own decoding of {@link #getPath()}.</p>
+ * <p>If there are multiple path parameters, only the last one is returned by {@link #getParam()}.</p>
  **/
 public interface HttpURI
 {
@@ -153,14 +144,15 @@ public interface HttpURI
     }
 
     /**
+     * <p>Creates a new unsafe {@code HttpURI} with the given arguments.</p>
      *
-     * @param scheme
-     * @param host
-     * @param port
-     * @param path
-     * @param query
-     * @param fragment
-     * @return
+     * @param scheme the URI scheme
+     * @param host the URI host
+     * @param port the URI port, or {@code -1} for no port
+     * @param path the URI path
+     * @param query the URI query
+     * @param fragment the URI fragment
+     * @return a new unsafe {@code HttpURI}
      * @deprecated use {@link Unsafe} instead
      */
     @Deprecated(since = "12.0.21", forRemoval = true)
@@ -315,13 +307,12 @@ public interface HttpURI
         private Immutable(String scheme, String host, int port, String path, String query, String fragment)
         {
             _uri = null;
-
             _scheme = URIUtil.normalizeScheme(scheme);
             _user = null;
             _host = host;
             _port = (port > 0) ? port : URIUtil.UNDEFINED_PORT;
             _path = path;
-            _canonicalPath = _path == null ? null : URIUtil.canonicalPath(_path);
+            _canonicalPath = path;
             _param = null;
             _query = query;
             _fragment = fragment;
@@ -518,8 +509,21 @@ public interface HttpURI
         }
     }
 
+    /**
+     * <p>An unsafe {@link HttpURI} that accepts URI parts without checking whether they are valid.</p>
+     */
     class Unsafe extends Immutable
     {
+        /**
+         * <p>Creates a new unsafe {@link HttpURI} with the given arguments.</p>
+         *
+         * @param scheme the URI scheme
+         * @param host the URI host
+         * @param port the URI port, or {@code -1} for no port
+         * @param path the URI path
+         * @param query the URI query
+         * @param fragment the URI fragment
+         */
         public Unsafe(String scheme, String host, int port, String path, String query, String fragment)
         {
             super(scheme, host, port, path, query, fragment);
@@ -1712,7 +1716,7 @@ public interface HttpURI
             if (ambiguous != null)
             {
                 // The segment is always ambiguous.
-                if (Boolean.TRUE.equals(ambiguous))
+                if (ambiguous)
                     addViolation(Violation.AMBIGUOUS_PATH_SEGMENT);
                 // The segment is ambiguous only when followed by a parameter.
                 if (param)

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MetaData.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MetaData.java
@@ -331,4 +331,121 @@ public class MetaData implements Iterable<HttpField>
             return String.format("%s{s=%d,h=%d,cl=%d}", getHttpVersion(), getStatus(), headers.size(), getContentLength());
         }
     }
+
+    /**
+     * <p>Marker interface to signal that a {@link MetaData} could not be created,
+     * for example due to an invalid URI or invalid headers.</p>
+     */
+    public interface Failed
+    {
+        /**
+         * <p>Inspects the given {@link MetaData}, and if it is an instance
+         * of this interface return its failure, otherwise returns {@code null}.</p>
+         *
+         * @param metaData the {@link MetaData} to inspect
+         * @return the failure if the given {@link MetaData} is an instance of this
+         * interface, otherwise {@code null}
+         */
+        static Throwable getFailure(MetaData metaData)
+        {
+            return metaData instanceof Failed f ? f.getFailure() : null;
+        }
+
+        /**
+         * <p>Creates a new failed {@link MetaData.Request}, with method {@code GET},
+         * empty {@link HttpURI} and empty {@link HttpFields}, with the given
+         * {@link HttpVersion} and failure.</p>
+         *
+         * @param httpVersion the HTTP version
+         * @param failure the failure cause
+         * @return a new failed  {@link MetaData.Request}
+         */
+        static MetaData.Request newFailedMetaDataRequest(HttpVersion httpVersion, Throwable failure)
+        {
+            return new FailedMetaDataRequest(httpVersion, failure);
+        }
+
+        /**
+         * <p>Creates a new failed {@link MetaData.Response}, with status {@code 0},
+         * no reason, empty {@link HttpFields}, with the given {@link HttpVersion}
+         * and failure.</p>
+         *
+         * @param httpVersion the HTTP version
+         * @param failure the failure cause
+         * @return a new failed  {@link MetaData.Response}
+         */
+        static MetaData.Response newFailedMetaDataResponse(HttpVersion httpVersion, Throwable failure)
+        {
+            return new FailedMetaDataResponse(httpVersion, failure);
+        }
+
+        /**
+         * <p>Creates a new failed {@link MetaData}, with empty {@link HttpFields},
+         * with the given {@link HttpVersion} and failure.</p>
+         *
+         * @param httpVersion the HTTP version
+         * @param failure the failure cause
+         * @return a new failed  {@link MetaData}
+         */
+        static MetaData newFailedMetaData(HttpVersion httpVersion, Throwable failure)
+        {
+            return new FailedMetaData(httpVersion, failure);
+        }
+
+        /**
+         * @return the failure cause
+         */
+        Throwable getFailure();
+    }
+
+    private static class FailedMetaDataRequest extends MetaData.Request implements Failed
+    {
+        private final Throwable failure;
+
+        private FailedMetaDataRequest(HttpVersion httpVersion, Throwable failure)
+        {
+            super("GET", HttpURI.build(), httpVersion, HttpFields.EMPTY);
+            this.failure = failure;
+        }
+
+        @Override
+        public Throwable getFailure()
+        {
+            return failure;
+        }
+    }
+
+    private static class FailedMetaDataResponse extends MetaData.Response implements Failed
+    {
+        private final Throwable failure;
+
+        private FailedMetaDataResponse(HttpVersion httpVersion, Throwable failure)
+        {
+            super(0, null, httpVersion, HttpFields.EMPTY);
+            this.failure = failure;
+        }
+
+        @Override
+        public Throwable getFailure()
+        {
+            return failure;
+        }
+    }
+
+    private static class FailedMetaData extends MetaData implements Failed
+    {
+        private final Throwable failure;
+
+        private FailedMetaData(HttpVersion httpVersion, Throwable failure)
+        {
+            super(httpVersion, HttpFields.EMPTY);
+            this.failure = failure;
+        }
+
+        @Override
+        public Throwable getFailure()
+        {
+            return failure;
+        }
+    }
 }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MetaData.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MetaData.java
@@ -405,7 +405,7 @@ public class MetaData implements Iterable<HttpField>
         private FailedMetaDataRequest(HttpVersion httpVersion, Throwable failure)
         {
             super("GET", HttpURI.build(), httpVersion, HttpFields.EMPTY);
-            this.failure = failure;
+            this.failure = Objects.requireNonNull(failure);
         }
 
         @Override
@@ -422,7 +422,7 @@ public class MetaData implements Iterable<HttpField>
         private FailedMetaDataResponse(HttpVersion httpVersion, Throwable failure)
         {
             super(0, null, httpVersion, HttpFields.EMPTY);
-            this.failure = failure;
+            this.failure = Objects.requireNonNull(failure);
         }
 
         @Override
@@ -439,7 +439,7 @@ public class MetaData implements Iterable<HttpField>
         private FailedMetaData(HttpVersion httpVersion, Throwable failure)
         {
             super(httpVersion, HttpFields.EMPTY);
-            this.failure = failure;
+            this.failure = Objects.requireNonNull(failure);
         }
 
         @Override

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpSenderOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpSenderOverHTTP2.java
@@ -72,6 +72,7 @@ public class HttpSenderOverHTTP2 extends HttpSender
         else
         {
             String path = relativize(request.getPath());
+            // TODO: revert to use build()
             HttpURI uri = HttpURI.from(
                 request.getScheme(),
                 request.getHost(),

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpSenderOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpSenderOverHTTP2.java
@@ -72,12 +72,13 @@ public class HttpSenderOverHTTP2 extends HttpSender
         else
         {
             String path = relativize(request.getPath());
-            HttpURI uri = HttpURI.build()
-                .scheme(request.getScheme())
-                .host(request.getHost())
-                .port(request.getPort())
-                .path(path)
-                .query(request.getQuery());
+            HttpURI uri = HttpURI.from(
+                request.getScheme(),
+                request.getHost(),
+                request.getPort(),
+                path,
+                request.getQuery(),
+                null);
             metaData = new MetaData.Request(request.getMethod(), uri, HttpVersion.HTTP_2, request.getHeaders(), -1, request.getTrailersSupplier());
         }
 

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpSenderOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpSenderOverHTTP2.java
@@ -72,14 +72,12 @@ public class HttpSenderOverHTTP2 extends HttpSender
         else
         {
             String path = relativize(request.getPath());
-            // TODO: revert to use build()
-            HttpURI uri = HttpURI.from(
-                request.getScheme(),
-                request.getHost(),
-                request.getPort(),
-                path,
-                request.getQuery(),
-                null);
+            HttpURI uri = HttpURI.build()
+                .scheme(request.getScheme())
+                .host(request.getHost())
+                .port(request.getPort())
+                .path(path)
+                .query(request.getQuery());
             metaData = new MetaData.Request(request.getMethod(), uri, HttpVersion.HTTP_2, request.getHeaders(), -1, request.getTrailersSupplier());
         }
 

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpSenderOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpSenderOverHTTP2.java
@@ -73,7 +73,7 @@ public class HttpSenderOverHTTP2 extends HttpSender
         {
             String path = relativize(request.getPath());
             // URI validations already performed by using the java.net.URI class.
-            HttpURI uri = new HttpURI.Unsafe(request.getScheme(), request.getHost(), request.getPort(), path, request.getQuery(), null);
+            HttpURI uri = HttpURI.from(request.getScheme(), request.getHost(), request.getPort(), path, request.getQuery(), null);
             metaData = new MetaData.Request(request.getMethod(), uri, HttpVersion.HTTP_2, request.getHeaders(), -1, request.getTrailersSupplier());
         }
 

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpSenderOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpSenderOverHTTP2.java
@@ -72,12 +72,8 @@ public class HttpSenderOverHTTP2 extends HttpSender
         else
         {
             String path = relativize(request.getPath());
-            HttpURI uri = HttpURI.build()
-                .scheme(request.getScheme())
-                .host(request.getHost())
-                .port(request.getPort())
-                .path(path)
-                .query(request.getQuery());
+            // URI validations already performed by using the java.net.URI class.
+            HttpURI uri = new HttpURI.Unsafe(request.getScheme(), request.getHost(), request.getPort(), path, request.getQuery(), null);
             metaData = new MetaData.Request(request.getMethod(), uri, HttpVersion.HTTP_2, request.getHeaders(), -1, request.getTrailersSupplier());
         }
 

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -642,12 +642,17 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
         HTTP2Stream stream = getStream(streamId);
         Callback callback = Callback.from(() -> reset(stream, new ResetFrame(streamId, error), Callback.NOOP));
         Throwable failure = toFailure(error, reason);
-        if (LOG.isDebugEnabled())
-            LOG.debug("Stream #{} failure {}", streamId, this, failure);
         if (stream != null)
-            failStream(stream, error, reason, failure, callback);
+            onStreamFailure(stream, error, reason, failure, callback);
         else
             callback.succeeded();
+    }
+
+    protected void onStreamFailure(Stream stream, int error, String reason, Throwable failure, Callback callback)
+    {
+        if (LOG.isDebugEnabled())
+            LOG.debug("Stream #{} failure {}", stream.getId(), this, failure);
+        failStream(stream, error, reason, failure, callback);
     }
 
     @Override

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -639,18 +639,15 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
     @Override
     public void onStreamFailure(int streamId, int error, String reason)
     {
-        Callback callback = Callback.from(() -> reset(getStream(streamId), new ResetFrame(streamId, error), Callback.NOOP));
+        HTTP2Stream stream = getStream(streamId);
+        Callback callback = Callback.from(() -> reset(stream, new ResetFrame(streamId, error), Callback.NOOP));
         Throwable failure = toFailure(error, reason);
         if (LOG.isDebugEnabled())
             LOG.debug("Stream #{} failure {}", streamId, this, failure);
-        HTTP2Stream stream = getStream(streamId);
         if (stream != null)
             failStream(stream, error, reason, failure, callback);
         else
-        {
             callback.succeeded();
-            // TODO: failStream to notify upper layer
-        }
     }
 
     @Override

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -647,7 +647,10 @@ public abstract class HTTP2Session extends ContainerLifeCycle implements Session
         if (stream != null)
             failStream(stream, error, reason, failure, callback);
         else
+        {
             callback.succeeded();
+            // TODO: failStream to notify upper layer
+        }
     }
 
     @Override

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
@@ -166,24 +166,20 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
             LOG.debug("Resetting {} {}", frame, this);
 
         int flowControlLength;
-        boolean reset;
+        boolean reset = true;
         Throwable resetFailure = null;
         try (AutoLock ignored = lock.lock())
         {
             flowControlLength = drain();
-            reset = !isRemotelyClosed();
-            if (reset)
+            if (localReset)
             {
-                if (isReset())
-                {
-                    reset = false;
-                    resetFailure = failure;
-                }
-                else
-                {
-                    localReset = true;
-                    failure = new EOFException("reset");
-                }
+                reset = false;
+                resetFailure = failure;
+            }
+            else
+            {
+                localReset = true;
+                failure = new EOFException("reset");
             }
         }
 

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
@@ -162,31 +162,45 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
     @Override
     public void reset(ResetFrame frame, Callback callback)
     {
+        if (LOG.isDebugEnabled())
+            LOG.debug("Resetting {} {}", frame, this);
+
         int flowControlLength;
+        boolean reset;
         Throwable resetFailure = null;
         try (AutoLock ignored = lock.lock())
         {
-            if (isReset())
-            {
-                resetFailure = failure;
-            }
-            else
-            {
-                localReset = true;
-                failure = new EOFException("reset");
-            }
             flowControlLength = drain();
+            reset = !isRemotelyClosed();
+            if (reset)
+            {
+                if (isReset())
+                {
+                    reset = false;
+                    resetFailure = failure;
+                }
+                else
+                {
+                    localReset = true;
+                    failure = new EOFException("reset");
+                }
+            }
         }
+
         session.dataConsumed(this, flowControlLength);
-        if (resetFailure != null)
+
+        if (reset)
         {
-            close();
-            session.removeStream(this);
-            callback.failed(resetFailure);
+            session.reset(this, frame, callback);
         }
         else
         {
-            session.reset(this, frame, callback);
+            close();
+            session.removeStream(this);
+            if (resetFailure == null)
+                callback.succeeded();
+            else
+                callback.failed(resetFailure);
         }
     }
 

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/ContinuationBodyParser.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/ContinuationBodyParser.java
@@ -20,6 +20,7 @@ import org.eclipse.jetty.http2.ErrorCode;
 import org.eclipse.jetty.http2.Flags;
 import org.eclipse.jetty.http2.frames.ContinuationFrame;
 import org.eclipse.jetty.http2.frames.HeadersFrame;
+import org.eclipse.jetty.http2.hpack.HpackException;
 import org.eclipse.jetty.io.RetainableByteBuffer;
 
 public class ContinuationBodyParser extends BodyParser
@@ -119,10 +120,11 @@ public class ContinuationBodyParser extends BodyParser
         HeadersFrame frame = new HeadersFrame(getStreamId(), metaData, headerBlockFragments.getPriorityFrame(), headerBlockFragments.isEndStream());
         headerBlockFragments.reset();
 
-        if (metaData instanceof HeaderBlockParser.SessionFailureMetaData)
+        Throwable metaDataFailure = MetaData.Failed.getFailure(metaData);
+        if (metaDataFailure instanceof HpackException.SessionException)
             return false;
 
-        if (metaData instanceof HeaderBlockParser.StreamFailureMetaData)
+        if (metaDataFailure != null)
         {
             if (!rateControlOnEvent(frame))
                 return connectionFailure(buffer, ErrorCode.ENHANCE_YOUR_CALM_ERROR.code, "invalid_headers_frame_rate");

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/ContinuationBodyParser.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/ContinuationBodyParser.java
@@ -119,18 +119,15 @@ public class ContinuationBodyParser extends BodyParser
         HeadersFrame frame = new HeadersFrame(getStreamId(), metaData, headerBlockFragments.getPriorityFrame(), headerBlockFragments.isEndStream());
         headerBlockFragments.reset();
 
-        if (metaData == HeaderBlockParser.SESSION_FAILURE)
+        if (metaData instanceof HeaderBlockParser.SessionFailureMetaData)
             return false;
 
-        if (metaData != HeaderBlockParser.STREAM_FAILURE)
-        {
-            notifyHeaders(frame);
-        }
-        else
+        if (metaData instanceof HeaderBlockParser.StreamFailureMetaData)
         {
             if (!rateControlOnEvent(frame))
                 return connectionFailure(buffer, ErrorCode.ENHANCE_YOUR_CALM_ERROR.code, "invalid_headers_frame_rate");
         }
+        notifyHeaders(frame);
         return true;
     }
 

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/HeaderBlockParser.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/HeaderBlockParser.java
@@ -15,6 +15,8 @@ package org.eclipse.jetty.http2.parser;
 
 import java.nio.ByteBuffer;
 
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.http2.ErrorCode;
@@ -28,8 +30,7 @@ import org.slf4j.LoggerFactory;
 
 public class HeaderBlockParser
 {
-    public static final MetaData STREAM_FAILURE = new MetaData(HttpVersion.HTTP_2, null);
-    public static final MetaData SESSION_FAILURE = new MetaData(HttpVersion.HTTP_2, null);
+    private static final SessionFailureMetaData SESSION_FAILURE = new SessionFailureMetaData();
     private static final Logger LOG = LoggerFactory.getLogger(HeaderBlockParser.class);
 
     private final HeaderParser headerParser;
@@ -57,9 +58,9 @@ public class HeaderBlockParser
      * @param buffer the buffer to parse
      * @param blockLength the length of the HPACK block
      * @return null, if the buffer contains less than {@code blockLength} bytes;
-     * {@link #STREAM_FAILURE} if parsing the HPACK block produced a stream failure;
-     * {@link #SESSION_FAILURE} if parsing the HPACK block produced a session failure;
-     * a valid MetaData object if the parsing was successful.
+     * an instance of {@link StreamFailureMetaData} if parsing the HPACK block produced a stream failure;
+     * an instance of {@link SessionFailureMetaData} if parsing the HPACK block produced a session failure;
+     * an instance of {@link MetaData} if the parsing was successful.
      */
     public MetaData parse(ByteBuffer buffer, int blockLength)
     {
@@ -106,8 +107,11 @@ public class HeaderBlockParser
             {
                 if (LOG.isDebugEnabled())
                     LOG.debug("Stream error, stream={}", headerParser.getStreamId(), x);
-                notifier.streamFailure(headerParser.getStreamId(), ErrorCode.PROTOCOL_ERROR.code, "invalid_hpack_block");
-                return STREAM_FAILURE;
+                if (x.isRequest())
+                    return new StreamFailureMetaDataRequest(x);
+                if (x.isResponse())
+                    return new StreamFailureMetaDataResponse(x);
+                return new StreamFailureMetaDataTrailer(x);
             }
             catch (HpackException.CompressionException x)
             {
@@ -133,6 +137,70 @@ public class HeaderBlockParser
                     blockBuffer = null;
                 }
             }
+        }
+    }
+
+    public static class SessionFailureMetaData extends MetaData
+    {
+        private SessionFailureMetaData()
+        {
+            super(HttpVersion.HTTP_2, HttpFields.EMPTY);
+        }
+    }
+
+    public interface StreamFailureMetaData
+    {
+        Throwable getFailure();
+    }
+
+    public static class StreamFailureMetaDataRequest extends MetaData.Request implements StreamFailureMetaData
+    {
+        private final Throwable failure;
+
+        private StreamFailureMetaDataRequest(Throwable failure)
+        {
+            super("GET", HttpURI.build(), HttpVersion.HTTP_2, HttpFields.EMPTY);
+            this.failure = failure;
+        }
+
+        @Override
+        public Throwable getFailure()
+        {
+            return failure;
+        }
+    }
+
+    public static class StreamFailureMetaDataResponse extends MetaData.Response implements StreamFailureMetaData
+    {
+        private final Throwable failure;
+
+        private StreamFailureMetaDataResponse(Throwable failure)
+        {
+            super(0, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
+            this.failure = failure;
+        }
+
+        @Override
+        public Throwable getFailure()
+        {
+            return failure;
+        }
+    }
+
+    public static class StreamFailureMetaDataTrailer extends MetaData implements StreamFailureMetaData
+    {
+        private final Throwable failure;
+
+        private StreamFailureMetaDataTrailer(Throwable failure)
+        {
+            super(HttpVersion.HTTP_2, HttpFields.EMPTY);
+            this.failure = failure;
+        }
+
+        @Override
+        public Throwable getFailure()
+        {
+            return failure;
         }
     }
 }

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/HeaderBlockParser.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/HeaderBlockParser.java
@@ -15,8 +15,6 @@ package org.eclipse.jetty.http2.parser;
 
 import java.nio.ByteBuffer;
 
-import org.eclipse.jetty.http.HttpFields;
-import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.http2.ErrorCode;
@@ -30,7 +28,6 @@ import org.slf4j.LoggerFactory;
 
 public class HeaderBlockParser
 {
-    private static final SessionFailureMetaData SESSION_FAILURE = new SessionFailureMetaData();
     private static final Logger LOG = LoggerFactory.getLogger(HeaderBlockParser.class);
 
     private final HeaderParser headerParser;
@@ -58,8 +55,7 @@ public class HeaderBlockParser
      * @param buffer the buffer to parse
      * @param blockLength the length of the HPACK block
      * @return null, if the buffer contains less than {@code blockLength} bytes;
-     * an instance of {@link StreamFailureMetaData} if parsing the HPACK block produced a stream failure;
-     * an instance of {@link SessionFailureMetaData} if parsing the HPACK block produced a session failure;
+     * an instance of {@link MetaData.Failed} if parsing the HPACK block produced a failure;
      * an instance of {@link MetaData} if the parsing was successful.
      */
     public MetaData parse(ByteBuffer buffer, int blockLength)
@@ -108,24 +104,24 @@ public class HeaderBlockParser
                 if (LOG.isDebugEnabled())
                     LOG.debug("Stream error, stream={}", headerParser.getStreamId(), x);
                 if (x.isRequest())
-                    return new StreamFailureMetaDataRequest(x);
+                    return MetaData.Failed.newFailedMetaDataRequest(HttpVersion.HTTP_2, x);
                 if (x.isResponse())
-                    return new StreamFailureMetaDataResponse(x);
-                return new StreamFailureMetaDataTrailer(x);
+                    return MetaData.Failed.newFailedMetaDataResponse(HttpVersion.HTTP_2, x);
+                return MetaData.Failed.newFailedMetaData(HttpVersion.HTTP_2, x);
             }
             catch (HpackException.CompressionException x)
             {
                 if (LOG.isDebugEnabled())
                     LOG.debug("Compression error, buffer={}", BufferUtil.toDetailString(buffer), x);
                 notifier.connectionFailure(buffer, ErrorCode.COMPRESSION_ERROR.code, "invalid_hpack_block");
-                return SESSION_FAILURE;
+                return MetaData.Failed.newFailedMetaData(HttpVersion.HTTP_2, x);
             }
             catch (HpackException.SessionException x)
             {
                 if (LOG.isDebugEnabled())
                     LOG.debug("Session error, buffer={}", BufferUtil.toDetailString(buffer), x);
                 notifier.connectionFailure(buffer, ErrorCode.PROTOCOL_ERROR.code, "invalid_hpack_block");
-                return SESSION_FAILURE;
+                return MetaData.Failed.newFailedMetaData(HttpVersion.HTTP_2, x);
             }
             finally
             {
@@ -137,70 +133,6 @@ public class HeaderBlockParser
                     blockBuffer = null;
                 }
             }
-        }
-    }
-
-    public static class SessionFailureMetaData extends MetaData
-    {
-        private SessionFailureMetaData()
-        {
-            super(HttpVersion.HTTP_2, HttpFields.EMPTY);
-        }
-    }
-
-    public interface StreamFailureMetaData
-    {
-        Throwable getFailure();
-    }
-
-    public static class StreamFailureMetaDataRequest extends MetaData.Request implements StreamFailureMetaData
-    {
-        private final Throwable failure;
-
-        private StreamFailureMetaDataRequest(Throwable failure)
-        {
-            super("GET", HttpURI.build(), HttpVersion.HTTP_2, HttpFields.EMPTY);
-            this.failure = failure;
-        }
-
-        @Override
-        public Throwable getFailure()
-        {
-            return failure;
-        }
-    }
-
-    public static class StreamFailureMetaDataResponse extends MetaData.Response implements StreamFailureMetaData
-    {
-        private final Throwable failure;
-
-        private StreamFailureMetaDataResponse(Throwable failure)
-        {
-            super(0, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
-            this.failure = failure;
-        }
-
-        @Override
-        public Throwable getFailure()
-        {
-            return failure;
-        }
-    }
-
-    public static class StreamFailureMetaDataTrailer extends MetaData implements StreamFailureMetaData
-    {
-        private final Throwable failure;
-
-        private StreamFailureMetaDataTrailer(Throwable failure)
-        {
-            super(HttpVersion.HTTP_2, HttpFields.EMPTY);
-            this.failure = failure;
-        }
-
-        @Override
-        public Throwable getFailure()
-        {
-            return failure;
         }
     }
 }

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/HeadersBodyParser.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/HeadersBodyParser.java
@@ -195,24 +195,30 @@ public class HeadersBodyParser extends BodyParser
                             return connectionFailure(buffer, ErrorCode.REFUSED_STREAM_ERROR.code, "invalid_headers_frame");
 
                         MetaData metaData = headerBlockParser.parse(buffer, length);
-                        if (metaData == HeaderBlockParser.SESSION_FAILURE)
+
+                        // Not enough bytes to parse the MetaData.
+                        if (metaData == null)
+                            break;
+
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("Parsed {} frame hpack from {}", FrameType.HEADERS, buffer);
+
+                        if (metaData instanceof HeaderBlockParser.SessionFailureMetaData)
                             return false;
-                        if (metaData != null)
+
+                        state = State.PADDING;
+                        loop = paddingLength == 0;
+
+                        if (metaData instanceof HeaderBlockParser.StreamFailureMetaData)
                         {
-                            if (LOG.isDebugEnabled())
-                                LOG.debug("Parsed {} frame hpack from {}", FrameType.HEADERS, buffer);
-                            state = State.PADDING;
-                            loop = paddingLength == 0;
-                            if (metaData != HeaderBlockParser.STREAM_FAILURE)
-                            {
-                                onHeaders(parentStreamId, weight, exclusive, metaData);
-                            }
-                            else
-                            {
-                                HeadersFrame frame = new HeadersFrame(getStreamId(), metaData, null, isEndStream());
-                                if (!rateControlOnEvent(frame))
-                                    return connectionFailure(buffer, ErrorCode.ENHANCE_YOUR_CALM_ERROR.code, "invalid_headers_frame_rate");
-                            }
+                            HeadersFrame frame = new HeadersFrame(getStreamId(), metaData, null, isEndStream());
+                            if (!rateControlOnEvent(frame))
+                                return connectionFailure(buffer, ErrorCode.ENHANCE_YOUR_CALM_ERROR.code, "invalid_headers_frame_rate");
+                            onHeaders(frame);
+                        }
+                        else
+                        {
+                            onHeaders(metaData);
                         }
                     }
                     else
@@ -255,7 +261,7 @@ public class HeadersBodyParser extends BodyParser
         return false;
     }
 
-    private void onHeaders(int parentStreamId, int weight, boolean exclusive, MetaData metaData)
+    private void onHeaders(MetaData metaData)
     {
         PriorityFrame priorityFrame = null;
         if (hasFlag(Flags.PRIORITY))

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/HeadersBodyParser.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/HeadersBodyParser.java
@@ -21,6 +21,7 @@ import org.eclipse.jetty.http2.Flags;
 import org.eclipse.jetty.http2.frames.FrameType;
 import org.eclipse.jetty.http2.frames.HeadersFrame;
 import org.eclipse.jetty.http2.frames.PriorityFrame;
+import org.eclipse.jetty.http2.hpack.HpackException;
 import org.eclipse.jetty.util.BufferUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -203,13 +204,14 @@ public class HeadersBodyParser extends BodyParser
                         if (LOG.isDebugEnabled())
                             LOG.debug("Parsed {} frame hpack from {}", FrameType.HEADERS, buffer);
 
-                        if (metaData instanceof HeaderBlockParser.SessionFailureMetaData)
+                        Throwable metaDataFailure = MetaData.Failed.getFailure(metaData);
+                        if (metaDataFailure instanceof HpackException.SessionException)
                             return false;
 
                         state = State.PADDING;
                         loop = paddingLength == 0;
 
-                        if (metaData instanceof HeaderBlockParser.StreamFailureMetaData)
+                        if (metaDataFailure != null)
                         {
                             HeadersFrame frame = new HeadersFrame(getStreamId(), metaData, null, isEndStream());
                             if (!rateControlOnEvent(frame))

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/PushPromiseBodyParser.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/PushPromiseBodyParser.java
@@ -18,7 +18,6 @@ import java.nio.ByteBuffer;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.http2.ErrorCode;
 import org.eclipse.jetty.http2.Flags;
-import org.eclipse.jetty.http2.frames.HeadersFrame;
 import org.eclipse.jetty.http2.frames.PushPromiseFrame;
 
 public class PushPromiseBodyParser extends BodyParser
@@ -120,23 +119,28 @@ public class PushPromiseBodyParser extends BodyParser
                     if (maxLength > 0 && length > maxLength)
                         return connectionFailure(buffer, ErrorCode.REFUSED_STREAM_ERROR.code, "invalid_headers_frame");
 
-                    MetaData.Request metaData = (MetaData.Request)headerBlockParser.parse(buffer, length);
-                    if (metaData == HeaderBlockParser.SESSION_FAILURE)
+                    MetaData metaData = headerBlockParser.parse(buffer, length);
+
+                    // Not enough bytes to parse the MetaData.
+                    if (metaData == null)
+                        break;
+
+                    if (metaData instanceof HeaderBlockParser.SessionFailureMetaData)
                         return false;
-                    if (metaData != null)
+
+                    state = State.PADDING;
+                    loop = paddingLength == 0;
+
+                    if (metaData instanceof HeaderBlockParser.StreamFailureMetaData)
                     {
-                        state = State.PADDING;
-                        loop = paddingLength == 0;
-                        if (metaData != HeaderBlockParser.STREAM_FAILURE)
-                        {
-                            onPushPromise(streamId, metaData);
-                        }
-                        else
-                        {
-                            HeadersFrame frame = new HeadersFrame(getStreamId(), metaData, null, isEndStream());
-                            if (!rateControlOnEvent(frame))
-                                return connectionFailure(buffer, ErrorCode.ENHANCE_YOUR_CALM_ERROR.code, "invalid_headers_frame_rate");
-                        }
+                        PushPromiseFrame frame = new PushPromiseFrame(getStreamId(), streamId, (MetaData.Request)metaData);
+                        if (!rateControlOnEvent(frame))
+                            return connectionFailure(buffer, ErrorCode.ENHANCE_YOUR_CALM_ERROR.code, "invalid_push_promise_frame_rate");
+                        onPushPromise(frame);
+                    }
+                    else
+                    {
+                        onPushPromise((MetaData.Request)metaData);
                     }
                     break;
                 }
@@ -161,9 +165,14 @@ public class PushPromiseBodyParser extends BodyParser
         return false;
     }
 
-    private void onPushPromise(int streamId, MetaData.Request metaData)
+    private void onPushPromise(MetaData.Request metaData)
     {
         PushPromiseFrame frame = new PushPromiseFrame(getStreamId(), streamId, metaData);
+        onPushPromise(frame);
+    }
+
+    private void onPushPromise(PushPromiseFrame frame)
+    {
         notifyPushPromise(frame);
     }
 

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/PushPromiseBodyParser.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/PushPromiseBodyParser.java
@@ -19,6 +19,7 @@ import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.http2.ErrorCode;
 import org.eclipse.jetty.http2.Flags;
 import org.eclipse.jetty.http2.frames.PushPromiseFrame;
+import org.eclipse.jetty.http2.hpack.HpackException;
 
 public class PushPromiseBodyParser extends BodyParser
 {
@@ -125,13 +126,14 @@ public class PushPromiseBodyParser extends BodyParser
                     if (metaData == null)
                         break;
 
-                    if (metaData instanceof HeaderBlockParser.SessionFailureMetaData)
+                    Throwable metaDataFailure = MetaData.Failed.getFailure(metaData);
+                    if (metaDataFailure instanceof HpackException.SessionException)
                         return false;
 
                     state = State.PADDING;
                     loop = paddingLength == 0;
 
-                    if (metaData instanceof HeaderBlockParser.StreamFailureMetaData)
+                    if (metaDataFailure != null)
                     {
                         PushPromiseFrame frame = new PushPromiseFrame(getStreamId(), streamId, (MetaData.Request)metaData);
                         if (!rateControlOnEvent(frame))

--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackEncoder.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackEncoder.java
@@ -190,7 +190,7 @@ public class HpackEncoder
                     String name = field.getName();
                     char firstChar = name.charAt(0);
                     if (firstChar <= ' ' || firstChar == ':')
-                        throw new HpackException.StreamException("Invalid header name: '%s'", name);
+                        throw new HpackException.StreamException(metadata.isRequest(), metadata.isResponse(), "Invalid header name: '%s'", name);
                 }
             }
 

--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackException.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackException.java
@@ -15,6 +15,11 @@ package org.eclipse.jetty.http2.hpack;
 
 public abstract class HpackException extends Exception
 {
+    HpackException(String messageFormat, Object... args)
+    {
+        super(String.format(messageFormat, args));
+    }
+
     HpackException(Throwable cause, String messageFormat, Object... args)
     {
         super(String.format(messageFormat, args), cause);
@@ -33,7 +38,8 @@ public abstract class HpackException extends Exception
 
         public StreamException(boolean request, boolean response, String messageFormat, Object... args)
         {
-            this(null, request, response, messageFormat, args);
+            super(messageFormat, args);
+            this.type = request ? Boolean.TRUE : response ? Boolean.FALSE : null;
         }
 
         public StreamException(Throwable cause, boolean request, boolean response, String messageFormat, Object... args)
@@ -62,7 +68,7 @@ public abstract class HpackException extends Exception
     {
         public SessionException(String messageFormat, Object... args)
         {
-            super(null, messageFormat, args);
+            super(messageFormat, args);
         }
     }
 

--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackException.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackException.java
@@ -15,9 +15,9 @@ package org.eclipse.jetty.http2.hpack;
 
 public abstract class HpackException extends Exception
 {
-    HpackException(String messageFormat, Object... args)
+    HpackException(Throwable cause, String messageFormat, Object... args)
     {
-        super(String.format(messageFormat, args));
+        super(String.format(messageFormat, args), cause);
     }
 
     /**
@@ -29,9 +29,27 @@ public abstract class HpackException extends Exception
      */
     public static class StreamException extends HpackException
     {
-        public StreamException(String messageFormat, Object... args)
+        private final Boolean type;
+
+        public StreamException(boolean request, boolean response, String messageFormat, Object... args)
         {
-            super(messageFormat, args);
+            this(null, request, response, messageFormat, args);
+        }
+
+        public StreamException(Throwable cause, boolean request, boolean response, String messageFormat, Object... args)
+        {
+            super(cause, messageFormat, args);
+            this.type = request ? Boolean.TRUE : response ? Boolean.FALSE : null;
+        }
+
+        public boolean isRequest()
+        {
+            return type == Boolean.TRUE;
+        }
+
+        public boolean isResponse()
+        {
+            return type == Boolean.FALSE;
         }
     }
 
@@ -44,7 +62,7 @@ public abstract class HpackException extends Exception
     {
         public SessionException(String messageFormat, Object... args)
         {
-            super(messageFormat, args);
+            super(null, messageFormat, args);
         }
     }
 

--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackException.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackException.java
@@ -34,28 +34,31 @@ public abstract class HpackException extends Exception
      */
     public static class StreamException extends HpackException
     {
-        private final Boolean type;
+        private final boolean request;
+        private final boolean response;
 
         public StreamException(boolean request, boolean response, String messageFormat, Object... args)
         {
             super(messageFormat, args);
-            this.type = request ? Boolean.TRUE : response ? Boolean.FALSE : null;
+            this.request = request;
+            this.response = response;
         }
 
         public StreamException(Throwable cause, boolean request, boolean response, String messageFormat, Object... args)
         {
             super(cause, messageFormat, args);
-            this.type = request ? Boolean.TRUE : response ? Boolean.FALSE : null;
+            this.request = request;
+            this.response = response;
         }
 
         public boolean isRequest()
         {
-            return type == Boolean.TRUE;
+            return request;
         }
 
         public boolean isResponse()
         {
-            return type == Boolean.FALSE;
+            return response;
         }
     }
 

--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/internal/MetaDataBuilder.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/internal/MetaDataBuilder.java
@@ -314,7 +314,7 @@ public class MetaDataBuilder
                 .port(_authority == null ? -1 : _authority.getPort())
                 .pathQuery(_path);
         }
-        catch(Throwable x)
+        catch (Throwable x)
         {
             throw new HpackException.StreamException(x, true, false, "Invalid URI");
         }

--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/internal/MetaDataBuilder.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/internal/MetaDataBuilder.java
@@ -213,7 +213,7 @@ public class MetaDataBuilder
 
     public void streamException(String messageFormat, Object... args)
     {
-        HpackException.StreamException stream = new HpackException.StreamException(messageFormat, args);
+        HpackException.StreamException stream = new HpackException.StreamException(_request, _response, messageFormat, args);
         if (_streamException == null)
             _streamException = stream;
         else
@@ -233,22 +233,6 @@ public class MetaDataBuilder
         return false;
     }
 
-    private HttpURI newHttpURI() throws HpackException.StreamException
-    {
-        try
-        {
-            return HttpURI.build()
-                .scheme(_scheme)
-                .host(_authority == null ? null : _authority.getHost())
-                .port(_authority == null ? -1 : _authority.getPort())
-                .pathQuery(_path);
-        }
-        catch(Throwable x)
-        {
-            throw new HpackException.StreamException("Invalid URI", x);
-        }
-    }
-
     public MetaData build() throws HpackException.StreamException
     {
         if (_streamException != null)
@@ -258,7 +242,7 @@ public class MetaDataBuilder
         }
 
         if (_request && _response)
-            throw new HpackException.StreamException("Request and Response headers");
+            throw new HpackException.StreamException(true, true, "Request and Response headers");
 
         HttpFields.Mutable fields = _fields;
         try
@@ -266,37 +250,39 @@ public class MetaDataBuilder
             if (_request)
             {
                 if (_method == null)
-                    throw new HpackException.StreamException("No Method");
+                    throw new HpackException.StreamException(true, false, "No Method");
                 boolean isConnect = HttpMethod.CONNECT.is(_method);
                 if (!isConnect || _protocol != null)
                 {
                     if (_scheme == null)
-                        throw new HpackException.StreamException("No Scheme");
+                        throw new HpackException.StreamException(true, false, "No Scheme");
                     if (_path == null)
-                        throw new HpackException.StreamException("No Path");
+                        throw new HpackException.StreamException(true, false, "No Path");
                 }
                 long nanoTime = _beginNanoTime == Long.MIN_VALUE ? NanoTime.now() : _beginNanoTime;
                 _beginNanoTime = Long.MIN_VALUE;
 
                 if (isConnect)
+                {
                     return new MetaData.ConnectRequest(nanoTime, _scheme, _authority, _path, fields, _protocol);
+                }
                 else
                 {
-                    HttpURI httpURI = newHttpURI();
                     return new MetaData.Request(
                         nanoTime,
                         _method,
-                        httpURI,
+                        newHttpURI(),
                         HttpVersion.HTTP_2,
                         fields,
                         _contentLength,
                         null);
                 }
             }
+
             if (_response)
             {
                 if (_status == null)
-                    throw new HpackException.StreamException("No Status");
+                    throw new HpackException.StreamException(false, true, "No Status");
                 return new MetaData.Response(_status, null, HttpVersion.HTTP_2, fields, _contentLength);
             }
 
@@ -315,6 +301,22 @@ public class MetaDataBuilder
             _protocol = null;
             _size = 0;
             _contentLength = -1;
+        }
+    }
+
+    private HttpURI newHttpURI() throws HpackException.StreamException
+    {
+        try
+        {
+            return HttpURI.build()
+                .scheme(_scheme)
+                .host(_authority == null ? null : _authority.getHost())
+                .port(_authority == null ? -1 : _authority.getPort())
+                .pathQuery(_path);
+        }
+        catch(Throwable x)
+        {
+            throw new HpackException.StreamException(x, true, false, "Invalid URI");
         }
     }
 }

--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/internal/MetaDataBuilder.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/internal/MetaDataBuilder.java
@@ -19,6 +19,7 @@ import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpScheme;
+import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.http2.hpack.HpackException;
@@ -232,6 +233,22 @@ public class MetaDataBuilder
         return false;
     }
 
+    private HttpURI newHttpURI() throws HpackException.StreamException
+    {
+        try
+        {
+            return HttpURI.build()
+                .scheme(_scheme)
+                .host(_authority == null ? null : _authority.getHost())
+                .port(_authority == null ? -1 : _authority.getPort())
+                .pathQuery(_path);
+        }
+        catch(Throwable x)
+        {
+            throw new HpackException.StreamException("Invalid URI", x);
+        }
+    }
+
     public MetaData build() throws HpackException.StreamException
     {
         if (_streamException != null)
@@ -260,18 +277,21 @@ public class MetaDataBuilder
                 }
                 long nanoTime = _beginNanoTime == Long.MIN_VALUE ? NanoTime.now() : _beginNanoTime;
                 _beginNanoTime = Long.MIN_VALUE;
+
                 if (isConnect)
                     return new MetaData.ConnectRequest(nanoTime, _scheme, _authority, _path, fields, _protocol);
                 else
+                {
+                    HttpURI httpURI = newHttpURI();
                     return new MetaData.Request(
                         nanoTime,
                         _method,
-                        _scheme.asString(),
-                        _authority,
-                        _path,
+                        httpURI,
                         HttpVersion.HTTP_2,
                         fields,
-                        _contentLength);
+                        _contentLength,
+                        null);
+                }
             }
             if (_response)
             {

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/HTTP2ServerConnectionFactory.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/HTTP2ServerConnectionFactory.java
@@ -28,6 +28,7 @@ import org.eclipse.jetty.http2.frames.HeadersFrame;
 import org.eclipse.jetty.http2.frames.PushPromiseFrame;
 import org.eclipse.jetty.http2.frames.ResetFrame;
 import org.eclipse.jetty.http2.server.internal.HTTP2ServerConnection;
+import org.eclipse.jetty.http2.server.internal.HTTP2ServerSession;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.io.EofException;
 import org.eclipse.jetty.io.QuietException;
@@ -76,7 +77,7 @@ public class HTTP2ServerConnectionFactory extends AbstractHTTP2ServerConnectionF
         return acceptable;
     }
 
-    protected class HTTPServerSessionListener implements ServerSessionListener, Stream.Listener
+    protected class HTTPServerSessionListener implements HTTP2ServerSession.Listener, Stream.Listener
     {
         private final EndPoint endPoint;
 
@@ -128,6 +129,12 @@ public class HTTP2ServerConnectionFactory extends AbstractHTTP2ServerConnectionF
         public void onFailure(Session session, Throwable failure, Callback callback)
         {
             getConnection().onSessionFailure(failure, callback);
+        }
+
+        @Override
+        public void onStreamFailure(Stream stream, Throwable failure, Callback callback)
+        {
+            onFailure(stream, failure, callback);
         }
 
         @Override

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HTTP2ServerSession.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HTTP2ServerSession.java
@@ -34,7 +34,6 @@ import org.eclipse.jetty.http2.frames.ResetFrame;
 import org.eclipse.jetty.http2.frames.SettingsFrame;
 import org.eclipse.jetty.http2.frames.WindowUpdateFrame;
 import org.eclipse.jetty.http2.generator.Generator;
-import org.eclipse.jetty.http2.parser.HeaderBlockParser;
 import org.eclipse.jetty.http2.parser.ServerParser;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.util.Callback;
@@ -116,12 +115,12 @@ public class HTTP2ServerSession extends HTTP2Session implements ServerParser.Lis
                             }
                         }
 
-                        if (metaData instanceof HeaderBlockParser.StreamFailureMetaData f)
+                        Throwable metaDataFailure = MetaData.Failed.getFailure(metaData);
+                        if (metaDataFailure != null)
                         {
                             // It's a bad request, request content will be dropped.
                             stream.updateClose(true, CloseState.Event.RECEIVED);
-                            Throwable failure = f.getFailure();
-                            notifyStreamFailure(stream, new BadMessageException(failure.getMessage(), failure), Callback.NOOP);
+                            notifyStreamFailure(stream, new BadMessageException(metaDataFailure.getMessage(), metaDataFailure), Callback.NOOP);
                         }
                         else
                         {
@@ -192,6 +191,10 @@ public class HTTP2ServerSession extends HTTP2Session implements ServerParser.Lis
             {
                 LOG.info("Failure while notifying listener {}", listener, x);
             }
+        }
+        else
+        {
+            onStreamFailure(stream, ErrorCode.CANCEL_STREAM_ERROR.code, failure.getMessage(), failure, callback);
         }
     }
 

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HTTP2ServerSession.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HTTP2ServerSession.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.http2.CloseState;
 import org.eclipse.jetty.http2.ErrorCode;
@@ -117,9 +118,10 @@ public class HTTP2ServerSession extends HTTP2Session implements ServerParser.Lis
 
                         if (metaData instanceof HeaderBlockParser.StreamFailureMetaData f)
                         {
-                            // No request content, but might write an error response.
+                            // It's a bad request, request content will be dropped.
                             stream.updateClose(true, CloseState.Event.RECEIVED);
-                            notifyStreamFailure(stream, f.getFailure(), Callback.NOOP);
+                            Throwable failure = f.getFailure();
+                            notifyStreamFailure(stream, new BadMessageException(failure.getMessage(), failure), Callback.NOOP);
                         }
                         else
                         {

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HTTP2ServerSession.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HTTP2ServerSession.java
@@ -33,6 +33,7 @@ import org.eclipse.jetty.http2.frames.ResetFrame;
 import org.eclipse.jetty.http2.frames.SettingsFrame;
 import org.eclipse.jetty.http2.frames.WindowUpdateFrame;
 import org.eclipse.jetty.http2.generator.Generator;
+import org.eclipse.jetty.http2.parser.HeaderBlockParser;
 import org.eclipse.jetty.http2.parser.ServerParser;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.util.Callback;
@@ -114,12 +115,21 @@ public class HTTP2ServerSession extends HTTP2Session implements ServerParser.Lis
                             }
                         }
 
-                        stream.process(frame, Callback.NOOP);
-                        boolean closed = stream.updateClose(frame.isEndStream(), CloseState.Event.RECEIVED);
-                        Stream.Listener listener = notifyNewStream(stream, frame);
-                        stream.setListener(listener);
-                        if (closed)
-                            removeStream(stream);
+                        if (metaData instanceof HeaderBlockParser.StreamFailureMetaData f)
+                        {
+                            // No request content, but might write an error response.
+                            stream.updateClose(true, CloseState.Event.RECEIVED);
+                            notifyStreamFailure(stream, f.getFailure(), Callback.NOOP);
+                        }
+                        else
+                        {
+                            stream.process(frame, Callback.NOOP);
+                            boolean closed = stream.updateClose(frame.isEndStream(), CloseState.Event.RECEIVED);
+                            Stream.Listener listener = notifyNewStream(stream, frame);
+                            stream.setListener(listener);
+                            if (closed)
+                                removeStream(stream);
+                        }
                     }
                 }
             }
@@ -168,6 +178,21 @@ public class HTTP2ServerSession extends HTTP2Session implements ServerParser.Lis
         }
     }
 
+    private void notifyStreamFailure(Stream stream, Throwable failure, Callback callback)
+    {
+        if (listener instanceof Listener l)
+        {
+            try
+            {
+                l.onStreamFailure(stream, failure, callback);
+            }
+            catch (Throwable x)
+            {
+                LOG.info("Failure while notifying listener {}", listener, x);
+            }
+        }
+    }
+
     @Override
     public void onFrame(Frame frame)
     {
@@ -190,5 +215,10 @@ public class HTTP2ServerSession extends HTTP2Session implements ServerParser.Lis
     public void standardUpgrade()
     {
         getParser().standardUpgrade();
+    }
+
+    public interface Listener extends ServerSessionListener
+    {
+        void onStreamFailure(Stream stream, Throwable failure, Callback callback);
     }
 }

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.http2.server.internal;
 
 import java.io.EOFException;
 import java.nio.ByteBuffer;
+import java.util.Objects;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
@@ -685,7 +686,7 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
         private FailureTask(Runnable task, Callback callback)
         {
             this.task = task;
-            this.callback = callback;
+            this.callback = Objects.requireNonNull(callback);
         }
 
         @Override

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
@@ -590,33 +590,8 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
     public Runnable onFailure(Throwable failure, Callback callback)
     {
         boolean remote = failure instanceof EOFException;
-        Runnable runnable = remote ? _httpChannel.onRemoteFailure(new EofException(failure)) : _httpChannel.onFailure(failure);
-
-        class FailureTask implements Runnable
-        {
-            @Override
-            public void run()
-            {
-                try
-                {
-                    if (runnable != null)
-                        runnable.run();
-                    callback.succeeded();
-                }
-                catch (Throwable x)
-                {
-                    callback.failed(x);
-                }
-            }
-
-            @Override
-            public String toString()
-            {
-                return "%s[%s]".formatted(getClass().getSimpleName(), runnable);
-            }
-        }
-
-        return new FailureTask();
+        Runnable task = remote ? _httpChannel.onRemoteFailure(new EofException(failure)) : _httpChannel.onFailure(failure);
+        return new FailureTask(task, callback);
     }
 
     @Override
@@ -699,6 +674,33 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
         public EndPoint getEndPoint()
         {
             return endPoint;
+        }
+    }
+
+    private static class FailureTask implements Runnable
+    {
+        private final Runnable task;
+        private final Callback callback;
+
+        private FailureTask(Runnable task, Callback callback)
+        {
+            this.task = task;
+            this.callback = callback;
+        }
+
+        @Override
+        public void run()
+        {
+            try
+            {
+                if (task != null)
+                    task.run();
+                callback.succeeded();
+            }
+            catch (Throwable x)
+            {
+                callback.failed(x);
+            }
         }
     }
 }

--- a/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpSenderOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpSenderOverHTTP3.java
@@ -72,12 +72,8 @@ public class HttpSenderOverHTTP3 extends HttpSender
         else
         {
             String path = relativize(request.getPath());
-            HttpURI uri = HttpURI.build()
-                .scheme(request.getScheme())
-                .host(request.getHost())
-                .port(request.getPort())
-                .path(path)
-                .query(request.getQuery());
+            // URI validations already performed by using the java.net.URI class.
+            HttpURI uri = new HttpURI.Unsafe(request.getScheme(), request.getHost(), request.getPort(), path, request.getQuery(), null);
             metaData = new MetaData.Request(request.getMethod(), uri, HttpVersion.HTTP_3, request.getHeaders(), -1, request.getTrailersSupplier());
         }
 

--- a/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpSenderOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpSenderOverHTTP3.java
@@ -73,7 +73,7 @@ public class HttpSenderOverHTTP3 extends HttpSender
         {
             String path = relativize(request.getPath());
             // URI validations already performed by using the java.net.URI class.
-            HttpURI uri = new HttpURI.Unsafe(request.getScheme(), request.getHost(), request.getPort(), path, request.getQuery(), null);
+            HttpURI uri = HttpURI.from(request.getScheme(), request.getHost(), request.getPort(), path, request.getQuery(), null);
             metaData = new MetaData.Request(request.getMethod(), uri, HttpVersion.HTTP_3, request.getHeaders(), -1, request.getTrailersSupplier());
         }
 

--- a/jetty-core/jetty-http3/jetty-http3-client/src/main/java/org/eclipse/jetty/http3/client/HTTP3StreamClient.java
+++ b/jetty-core/jetty-http3/jetty-http3-client/src/main/java/org/eclipse/jetty/http3/client/HTTP3StreamClient.java
@@ -148,7 +148,7 @@ public class HTTP3StreamClient extends HTTP3Stream implements Stream.Client
     }
 
     @Override
-    protected void notifyFailure(long error, Throwable failure)
+    public void notifyFailure(long error, Throwable failure)
     {
         Listener listener = getListener();
         try

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/HTTP3Stream.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/HTTP3Stream.java
@@ -376,7 +376,7 @@ public abstract class HTTP3Stream implements Stream, CyclicTimeouts.Expirable, A
         session.removeStream(this, failure);
     }
 
-    protected abstract void notifyFailure(long error, Throwable failure);
+    public abstract void notifyFailure(long error, Throwable failure);
 
     protected boolean validateAndUpdate(EnumSet<FrameState> allowed, FrameState target)
     {

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/parser/HeadersBodyParser.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/parser/HeadersBodyParser.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BooleanSupplier;
 
+import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.http3.HTTP3ErrorCode;
 import org.eclipse.jetty.http3.frames.HeadersFrame;
@@ -127,7 +128,13 @@ public class HeadersBodyParser extends BodyParser
         {
             if (LOG.isDebugEnabled())
                 LOG.debug("decode failure", x);
-            notifyStreamFailure(streamId, x.getErrorCode(), x);
+            if (x.isRequest())
+                onHeaders(MetaData.Failed.newFailedMetaDataRequest(HttpVersion.HTTP_3, x), true, false);
+            else if (x.isResponse())
+                onHeaders(MetaData.Failed.newFailedMetaDataResponse(HttpVersion.HTTP_3, x), true, false);
+            else
+                onHeaders(MetaData.Failed.newFailedMetaData(HttpVersion.HTTP_3, x), true, false);
+            return true;
         }
         catch (QpackException.SessionException x)
         {

--- a/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/QpackDecoder.java
+++ b/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/QpackDecoder.java
@@ -40,7 +40,6 @@ import org.eclipse.jetty.util.component.Dumpable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.eclipse.jetty.http3.qpack.QpackException.H3_GENERAL_PROTOCOL_ERROR;
 import static org.eclipse.jetty.http3.qpack.QpackException.QPACK_DECOMPRESSION_FAILED;
 import static org.eclipse.jetty.http3.qpack.QpackException.QPACK_ENCODER_STREAM_ERROR;
 
@@ -208,9 +207,9 @@ public class QpackDecoder implements Dumpable
             notifyMetaDataHandler(false);
             return hadMetaData;
         }
-        catch (QpackException.SessionException e)
+        catch (QpackException x)
         {
-            throw e;
+            throw x;
         }
         catch (Throwable t)
         {
@@ -368,7 +367,7 @@ public class QpackDecoder implements Dumpable
         public void onSetDynamicTableCapacity(int capacity) throws QpackException
         {
             if (capacity > getMaxTableCapacity())
-                throw new QpackException.StreamException(H3_GENERAL_PROTOCOL_ERROR, "DynamicTable capacity exceeds max capacity");
+                throw new QpackException.SessionException(QPACK_ENCODER_STREAM_ERROR, "DynamicTable capacity exceeds max capacity");
             _context.getDynamicTable().setCapacity(capacity);
         }
 

--- a/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/QpackEncoder.java
+++ b/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/QpackEncoder.java
@@ -207,7 +207,7 @@ public class QpackEncoder implements Dumpable
                     String name = field.getName();
                     char firstChar = name.charAt(0);
                     if (firstChar <= ' ')
-                        throw new QpackException.StreamException(H3_GENERAL_PROTOCOL_ERROR, String.format("Invalid header name: '%s'", name));
+                        throw new QpackException.StreamException(metadata.isRequest(), metadata.isResponse(), H3_GENERAL_PROTOCOL_ERROR, String.format("Invalid header name: '%s'", name));
                 }
             }
 
@@ -275,7 +275,7 @@ public class QpackEncoder implements Dumpable
                 notifyInstructionHandler();
                 streamInfo.remove(sectionInfo);
                 sectionInfo.release();
-                throw new QpackException.StreamException(H3_GENERAL_PROTOCOL_ERROR, "buffer_space_exceeded", e);
+                throw new QpackException.StreamException(metadata.isRequest(), metadata.isResponse(), H3_GENERAL_PROTOCOL_ERROR, "buffer_space_exceeded", e);
             }
             catch (Throwable t)
             {

--- a/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/QpackException.java
+++ b/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/QpackException.java
@@ -47,28 +47,31 @@ public abstract class QpackException extends Exception
      */
     public static class StreamException extends QpackException
     {
-        private final Boolean type;
+        private final boolean request;
+        private final boolean response;
 
         public StreamException(boolean request, boolean response, long errorCode, String message)
         {
             super(errorCode, message);
-            this.type = request ? Boolean.TRUE : response ? Boolean.FALSE : null;
+            this.request = request;
+            this.response = response;
         }
 
         public StreamException(boolean request, boolean response, long errorCode, String message, Throwable cause)
         {
             super(errorCode, message, cause);
-            this.type = request ? Boolean.TRUE : response ? Boolean.FALSE : null;
+            this.request = request;
+            this.response = response;
         }
 
         public boolean isRequest()
         {
-            return type == Boolean.TRUE;
+            return request;
         }
 
         public boolean isResponse()
         {
-            return type == Boolean.FALSE;
+            return response;
         }
     }
 

--- a/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/QpackException.java
+++ b/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/QpackException.java
@@ -21,9 +21,15 @@ public abstract class QpackException extends Exception
     public static final long H3_GENERAL_PROTOCOL_ERROR = 0x0101;
     private final long _errorCode;
 
-    QpackException(long errorCode, String messageFormat, Throwable cause)
+    QpackException(long errorCode, String message)
     {
-        super(messageFormat, cause);
+        super(message);
+        _errorCode = errorCode;
+    }
+
+    QpackException(long errorCode, String message, Throwable cause)
+    {
+        super(message, cause);
         _errorCode = errorCode;
     }
 
@@ -41,14 +47,28 @@ public abstract class QpackException extends Exception
      */
     public static class StreamException extends QpackException
     {
-        public StreamException(long errorCode, String messageFormat)
+        private final Boolean type;
+
+        public StreamException(boolean request, boolean response, long errorCode, String message)
         {
-            this(errorCode, messageFormat, null);
+            super(errorCode, message);
+            this.type = request ? Boolean.TRUE : response ? Boolean.FALSE : null;
         }
 
-        public StreamException(long errorCode, String messageFormat, Throwable cause)
+        public StreamException(boolean request, boolean response, long errorCode, String message, Throwable cause)
         {
-            super(errorCode, messageFormat, cause);
+            super(errorCode, message, cause);
+            this.type = request ? Boolean.TRUE : response ? Boolean.FALSE : null;
+        }
+
+        public boolean isRequest()
+        {
+            return type == Boolean.TRUE;
+        }
+
+        public boolean isResponse()
+        {
+            return type == Boolean.FALSE;
         }
     }
 

--- a/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HTTP3StreamServer.java
+++ b/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HTTP3StreamServer.java
@@ -120,7 +120,7 @@ public class HTTP3StreamServer extends HTTP3Stream implements Stream.Server
     }
 
     @Override
-    protected void notifyFailure(long error, Throwable failure)
+    public void notifyFailure(long error, Throwable failure)
     {
         Listener listener = this.listener;
         try

--- a/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/ServerHTTP3StreamConnection.java
+++ b/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/ServerHTTP3StreamConnection.java
@@ -51,13 +51,19 @@ public class ServerHTTP3StreamConnection extends HTTP3StreamConnection
 
     public Runnable onRequest(HTTP3StreamServer stream, HeadersFrame frame)
     {
+        HttpStreamOverHTTP3 httpStream = newHttpStreamOverHTTP3(stream);
+        return httpStream.onRequest(frame);
+    }
+
+    private HttpStreamOverHTTP3 newHttpStreamOverHTTP3(HTTP3StreamServer stream)
+    {
         // Create new metadata for every request as the local or remote address may have changed.
         HttpChannel httpChannel = httpChannelFactory.newHttpChannel(new MetaData());
         httpChannel.initialize();
         HttpStreamOverHTTP3 httpStream = new HttpStreamOverHTTP3(this, httpChannel, stream);
         httpChannel.setHttpStream(httpStream);
         stream.setAttachment(httpStream);
-        return httpStream.onRequest(frame);
+        return httpStream;
     }
 
     public Runnable onDataAvailable(HTTP3Stream stream)
@@ -81,6 +87,8 @@ public class ServerHTTP3StreamConnection extends HTTP3StreamConnection
     public Runnable onFailure(HTTP3Stream stream, Throwable failure)
     {
         HttpStreamOverHTTP3 httpStream = (HttpStreamOverHTTP3)stream.getAttachment();
+        if (httpStream == null)
+            httpStream = newHttpStreamOverHTTP3((HTTP3StreamServer)stream);
         return httpStream.onFailure(failure);
     }
 

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/pom.xml
@@ -6,48 +6,19 @@
     <artifactId>jetty-ee10-tests</artifactId>
     <version>12.0.21-SNAPSHOT</version>
   </parent>
+
   <artifactId>jetty-ee10-test-integration</artifactId>
   <packaging>jar</packaging>
   <name>EE10 :: Tests :: Integrations</name>
+
   <properties>
     <bundle-symbolic-name>${project.groupId}.integrations</bundle-symbolic-name>
     <test-home-dir>${project.build.directory}/test-dist</test-home-dir>
     <test-libs-dir>${project.build.directory}/test-libs</test-libs-dir>
     <test-wars-dir>${project.build.directory}/test-wars</test-wars-dir>
   </properties>
+
   <dependencies>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-client</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-deploy</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-plus</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-rewrite</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty.ee10</groupId>
-      <artifactId>jetty-ee10-apache-jsp</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty.ee10</groupId>
-      <artifactId>jetty-ee10-webapp</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty.http2</groupId>
-      <artifactId>jetty-http2-server</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
@@ -58,15 +29,29 @@
       <artifactId>jetty-alpn-server</artifactId>
       <scope>test</scope>
     </dependency>
-    <!-- dependency>
+    <dependency>
       <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-home</artifactId>
-      <version>${project.version}</version>
-      <type>pom</type>
-    </dependency -->
+      <artifactId>jetty-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-deploy</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-http-tools</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-plus</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-rewrite</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -81,6 +66,11 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-apache-jsp</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.ee10</groupId>
       <artifactId>jetty-ee10-servlets</artifactId>
       <scope>test</scope>
     </dependency>
@@ -89,6 +79,11 @@
       <artifactId>jetty-ee10-test-webapp-rfc2616</artifactId>
       <version>${project.version}</version>
       <type>war</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-webapp</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -108,8 +103,23 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.toolchain</groupId>
-      <artifactId>jetty-test-helper</artifactId>
+      <groupId>org.eclipse.jetty.http2</groupId>
+      <artifactId>jetty-http2-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.http2</groupId>
+      <artifactId>jetty-http2-server</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.http3</groupId>
+      <artifactId>jetty-http3-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.http3</groupId>
+      <artifactId>jetty-http3-server</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -117,7 +127,13 @@
       <artifactId>jetty-websocket-jetty-client</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+
   <build>
     <plugins>
       <plugin>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/HTTP2RequestTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/HTTP2RequestTest.java
@@ -11,7 +11,7 @@
 // ========================================================================
 //
 
-package org.eclipse.jetty.ee9.test;
+package org.eclipse.jetty.ee10.test;
 
 import java.net.Socket;
 import java.net.SocketTimeoutException;
@@ -24,8 +24,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
-import org.eclipse.jetty.ee9.servlet.ServletHolder;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpScheme;

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/HTTP2RequestTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/HTTP2RequestTest.java
@@ -13,10 +13,7 @@
 
 package org.eclipse.jetty.ee10.test;
 
-import java.net.Socket;
-import java.net.SocketTimeoutException;
-import java.nio.ByteBuffer;
-import java.util.HashMap;
+import java.net.InetSocketAddress;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -33,18 +30,16 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.http2.api.Session;
+import org.eclipse.jetty.http2.api.Stream;
+import org.eclipse.jetty.http2.client.HTTP2Client;
 import org.eclipse.jetty.http2.frames.HeadersFrame;
-import org.eclipse.jetty.http2.frames.PrefaceFrame;
-import org.eclipse.jetty.http2.frames.SettingsFrame;
-import org.eclipse.jetty.http2.generator.Generator;
-import org.eclipse.jetty.http2.parser.Parser;
+import org.eclipse.jetty.http2.frames.ResetFrame;
 import org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory;
-import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.ErrorHandler;
-import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.hamcrest.Matchers;
@@ -53,6 +48,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HTTP2RequestTest
@@ -105,64 +101,70 @@ public class HTTP2RequestTest
             }
         });
 
-        ByteBufferPool bufferPool = connector.getByteBufferPool();
-        Generator generator = new Generator(bufferPool);
-
-        // Craft a request with a bad URI, it will not hit the Servlet.
-        MetaData.Request metaData = new MetaData.Request(
-            HttpMethod.GET.asString(),
-            new HttpURI.Unsafe(HttpScheme.HTTPS.asString(), "localhost", connector.getLocalPort(), badPath, null, null),
-            HttpVersion.HTTP_2,
-            HttpFields.EMPTY
-        );
-        ByteBufferPool.Accumulator accumulator = new ByteBufferPool.Accumulator();
-        generator.control(accumulator, new PrefaceFrame());
-        generator.control(accumulator, new SettingsFrame(new HashMap<>(), false));
-        generator.control(accumulator, new HeadersFrame(1, metaData, null, true));
-
-        try (Socket socket = new Socket("localhost", connector.getLocalPort()))
+        try (HTTP2Client http2Client = new HTTP2Client())
         {
-            for (ByteBuffer buffer : accumulator.getByteBuffers())
-            {
-                socket.getOutputStream().write(BufferUtil.toArray(buffer));
-            }
-            socket.getOutputStream().flush();
+            http2Client.start();
+
+            InetSocketAddress address = new InetSocketAddress("localhost", connector.getLocalPort());
+            Session session = http2Client.connect(address, new Session.Listener() {}).get(5, TimeUnit.SECONDS);
+
+            // Craft a request with a bad URI, it will not hit the Servlet.
+            MetaData.Request metaData = new MetaData.Request(
+                HttpMethod.GET.asString(),
+                new HttpURI.Unsafe(HttpScheme.HTTPS.asString(), "localhost", connector.getLocalPort(), badPath, null, null),
+                HttpVersion.HTTP_3,
+                HttpFields.EMPTY
+            );
 
             AtomicReference<MetaData.Response> responseRef = new AtomicReference<>();
             CountDownLatch responseLatch = new CountDownLatch(1);
-            Parser parser = new Parser(bufferPool, 8192);
-            parser.init(new Parser.Listener()
+            CountDownLatch failureLatch = new CountDownLatch(1);
+            session.newStream(new HeadersFrame(metaData, null, true), new Stream.Listener()
             {
                 @Override
-                public void onHeaders(HeadersFrame frame)
+                public void onHeaders(Stream stream, HeadersFrame frame)
                 {
                     responseRef.set((MetaData.Response)frame.getMetaData());
-                    responseLatch.countDown();
+                    if (frame.isEndStream())
+                        responseLatch.countDown();
+                    else
+                        stream.demand();
+                }
+
+                @Override
+                public void onDataAvailable(Stream stream)
+                {
+                    Stream.Data data = stream.readData();
+                    if (data == null)
+                    {
+                        stream.demand();
+                        return;
+                    }
+                    data.release();
+                    if (data.frame().isEndStream())
+                        responseLatch.countDown();
+                    else
+                        stream.demand();
+                }
+
+                @Override
+                public void onReset(Stream stream, ResetFrame frame, Callback callback)
+                {
+                    failureLatch.countDown();
+                }
+
+                @Override
+                public void onFailure(Stream stream, int error, String reason, Throwable failure, Callback callback)
+                {
+                    failureLatch.countDown();
                 }
             });
-
-            byte[] bytes = new byte[2048];
-            socket.setSoTimeout(1000);
-
-            while (true)
-            {
-                try
-                {
-                    int read = socket.getInputStream().read(bytes);
-                    if (read < 0)
-                        break;
-                    parser.parse(ByteBuffer.wrap(bytes, 0, read));
-                }
-                catch (SocketTimeoutException x)
-                {
-                    break;
-                }
-            }
 
             assertTrue(errorHandlerLatch.await(5, TimeUnit.SECONDS));
             assertTrue(responseLatch.await(5, TimeUnit.SECONDS));
             MetaData.Response response = responseRef.get();
             assertThat(response.getStatus(), Matchers.is(HttpStatus.BAD_REQUEST_400));
+            assertFalse(failureLatch.await(1, TimeUnit.SECONDS));
         }
     }
 }

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/HTTP3RequestTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/HTTP3RequestTest.java
@@ -11,9 +11,11 @@
 // ========================================================================
 //
 
-package org.eclipse.jetty.ee9.test;
+package org.eclipse.jetty.ee10.test;
 
 import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -21,8 +23,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
-import org.eclipse.jetty.ee9.servlet.ServletHolder;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpScheme;
@@ -30,20 +32,27 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http.MetaData;
-import org.eclipse.jetty.http2.api.Session;
-import org.eclipse.jetty.http2.api.Stream;
-import org.eclipse.jetty.http2.client.HTTP2Client;
-import org.eclipse.jetty.http2.frames.HeadersFrame;
-import org.eclipse.jetty.http2.frames.ResetFrame;
-import org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory;
+import org.eclipse.jetty.http3.api.Session;
+import org.eclipse.jetty.http3.api.Stream;
+import org.eclipse.jetty.http3.client.HTTP3Client;
+import org.eclipse.jetty.http3.frames.HeadersFrame;
+import org.eclipse.jetty.http3.server.HTTP3ServerConnectionFactory;
+import org.eclipse.jetty.quic.client.ClientQuicConfiguration;
+import org.eclipse.jetty.quic.server.QuicServerConnector;
+import org.eclipse.jetty.quic.server.ServerQuicConfiguration;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.ErrorHandler;
+import org.eclipse.jetty.toolchain.test.MavenPaths;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.component.LifeCycle;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -51,13 +60,22 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class HTTP2RequestTest
+@ExtendWith(WorkDirExtension.class)
+public class HTTP3RequestTest
 {
+    public WorkDir workDir;
+    private Path pemDir;
     private Server server;
-    private ServerConnector connector;
+    private QuicServerConnector connector;
+
+    @BeforeEach
+    public void prepare()
+    {
+        pemDir = workDir.getEmptyPathDir();
+    }
 
     @AfterEach
-    public void stopAll()
+    public void dispose()
     {
         LifeCycle.stop(server);
     }
@@ -66,7 +84,12 @@ public class HTTP2RequestTest
     {
         server = new Server();
 
-        connector = new ServerConnector(server, new HTTP2ServerConnectionFactory());
+        SslContextFactory.Server ssl = new SslContextFactory.Server();
+        ssl.setKeyStorePath(MavenPaths.findTestResourceFile("keystore.p12").toString());
+        ssl.setKeyStorePassword("storepwd");
+        Path serverPemDirectory = Files.createDirectories(pemDir.resolve("server"));
+        ServerQuicConfiguration serverQuicConfig = new ServerQuicConfiguration(ssl, serverPemDirectory);
+        connector = new QuicServerConnector(server, serverQuicConfig, new HTTP3ServerConnectionFactory(serverQuicConfig));
         server.addConnector(connector);
 
         ServletContextHandler contextHandler = new ServletContextHandler();
@@ -101,12 +124,12 @@ public class HTTP2RequestTest
             }
         });
 
-        try (HTTP2Client http2Client = new HTTP2Client())
+        try (HTTP3Client http3Client = new HTTP3Client(new ClientQuicConfiguration(new SslContextFactory.Client(true), null)))
         {
-            http2Client.start();
+            http3Client.start();
 
             InetSocketAddress address = new InetSocketAddress("localhost", connector.getLocalPort());
-            Session session = http2Client.connect(address, new Session.Listener() {}).get(5, TimeUnit.SECONDS);
+            Session.Client session = http3Client.connect(address, new Session.Client.Listener() {}).get(5, TimeUnit.SECONDS);
 
             // Craft a request with a bad URI, it will not hit the Servlet.
             MetaData.Request metaData = new MetaData.Request(
@@ -119,20 +142,20 @@ public class HTTP2RequestTest
             AtomicReference<MetaData.Response> responseRef = new AtomicReference<>();
             CountDownLatch responseLatch = new CountDownLatch(1);
             CountDownLatch failureLatch = new CountDownLatch(1);
-            session.newStream(new HeadersFrame(metaData, null, true), new Stream.Listener()
+            session.newRequest(new HeadersFrame(metaData, true), new Stream.Client.Listener()
             {
                 @Override
-                public void onHeaders(Stream stream, HeadersFrame frame)
+                public void onResponse(Stream.Client stream, HeadersFrame frame)
                 {
                     responseRef.set((MetaData.Response)frame.getMetaData());
-                    if (frame.isEndStream())
+                    if (frame.isLast())
                         responseLatch.countDown();
                     else
                         stream.demand();
                 }
 
                 @Override
-                public void onDataAvailable(Stream stream)
+                public void onDataAvailable(Stream.Client stream)
                 {
                     Stream.Data data = stream.readData();
                     if (data == null)
@@ -141,20 +164,14 @@ public class HTTP2RequestTest
                         return;
                     }
                     data.release();
-                    if (data.frame().isEndStream())
+                    if (data.isLast())
                         responseLatch.countDown();
                     else
                         stream.demand();
                 }
 
                 @Override
-                public void onReset(Stream stream, ResetFrame frame, Callback callback)
-                {
-                    failureLatch.countDown();
-                }
-
-                @Override
-                public void onFailure(Stream stream, int error, String reason, Throwable failure, Callback callback)
+                public void onFailure(Stream.Client stream, long error, Throwable failure)
                 {
                     failureLatch.countDown();
                 }

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/pom.xml
@@ -6,58 +6,19 @@
     <artifactId>jetty-ee9-tests</artifactId>
     <version>12.0.21-SNAPSHOT</version>
   </parent>
+
   <artifactId>jetty-ee9-test-integration</artifactId>
   <packaging>jar</packaging>
   <name>EE9 :: Tests :: Integration</name>
+
   <properties>
     <bundle-symbolic-name>${project.groupId}.integrations</bundle-symbolic-name>
     <test-home-dir>${project.build.directory}/test-dist</test-home-dir>
     <test-libs-dir>${project.build.directory}/test-libs</test-libs-dir>
     <test-wars-dir>${project.build.directory}/test-wars</test-wars-dir>
   </properties>
+
   <dependencies>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-client</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-deploy</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-plus</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-rewrite</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty.ee9</groupId>
-      <artifactId>jetty-ee9-apache-jsp</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty.ee9</groupId>
-      <artifactId>jetty-ee9-plus</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>jakarta.el</groupId>
-          <artifactId>jakarta.el-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty.ee9</groupId>
-      <artifactId>jetty-ee9-webapp</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty.http2</groupId>
-      <artifactId>jetty-http2-server</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
@@ -75,7 +36,27 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-deploy</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-http-tools</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-plus</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-rewrite</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -96,6 +77,22 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.ee9</groupId>
+      <artifactId>jetty-ee9-apache-jsp</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.ee9</groupId>
+      <artifactId>jetty-ee9-plus</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>jakarta.el</groupId>
+          <artifactId>jakarta.el-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.ee9</groupId>
       <artifactId>jetty-ee9-servlets</artifactId>
       <scope>test</scope>
     </dependency>
@@ -104,6 +101,11 @@
       <artifactId>jetty-ee9-test-webapp-rfc2616</artifactId>
       <version>${project.version}</version>
       <type>war</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.ee9</groupId>
+      <artifactId>jetty-ee9-webapp</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -138,11 +140,32 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jetty.http2</groupId>
+      <artifactId>jetty-http2-server</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.http3</groupId>
+      <artifactId>jetty-http3-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.http3</groupId>
+      <artifactId>jetty-http3-server</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty.toolchain</groupId>
       <artifactId>jetty-test-helper</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+
   <build>
     <plugins>
       <plugin>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/pom.xml
@@ -52,16 +52,6 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.http2</groupId>
-      <artifactId>jetty-http2-client</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty.http2</groupId>
-      <artifactId>jetty-http2-client-transport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty.http2</groupId>
       <artifactId>jetty-http2-server</artifactId>
     </dependency>
     <dependency>
@@ -135,6 +125,16 @@
     <dependency>
       <groupId>org.eclipse.jetty.ee9.websocket</groupId>
       <artifactId>jetty-ee9-websocket-jetty-server</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.http2</groupId>
+      <artifactId>jetty-http2-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.http2</groupId>
+      <artifactId>jetty-http2-client-transport</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/pom.xml
@@ -52,6 +52,16 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.http2</groupId>
+      <artifactId>jetty-http2-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.http2</groupId>
+      <artifactId>jetty-http2-client-transport</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.http2</groupId>
       <artifactId>jetty-http2-server</artifactId>
     </dependency>
     <dependency>
@@ -61,6 +71,11 @@
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-alpn-java-server</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/HTTP2RequestTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/HTTP2RequestTest.java
@@ -1,0 +1,165 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee9.test;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory;
+import org.eclipse.jetty.client.ContentResponse;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
+import org.eclipse.jetty.http.HttpScheme;
+import org.eclipse.jetty.http2.HTTP2Cipher;
+import org.eclipse.jetty.http2.client.HTTP2Client;
+import org.eclipse.jetty.http2.client.transport.HttpClientTransportOverHTTP2;
+import org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory;
+import org.eclipse.jetty.io.ClientConnector;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.SecureRequestCustomizer;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.SslConnectionFactory;
+import org.eclipse.jetty.toolchain.test.MavenPaths;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class HTTP2RequestTest
+{
+    private Server server;
+    private HttpClient client;
+
+    @BeforeEach
+    public void startClient() throws Exception
+    {
+        ClientConnector clientConnector = new ClientConnector();
+        clientConnector.setSslContextFactory(new SslContextFactory.Client(true));
+        HTTP2Client http2Client = new HTTP2Client(clientConnector);
+        client = new HttpClient(new HttpClientTransportOverHTTP2(http2Client));
+        client.start();
+    }
+
+    @AfterEach
+    public void stopAll()
+    {
+        LifeCycle.stop(server);
+        LifeCycle.stop(client);
+    }
+
+    public void startServer(ServletContextHandler contextHandler) throws Exception
+    {
+        server = new Server();
+
+        SslContextFactory.Server serverTLS = new SslContextFactory.Server();
+        Path keystore = MavenPaths.findTestResourceFile("keystore.p12");
+        serverTLS.setKeyStorePath(keystore.toString());
+        serverTLS.setKeyStorePassword("storepwd");
+        serverTLS.setCipherComparator(new HTTP2Cipher.CipherComparator());
+
+        HttpConfiguration httpsConfig = new HttpConfiguration();
+        SecureRequestCustomizer secureRequestCustomizer = new SecureRequestCustomizer();
+        secureRequestCustomizer.setSniRequired(false);
+        secureRequestCustomizer.setSniHostCheck(false);
+        httpsConfig.addCustomizer(secureRequestCustomizer);
+
+        HttpConnectionFactory h1 = new HttpConnectionFactory(httpsConfig);
+        ALPNServerConnectionFactory alpn = new ALPNServerConnectionFactory();
+        alpn.setDefaultProtocol(h1.getProtocol());
+        SslConnectionFactory ssl = new SslConnectionFactory(serverTLS, alpn.getProtocol());
+        HTTP2ServerConnectionFactory h2 = new HTTP2ServerConnectionFactory(httpsConfig);
+
+        ServerConnector connector = new ServerConnector(server, ssl, alpn, h2, h1);
+        server.addConnector(connector);
+
+        server.setHandler(contextHandler);
+        server.start();
+    }
+
+    @Test
+    public void testNormalDump() throws Exception
+    {
+        ServletContextHandler contextHandler = new ServletContextHandler();
+        contextHandler.setContextPath("/demo");
+        contextHandler.addServlet(DumpServlet.class, "/dump/*");
+        startServer(contextHandler);
+
+        URI uri = server.getURI().resolve("/demo/dump/");
+
+        ContentResponse response = client.newRequest(uri.getHost(), uri.getPort())
+            .scheme(HttpScheme.HTTPS.asString())
+            .path(uri.getPath())
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(200, response.getStatus());
+        assertThat(response.getContentAsString(), allOf(
+            containsString("RequestURI: /demo/dump/\n"),
+            containsString("QueryString: null\n")
+        ));
+    }
+
+    @Test
+    public void testBadPathDump() throws Exception
+    {
+        ServletContextHandler contextHandler = new ServletContextHandler();
+        contextHandler.setContextPath("/demo");
+        contextHandler.addServlet(DumpServlet.class, "/dump/*");
+        startServer(contextHandler);
+
+        // The "%00" will trigger a IllegalArgumentException: Illegal character in path (on server)
+        // This character is allowed in the java.net.URI case.
+        URI uri = server.getURI().resolve("/demo/dump/%00");
+
+        ContentResponse response = client.newRequest(uri)
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(200, response.getStatus());
+        assertThat(response.getContentAsString(), allOf(
+            containsString("RequestURI: /demo/dump/%00\n"),
+            containsString("QueryString: null\n")
+        ));
+    }
+
+    public static class DumpServlet extends HttpServlet
+    {
+        @Override
+        protected void service(HttpServletRequest req, HttpServletResponse resp) throws IOException
+        {
+            resp.setStatus(200);
+            resp.setContentType("text/plain");
+            resp.setCharacterEncoding("utf-8");
+            PrintWriter out = resp.getWriter();
+            out.printf("Method: %s\n", req.getMethod());
+            out.printf("RequestURL: %s\n", req.getRequestURL());
+            out.printf("RequestURI: %s\n", req.getRequestURI());
+            out.printf("QueryString: %s\n", req.getQueryString());
+        }
+    }
+}

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/HTTP3RequestTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/HTTP3RequestTest.java
@@ -14,6 +14,8 @@
 package org.eclipse.jetty.ee9.test;
 
 import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -30,20 +32,27 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http.MetaData;
-import org.eclipse.jetty.http2.api.Session;
-import org.eclipse.jetty.http2.api.Stream;
-import org.eclipse.jetty.http2.client.HTTP2Client;
-import org.eclipse.jetty.http2.frames.HeadersFrame;
-import org.eclipse.jetty.http2.frames.ResetFrame;
-import org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory;
+import org.eclipse.jetty.http3.api.Session;
+import org.eclipse.jetty.http3.api.Stream;
+import org.eclipse.jetty.http3.client.HTTP3Client;
+import org.eclipse.jetty.http3.frames.HeadersFrame;
+import org.eclipse.jetty.http3.server.HTTP3ServerConnectionFactory;
+import org.eclipse.jetty.quic.client.ClientQuicConfiguration;
+import org.eclipse.jetty.quic.server.QuicServerConnector;
+import org.eclipse.jetty.quic.server.ServerQuicConfiguration;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.ErrorHandler;
+import org.eclipse.jetty.toolchain.test.MavenPaths;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.component.LifeCycle;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -51,13 +60,22 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class HTTP2RequestTest
+@ExtendWith(WorkDirExtension.class)
+public class HTTP3RequestTest
 {
+    public WorkDir workDir;
+    private Path pemDir;
     private Server server;
-    private ServerConnector connector;
+    private QuicServerConnector connector;
+
+    @BeforeEach
+    public void prepare()
+    {
+        pemDir = workDir.getEmptyPathDir();
+    }
 
     @AfterEach
-    public void stopAll()
+    public void dispose()
     {
         LifeCycle.stop(server);
     }
@@ -66,7 +84,12 @@ public class HTTP2RequestTest
     {
         server = new Server();
 
-        connector = new ServerConnector(server, new HTTP2ServerConnectionFactory());
+        SslContextFactory.Server ssl = new SslContextFactory.Server();
+        ssl.setKeyStorePath(MavenPaths.findTestResourceFile("keystore.p12").toString());
+        ssl.setKeyStorePassword("storepwd");
+        Path serverPemDirectory = Files.createDirectories(pemDir.resolve("server"));
+        ServerQuicConfiguration serverQuicConfig = new ServerQuicConfiguration(ssl, serverPemDirectory);
+        connector = new QuicServerConnector(server, serverQuicConfig, new HTTP3ServerConnectionFactory(serverQuicConfig));
         server.addConnector(connector);
 
         ServletContextHandler contextHandler = new ServletContextHandler();
@@ -101,12 +124,12 @@ public class HTTP2RequestTest
             }
         });
 
-        try (HTTP2Client http2Client = new HTTP2Client())
+        try (HTTP3Client http3Client = new HTTP3Client(new ClientQuicConfiguration(new SslContextFactory.Client(true), null)))
         {
-            http2Client.start();
+            http3Client.start();
 
             InetSocketAddress address = new InetSocketAddress("localhost", connector.getLocalPort());
-            Session session = http2Client.connect(address, new Session.Listener() {}).get(5, TimeUnit.SECONDS);
+            Session.Client session = http3Client.connect(address, new Session.Client.Listener() {}).get(5, TimeUnit.SECONDS);
 
             // Craft a request with a bad URI, it will not hit the Servlet.
             MetaData.Request metaData = new MetaData.Request(
@@ -119,20 +142,20 @@ public class HTTP2RequestTest
             AtomicReference<MetaData.Response> responseRef = new AtomicReference<>();
             CountDownLatch responseLatch = new CountDownLatch(1);
             CountDownLatch failureLatch = new CountDownLatch(1);
-            session.newStream(new HeadersFrame(metaData, null, true), new Stream.Listener()
+            session.newRequest(new HeadersFrame(metaData, true), new Stream.Client.Listener()
             {
                 @Override
-                public void onHeaders(Stream stream, HeadersFrame frame)
+                public void onResponse(Stream.Client stream, HeadersFrame frame)
                 {
                     responseRef.set((MetaData.Response)frame.getMetaData());
-                    if (frame.isEndStream())
+                    if (frame.isLast())
                         responseLatch.countDown();
                     else
                         stream.demand();
                 }
 
                 @Override
-                public void onDataAvailable(Stream stream)
+                public void onDataAvailable(Stream.Client stream)
                 {
                     Stream.Data data = stream.readData();
                     if (data == null)
@@ -141,20 +164,14 @@ public class HTTP2RequestTest
                         return;
                     }
                     data.release();
-                    if (data.frame().isEndStream())
+                    if (data.isLast())
                         responseLatch.countDown();
                     else
                         stream.demand();
                 }
 
                 @Override
-                public void onReset(Stream stream, ResetFrame frame, Callback callback)
-                {
-                    failureLatch.countDown();
-                }
-
-                @Override
-                public void onFailure(Stream stream, int error, String reason, Throwable failure, Callback callback)
+                public void onFailure(Stream.Client stream, long error, Throwable failure)
                 {
                     failureLatch.countDown();
                 }

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/resources/jetty-logging.properties
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/resources/jetty-logging.properties
@@ -3,5 +3,3 @@
 #org.eclipse.jetty.websocket.LEVEL=DEBUG
 #org.eclipse.jetty.util.ssl.KeyStoreScanner.LEVEL=DEBUG
 #org.eclipse.jetty.util.Scanner.LEVEL=DEBUG
-org.eclipse.jetty.http.LEVEL=DEBUG
-org.eclipse.jetty.http2.LEVEL=DEBUG

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/resources/jetty-logging.properties
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/resources/jetty-logging.properties
@@ -3,3 +3,5 @@
 #org.eclipse.jetty.websocket.LEVEL=DEBUG
 #org.eclipse.jetty.util.ssl.KeyStoreScanner.LEVEL=DEBUG
 #org.eclipse.jetty.util.Scanner.LEVEL=DEBUG
+org.eclipse.jetty.http.LEVEL=DEBUG
+org.eclipse.jetty.http2.LEVEL=DEBUG


### PR DESCRIPTION
Errors happening before the request is handled are now handled similarly to HTTP/1.1, and are now hitting the `ErrorHandler`, so that a 400 response can be generated.