### PR TITLE
Remove no longer needed surefire configuration

### DIFF
--- a/jetty-core/jetty-deploy/pom.xml
+++ b/jetty-core/jetty-deploy/pom.xml
@@ -86,15 +86,6 @@
           <excludePackageNames>*.internal,*.internal.*</excludePackageNames>
         </configuration>
       </plugin>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <argLine>@{argLine} ${jetty.surefire.argLine}
-            --add-modules org.eclipse.jetty.jmx
-            --add-reads org.eclipse.jetty.deploy=org.eclipse.jetty.http
-            --add-reads org.eclipse.jetty.deploy=org.eclipse.jetty.logging</argLine>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
The surefire configuration is no longer needed.
And it causes testing failures in newer IDEs.

