### PR TITLE
Issue #13144 - Cross context dispatch in ee9/ee8 breaks AsyncContext.dispatch

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/AsyncContextEvent.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/AsyncContextEvent.java
@@ -43,7 +43,7 @@ public class AsyncContextEvent extends AsyncEvent implements Runnable
         _servletContext = ServletContextHandler.getServletContext(context);
         _state = state;
         // TODO better than this:
-        _baseURI = request == null ? null : (request instanceof HttpServletRequest hr) ? HttpURI.from(hr.getRequestURI()) : null;
+        _baseURI = request == null ? null : (request instanceof HttpServletRequest hr) ? ServletContextRequest.getServletContextRequest(hr).getHttpURI() : null;
 
         // TODO: Should we store a wrapped request with the attributes?
         // We are setting these attributes during startAsync, when the spec implies that

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/AsyncContextEvent.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/AsyncContextEvent.java
@@ -42,8 +42,11 @@ public class AsyncContextEvent extends AsyncEvent implements Runnable
         _asyncContext = asyncContext;
         _servletContext = ServletContextHandler.getServletContext(context);
         _state = state;
-        // TODO better than this:
-        _baseURI = request == null ? null : (request instanceof HttpServletRequest hr) ? ServletContextRequest.getServletContextRequest(hr).getHttpURI() : null;
+
+        if (request instanceof HttpServletRequest hr)
+            _baseURI = HttpURI.build(hr.getRequestURI()).query(hr.getQueryString());
+        else
+            _baseURI = null;
 
         // TODO: Should we store a wrapped request with the attributes?
         // We are setting these attributes during startAsync, when the spec implies that

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/AsyncContextEvent.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/AsyncContextEvent.java
@@ -43,10 +43,7 @@ public class AsyncContextEvent extends AsyncEvent implements Runnable
         _servletContext = ServletContextHandler.getServletContext(context);
         _state = state;
 
-        if (request instanceof HttpServletRequest hr)
-            _baseURI = HttpURI.build(hr.getRequestURI()).query(hr.getQueryString());
-        else
-            _baseURI = null;
+        _baseURI =  (request instanceof HttpServletRequest hsr) ? HttpURI.build(hsr.getRequestURI()).query(hsr.getQueryString()) : null;
 
         // TODO: Should we store a wrapped request with the attributes?
         // We are setting these attributes during startAsync, when the spec implies that

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/CrossContextDispatcher.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/CrossContextDispatcher.java
@@ -240,6 +240,7 @@ class CrossContextDispatcher implements RequestDispatcher
         HttpServletResponse httpResponse = (response instanceof HttpServletResponse) ? (HttpServletResponse)response : new ServletResponseHttpWrapper(response);
 
         AsyncRequest asyncRequest = new AsyncRequest(httpServletRequest);
+        // We must block when do a cross context async dispatch, as we cannot combine the state machines of the servletChannel from the source context and that of the target
         try (Blocker.Callback callback = Blocker.callback())
         {
             _targetContext.getTargetContext().getContextHandler().handle(asyncRequest, new ServletCoreResponse(asyncRequest, httpResponse, false), callback);

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/CrossContextDispatcher.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/CrossContextDispatcher.java
@@ -152,9 +152,26 @@ class CrossContextDispatcher implements RequestDispatcher
         }
     }
 
+    private class AsyncRequest extends ServletCoreRequest
+    {
+        private final HttpURI _fullyQualifiedURI;
+
+        public AsyncRequest(HttpServletRequest httpServletRequest)
+        {
+            super(httpServletRequest, new ServletAttributes(httpServletRequest));
+            _fullyQualifiedURI = HttpURI.build(httpServletRequest.getRequestURL().toString()).pathQuery(_uri.getPathQuery()).asImmutable();
+        }
+
+        @Override
+        public HttpURI getHttpURI()
+        {
+            return _fullyQualifiedURI;
+        }
+    }
+
     private class ForwardRequest extends ServletCoreRequest
     {
-         private HttpURI _fullyQualifiedURI;
+         private final HttpURI _fullyQualifiedURI;
 
         /**
          * @param httpServletRequest the request to wrap
@@ -215,6 +232,23 @@ class CrossContextDispatcher implements RequestDispatcher
         _targetContext = targetContext;
         _uri = uri;
         _decodedPathInContext = decodedPathInContext;
+    }
+
+    public void async(ServletRequest servletRequest, ServletResponse response) throws ServletException, IOException
+    {
+        HttpServletRequest httpServletRequest = (servletRequest instanceof HttpServletRequest) ? ((HttpServletRequest)servletRequest) : new ServletRequestHttpWrapper(servletRequest);
+        HttpServletResponse httpResponse = (response instanceof HttpServletResponse) ? (HttpServletResponse)response : new ServletResponseHttpWrapper(response);
+
+        AsyncRequest asyncRequest = new AsyncRequest(httpServletRequest);
+        try (Blocker.Callback callback = Blocker.callback())
+        {
+            _targetContext.getTargetContext().getContextHandler().handle(asyncRequest, new ServletCoreResponse(asyncRequest, httpResponse, false), callback);
+            callback.block();
+        }
+        catch (Exception e)
+        {
+            throw new ServletException(e);
+        }
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/Dispatcher.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/Dispatcher.java
@@ -756,8 +756,9 @@ public class Dispatcher implements RequestDispatcher
         }
 
         /**
-         * Get the parameters merged from the wrapped request, and the dispatch URI.
-         * If the dispatch URI is the same as the URI of the wrapped request, then
+         * Get the parameters merged from the request wrapped by this {@code AsyncRequest}
+         * and those in the {@code RequestDispatcher}.
+         * If the target path is the same as the request path, then
          * we do not want to re-extract the query string, as the wrapped request will
          * have already done the extraction.
          * @return the request parameters

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/Dispatcher.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/Dispatcher.java
@@ -45,6 +45,7 @@ import org.eclipse.jetty.io.WriterOutputStream;
 import org.eclipse.jetty.util.Fields;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.StringUtil;
+import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.UrlEncoded;
 
 public class Dispatcher implements RequestDispatcher
@@ -177,7 +178,7 @@ public class Dispatcher implements RequestDispatcher
             super(request);
         }
 
-        private Fields getParameters()
+        protected Fields getParameters()
         {
             if (_parameters == null)
             {
@@ -752,6 +753,36 @@ public class Dispatcher implements RequestDispatcher
             names.add(AsyncContextState.ASYNC_MAPPING);
             names.add(AsyncContextState.ASYNC_QUERY_STRING);
             return Collections.enumeration(names);
+        }
+
+        /**
+         * Get the parameters merged from the wrapped request, and the dispatch URI.
+         * If the dispatch URI is the same as the URI of the wrapped request, then
+         * we do not want to re-extract the query string, as the wrapped request will
+         * have already done the extraction.
+         * @return the request parameters
+         */
+        @Override
+        protected Fields getParameters()
+        {
+            // The AsyncRequest may have been dispatched to the same URI as the request that it is
+            //wrapping. If so, We should not re-extract the parameters, just use what is there.
+            if (getRequest() instanceof HttpServletRequest httpServletRequest)
+            {
+                HttpURI requestURI = HttpURI.build(httpServletRequest.getRequestURI()).query(httpServletRequest.getQueryString());
+                if (requestURI.equals(_uri))
+                {
+                    if (getRequest() instanceof ParameterRequestWrapper parameterRequestWrapper)
+                        return parameterRequestWrapper.getParameters();
+                    else if (getRequest() instanceof ServletApiRequest servletApiRequest)
+                        return servletApiRequest.getParameters();
+                    else
+                        return super.getParameters();
+                }
+                else
+                    return super.getParameters();
+            }
+            return super.getParameters();
         }
     }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiRequest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiRequest.java
@@ -1358,6 +1358,8 @@ public class ServletApiRequest implements HttpServletRequest
         if (_async == null)
             _async = new AsyncContextState(state);
 
+        // We must remember the request as last dispatched by the container so that we can use its uri for
+        // possible subsequent dispatch
         ServletRequestInfo servletRequestInfo = getServletRequestInfo();
         AsyncContextEvent event = new AsyncContextEvent(getServletRequestInfo().getServletContext(), _async, state, servletRequestInfo.getServletChannel().getServletContextRequest().getServletApiRequest(), servletRequestInfo.getServletChannel().getServletContextResponse().getServletApiResponse());
         state.startAsync(event);
@@ -1372,6 +1374,7 @@ public class ServletApiRequest implements HttpServletRequest
         ServletChannelState state = getServletRequestInfo().getState();
         if (_async == null)
             _async = new AsyncContextState(state);
+        //We must remember the request and response passed in for use in a possible subsequent dispatch
         AsyncContextEvent event = new AsyncContextEvent(getServletRequestInfo().getServletContext(), _async, state, servletRequest, servletResponse);
         state.startAsync(event);
         return _async;

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiRequest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiRequest.java
@@ -1357,8 +1357,9 @@ public class ServletApiRequest implements HttpServletRequest
         ServletChannelState state = getServletRequestInfo().getState();
         if (_async == null)
             _async = new AsyncContextState(state);
+
         ServletRequestInfo servletRequestInfo = getServletRequestInfo();
-        AsyncContextEvent event = new AsyncContextEvent(getServletRequestInfo().getServletContext(), _async, state, this, servletRequestInfo.getServletChannel().getServletContextResponse().getServletApiResponse());
+        AsyncContextEvent event = new AsyncContextEvent(getServletRequestInfo().getServletContext(), _async, state, servletRequestInfo.getServletChannel().getServletContextRequest().getServletApiRequest(), servletRequestInfo.getServletChannel().getServletContextResponse().getServletApiResponse());
         state.startAsync(event);
         return _async;
     }

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
@@ -862,7 +862,7 @@ public class ServletChannel
                 }
                 else
                 {
-                    //dispatch to original path in current context
+                    //dispatch to original path of event's request in current context
                     uri = asyncContextEvent.getBaseURI();
                     if (uri == null)
                     {

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
@@ -16,10 +16,13 @@ package org.eclipse.jetty.ee10.servlet;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.Objects;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 
 import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
 import org.eclipse.jetty.ee10.servlet.ServletChannelState.Action;
 import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HttpFields;
@@ -40,6 +43,7 @@ import org.eclipse.jetty.server.handler.ContextRequest;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.ExceptionUtil;
 import org.eclipse.jetty.util.HostPort;
+import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -826,50 +830,138 @@ public class ServletChannel
 
     public void dispatchAsync() throws Exception
     {
-        ServletContextHandler servletContextHandler = getServletContextHandler();
+        ServletContextHandler targetContextHandler = getServletContextHandler();
         ServletContextRequest servletContextRequest = getServletContextRequest();
         ServletApiRequest servletApiRequest = servletContextRequest.getServletApiRequest();
         try
         {
-            servletContextHandler.requestInitialized(servletContextRequest, servletApiRequest);
-
-            HttpURI uri;
-            String pathInContext;
             AsyncContextEvent asyncContextEvent = _state.getAsyncContextEvent();
             String dispatchString = asyncContextEvent.getDispatchPath();
-            if (dispatchString != null)
+
+            if (asyncContextEvent.getDispatchContext() instanceof CrossContextServletContext crossContextServletContext)
             {
-                String contextPath = _context.getContextPath();
-                HttpURI.Immutable dispatchUri = HttpURI.from(dispatchString);
-                pathInContext = URIUtil.canonicalPath(dispatchUri.getPath());
-                uri = HttpURI.build(servletContextRequest.getHttpURI())
-                    .path(URIUtil.addPaths(contextPath, pathInContext))
-                    .query(dispatchUri.getQuery());
+                dispatchCrossContextAsync(crossContextServletContext);
             }
-            else
+            else if (asyncContextEvent.getDispatchContext() == null)
             {
-                uri = asyncContextEvent.getBaseURI();
-                if (uri == null)
+                //the user dispatched to the current context
+                targetContextHandler.requestInitialized(servletContextRequest, servletApiRequest);
+
+                String pathInContext;
+                HttpURI uri;
+
+                if (dispatchString != null)
                 {
-                    uri = servletContextRequest.getHttpURI();
-                    pathInContext = Request.getPathInContext(servletContextRequest);
+                    //dispatch to different path in current context
+                    String contextPath = _context.getContextPath();
+                    HttpURI.Immutable dispatchUri = HttpURI.from(dispatchString);
+                    pathInContext = URIUtil.canonicalPath(dispatchUri.getPath());
+                    uri = HttpURI.build(servletContextRequest.getHttpURI())
+                        .path(URIUtil.addPaths(contextPath, pathInContext))
+                        .query(dispatchUri.getQuery());
                 }
                 else
                 {
-                    pathInContext = uri.getCanonicalPath();
-                    int length = _context.getContextPath().length();
-                    if (length > 1)
-                        pathInContext = pathInContext.substring(length);
+                    //dispatch to original path in current context
+                    uri = asyncContextEvent.getBaseURI();
+                    if (uri == null)
+                    {
+                        uri = servletContextRequest.getHttpURI();
+                        pathInContext = Request.getPathInContext(servletContextRequest);
+                    }
+                    else
+                    {
+                        pathInContext = uri.getCanonicalPath();
+                        int length = _context.getContextPath().length();
+                        if (length > 1)
+                            pathInContext = pathInContext.substring(length);
+                    }
                 }
+
+                // We first worked with the core pathInContext above, but now need to convert to servlet style
+                String decodedPathInContext = URIUtil.decodePath(pathInContext);
+                Dispatcher dispatcher = new Dispatcher(targetContextHandler, uri, decodedPathInContext);
+                dispatcher.async(asyncContextEvent.getSuppliedRequest(), asyncContextEvent.getSuppliedResponse());
             }
-            // We first worked with the core pathInContext above, but now need to convert to servlet style
-            String decodedPathInContext = URIUtil.decodePath(pathInContext);
-            Dispatcher dispatcher = new Dispatcher(servletContextHandler, uri, decodedPathInContext);
-            dispatcher.async(asyncContextEvent.getSuppliedRequest(), asyncContextEvent.getSuppliedResponse());
+            else
+            {
+                //the container has dispatched to a different context
+                ServletContext targetContext = getServletContextHandler().getServletContext().getContext(asyncContextEvent.getDispatchContext().getContextPath());
+                if (targetContext instanceof CrossContextServletContext crossContextServletContext)
+                    dispatchCrossContextAsync(crossContextServletContext);
+            }
         }
         finally
         {
-            servletContextHandler.requestDestroyed(servletContextRequest, servletApiRequest);
+            targetContextHandler.requestDestroyed(servletContextRequest, servletApiRequest);
         }
+    }
+
+    private void dispatchCrossContextAsync(CrossContextServletContext crossContextServletContext) throws ServletException, IOException
+    {
+        HttpURI uri;
+        ServletContextHandler targetContextHandler = crossContextServletContext.getTargetContext().getContextHandler();
+        AsyncContextEvent asyncContextEvent = _state.getAsyncContextEvent();
+        String dispatchPathInContext = asyncContextEvent.getDispatchPath();
+
+        if (dispatchPathInContext != null)
+        {
+            //dispatch is to a specific path
+            String encodedPathQuery = URIUtil.normalizePath(URIUtil.addEncodedPaths(targetContextHandler.getContextPath(), dispatchPathInContext));
+            if (encodedPathQuery == null)
+                throw new BadMessageException(500, "Bad dispatch path");
+
+            //Add in any query params
+            if (asyncContextEvent.getBaseURI() != null)
+            {
+                HttpURI.Mutable builder = HttpURI.build(asyncContextEvent.getBaseURI(), encodedPathQuery);
+                if (StringUtil.isEmpty(builder.getParam()))
+                    builder.param(asyncContextEvent.getBaseURI().getParam());
+                if (StringUtil.isEmpty(builder.getQuery()))
+                    builder.query(asyncContextEvent.getBaseURI().getQuery());
+
+                uri = builder.asImmutable();
+                dispatchPathInContext = uri.getPathQuery();
+            }
+            else
+            {
+                //no base request URI, do our best with the context and dispatch path
+                HttpURI.Mutable mutableHttpURI = HttpURI.build(dispatchPathInContext);
+
+                String targetContextPath = targetContextHandler.getContextPath();
+                if (!StringUtil.isEmpty(targetContextPath) && !targetContextPath.equals("/"))
+                {
+                    mutableHttpURI.path(URIUtil.addPaths(targetContextPath, mutableHttpURI.getPath()));
+                }
+                uri = mutableHttpURI.asImmutable();
+            }
+        }
+        else
+        {
+            //no dispatch path, assume path as at time of start async
+            uri = asyncContextEvent.getBaseURI();
+            String contextPath;
+            if (uri == null)
+            {
+                //use the current request's uri and the current context path to extract just the servlet path
+                uri = getServletContextRequest().getHttpURI();
+                contextPath = getContext().getContextPath();
+            }
+            else
+            {
+                //use the context path at the time of start async to extract just the servlet path
+                contextPath = asyncContextEvent.getContext().getContextPath();
+            }
+            dispatchPathInContext = uri.getCanonicalPath();
+            int length = contextPath.length();
+            if (length > 1)
+                dispatchPathInContext = dispatchPathInContext.substring(length);
+            HttpURI.Mutable mutableHttpURI = HttpURI.build(dispatchPathInContext);
+            mutableHttpURI.path(URIUtil.addPaths(targetContextHandler.getContextPath(), dispatchPathInContext));
+            uri = mutableHttpURI.asImmutable();
+        }
+
+        CrossContextDispatcher dispatcher = new CrossContextDispatcher(crossContextServletContext, uri, dispatchPathInContext);
+        dispatcher.async(asyncContextEvent.getSuppliedRequest(), asyncContextEvent.getSuppliedResponse());
     }
 }

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
@@ -828,6 +828,11 @@ public class ServletChannel
         }
     }
 
+    /**
+     * An AsyncContext dispatch method was called. We may need to dispatch to
+     * a different context.
+     * @throws Exception
+     */
     public void dispatchAsync() throws Exception
     {
         ServletContextHandler targetContextHandler = getServletContextHandler();
@@ -897,6 +902,15 @@ public class ServletChannel
         }
     }
 
+    /**
+     * Async has been started, but dispatched to a different context. This can happen
+     * either via application code calling {@link jakarta.servlet.AsyncContext#dispatch(ServletContext, String)}
+     * or the container dispatching after application code returns without having performed a dispatch or otherwise
+     * completed async.
+     * @param crossContextServletContext the special context containing both the origin context and the destination context
+     * @throws ServletException
+     * @throws IOException
+     */
     private void dispatchCrossContextAsync(CrossContextServletContext crossContextServletContext) throws ServletException, IOException
     {
         HttpURI uri;

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannelState.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannelState.java
@@ -684,8 +684,10 @@ public class ServletChannelState
                     throw new IllegalStateException(this.getStatusStringLocked());
             }
 
+            //the context will be null if {@link AsyncContext#dispatch()} or {@link AsyncContext#dispatch(String)} were called
             if (context != null)
                 _event.setDispatchContext(context);
+            //the path will be null if {@link AsyncContext#dispatch()} was called
             if (path != null)
                 _event.setDispatchPath(path);
 

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/CrossContextDispatcherFilterTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/CrossContextDispatcherFilterTest.java
@@ -156,7 +156,7 @@ public class CrossContextDispatcherFilterTest
         assertThat(eventsInOrder, ordered(expectedEvents));
     }
 
-    @Test
+     @Test
     public void testFilterInitiatedWithAsync() throws Exception
     {
         final CountDownLatch filterCompleteLatch = new CountDownLatch(1);
@@ -184,14 +184,14 @@ public class CrossContextDispatcherFilterTest
             public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException
             {
                 HttpServletRequest httpRequest = (HttpServletRequest)request;
-                events.add("Reached Filter (context=" + request.getServletContext().getContextPath() + ")");
+                events.add("Reached Filter (context=" + request.getServletContext().getContextPath() + ", Dispatchertype=" + request.getDispatcherType() + ")");
                 ServletContext otherContext = request.getServletContext().getContext("/service");
                 RequestDispatcher dispatcher = otherContext.getRequestDispatcher("/alt/foo.hello");
-                events.add("Filter Dispatcher Forward (context=" + request.getServletContext().getContextPath() + ")");
+                events.add("Filter Dispatcher Forward (context=" + request.getServletContext().getContextPath() + ", Dispatchertype=" + request.getDispatcherType() + ")");
                 events.add(" + http.requestURI=" + httpRequest.getRequestURI());
                 events.add(" + http.requestURL=" + httpRequest.getRequestURL());
                 dispatcher.forward(request, response);
-                events.add("Filter Returned from Forward Dispatch (context=" + request.getServletContext().getContextPath() + ")");
+                events.add("Filter Returned from Forward Dispatch (context=" + request.getServletContext().getContextPath() + ", Dispatchertype=" + request.getDispatcherType() + ")");
                 events.add(" - http.requestURI=" + httpRequest.getRequestURI());
                 events.add(" - http.requestURL=" + httpRequest.getRequestURL());
                 filterCompleteLatch.countDown();
@@ -205,18 +205,17 @@ public class CrossContextDispatcherFilterTest
         contextService.setContextPath("/service");
         ServletHolder serviceHolder = new ServletHolder("service-servlet", new HttpServlet()
         {
-            static final String ASYNC_CONTEXT = "async.context";
+            static final String ASYNC_FLAG_NAME = "async.flag";
 
             @Override
             protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
             {
-                events.add("Service Servlet GET (context=" + getServletContext().getContextPath() + ")");
-                AsyncContext asyncContext = (AsyncContext)req.getAttribute(ASYNC_CONTEXT);
-                if (asyncContext == null)
+                if (req.getAttribute(ASYNC_FLAG_NAME) == null)
                 {
-                    asyncContext = req.startAsync(req, resp);
-                    req.setAttribute(ASYNC_CONTEXT, asyncContext);
-                    asyncContext.setTimeout(100);
+                    events.add("Service Servlet GET (context=" + getServletContext().getContextPath() + ", Dispatchertype=" + req.getDispatcherType() + ") startAsync");
+                    AsyncContext asyncContext = req.startAsync(req, resp);
+                    req.setAttribute(ASYNC_FLAG_NAME, new Object());
+                    asyncContext.setTimeout(1000);
                     asyncContext.addListener(new AsyncListener()
                     {
                         @Override
@@ -228,7 +227,9 @@ public class CrossContextDispatcherFilterTest
                         public void onTimeout(AsyncEvent event)
                         {
                             // trigger redispatch back to this servlet
+                            events.add("Async onTimeout predispatch");
                             event.getAsyncContext().dispatch();
+                            events.add("Async onTimeout postdispatch");
                         }
 
                         @Override
@@ -244,10 +245,10 @@ public class CrossContextDispatcherFilterTest
                 }
                 else
                 {
+                    events.add("Service Servlet GET (context=" + getServletContext().getContextPath() + ", Dispatchertype=" + req.getDispatcherType() + ") afterDispatch");
                     resp.setCharacterEncoding("utf-8");
                     resp.setContentType("text/plain");
                     resp.getWriter().println("Reached Service context");
-                    asyncContext.complete();
                 }
             }
         });
@@ -272,14 +273,18 @@ public class CrossContextDispatcherFilterTest
 
         assertTrue(filterCompleteLatch.await(5, TimeUnit.SECONDS));
         List<String> expectedEvents = new ArrayList<>();
-        expectedEvents.add("Reached Filter (context=)");
-        expectedEvents.add("Filter Dispatcher Forward (context=)");
+        expectedEvents.add("Reached Filter (context=, Dispatchertype=REQUEST)");
+        expectedEvents.add("Filter Dispatcher Forward (context=, Dispatchertype=REQUEST)");
         expectedEvents.add(" + http.requestURI=/group/formal.hello");
         expectedEvents.add(" + http.requestURL=http://local/group/formal.hello");
-        expectedEvents.add("Service Servlet GET (context=/service)");
-        expectedEvents.add("Filter Returned from Forward Dispatch (context=)");
+        expectedEvents.add("Service Servlet GET (context=/service, Dispatchertype=FORWARD) startAsync");
+        expectedEvents.add("Filter Returned from Forward Dispatch (context=, Dispatchertype=REQUEST)");
         expectedEvents.add(" - http.requestURI=/group/formal.hello");
         expectedEvents.add(" - http.requestURL=http://local/group/formal.hello");
+        expectedEvents.add("Service Servlet GET (context=/service, DispatcherType=ASYNC) afterDispatch");
+        expectedEvents.add("Async onTimeout predispatch");
+        expectedEvents.add("Async onTimeout postdispatch");
+
         List<String> eventsInOrder = new ArrayList<>(events);
         assertThat(eventsInOrder, ordered(expectedEvents));
     }

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/CrossContextDispatcherFilterTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/CrossContextDispatcherFilterTest.java
@@ -283,7 +283,7 @@ public class CrossContextDispatcherFilterTest
         expectedEvents.add("Service Servlet GET (context=/service, Dispatchertype=FORWARD) startAsync");
         expectedEvents.add("Async onTimeout predispatch");
         expectedEvents.add("Async onTimeout postdispatch");
-        expectedEvents.add("Service Servlet GET (context=/service, DispatcherType=ASYNC) afterDispatch");
+        expectedEvents.add("Service Servlet GET (context=/service, Dispatchertype=ASYNC) afterDispatch");
         expectedEvents.add("Filter Returned from Forward Dispatch (context=, Dispatchertype=REQUEST)");
         expectedEvents.add(" - http.requestURI=/group/formal.hello");
         expectedEvents.add(" - http.requestURL=http://local/group/formal.hello");

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/CrossContextDispatcherFilterTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/CrossContextDispatcherFilterTest.java
@@ -270,20 +270,23 @@ public class CrossContextDispatcherFilterTest
         HttpTester.Response response = HttpTester.parseResponse(connector.getResponse(rawRequest));
         assertThat(response.getStatus(), is(200));
         assertThat(response.getContent(), containsString("Reached Service context"));
-
         assertTrue(filterCompleteLatch.await(5, TimeUnit.SECONDS));
+
+        //Note that events are in a different order than ee9: in ee10 and above the forward
+        //from the first context to the second context cannot complete until the async
+        //dispatch that is started within the second context has completed.
         List<String> expectedEvents = new ArrayList<>();
         expectedEvents.add("Reached Filter (context=, Dispatchertype=REQUEST)");
         expectedEvents.add("Filter Dispatcher Forward (context=, Dispatchertype=REQUEST)");
         expectedEvents.add(" + http.requestURI=/group/formal.hello");
         expectedEvents.add(" + http.requestURL=http://local/group/formal.hello");
         expectedEvents.add("Service Servlet GET (context=/service, Dispatchertype=FORWARD) startAsync");
+        expectedEvents.add("Async onTimeout predispatch");
+        expectedEvents.add("Async onTimeout postdispatch");
+        expectedEvents.add("Service Servlet GET (context=/service, DispatcherType=ASYNC) afterDispatch");
         expectedEvents.add("Filter Returned from Forward Dispatch (context=, Dispatchertype=REQUEST)");
         expectedEvents.add(" - http.requestURI=/group/formal.hello");
         expectedEvents.add(" - http.requestURL=http://local/group/formal.hello");
-        expectedEvents.add("Service Servlet GET (context=/service, DispatcherType=ASYNC) afterDispatch");
-        expectedEvents.add("Async onTimeout predispatch");
-        expectedEvents.add("Async onTimeout postdispatch");
 
         List<String> eventsInOrder = new ArrayList<>(events);
         assertThat(eventsInOrder, ordered(expectedEvents));

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/CrossContextDispatcherFilterTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/CrossContextDispatcherFilterTest.java
@@ -1,0 +1,286 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee10.servlet;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.AsyncEvent;
+import jakarta.servlet.AsyncListener;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.LocalConnector;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.ContextHandlerCollection;
+import org.junit.jupiter.api.Test;
+
+import static org.eclipse.jetty.toolchain.test.ExtraMatchers.ordered;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CrossContextDispatcherFilterTest
+{
+    private Server server;
+    private LocalConnector connector;
+
+    public void startServer(ContextHandlerCollection contextHandlerCollection) throws Exception
+    {
+        server = new Server();
+        connector = new LocalConnector(server);
+        connector.getConnectionFactory(HttpConfiguration.ConnectionFactory.class).getHttpConfiguration().setSendServerVersion(false);
+        connector.getConnectionFactory(HttpConfiguration.ConnectionFactory.class).getHttpConfiguration().setSendDateHeader(false);
+        server.addConnector(connector);
+
+        server.setHandler(contextHandlerCollection);
+        server.start();
+    }
+
+    @Test
+    public void testFilterInitiated() throws Exception
+    {
+        final CountDownLatch filterCompleteLatch = new CountDownLatch(1);
+        final BlockingQueue<String> events = new LinkedBlockingDeque<>();
+
+        // Root Context
+        ServletContextHandler contextRoot = new ServletContextHandler();
+        contextRoot.setCrossContextDispatchSupported(true);
+        contextRoot.setContextPath("/");
+        ServletHolder helloServlet = new ServletHolder("hello-servlet", new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                events.add("Hello Servlet GET (context=" + getServletContext().getContextPath() + ")");
+                resp.setCharacterEncoding("utf-8");
+                resp.setContentType("text/plain");
+                resp.getWriter().println("Reached HelloServlet");
+            }
+        });
+        contextRoot.addServlet(helloServlet, "*.hello");
+        FilterHolder dispatchFilter = new FilterHolder(new Filter()
+        {
+            @Override
+            public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException
+            {
+                HttpServletRequest httpRequest = (HttpServletRequest)request;
+                events.add("Reached Filter (context=" + request.getServletContext().getContextPath() + ")");
+                ServletContext otherContext = request.getServletContext().getContext("/service");
+                RequestDispatcher dispatcher = otherContext.getRequestDispatcher("/alt/foo.hello");
+                events.add("Filter Dispatcher Forward (context=" + request.getServletContext().getContextPath() + ")");
+                events.add(" + http.requestURI=" + httpRequest.getRequestURI());
+                events.add(" + http.requestURL=" + httpRequest.getRequestURL());
+                dispatcher.forward(request, response);
+                events.add("Filter Returned from Forward Dispatch (context=" + request.getServletContext().getContextPath() + ")");
+                events.add(" - http.requestURI=" + httpRequest.getRequestURI());
+                events.add(" - http.requestURL=" + httpRequest.getRequestURL());
+                filterCompleteLatch.countDown();
+            }
+        });
+        contextRoot.addFilter(dispatchFilter, "/group/*", EnumSet.of(DispatcherType.REQUEST));
+
+        // Service Context
+        ServletContextHandler contextService = new ServletContextHandler();
+        contextService.setCrossContextDispatchSupported(true);
+        contextService.setContextPath("/service");
+        ServletHolder serviceHolder = new ServletHolder("service-servlet", new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                events.add("Service Servlet GET (context=" + getServletContext().getContextPath() + ")");
+                resp.setCharacterEncoding("utf-8");
+                resp.setContentType("text/plain");
+                resp.getWriter().println("Reached Service context");
+            }
+        });
+        contextService.addServlet(serviceHolder, "/alt/*");
+
+        ContextHandlerCollection contextHandlerCollection = new ContextHandlerCollection();
+        contextHandlerCollection.addHandler(contextRoot);
+        contextHandlerCollection.addHandler(contextService);
+
+        startServer(contextHandlerCollection);
+
+        String rawRequest = """
+            GET /group/formal.hello HTTP/1.1
+            Host: local
+            Connection: close
+            
+            """;
+        HttpTester.Response response = HttpTester.parseResponse(connector.getResponse(rawRequest));
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.getContent(), containsString("Reached Service context"));
+
+        assertTrue(filterCompleteLatch.await(5, TimeUnit.SECONDS));
+        List<String> expectedEvents = new ArrayList<>();
+        expectedEvents.add("Reached Filter (context=)");
+        expectedEvents.add("Filter Dispatcher Forward (context=)");
+        expectedEvents.add(" + http.requestURI=/group/formal.hello");
+        expectedEvents.add(" + http.requestURL=http://local/group/formal.hello");
+        expectedEvents.add("Service Servlet GET (context=/service)");
+        expectedEvents.add("Filter Returned from Forward Dispatch (context=)");
+        expectedEvents.add(" - http.requestURI=/group/formal.hello");
+        expectedEvents.add(" - http.requestURL=http://local/group/formal.hello");
+        List<String> eventsInOrder = new ArrayList<>(events);
+        assertThat(eventsInOrder, ordered(expectedEvents));
+    }
+
+    @Test
+    public void testFilterInitiatedWithAsync() throws Exception
+    {
+        final CountDownLatch filterCompleteLatch = new CountDownLatch(1);
+        final BlockingQueue<String> events = new LinkedBlockingDeque<>();
+
+        // Root Context
+        ServletContextHandler contextRoot = new ServletContextHandler();
+        contextRoot.setCrossContextDispatchSupported(true);
+        contextRoot.setContextPath("/");
+        ServletHolder helloServlet = new ServletHolder("hello-servlet", new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                events.add("Hello Servlet GET (context=" + getServletContext().getContextPath() + ")");
+                resp.setCharacterEncoding("utf-8");
+                resp.setContentType("text/plain");
+                resp.getWriter().println("Reached HelloServlet");
+            }
+        });
+        contextRoot.addServlet(helloServlet, "*.hello");
+        FilterHolder dispatchFilter = new FilterHolder(new Filter()
+        {
+            @Override
+            public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException
+            {
+                HttpServletRequest httpRequest = (HttpServletRequest)request;
+                events.add("Reached Filter (context=" + request.getServletContext().getContextPath() + ")");
+                ServletContext otherContext = request.getServletContext().getContext("/service");
+                RequestDispatcher dispatcher = otherContext.getRequestDispatcher("/alt/foo.hello");
+                events.add("Filter Dispatcher Forward (context=" + request.getServletContext().getContextPath() + ")");
+                events.add(" + http.requestURI=" + httpRequest.getRequestURI());
+                events.add(" + http.requestURL=" + httpRequest.getRequestURL());
+                dispatcher.forward(request, response);
+                events.add("Filter Returned from Forward Dispatch (context=" + request.getServletContext().getContextPath() + ")");
+                events.add(" - http.requestURI=" + httpRequest.getRequestURI());
+                events.add(" - http.requestURL=" + httpRequest.getRequestURL());
+                filterCompleteLatch.countDown();
+            }
+        });
+        contextRoot.addFilter(dispatchFilter, "/group/*", EnumSet.of(DispatcherType.REQUEST));
+
+        // Service Context
+        ServletContextHandler contextService = new ServletContextHandler();
+        contextService.setCrossContextDispatchSupported(true);
+        contextService.setContextPath("/service");
+        ServletHolder serviceHolder = new ServletHolder("service-servlet", new HttpServlet()
+        {
+            static final String ASYNC_CONTEXT = "async.context";
+
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                events.add("Service Servlet GET (context=" + getServletContext().getContextPath() + ")");
+                AsyncContext asyncContext = (AsyncContext)req.getAttribute(ASYNC_CONTEXT);
+                if (asyncContext == null)
+                {
+                    asyncContext = req.startAsync(req, resp);
+                    req.setAttribute(ASYNC_CONTEXT, asyncContext);
+                    asyncContext.setTimeout(100);
+                    asyncContext.addListener(new AsyncListener()
+                    {
+                        @Override
+                        public void onComplete(AsyncEvent event)
+                        {
+                        }
+
+                        @Override
+                        public void onTimeout(AsyncEvent event)
+                        {
+                            // trigger redispatch back to this servlet
+                            event.getAsyncContext().dispatch();
+                        }
+
+                        @Override
+                        public void onError(AsyncEvent event)
+                        {
+                        }
+
+                        @Override
+                        public void onStartAsync(AsyncEvent event)
+                        {
+                        }
+                    });
+                }
+                else
+                {
+                    resp.setCharacterEncoding("utf-8");
+                    resp.setContentType("text/plain");
+                    resp.getWriter().println("Reached Service context");
+                    asyncContext.complete();
+                }
+            }
+        });
+        serviceHolder.setAsyncSupported(true);
+        contextService.addServlet(serviceHolder, "/alt/*");
+
+        ContextHandlerCollection contextHandlerCollection = new ContextHandlerCollection();
+        contextHandlerCollection.addHandler(contextRoot);
+        contextHandlerCollection.addHandler(contextService);
+
+        startServer(contextHandlerCollection);
+
+        String rawRequest = """
+            GET /group/formal.hello HTTP/1.1
+            Host: local
+            Connection: close
+            
+            """;
+        HttpTester.Response response = HttpTester.parseResponse(connector.getResponse(rawRequest));
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.getContent(), containsString("Reached Service context"));
+
+        assertTrue(filterCompleteLatch.await(5, TimeUnit.SECONDS));
+        List<String> expectedEvents = new ArrayList<>();
+        expectedEvents.add("Reached Filter (context=)");
+        expectedEvents.add("Filter Dispatcher Forward (context=)");
+        expectedEvents.add(" + http.requestURI=/group/formal.hello");
+        expectedEvents.add(" + http.requestURL=http://local/group/formal.hello");
+        expectedEvents.add("Service Servlet GET (context=/service)");
+        expectedEvents.add("Filter Returned from Forward Dispatch (context=)");
+        expectedEvents.add(" - http.requestURI=/group/formal.hello");
+        expectedEvents.add(" - http.requestURL=http://local/group/formal.hello");
+        List<String> eventsInOrder = new ArrayList<>(events);
+        assertThat(eventsInOrder, ordered(expectedEvents));
+    }
+}

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-common/src/test/java/org/eclipse/jetty/ee10/session/AsyncTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-common/src/test/java/org/eclipse/jetty/ee10/session/AsyncTest.java
@@ -15,11 +15,18 @@ package org.eclipse.jetty.ee10.session;
 
 import java.io.IOException;
 import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import jakarta.servlet.AsyncContext;
+import jakarta.servlet.AsyncEvent;
+import jakarta.servlet.AsyncListener;
+import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.ServletRequestEvent;
+import jakarta.servlet.ServletRequestListener;
 import jakarta.servlet.WriteListener;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -30,7 +37,12 @@ import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee10.servlet.ServletHolder;
+import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.logging.StacklessLogging;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.LocalConnector;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.session.DefaultSessionCacheFactory;
 import org.eclipse.jetty.session.SessionCache;
 import org.eclipse.jetty.session.SessionDataStoreFactory;
@@ -38,9 +50,13 @@ import org.eclipse.jetty.session.test.Foo;
 import org.eclipse.jetty.session.test.FooInvocationHandler;
 import org.eclipse.jetty.session.test.TestFoo;
 import org.eclipse.jetty.session.test.TestSessionDataStoreFactory;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -149,7 +165,131 @@ public class AsyncTest
         }
     }
 
-    @Disabled //TODO cross context not supported
+    @Test
+    public void testSimpleCrossContextAsync() throws Exception
+    {
+        //Test async cross context dispatch from context A to context B
+        Server server = new Server();
+        ContextHandlerCollection contextHandlerCollection = new ContextHandlerCollection();
+
+        final List<String> events = new ArrayList<>();
+
+        ServletContextHandler contextA = new ServletContextHandler();
+        contextA.addEventListener(new ServletRequestListener()
+        {
+            @Override
+            public void requestDestroyed(ServletRequestEvent sre)
+            {
+                events.add("Request Destroyed: " + sre.getServletRequest().getServletContext().getContextPath());
+                ServletRequestListener.super.requestDestroyed(sre);
+            }
+
+            @Override
+            public void requestInitialized(ServletRequestEvent sre)
+            {
+                events.add("Request Initialized: " + sre.getServletRequest().getServletContext().getContextPath());
+                ServletRequestListener.super.requestInitialized(sre);
+            }
+        });
+        contextA.setContextPath("/ctxA");
+        contextA.setCrossContextDispatchSupported(true);
+        final String ASYNC_FLAG_NAME = "async.flag";
+
+        ServletHolder serviceHolder = new ServletHolder("service-servlet", new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                if (req.getAttribute(ASYNC_FLAG_NAME) == null)
+                {
+                    AsyncContext asyncContext = req.startAsync(req, resp);
+                    req.setAttribute(ASYNC_FLAG_NAME, new Object());
+                    asyncContext.setTimeout(100);
+                    asyncContext.addListener(new AsyncListener()
+                    {
+                        @Override
+                        public void onComplete(AsyncEvent event)
+                        {
+                            events.add("ON complete");
+                        }
+
+                        @Override
+                        public void onTimeout(AsyncEvent event)
+                        {
+                            events.add("ON timeout");
+                        }
+
+                        @Override
+                        public void onError(AsyncEvent event)
+                        {
+                            events.add("ON error");
+                        }
+
+                        @Override
+                        public void onStartAsync(AsyncEvent event)
+                        {
+                            events.add("ON startasync");
+                        }
+                    });
+                    //perform cross context dispatch
+                    ServletContext destination = req.getServletContext().getContext("/ctxB");
+                    asyncContext.dispatch(destination, "/dispatched/z");
+                }
+            }
+        });
+
+        serviceHolder.setAsyncSupported(true);
+        contextA.addServlet(serviceHolder, "/dispatcher/*");
+        contextHandlerCollection.addHandler(contextA);
+
+        ServletContextHandler contextB = new ServletContextHandler();
+        contextB.setContextPath("/ctxB");
+        contextB.setCrossContextDispatchSupported(true);
+
+        ServletHolder testHolder = new ServletHolder("test-servlet", new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                resp.setCharacterEncoding("utf-8");
+                resp.setContentType("text/plain");
+                resp.getWriter().println("Dispatched to ctxB in test-servlet");
+                resp.getWriter().println(req.getQueryString());
+            }
+        });
+
+        contextB.addServlet(testHolder, "/dispatched/*");
+        contextHandlerCollection.addHandler(contextB);
+        server.setHandler(contextHandlerCollection);
+        LocalConnector connector = new LocalConnector(server);
+        connector.getConnectionFactory(HttpConfiguration.ConnectionFactory.class).getHttpConfiguration().setSendServerVersion(false);
+        connector.getConnectionFactory(HttpConfiguration.ConnectionFactory.class).getHttpConfiguration().setSendDateHeader(false);
+        server.addConnector(connector);
+
+        server.start();
+
+        try
+        {
+
+            String rawRequest = """
+                GET /ctxA/dispatcher/x?foo=bar HTTP/1.1
+                Host: local
+                Connection: close
+                            
+                """;
+
+            HttpTester.Response response = HttpTester.parseResponse(connector.getResponse(rawRequest));
+            assertThat(response.getStatus(), is(200));
+            assertThat(events, Matchers.containsInRelativeOrder("Request Initialized: /ctxA", "Request Destroyed: /ctxA"));
+            assertThat(response.getContent(), containsString("Dispatched to ctxB in test-servlet"));
+            assertThat(response.getContent(), containsString("foo=bar"));
+        }
+        finally
+        {
+            server.stop();
+        }
+    }
+
     @Test
     public void testSessionWithCrossContextAsync() throws Exception
     {
@@ -163,11 +303,13 @@ public class AsyncTest
         SessionTestSupport server = new SessionTestSupport(0, -1, -1, cacheFactory, storeFactory);
 
         ServletContextHandler contextA = server.addContext("/ctxA");
+        contextA.setCrossContextDispatchSupported(true);
         CrossContextServlet ccServlet = new CrossContextServlet();
         ServletHolder ccHolder = new ServletHolder(ccServlet);
         contextA.addServlet(ccHolder, "/*");
 
         ServletContextHandler contextB = server.addContext("/ctxB");
+        contextB.setCrossContextDispatchSupported(true);
         TestServlet testServlet = new TestServlet();
         ServletHolder testHolder = new ServletHolder(testServlet);
         contextB.addServlet(testHolder, "/*");
@@ -250,7 +392,8 @@ public class AsyncTest
         }   
     }
 
-    @Disabled //TODO cross context not supported
+
+
     @Test
     public void testSessionWithCrossContextAsyncComplete() throws Exception
     {
@@ -265,11 +408,13 @@ public class AsyncTest
         SessionTestSupport server = new SessionTestSupport(0, -1, -1, cacheFactory, storeFactory);
 
         ServletContextHandler contextA = server.addContext("/ctxA");
+        contextA.setCrossContextDispatchSupported(true);
         CrossContextServlet ccServlet = new CrossContextServlet();
         ServletHolder ccHolder = new ServletHolder(ccServlet);
         contextA.addServlet(ccHolder, "/*");
 
         ServletContextHandler contextB = server.addContext("/ctxB");
+        contextB.setCrossContextDispatchSupported(true);
         TestServlet testServlet = new TestServlet();
         ServletHolder testHolder = new ServletHolder(testServlet);
         contextB.addServlet(testHolder, "/*");
@@ -280,7 +425,6 @@ public class AsyncTest
 
         try (StacklessLogging stackless = new StacklessLogging(AsyncTest.class.getPackage()))
         {
-
             client.start();
             String url = "http://localhost:" + port + "/ctxA/test?action=asyncComplete";
 
@@ -384,7 +528,7 @@ public class AsyncTest
                     @Override
                     public void onError(Throwable t)
                     {
-
+                        t.printStackTrace();
                     }
                 });
             }

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-common/src/test/java/org/eclipse/jetty/ee10/session/AsyncTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-common/src/test/java/org/eclipse/jetty/ee10/session/AsyncTest.java
@@ -392,8 +392,6 @@ public class AsyncTest
         }   
     }
 
-
-
     @Test
     public void testSessionWithCrossContextAsyncComplete() throws Exception
     {

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-common/src/test/java/org/eclipse/jetty/ee10/session/AsyncTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-common/src/test/java/org/eclipse/jetty/ee10/session/AsyncTest.java
@@ -398,8 +398,12 @@ public class AsyncTest
     public void testSessionWithCrossContextAsyncComplete() throws Exception
     {
         // Test async dispatch from context A to context B, which then does an
-        // async write, which creates a session (in context A) and completes outside of a
-        // dispatch
+        // async write, which creates a session and completes outside of a
+        // dispatch. Note that the session will be created in context B, because
+        // requests are immutable: the request that called startAsync retains its
+        // pathInContext etc. In earlier versions of the Servlet Spec, the request
+        // will have been mutated back to it's pre-async dispatch pathInContext
+        // etc after returning to the container and concluding the async dispatch.
 
         DefaultSessionCacheFactory cacheFactory = new DefaultSessionCacheFactory();
         cacheFactory.setEvictionPolicy(SessionCache.EVICT_ON_SESSION_EXIT);
@@ -436,11 +440,11 @@ public class AsyncTest
 
             assertNotNull(sessionCookie);
 
-            //session should now be evicted from the cache A after request exited
+            //session should now be evicted from the ctx B sessioncache after request exited
             String id = SessionTestSupport.extractSessionId(sessionCookie);
             Awaitility.await().atMost(30, TimeUnit.SECONDS)
-                .until(() -> !contextA.getSessionHandler().getSessionCache().contains(id));
-            assertTrue(contextA.getSessionHandler().getSessionCache().getSessionDataStore().exists(id));
+                .until(() -> !contextB.getSessionHandler().getSessionCache().contains(id));
+            assertTrue(contextB.getSessionHandler().getSessionCache().getSessionDataStore().exists(id));
         }
         finally
         {
@@ -519,6 +523,8 @@ public class AsyncTest
                     {
                         if (out.isReady())
                         {
+                            //This is a really BAD idea. You should not be creating a
+                            //new session when you are supposed to be producing output.
                             HttpSession s = request.getSession(true);
                             out.print("OK\n");
                             acontext.complete();

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/AsyncContextState.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/AsyncContextState.java
@@ -22,6 +22,7 @@ import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
+import org.eclipse.jetty.util.TypeUtil;
 
 public class AsyncContextState implements AsyncContext
 {
@@ -157,6 +158,12 @@ public class AsyncContextState implements AsyncContext
     public HttpChannelState getHttpChannelState()
     {
         return state();
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("%s@%h(state=%s,channel=%s)", TypeUtil.toShortName(AsyncContextState.class), hashCode(), _state, _channel);
     }
 
     public static class WrappedAsyncListener implements AsyncListener

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
@@ -1738,7 +1738,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
     {
         AsyncContextEvent event = channel.getState().getAsyncContextEvent();
 
-        //if dispatch to ee9, then we must mutate the request
+        // we must mutate the request
         Request request = event.getHttpChannelState().getBaseRequest();
         HttpURI baseUri = event.getBaseURI();
         APIContext oldContext = request.getContext();
@@ -1746,7 +1746,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
         String oldPathInContext = request.getPathInContext();
         Fields oldQueryFields = request.getQueryFields();
 
-        //the path in the target context (encoded with possible query string)
+        //the path in the context (encoded with possible query string)
         String encodedPathQuery = event.getDispatchPath();
         if (encodedPathQuery == null && baseUri == null)
         {

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
@@ -1728,6 +1728,75 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
     {
     }
 
+    /** A request has come in via an async dispatch from a different context.
+     *
+     * @param channel the HttpChannel associated with the request
+     * @throws IOException
+     * @throws ServletException
+     */
+    public void handleCrossContextAsync(HttpChannel channel) throws IOException, ServletException
+    {
+        AsyncContextEvent event = channel.getState().getAsyncContextEvent();
+
+        //if dispatch to ee9, then we must mutate the request
+        Request request = event.getHttpChannelState().getBaseRequest();
+        HttpURI baseUri = event.getBaseURI();
+        APIContext oldContext = request.getContext();
+        HttpURI oldURI = request.getHttpURI();
+        String oldPathInContext = request.getPathInContext();
+        Fields oldQueryFields = request.getQueryFields();
+
+        //the path in the target context (encoded with possible query string)
+        String encodedPathQuery = event.getDispatchPath();
+        if (encodedPathQuery == null && baseUri == null)
+        {
+            //TODO - what would this mean?
+        }
+        else
+        {
+            try
+            {
+                if (encodedPathQuery == null)
+                {
+                    request.setHttpURI(baseUri);
+                }
+                else
+                {
+                    String encodedContextPath = URIUtil.encodePath(getContextPath());
+                    if (!StringUtil.isEmpty(encodedContextPath))
+                    {
+                        encodedPathQuery = URIUtil.canonicalPath(URIUtil.addEncodedPaths(encodedContextPath, encodedPathQuery));
+                        if (encodedPathQuery == null)
+                            throw new BadMessageException(500, "Bad dispatch path");
+                    }
+
+                    if (baseUri == null)
+                        baseUri = request.getHttpURI();
+                    HttpURI.Mutable builder = HttpURI.build(baseUri, encodedPathQuery);
+
+                    if (StringUtil.isEmpty(builder.getParam()))
+                        builder.param(baseUri.getParam());
+                    if (StringUtil.isEmpty(builder.getQuery()))
+                        builder.query(baseUri.getQuery());
+
+                    request.setHttpURI(builder);
+
+                    if (baseUri.getQuery() != null && request.getQueryString() != null)
+                        request.mergeQueryParameters(request.getHttpURI().getQuery(), request.getQueryString());
+                }
+
+                request.setContext(_apiContext, event.getDispatchPath());
+                handleAsync(channel, event, request);
+            }
+            finally
+            {
+                request.setContext(oldContext, oldPathInContext);
+                request.setHttpURI(oldURI);
+                request.setQueryFields(oldQueryFields);
+            }
+        }
+    }
+
     /* Handle a request from a connection.
      * Called to handle a request on the connection when either the header has been received,
      * or after the entire request has been received (for short requests of known length), or

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
@@ -1573,19 +1573,19 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
         {
             AsyncContextEvent event = HttpChannel.this.getState().getAsyncContextEvent();
 
-            //dispatch to the same context
+            //the user has dispatched to the same current context
             if (event == null || event.getDispatchContext() == null || event.getDispatchContext() == _contextHandler.getServletContext())
                 _contextHandler.handleAsync(HttpChannel.this);
             else
             {
-                //dispatch to different context (in same environment)
+                //the user has dispatched to a different context
                 if (event.getDispatchContext() instanceof CrossContextServletContext crossContextServletContext)
                 {
                    dispatchCrossContext(crossContextServletContext);
                 }
                 else
                 {
-                    //we are in a different context to the one that should be dispatched
+                    //the container has dispatched us to a different context
                     ServletContext targetContext = _contextHandler.getServletContext().getContext(event.getDispatchContext().getContextPath());
                     if (targetContext instanceof CrossContextServletContext crossContextServletContext)
                         dispatchCrossContext(crossContextServletContext);

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
@@ -32,6 +32,7 @@ import java.util.stream.Stream;
 
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
 import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HttpException;
@@ -1570,7 +1571,36 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
         @Override
         public void dispatch() throws IOException, ServletException
         {
-            _contextHandler.handleAsync(HttpChannel.this);
+            AsyncContextEvent event = HttpChannel.this.getState().getAsyncContextEvent();
+
+            //dispatch to the same context
+            if (event == null || event.getDispatchContext() == null || event.getDispatchContext() == _contextHandler.getServletContext())
+                _contextHandler.handleAsync(HttpChannel.this);
+            else
+            {
+                //dispatch to different context (in same environment)
+                if (event.getDispatchContext() instanceof CrossContextServletContext crossContextServletContext)
+                {
+                   dispatchCrossContext(crossContextServletContext);
+                }
+                else
+                {
+                    //we are in a different context to the one that should be dispatched
+                    ServletContext targetContext = _contextHandler.getServletContext().getContext(event.getDispatchContext().getContextPath());
+                    if (targetContext instanceof CrossContextServletContext crossContextServletContext)
+                        dispatchCrossContext(crossContextServletContext);
+                    else
+                        throw new IllegalStateException("Dispatch " + _contextHandler.getContextPath() + " -> non CrossContextServletContext" + event.getDispatchContext().getContextPath() + event.getDispatchContext());
+                }
+            }
+        }
+
+        private void dispatchCrossContext(CrossContextServletContext crossContextServletContext) throws ServletException, IOException
+        {
+            if (crossContextServletContext.getTargetContext().getContextHandler() instanceof ContextHandler.CoreContextHandler coreContextHandler)
+            {
+                coreContextHandler.getContextHandler().handleCrossContextAsync(HttpChannel.this);
+            }
         }
     }
 

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannelState.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannelState.java
@@ -1235,9 +1235,14 @@ public class HttpChannelState
     {
         if (event != null)
         {
-            ContextHandler.APIContext context = ((ContextHandler.APIContext)event.getServletContext());
-            if (context != null)
-                return context.getContextHandler();
+            ServletContext servletContext = event.getServletContext();
+            if (servletContext instanceof CrossContextServletContext crossContextServletContext)
+            {
+                if (crossContextServletContext.getTargetContext().getContextHandler() instanceof ContextHandler.CoreContextHandler coreContextHandler)
+                    return  coreContextHandler.getContextHandler();
+            }
+            if (servletContext instanceof ContextHandler.APIContext apiContext)
+                return apiContext.getContextHandler();
         }
         return null;
     }

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
@@ -1944,6 +1944,8 @@ public class Request implements HttpServletRequest
         if (_async == null)
             _async = new AsyncContextState(state);
         AsyncContextEvent event = new AsyncContextEvent(_context, _async, state, this, this, getResponse());
+        event.setDispatchContext(getServletContext());
+        event.setDispatchPath(state.getBaseRequest().getPathInContext());
         state.startAsync(event);
         return _async;
     }
@@ -1957,6 +1959,7 @@ public class Request implements HttpServletRequest
         if (_async == null)
             _async = new AsyncContextState(state);
         AsyncContextEvent event = new AsyncContextEvent(_context, _async, state, this, servletRequest, servletResponse, getHttpURI());
+        event.setDispatchPath(Request.getBaseRequest(servletRequest).getPathInContext());
         event.setDispatchContext(getServletContext());
         state.startAsync(event);
         return _async;

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
@@ -1944,8 +1944,8 @@ public class Request implements HttpServletRequest
         if (_async == null)
             _async = new AsyncContextState(state);
         AsyncContextEvent event = new AsyncContextEvent(_context, _async, state, this, this, getResponse());
-        event.setDispatchContext(getServletContext());
-        event.setDispatchPath(state.getBaseRequest().getPathInContext());
+        //Note that we do not remember the context, httpuri or the path, as null values for these are used by
+        //ContextHandler.handleAsync to recognize a non-cross context async dispatch
         state.startAsync(event);
         return _async;
     }
@@ -1959,7 +1959,7 @@ public class Request implements HttpServletRequest
         if (_async == null)
             _async = new AsyncContextState(state);
         AsyncContextEvent event = new AsyncContextEvent(_context, _async, state, this, servletRequest, servletResponse, getHttpURI());
-        event.setDispatchPath(Request.getBaseRequest(servletRequest).getPathInContext());
+        event.setDispatchPath(URIUtil.encodePath(Request.getBaseRequest(servletRequest).getPathInContext()));
         event.setDispatchContext(getServletContext());
         state.startAsync(event);
         return _async;

--- a/jetty-ee9/jetty-ee9-servlet/pom.xml
+++ b/jetty-ee9/jetty-ee9-servlet/pom.xml
@@ -74,7 +74,6 @@
         <configuration>
           <reuseForks>true</reuseForks>
           <argLine>@{argLine} ${jetty.surefire.argLine}
-            --add-modules org.eclipse.jetty.util.ajax
             --add-reads org.eclipse.jetty.ee9.servlet=org.eclipse.jetty.logging</argLine>
         </configuration>
       </plugin>

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/CrossContextDispatcherFilterTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/CrossContextDispatcherFilterTest.java
@@ -205,17 +205,16 @@ public class CrossContextDispatcherFilterTest
         contextService.setContextPath("/service");
         ServletHolder serviceHolder = new ServletHolder("service-servlet", new HttpServlet()
         {
-            static final String ASYNC_CONTEXT = "async.context";
+            static final String ASYNC_FLAG_NAME = "async.flag";
 
             @Override
             protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
             {
-                events.add("Service Servlet GET (context=" + getServletContext().getContextPath() + ")");
-                AsyncContext asyncContext = (AsyncContext)req.getAttribute(ASYNC_CONTEXT);
-                if (asyncContext == null)
+                if (req.getAttribute(ASYNC_FLAG_NAME) == null)
                 {
-                    asyncContext = req.startAsync(req, resp);
-                    req.setAttribute(ASYNC_CONTEXT, asyncContext);
+                    events.add("Service Servlet GET (context=" + getServletContext().getContextPath() + ") startAsync");
+                    AsyncContext asyncContext = req.startAsync(req, resp);
+                    req.setAttribute(ASYNC_FLAG_NAME, new Object());
                     asyncContext.setTimeout(100);
                     asyncContext.addListener(new AsyncListener()
                     {
@@ -244,10 +243,10 @@ public class CrossContextDispatcherFilterTest
                 }
                 else
                 {
+                    events.add("Service Servlet GET (context=" + getServletContext().getContextPath() + ") afterDispatch");
                     resp.setCharacterEncoding("utf-8");
                     resp.setContentType("text/plain");
                     resp.getWriter().println("Reached Service context");
-                    asyncContext.complete();
                 }
             }
         });
@@ -276,10 +275,11 @@ public class CrossContextDispatcherFilterTest
         expectedEvents.add("Filter Dispatcher Forward (context=)");
         expectedEvents.add(" + http.requestURI=/group/formal.hello");
         expectedEvents.add(" + http.requestURL=http://local/group/formal.hello");
-        expectedEvents.add("Service Servlet GET (context=/service)");
+        expectedEvents.add("Service Servlet GET (context=/service) startAsync");
         expectedEvents.add("Filter Returned from Forward Dispatch (context=)");
         expectedEvents.add(" - http.requestURI=/group/formal.hello");
         expectedEvents.add(" - http.requestURL=http://local/group/formal.hello");
+        expectedEvents.add("Service Servlet GET (context=/service) afterDispatch");
         List<String> eventsInOrder = new ArrayList<>(events);
         assertThat(eventsInOrder, ordered(expectedEvents));
     }

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/CrossContextDispatcherFilterTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/CrossContextDispatcherFilterTest.java
@@ -1,0 +1,286 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee9.servlet;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.AsyncEvent;
+import jakarta.servlet.AsyncListener;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.LocalConnector;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.ContextHandlerCollection;
+import org.junit.jupiter.api.Test;
+
+import static org.eclipse.jetty.toolchain.test.ExtraMatchers.ordered;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CrossContextDispatcherFilterTest
+{
+    private Server server;
+    private LocalConnector connector;
+
+    public void startServer(ContextHandlerCollection contextHandlerCollection) throws Exception
+    {
+        server = new Server();
+        connector = new LocalConnector(server);
+        connector.getConnectionFactory(HttpConfiguration.ConnectionFactory.class).getHttpConfiguration().setSendServerVersion(false);
+        connector.getConnectionFactory(HttpConfiguration.ConnectionFactory.class).getHttpConfiguration().setSendDateHeader(false);
+        server.addConnector(connector);
+
+        server.setHandler(contextHandlerCollection);
+        server.start();
+    }
+
+    @Test
+    public void testFilterInitiated() throws Exception
+    {
+        final CountDownLatch filterCompleteLatch = new CountDownLatch(1);
+        final BlockingQueue<String> events = new LinkedBlockingDeque<>();
+
+        // Root Context
+        ServletContextHandler contextRoot = new ServletContextHandler();
+        contextRoot.setCrossContextDispatchSupported(true);
+        contextRoot.setContextPath("/");
+        ServletHolder helloServlet = new ServletHolder("hello-servlet", new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                events.add("Hello Servlet GET (context=" + getServletContext().getContextPath() + ")");
+                resp.setCharacterEncoding("utf-8");
+                resp.setContentType("text/plain");
+                resp.getWriter().println("Reached HelloServlet");
+            }
+        });
+        contextRoot.addServlet(helloServlet, "*.hello");
+        FilterHolder dispatchFilter = new FilterHolder(new Filter()
+        {
+            @Override
+            public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException
+            {
+                HttpServletRequest httpRequest = (HttpServletRequest)request;
+                events.add("Reached Filter (context=" + request.getServletContext().getContextPath() + ")");
+                ServletContext otherContext = request.getServletContext().getContext("/service");
+                RequestDispatcher dispatcher = otherContext.getRequestDispatcher("/alt/foo.hello");
+                events.add("Filter Dispatcher Forward (context=" + request.getServletContext().getContextPath() + ")");
+                events.add(" + http.requestURI=" + httpRequest.getRequestURI());
+                events.add(" + http.requestURL=" + httpRequest.getRequestURL());
+                dispatcher.forward(request, response);
+                events.add("Filter Returned from Forward Dispatch (context=" + request.getServletContext().getContextPath() + ")");
+                events.add(" - http.requestURI=" + httpRequest.getRequestURI());
+                events.add(" - http.requestURL=" + httpRequest.getRequestURL());
+                filterCompleteLatch.countDown();
+            }
+        });
+        contextRoot.addFilter(dispatchFilter, "/group/*", EnumSet.of(DispatcherType.REQUEST));
+
+        // Service Context
+        ServletContextHandler contextService = new ServletContextHandler();
+        contextService.setCrossContextDispatchSupported(true);
+        contextService.setContextPath("/service");
+        ServletHolder serviceHolder = new ServletHolder("service-servlet", new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                events.add("Service Servlet GET (context=" + getServletContext().getContextPath() + ")");
+                resp.setCharacterEncoding("utf-8");
+                resp.setContentType("text/plain");
+                resp.getWriter().println("Reached Service context");
+            }
+        });
+        contextService.addServlet(serviceHolder, "/alt/*");
+
+        ContextHandlerCollection contextHandlerCollection = new ContextHandlerCollection();
+        contextHandlerCollection.addHandler(contextRoot);
+        contextHandlerCollection.addHandler(contextService);
+
+        startServer(contextHandlerCollection);
+
+        String rawRequest = """
+            GET /group/formal.hello HTTP/1.1
+            Host: local
+            Connection: close
+            
+            """;
+        HttpTester.Response response = HttpTester.parseResponse(connector.getResponse(rawRequest));
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.getContent(), containsString("Reached Service context"));
+
+        assertTrue(filterCompleteLatch.await(5, TimeUnit.SECONDS));
+        List<String> expectedEvents = new ArrayList<>();
+        expectedEvents.add("Reached Filter (context=)");
+        expectedEvents.add("Filter Dispatcher Forward (context=)");
+        expectedEvents.add(" + http.requestURI=/group/formal.hello");
+        expectedEvents.add(" + http.requestURL=http://local/group/formal.hello");
+        expectedEvents.add("Service Servlet GET (context=/service)");
+        expectedEvents.add("Filter Returned from Forward Dispatch (context=)");
+        expectedEvents.add(" - http.requestURI=/group/formal.hello");
+        expectedEvents.add(" - http.requestURL=http://local/group/formal.hello");
+        List<String> eventsInOrder = new ArrayList<>(events);
+        assertThat(eventsInOrder, ordered(expectedEvents));
+    }
+
+    @Test
+    public void testFilterInitiatedWithAsync() throws Exception
+    {
+        final CountDownLatch filterCompleteLatch = new CountDownLatch(1);
+        final BlockingQueue<String> events = new LinkedBlockingDeque<>();
+
+        // Root Context
+        ServletContextHandler contextRoot = new ServletContextHandler();
+        contextRoot.setCrossContextDispatchSupported(true);
+        contextRoot.setContextPath("/");
+        ServletHolder helloServlet = new ServletHolder("hello-servlet", new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                events.add("Hello Servlet GET (context=" + getServletContext().getContextPath() + ")");
+                resp.setCharacterEncoding("utf-8");
+                resp.setContentType("text/plain");
+                resp.getWriter().println("Reached HelloServlet");
+            }
+        });
+        contextRoot.addServlet(helloServlet, "*.hello");
+        FilterHolder dispatchFilter = new FilterHolder(new Filter()
+        {
+            @Override
+            public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException
+            {
+                HttpServletRequest httpRequest = (HttpServletRequest)request;
+                events.add("Reached Filter (context=" + request.getServletContext().getContextPath() + ")");
+                ServletContext otherContext = request.getServletContext().getContext("/service");
+                RequestDispatcher dispatcher = otherContext.getRequestDispatcher("/alt/foo.hello");
+                events.add("Filter Dispatcher Forward (context=" + request.getServletContext().getContextPath() + ")");
+                events.add(" + http.requestURI=" + httpRequest.getRequestURI());
+                events.add(" + http.requestURL=" + httpRequest.getRequestURL());
+                dispatcher.forward(request, response);
+                events.add("Filter Returned from Forward Dispatch (context=" + request.getServletContext().getContextPath() + ")");
+                events.add(" - http.requestURI=" + httpRequest.getRequestURI());
+                events.add(" - http.requestURL=" + httpRequest.getRequestURL());
+                filterCompleteLatch.countDown();
+            }
+        });
+        contextRoot.addFilter(dispatchFilter, "/group/*", EnumSet.of(DispatcherType.REQUEST));
+
+        // Service Context
+        ServletContextHandler contextService = new ServletContextHandler();
+        contextService.setCrossContextDispatchSupported(true);
+        contextService.setContextPath("/service");
+        ServletHolder serviceHolder = new ServletHolder("service-servlet", new HttpServlet()
+        {
+            final static String ASYNC_CONTEXT = "async.context";
+
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                events.add("Service Servlet GET (context=" + getServletContext().getContextPath() + ")");
+                AsyncContext asyncContext = (AsyncContext)req.getAttribute(ASYNC_CONTEXT);
+                if (asyncContext == null)
+                {
+                    asyncContext = req.startAsync(req, resp);
+                    req.setAttribute(ASYNC_CONTEXT, asyncContext);
+                    asyncContext.setTimeout(100);
+                    asyncContext.addListener(new AsyncListener()
+                    {
+                        @Override
+                        public void onComplete(AsyncEvent event)
+                        {
+                        }
+
+                        @Override
+                        public void onTimeout(AsyncEvent event)
+                        {
+                            // trigger redispatch back to this servlet
+                            event.getAsyncContext().dispatch();
+                        }
+
+                        @Override
+                        public void onError(AsyncEvent event)
+                        {
+                        }
+
+                        @Override
+                        public void onStartAsync(AsyncEvent event)
+                        {
+                        }
+                    });
+                }
+                else
+                {
+                    resp.setCharacterEncoding("utf-8");
+                    resp.setContentType("text/plain");
+                    resp.getWriter().println("Reached Service context");
+                    asyncContext.complete();
+                }
+            }
+        });
+        serviceHolder.setAsyncSupported(true);
+        contextService.addServlet(serviceHolder, "/alt/*");
+
+        ContextHandlerCollection contextHandlerCollection = new ContextHandlerCollection();
+        contextHandlerCollection.addHandler(contextRoot);
+        contextHandlerCollection.addHandler(contextService);
+
+        startServer(contextHandlerCollection);
+
+        String rawRequest = """
+            GET /group/formal.hello HTTP/1.1
+            Host: local
+            Connection: close
+            
+            """;
+        HttpTester.Response response = HttpTester.parseResponse(connector.getResponse(rawRequest));
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.getContent(), containsString("Reached Service context"));
+
+        assertTrue(filterCompleteLatch.await(5, TimeUnit.SECONDS));
+        List<String> expectedEvents = new ArrayList<>();
+        expectedEvents.add("Reached Filter (context=)");
+        expectedEvents.add("Filter Dispatcher Forward (context=)");
+        expectedEvents.add(" + http.requestURI=/group/formal.hello");
+        expectedEvents.add(" + http.requestURL=http://local/group/formal.hello");
+        expectedEvents.add("Service Servlet GET (context=/service)");
+        expectedEvents.add("Filter Returned from Forward Dispatch (context=)");
+        expectedEvents.add(" - http.requestURI=/group/formal.hello");
+        expectedEvents.add(" - http.requestURL=http://local/group/formal.hello");
+        List<String> eventsInOrder = new ArrayList<>(events);
+        assertThat(eventsInOrder, ordered(expectedEvents));
+    }
+}

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/CrossContextDispatcherFilterTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/CrossContextDispatcherFilterTest.java
@@ -227,7 +227,9 @@ public class CrossContextDispatcherFilterTest
                         public void onTimeout(AsyncEvent event)
                         {
                             // trigger redispatch back to this servlet
+                            events.add("Async onTimeout predispatch");
                             event.getAsyncContext().dispatch();
+                            events.add("Async onTimeout postdispatch");
                         }
 
                         @Override
@@ -279,6 +281,8 @@ public class CrossContextDispatcherFilterTest
         expectedEvents.add("Filter Returned from Forward Dispatch (context=)");
         expectedEvents.add(" - http.requestURI=/group/formal.hello");
         expectedEvents.add(" - http.requestURL=http://local/group/formal.hello");
+        expectedEvents.add("Async onTimeout predispatch");
+        expectedEvents.add("Async onTimeout postdispatch");
         expectedEvents.add("Service Servlet GET (context=/service) afterDispatch");
         List<String> eventsInOrder = new ArrayList<>(events);
         assertThat(eventsInOrder, ordered(expectedEvents));

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/CrossContextDispatcherFilterTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/CrossContextDispatcherFilterTest.java
@@ -205,7 +205,7 @@ public class CrossContextDispatcherFilterTest
         contextService.setContextPath("/service");
         ServletHolder serviceHolder = new ServletHolder("service-servlet", new HttpServlet()
         {
-            final static String ASYNC_CONTEXT = "async.context";
+            static final String ASYNC_CONTEXT = "async.context";
 
             @Override
             protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-common/src/test/java/org/eclipse/jetty/ee9/session/AsyncTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-common/src/test/java/org/eclipse/jetty/ee9/session/AsyncTest.java
@@ -15,11 +15,18 @@ package org.eclipse.jetty.ee9.session;
 
 import java.io.IOException;
 import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import jakarta.servlet.AsyncContext;
+import jakarta.servlet.AsyncEvent;
+import jakarta.servlet.AsyncListener;
+import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.ServletRequestEvent;
+import jakarta.servlet.ServletRequestListener;
 import jakarta.servlet.WriteListener;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -30,7 +37,12 @@ import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee9.servlet.ServletHolder;
+import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.logging.StacklessLogging;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.LocalConnector;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.session.DefaultSessionCacheFactory;
 import org.eclipse.jetty.session.SessionCache;
 import org.eclipse.jetty.session.SessionDataStoreFactory;
@@ -38,9 +50,12 @@ import org.eclipse.jetty.session.test.Foo;
 import org.eclipse.jetty.session.test.FooInvocationHandler;
 import org.eclipse.jetty.session.test.TestFoo;
 import org.eclipse.jetty.session.test.TestSessionDataStoreFactory;
-import org.junit.jupiter.api.Disabled;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -145,7 +160,130 @@ public class AsyncTest
         }
     }
 
-    @Disabled //TODO cross context not supported
+    @Test
+    public void testSimpleCrossContextAsync() throws Exception
+    {
+        //Test async cross context dispatch from context A to context B
+        Server server = new Server();
+        ContextHandlerCollection contextHandlerCollection = new ContextHandlerCollection();
+
+        final List<String> events = new ArrayList<>();
+
+        ServletContextHandler contextA = new ServletContextHandler();
+        contextA.addEventListener(new ServletRequestListener()
+        {
+            @Override
+            public void requestDestroyed(ServletRequestEvent sre)
+            {
+                events.add("Request Destroyed: " + sre.getServletRequest().getServletContext().getContextPath());
+                ServletRequestListener.super.requestDestroyed(sre);
+            }
+
+            @Override
+            public void requestInitialized(ServletRequestEvent sre)
+            {
+                events.add("Request Initialized: " + sre.getServletRequest().getServletContext().getContextPath());
+                ServletRequestListener.super.requestInitialized(sre);
+            }
+        });
+        contextA.setContextPath("/ctxA");
+        contextA.setCrossContextDispatchSupported(true);
+        final String ASYNC_FLAG_NAME = "async.flag";
+
+        ServletHolder serviceHolder = new ServletHolder("service-servlet", new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                if (req.getAttribute(ASYNC_FLAG_NAME) == null)
+                {
+                    AsyncContext asyncContext = req.startAsync(req, resp);
+                    req.setAttribute(ASYNC_FLAG_NAME, new Object());
+                    asyncContext.setTimeout(100);
+                    asyncContext.addListener(new AsyncListener()
+                    {
+                        @Override
+                        public void onComplete(AsyncEvent event)
+                        {
+                            events.add("ON complete");
+                        }
+
+                        @Override
+                        public void onTimeout(AsyncEvent event)
+                        {
+                            events.add("ON timeout");
+                        }
+
+                        @Override
+                        public void onError(AsyncEvent event)
+                        {
+                            events.add("ON error");
+                        }
+
+                        @Override
+                        public void onStartAsync(AsyncEvent event)
+                        {
+                            events.add("ON startasync");
+                        }
+                    });
+                    //perform cross context dispatch
+                    ServletContext destination = req.getServletContext().getContext("/ctxB");
+                    asyncContext.dispatch(destination, "/dispatched/z");
+                }
+            }
+        });
+
+        serviceHolder.setAsyncSupported(true);
+        contextA.addServlet(serviceHolder, "/dispatcher/*");
+        contextHandlerCollection.addHandler(contextA);
+
+        ServletContextHandler contextB = new ServletContextHandler();
+        contextB.setContextPath("/ctxB");
+        contextB.setCrossContextDispatchSupported(true);
+
+        ServletHolder testHolder = new ServletHolder("test-servlet", new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                AsyncContext asyncContext = (AsyncContext)req.getAttribute(ASYNC_FLAG_NAME);
+                resp.setCharacterEncoding("utf-8");
+                resp.setContentType("text/plain");
+                resp.getWriter().println("Dispatched to ctxB in test-servlet");
+            }
+        });
+
+        contextB.addServlet(testHolder, "/dispatched/*");
+        contextHandlerCollection.addHandler(contextB);
+        server.setHandler(contextHandlerCollection);
+        LocalConnector connector = new LocalConnector(server);
+        connector.getConnectionFactory(HttpConfiguration.ConnectionFactory.class).getHttpConfiguration().setSendServerVersion(false);
+        connector.getConnectionFactory(HttpConfiguration.ConnectionFactory.class).getHttpConfiguration().setSendDateHeader(false);
+        server.addConnector(connector);
+
+        server.start();
+
+        try
+        {
+
+            String rawRequest = """
+                GET /ctxA/dispatcher/x HTTP/1.1
+                Host: local
+                Connection: close
+                            
+                """;
+
+            HttpTester.Response response = HttpTester.parseResponse(connector.getResponse(rawRequest));
+            assertThat(response.getStatus(), is(200));
+            assertThat(events, Matchers.containsInRelativeOrder("Request Initialized: /ctxA", "Request Destroyed: /ctxA"));
+            assertThat(response.getContent(), containsString("Dispatched to ctxB in test-servlet"));
+        }
+        finally
+        {
+            server.stop();
+        }
+    }
+
     @Test
     public void testSessionWithCrossContextAsync() throws Exception
     {
@@ -160,10 +298,12 @@ public class AsyncTest
 
         ServletContextHandler contextA = server.addContext("/ctxA");
         CrossContextServlet ccServlet = new CrossContextServlet();
+        contextA.setCrossContextDispatchSupported(true);
         ServletHolder ccHolder = new ServletHolder(ccServlet);
         contextA.addServlet(ccHolder, "/*");
 
         ServletContextHandler contextB = server.addContext("/ctxB");
+        contextB.setCrossContextDispatchSupported(true);
         TestServlet testServlet = new TestServlet();
         ServletHolder testHolder = new ServletHolder(testServlet);
         contextB.addServlet(testHolder, "/*");
@@ -244,7 +384,6 @@ public class AsyncTest
         }   
     }
 
-    @Disabled //TODO cross context not supported
     @Test
     public void testSessionWithCrossContextAsyncComplete() throws Exception
     {
@@ -259,11 +398,13 @@ public class AsyncTest
         SessionTestSupport server = new SessionTestSupport(0, -1, -1, cacheFactory, storeFactory);
 
         ServletContextHandler contextA = server.addContext("/ctxA");
+        contextA.setCrossContextDispatchSupported(true);
         CrossContextServlet ccServlet = new CrossContextServlet();
         ServletHolder ccHolder = new ServletHolder(ccServlet);
         contextA.addServlet(ccHolder, "/*");
 
         ServletContextHandler contextB = server.addContext("/ctxB");
+        contextB.setCrossContextDispatchSupported(true);
         TestServlet testServlet = new TestServlet();
         ServletHolder testHolder = new ServletHolder(testServlet);
         contextB.addServlet(testHolder, "/*");

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-common/src/test/java/org/eclipse/jetty/ee9/session/AsyncTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-common/src/test/java/org/eclipse/jetty/ee9/session/AsyncTest.java
@@ -246,10 +246,10 @@ public class AsyncTest
             @Override
             protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
             {
-                AsyncContext asyncContext = (AsyncContext)req.getAttribute(ASYNC_FLAG_NAME);
                 resp.setCharacterEncoding("utf-8");
                 resp.setContentType("text/plain");
                 resp.getWriter().println("Dispatched to ctxB in test-servlet");
+                resp.getWriter().println(req.getQueryString());
             }
         });
 
@@ -267,7 +267,7 @@ public class AsyncTest
         {
 
             String rawRequest = """
-                GET /ctxA/dispatcher/x HTTP/1.1
+                GET /ctxA/dispatcher/x?foo=bar HTTP/1.1
                 Host: local
                 Connection: close
                             
@@ -277,6 +277,7 @@ public class AsyncTest
             assertThat(response.getStatus(), is(200));
             assertThat(events, Matchers.containsInRelativeOrder("Request Initialized: /ctxA", "Request Destroyed: /ctxA"));
             assertThat(response.getContent(), containsString("Dispatched to ctxB in test-servlet"));
+            assertThat(response.getContent(), containsString("foo=bar"));
         }
         finally
         {
@@ -415,7 +416,6 @@ public class AsyncTest
 
         try (StacklessLogging stackless = new StacklessLogging(AsyncTest.class.getPackage()))
         {
-
             client.start();
             String url = "http://localhost:" + port + "/ctxA/test?action=asyncComplete";
 

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-common/src/test/java/org/eclipse/jetty/ee9/session/AsyncTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-common/src/test/java/org/eclipse/jetty/ee9/session/AsyncTest.java
@@ -510,6 +510,9 @@ public class AsyncTest
                     {
                         if (out.isReady())
                         {
+                            //This test is a really BAD idea - you should not be
+                            //creating a HttpSession in a thread that should merely
+                            //be performing writes on the response.
                             HttpSession s = request.getSession(true);
                             out.print("OK\n");
                             acontext.complete();


### PR DESCRIPTION
The reset of the request, and the reset of the context, is too aggressive when dealing with `AsyncContext.dispatch()` behaviors.

See issue for details on where the resets occur.

Closes: #13144