### PR TITLE
Support `maven.offline` property in jetty-start, to control of download of maven files from remote repos during `--add-modules`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -157,14 +157,14 @@ def mavenBuild(jdk, cmdline, mvnName) {
           if(saveHome()) {
             archiveArtifacts artifacts: ".repository/org/eclipse/jetty/jetty-home/**/jetty-home-*", allowEmptyArchive: true, onlyIfSuccessful: false
           }
-          // temporary logs to remove
-          sh "ls -lrt ~/.mimir/"
         }
       }
     }
     finally
     {
       junit testResults: '**/target/surefire-reports/TEST**.xml,**/target/invoker-reports/TEST*.xml', allowEmptyResults: true
+      // temporary logs to remove
+      sh "ls -lrt ~/.mimir/"
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -149,6 +149,7 @@ def mavenBuild(jdk, cmdline, mvnName) {
           if(useEclipseDash()) {
             dashProfile = " -Peclipse-dash "
           }
+<<<<<<< HEAD
           sh "mkdir ~/.mimir"
           sh "cp jenkins-mimir-daemon.properties ~/.mimir/daemon.properties"
           sh "cat ~/.mimir/daemon.properties"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -149,7 +149,6 @@ def mavenBuild(jdk, cmdline, mvnName) {
           if(useEclipseDash()) {
             dashProfile = " -Peclipse-dash "
           }
-<<<<<<< HEAD
           sh "mkdir ~/.mimir"
           sh "cp jenkins-mimir-daemon.properties ~/.mimir/daemon.properties"
           sh "cat ~/.mimir/daemon.properties"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -152,7 +152,6 @@ def mavenBuild(jdk, cmdline, mvnName) {
           sh "mkdir ~/.mimir"
           sh "cp jenkins-mimir-daemon.properties ~/.mimir/daemon.properties"
           sh "cat ~/.mimir/daemon.properties"
-          sh "rm -rf .repository"
           sh "mvn $extraArgs $dashProfile -s $GLOBAL_MVN_SETTINGS -DsettingsPath=$GLOBAL_MVN_SETTINGS -Dmaven.repo.uri=http://nexus-service.nexus.svc.cluster.local:8081/repository/maven-public/ -ntp -Dmaven.repo.local=.repository -Pci -V -B -e -U $cmdline"
           if(saveHome()) {
             archiveArtifacts artifacts: ".repository/org/eclipse/jetty/jetty-home/**/jetty-home-*", allowEmptyArchive: true, onlyIfSuccessful: false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -152,6 +152,7 @@ def mavenBuild(jdk, cmdline, mvnName) {
           sh "mkdir ~/.mimir"
           sh "cp jenkins-mimir-daemon.properties ~/.mimir/daemon.properties"
           sh "cat ~/.mimir/daemon.properties"
+          sh "rm -rf .repository"
           sh "mvn $extraArgs $dashProfile -s $GLOBAL_MVN_SETTINGS -DsettingsPath=$GLOBAL_MVN_SETTINGS -Dmaven.repo.uri=http://nexus-service.nexus.svc.cluster.local:8081/repository/maven-public/ -ntp -Dmaven.repo.local=.repository -Pci -V -B -e -U $cmdline"
           if(saveHome()) {
             archiveArtifacts artifacts: ".repository/org/eclipse/jetty/jetty-home/**/jetty-home-*", allowEmptyArchive: true, onlyIfSuccessful: false

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/BaseBuilder.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/BaseBuilder.java
@@ -93,7 +93,7 @@ public class BaseBuilder
                 // Use provided local repo directory
                 fileInitializers.add(new MavenLocalRepoFileInitializer(baseHome, localRepoDir,
                     args.getMavenLocalRepoDir() == null,
-                    startArgs.getMavenBaseUri()));
+                    startArgs.getMavenBaseUri()).onlyLocalRepo(args.useOnlyLocalMavenRepo()));
             }
             else
             {

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/BaseBuilder.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/BaseBuilder.java
@@ -93,7 +93,7 @@ public class BaseBuilder
                 // Use provided local repo directory
                 fileInitializers.add(new MavenLocalRepoFileInitializer(baseHome, localRepoDir,
                     args.getMavenLocalRepoDir() == null,
-                    startArgs.getMavenBaseUri()).onlyLocalRepo(args.useOnlyLocalMavenRepo()));
+                    startArgs.getMavenBaseUri()).offline(args.useMavenOffline()));
             }
             else
             {

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
@@ -670,17 +670,16 @@ public class StartArgs
         return mainClass;
     }
 
-    public boolean useOnlyLocalMavenRepo()
+    public boolean useMavenOffline()
     {
-        String onlyLocalRepo = getJettyEnvironment().getProperties().getString("maven.only.local.repo");
-        if (Utils.isBlank(onlyLocalRepo))
-            onlyLocalRepo = System.getenv("JETTY_MAVEN_ONLY_LOCAL_REPO");
+        String offline = getJettyEnvironment().getProperties().getString("maven.offline");
+        if (Utils.isBlank(offline))
+            offline = System.getenv("JETTY_MAVEN_OFFLINE");
 
-        if (Utils.isBlank(onlyLocalRepo))
-            onlyLocalRepo = System.getenv("MAVEN_ONLY_LOCAL_REPO");
+        if (Utils.isBlank(offline))
+            offline = System.getenv("MAVEN_OFFLINE");
 
-        return Boolean.parseBoolean(onlyLocalRepo);
-
+        return Boolean.parseBoolean(offline);
     }
 
     public String getMavenLocalRepoDir()

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
@@ -670,6 +670,19 @@ public class StartArgs
         return mainClass;
     }
 
+    public boolean useOnlyLocalMavenRepo()
+    {
+        String onlyLocalRepo = getJettyEnvironment().getProperties().getString("maven.only.local.repo");
+        if (Utils.isBlank(onlyLocalRepo))
+            onlyLocalRepo = System.getenv("JETTY_MAVEN_ONLY_LOCAL_REPO");
+
+        if (Utils.isBlank(onlyLocalRepo))
+            onlyLocalRepo = System.getenv("MAVEN_ONLY_LOCAL_REPO");
+
+        return Boolean.parseBoolean(onlyLocalRepo);
+
+    }
+
     public String getMavenLocalRepoDir()
     {
         String localRepo = getJettyEnvironment().getProperties().getString("maven.local.repo");

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/fileinits/MavenLocalRepoFileInitializer.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/fileinits/MavenLocalRepoFileInitializer.java
@@ -106,6 +106,7 @@ public class MavenLocalRepoFileInitializer extends DownloadFileInitializer
 
     private final boolean readonly;
     private String mavenRepoUri;
+    private boolean onlyLocalRepo;
 
     public MavenLocalRepoFileInitializer(BaseHome baseHome)
     {
@@ -213,6 +214,12 @@ public class MavenLocalRepoFileInitializer extends DownloadFileInitializer
                 StartLog.info("copy %s to %s", localRepoFile, _basehome.toShortForm(destination));
                 Files.copy(localRepoFile, destination);
                 return true;
+            }
+
+            if (onlyLocalRepo)
+            {
+                StartLog.warn("Can only use files from Maven local repository");
+                return false;
             }
 
             // normal non-local repo version
@@ -376,4 +383,11 @@ public class MavenLocalRepoFileInitializer extends DownloadFileInitializer
     {
         super.download(uri, destination);
     }
+
+    public MavenLocalRepoFileInitializer onlyLocalRepo(boolean onlyLocalRepo)
+    {
+        this.onlyLocalRepo = onlyLocalRepo;
+        return this;
+    }
+
 }

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/fileinits/MavenLocalRepoFileInitializer.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/fileinits/MavenLocalRepoFileInitializer.java
@@ -181,7 +181,7 @@ public class MavenLocalRepoFileInitializer extends DownloadFileInitializer
                 if (offline)
                 {
                     StartLog.warn("Maven is offline, but Local Maven Repo does not contain: %s%n", coords);
-                    return false;
+                    throw new IllegalStateException("Maven is offline, but Local Maven Repo does not contain: %s%n".formatted(coords));
                 }
                 else
                 {
@@ -240,7 +240,7 @@ public class MavenLocalRepoFileInitializer extends DownloadFileInitializer
             if (offline)
             {
                 StartLog.warn("Maven is offline, but Local Maven Repo does not contain: %s%n", coords);
-                return false;
+                throw new IllegalStateException("Maven is offline, but Local Maven Repo does not contain: %s%n".formatted(coords));
             }
             else
             {
@@ -264,7 +264,7 @@ public class MavenLocalRepoFileInitializer extends DownloadFileInitializer
             if (offline)
             {
                 StartLog.warn("Maven is offline, but Local Maven Repo does not contain: %s%n", coords);
-                return null;
+                throw new IllegalStateException("Maven is offline, but Local Maven Repo does not contain: %s%n".formatted(coords));
             }
             download(coords, localFile);
             return localFile;

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/fileinits/MavenLocalRepoFileInitializer.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/fileinits/MavenLocalRepoFileInitializer.java
@@ -102,17 +102,14 @@ public class MavenLocalRepoFileInitializer extends DownloadFileInitializer
         @Override
         public String toString()
         {
-            StringBuilder pathlike = new StringBuilder();
-            pathlike.append(groupId);
-            pathlike.append(':').append(artifactId);
-            pathlike.append(':').append(version);
-            pathlike.append(':').append(artifactId);
+            StringBuilder str = new StringBuilder();
+            str.append(groupId);
+            str.append(':').append(artifactId);
+            str.append(':').append(version);
+            str.append(':').append(type);
             if (classifier != null)
-            {
-                pathlike.append(':').append(classifier);
-            }
-            pathlike.append(':').append(type);
-            return pathlike.toString();
+                str.append(':').append(classifier);
+            return str.toString();
         }
     }
 

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/fileinits/MavenLocalRepoFileInitializer.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/fileinits/MavenLocalRepoFileInitializer.java
@@ -98,6 +98,22 @@ public class MavenLocalRepoFileInitializer extends DownloadFileInitializer
         {
             return URI.create(mavenRepoUri + toMetadataPath());
         }
+
+        @Override
+        public String toString()
+        {
+            StringBuilder pathlike = new StringBuilder();
+            pathlike.append(groupId);
+            pathlike.append(':').append(artifactId);
+            pathlike.append(':').append(version);
+            pathlike.append(':').append(artifactId);
+            if (classifier != null)
+            {
+                pathlike.append(':').append(classifier);
+            }
+            pathlike.append(':').append(type);
+            return pathlike.toString();
+        }
     }
 
     private final Path localRepositoryDir;
@@ -105,8 +121,8 @@ public class MavenLocalRepoFileInitializer extends DownloadFileInitializer
     private static final String DEFAULT_REMOTE_REPO = "https://repo1.maven.org/maven2/";
 
     private final boolean readonly;
-    private String mavenRepoUri;
-    private boolean onlyLocalRepo;
+    private final String mavenRepoUri;
+    private boolean offline;
 
     public MavenLocalRepoFileInitializer(BaseHome baseHome)
     {
@@ -165,12 +181,20 @@ public class MavenLocalRepoFileInitializer extends DownloadFileInitializer
             Path localFile = localRepositoryDir.resolve(coords.toPath());
             if (!FS.canReadFile(localFile))
             {
-                if (FS.ensureDirectoryExists(localFile.getParent()))
-                    StartLog.info("mkdir %s", _basehome.toShortForm(localFile.getParent()));
-                download(coords, localFile);
-                if (!FS.canReadFile(localFile))
+                if (offline)
                 {
-                    throw new IOException("Unable to establish temp copy of file to extract: " + localFile);
+                    StartLog.warn("Maven is offline, but Local Maven Repo does not contain: %s%n", coords);
+                    return false;
+                }
+                else
+                {
+                    if (FS.ensureDirectoryExists(localFile.getParent()))
+                        StartLog.info("mkdir %s", _basehome.toShortForm(localFile.getParent()));
+                    download(coords, localFile);
+                    if (!FS.canReadFile(localFile))
+                    {
+                        throw new IOException("Unable to establish temp copy of file to extract: " + localFile);
+                    }
                 }
             }
 
@@ -216,14 +240,16 @@ public class MavenLocalRepoFileInitializer extends DownloadFileInitializer
                 return true;
             }
 
-            if (onlyLocalRepo)
+            if (offline)
             {
-                StartLog.warn("Can only use files from Maven local repository");
+                StartLog.warn("Maven is offline, but Local Maven Repo does not contain: %s%n", coords);
                 return false;
             }
-
-            // normal non-local repo version
-            download(coords, destination);
+            else
+            {
+                // normal non-local repo version
+                download(coords, destination);
+            }
         }
 
         return true;
@@ -238,6 +264,11 @@ public class MavenLocalRepoFileInitializer extends DownloadFileInitializer
         // Download, if needed
         if (!readonly)
         {
+            if (offline)
+            {
+                StartLog.warn("Maven is offline, but Local Maven Repo does not contain: %s%n", coords);
+                return null;
+            }
             download(coords, localFile);
             return localFile;
         }
@@ -315,6 +346,12 @@ public class MavenLocalRepoFileInitializer extends DownloadFileInitializer
     protected void download(Coordinates coords, Path destination)
         throws IOException
     {
+        if (offline)
+        {
+            StartLog.warn("Maven configuration is set to offline, unable to download: %s", coords);
+            return;
+        }
+
         if (coords.version.endsWith("-SNAPSHOT"))
         {
             Path localRepoMetadataPath = localRepositoryDir.resolve(coords.toMetadataPath());
@@ -374,7 +411,7 @@ public class MavenLocalRepoFileInitializer extends DownloadFileInitializer
     /**
      * protected only for testing purpose
      *
-     * @param uri the the uri to download
+     * @param uri the uri to download
      * @param destination the destination File
      */
     @Override
@@ -384,10 +421,9 @@ public class MavenLocalRepoFileInitializer extends DownloadFileInitializer
         super.download(uri, destination);
     }
 
-    public MavenLocalRepoFileInitializer onlyLocalRepo(boolean onlyLocalRepo)
+    public MavenLocalRepoFileInitializer offline(boolean offline)
     {
-        this.onlyLocalRepo = onlyLocalRepo;
+        this.offline = offline;
         return this;
     }
-
 }

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/fileinits/MavenLocalRepoFileInitializerTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/fileinits/MavenLocalRepoFileInitializerTest.java
@@ -86,72 +86,72 @@ public class MavenLocalRepoFileInitializerTest
     public void testGetCoordinateNormal()
     {
         MavenLocalRepoFileInitializer repo = new MavenLocalRepoFileInitializer(baseHome);
-        String ref = "maven://org.eclipse.jetty/jetty-start/9.3.x";
+        String ref = "maven://org.eclipse.jetty/jetty-start/12.0.x";
         Coordinates coords = repo.getCoordinates(URI.create(ref));
         assertThat("Coordinates", coords, notNullValue());
 
         assertThat("coords.groupId", coords.groupId, is("org.eclipse.jetty"));
         assertThat("coords.artifactId", coords.artifactId, is("jetty-start"));
-        assertThat("coords.version", coords.version, is("9.3.x"));
+        assertThat("coords.version", coords.version, is("12.0.x"));
         assertThat("coords.type", coords.type, is("jar"));
         assertThat("coords.classifier", coords.classifier, nullValue());
 
         assertThat("coords.toCentralURI", coords.toCentralURI().toASCIIString(),
-            is(repo.getRemoteUri() + "org/eclipse/jetty/jetty-start/9.3.x/jetty-start-9.3.x.jar"));
+            is(repo.getRemoteUri() + "org/eclipse/jetty/jetty-start/12.0.x/jetty-start-12.0.x.jar"));
     }
 
     @Test
     public void testGetCoordinateZip()
     {
         MavenLocalRepoFileInitializer repo = new MavenLocalRepoFileInitializer(baseHome);
-        String ref = "maven://org.eclipse.jetty/jetty-home/11.0.0/zip";
+        String ref = "maven://org.eclipse.jetty/jetty-home/12.0.21/zip";
         Coordinates coords = repo.getCoordinates(URI.create(ref));
         assertThat("Coordinates", coords, notNullValue());
 
         assertThat("coords.groupId", coords.groupId, is("org.eclipse.jetty"));
         assertThat("coords.artifactId", coords.artifactId, is("jetty-home"));
-        assertThat("coords.version", coords.version, is("11.0.0"));
+        assertThat("coords.version", coords.version, is("12.0.21"));
         assertThat("coords.type", coords.type, is("zip"));
         assertThat("coords.classifier", coords.classifier, nullValue());
 
         assertThat("coords.toCentralURI", coords.toCentralURI().toASCIIString(),
-                   is(repo.getRemoteUri() + "org/eclipse/jetty/jetty-home/11.0.0/jetty-home-11.0.0.zip"));
+                   is(repo.getRemoteUri() + "org/eclipse/jetty/jetty-home/12.0.21/jetty-home-12.0.21.zip"));
     }
 
     @Test
     public void testGetCoordinateTestJar()
     {
         MavenLocalRepoFileInitializer repo = new MavenLocalRepoFileInitializer(baseHome);
-        String ref = "maven://org.eclipse.jetty/jetty-http/9.3.x/jar/tests";
+        String ref = "maven://org.eclipse.jetty/jetty-http/12.0.x/jar/tests";
         Coordinates coords = repo.getCoordinates(URI.create(ref));
         assertThat("Coordinates", coords, notNullValue());
 
         assertThat("coords.groupId", coords.groupId, is("org.eclipse.jetty"));
         assertThat("coords.artifactId", coords.artifactId, is("jetty-http"));
-        assertThat("coords.version", coords.version, is("9.3.x"));
+        assertThat("coords.version", coords.version, is("12.0.x"));
         assertThat("coords.type", coords.type, is("jar"));
         assertThat("coords.classifier", coords.classifier, is("tests"));
 
         assertThat("coords.toCentralURI", coords.toCentralURI().toASCIIString(),
-            is(repo.getRemoteUri() + "org/eclipse/jetty/jetty-http/9.3.x/jetty-http-9.3.x-tests.jar"));
+            is(repo.getRemoteUri() + "org/eclipse/jetty/jetty-http/12.0.x/jetty-http-12.0.x-tests.jar"));
     }
 
     @Test
     public void testGetCoordinateTestUnspecifiedType()
     {
         MavenLocalRepoFileInitializer repo = new MavenLocalRepoFileInitializer(baseHome);
-        String ref = "maven://org.eclipse.jetty/jetty-http/9.3.x//tests";
+        String ref = "maven://org.eclipse.jetty/jetty-http/12.0.x//tests";
         Coordinates coords = repo.getCoordinates(URI.create(ref));
         assertThat("Coordinates", coords, notNullValue());
 
         assertThat("coords.groupId", coords.groupId, is("org.eclipse.jetty"));
         assertThat("coords.artifactId", coords.artifactId, is("jetty-http"));
-        assertThat("coords.version", coords.version, is("9.3.x"));
+        assertThat("coords.version", coords.version, is("12.0.x"));
         assertThat("coords.type", coords.type, is("jar"));
         assertThat("coords.classifier", coords.classifier, is("tests"));
 
         assertThat("coords.toCentralURI", coords.toCentralURI().toASCIIString(),
-            is(repo.getRemoteUri() + "org/eclipse/jetty/jetty-http/9.3.x/jetty-http-9.3.x-tests.jar"));
+            is(repo.getRemoteUri() + "org/eclipse/jetty/jetty-http/12.0.x/jetty-http-12.0.x-tests.jar"));
     }
 
     @Test
@@ -160,18 +160,18 @@ public class MavenLocalRepoFileInitializerTest
         MavenLocalRepoFileInitializer repo =
             new MavenLocalRepoFileInitializer(baseHome, null, false,
                 "https://repo1.maven.org/maven2/");
-        String ref = "maven://org.eclipse.jetty/jetty-http/9.3.x/jar/tests";
+        String ref = "maven://org.eclipse.jetty/jetty-http/12.0.x/jar/tests";
         Coordinates coords = repo.getCoordinates(URI.create(ref));
         assertThat("Coordinates", coords, notNullValue());
 
         assertThat("coords.groupId", coords.groupId, is("org.eclipse.jetty"));
         assertThat("coords.artifactId", coords.artifactId, is("jetty-http"));
-        assertThat("coords.version", coords.version, is("9.3.x"));
+        assertThat("coords.version", coords.version, is("12.0.x"));
         assertThat("coords.type", coords.type, is("jar"));
         assertThat("coords.classifier", coords.classifier, is("tests"));
 
         assertThat("coords.toCentralURI", coords.toCentralURI().toASCIIString(),
-            is(repo.getRemoteUri() + "org/eclipse/jetty/jetty-http/9.3.x/jetty-http-9.3.x-tests.jar"));
+            is(repo.getRemoteUri() + "org/eclipse/jetty/jetty-http/12.0.x/jetty-http-12.0.x-tests.jar"));
     }
 
     @Test
@@ -181,24 +181,24 @@ public class MavenLocalRepoFileInitializerTest
     {
         MavenLocalRepoFileInitializer repo =
             new MavenLocalRepoFileInitializer(baseHome, null, false);
-        String ref = "maven://org.eclipse.jetty/jetty-http/9.4.31.v20200723/jar/tests";
+        String ref = "maven://org.eclipse.jetty/jetty-session/12.0.21/jar/tests";
         Coordinates coords = repo.getCoordinates(URI.create(ref));
         assertThat("Coordinates", coords, notNullValue());
 
         assertThat("coords.groupId", coords.groupId, is("org.eclipse.jetty"));
-        assertThat("coords.artifactId", coords.artifactId, is("jetty-http"));
-        assertThat("coords.version", coords.version, is("9.4.31.v20200723"));
+        assertThat("coords.artifactId", coords.artifactId, is("jetty-session"));
+        assertThat("coords.version", coords.version, is("12.0.21"));
         assertThat("coords.type", coords.type, is("jar"));
         assertThat("coords.classifier", coords.classifier, is("tests"));
 
         assertThat("coords.toCentralURI", coords.toCentralURI().toASCIIString(),
-                   is(repo.getRemoteUri() + "org/eclipse/jetty/jetty-http/9.4.31.v20200723/jetty-http-9.4.31.v20200723-tests.jar"));
+                   is(repo.getRemoteUri() + "org/eclipse/jetty/jetty-session/12.0.21/jetty-session-12.0.21-tests.jar"));
 
-        Path destination = testdir.resolve("jetty-http-9.4.31.v20200723-tests.jar");
+        Path destination = testdir.resolve("jetty-session-12.0.21-tests.jar");
         Files.deleteIfExists(destination);
         repo.download(coords.toCentralURI(), destination);
         assertThat(Files.exists(destination), is(true));
-        assertThat(Files.size(destination), is(986193L));
+        assertThat(Files.size(destination), is(89867L));
     }
 
     @Test
@@ -211,20 +211,20 @@ public class MavenLocalRepoFileInitializerTest
 
         MavenLocalRepoFileInitializer repo =
             new MavenLocalRepoFileInitializer(baseHome, snapshotLocalRepoDir, false, "https://oss.sonatype.org/content/repositories/jetty-snapshots/");
-        String ref = "maven://org.eclipse.jetty/jetty-rewrite/11.0.14-SNAPSHOT/jar";
+        String ref = "maven://org.eclipse.jetty/jetty-rewrite/12.0.22-SNAPSHOT/jar";
         Coordinates coords = repo.getCoordinates(URI.create(ref));
         assertThat("Coordinates", coords, notNullValue());
 
         assertThat("coords.groupId", coords.groupId, is("org.eclipse.jetty"));
         assertThat("coords.artifactId", coords.artifactId, is("jetty-rewrite"));
-        assertThat("coords.version", coords.version, is("11.0.14-SNAPSHOT"));
+        assertThat("coords.version", coords.version, is("12.0.22-SNAPSHOT"));
         assertThat("coords.type", coords.type, is("jar"));
         assertThat("coords.classifier", coords.classifier, is(nullValue()));
 
         assertThat("coords.toCentralURI", coords.toCentralURI().toASCIIString(),
-            is("https://oss.sonatype.org/content/repositories/jetty-snapshots/org/eclipse/jetty/jetty-rewrite/11.0.14-SNAPSHOT/jetty-rewrite-11.0.14-SNAPSHOT.jar"));
+            is("https://oss.sonatype.org/content/repositories/jetty-snapshots/org/eclipse/jetty/jetty-rewrite/12.0.22-SNAPSHOT/jetty-rewrite-12.0.22-SNAPSHOT.jar"));
 
-        Path destination = baseHome.getBasePath().resolve("jetty-rewrite-11.0.14-SNAPSHOT.jar");
+        Path destination = baseHome.getBasePath().resolve("jetty-rewrite-12.0.22-SNAPSHOT.jar");
         repo.download(coords, destination);
         assertThat(Files.exists(destination), is(true));
         assertThat("Snapshot File size", Files.size(destination), greaterThan(10_000L));
@@ -241,11 +241,11 @@ public class MavenLocalRepoFileInitializerTest
         MavenLocalRepoFileInitializer repo =
             new MavenLocalRepoFileInitializer(baseHome, snapshotLocalRepoDir, false,
                 "https://oss.sonatype.org/content/repositories/jetty-snapshots/");
-        String ref = "maven://org.eclipse.jetty.demos/demo-simple-webapp/11.0.14-SNAPSHOT/jar/config";
+        String ref = "maven://org.eclipse.jetty.ee10.demos/jetty-ee10-demo-simple-webapp/12.0.22-SNAPSHOT/jar/config";
         Path baseDir = baseHome.getBasePath();
         repo.create(URI.create(ref), "extract:company/");
 
-        assertThat(Files.exists(baseDir.resolve("company/modules/demo-simple.mod")), is(true));
+        assertThat(Files.exists(baseDir.resolve("company/modules/ee10-demo-simple.mod")), is(true));
     }
 
     @Test
@@ -259,10 +259,28 @@ public class MavenLocalRepoFileInitializerTest
         MavenLocalRepoFileInitializer repo =
             new MavenLocalRepoFileInitializer(baseHome, snapshotLocalRepoDir, false,
                 "https://oss.sonatype.org/content/repositories/jetty-snapshots/");
-        String ref = "maven://org.eclipse.jetty.demos/demo-simple-webapp/11.0.14-SNAPSHOT/jar/config";
+        String ref = "maven://org.eclipse.jetty.ee10.demos/jetty-ee10-demo-simple-webapp/12.0.22-SNAPSHOT/jar/config";
         Path baseDir = baseHome.getBasePath();
         repo.create(URI.create(ref), "extract:/");
 
-        assertThat(Files.exists(baseDir.resolve("modules/demo-simple.mod")), is(true));
+        assertThat(Files.exists(baseDir.resolve("modules/ee10-demo-simple.mod")), is(true));
+    }
+
+    @Test
+    @Tag("external")
+    public void testDownloadButOffline()
+        throws Exception
+    {
+        Path snapshotLocalRepoDir = testdir.resolve("snapshot-repo");
+        FS.ensureEmpty(snapshotLocalRepoDir);
+
+        MavenLocalRepoFileInitializer repo =
+            new MavenLocalRepoFileInitializer(baseHome, snapshotLocalRepoDir, false,
+                "https://oss.sonatype.org/content/repositories/jetty-snapshots/").offline(true);
+        String ref = "maven://org.eclipse.jetty.ee10.demos/jetty-ee10-demo-simple-webapp/12.0.22-SNAPSHOT/jar/config";
+        Path baseDir = baseHome.getBasePath();
+        repo.create(URI.create(ref), "extract:/");
+
+        assertThat(Files.exists(baseDir.resolve("modules/ee10-demo-simple.mod")), is(false));
     }
 }

--- a/tests/jetty-testers/pom.xml
+++ b/tests/jetty-testers/pom.xml
@@ -37,6 +37,10 @@
       <artifactId>jetty-test-helper</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
     </dependency>

--- a/tests/jetty-testers/pom.xml
+++ b/tests/jetty-testers/pom.xml
@@ -25,6 +25,10 @@
       <artifactId>maven-resolver-supplier</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-xml</artifactId>
     </dependency>

--- a/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/JettyHomeTester.java
+++ b/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/JettyHomeTester.java
@@ -155,9 +155,9 @@ public class JettyHomeTester
         if (StringUtils.isNotBlank(mavenLocalRepository))
             args.add("maven.local.repo=" + mavenLocalRepository);
 
-        String mavenOnlyLocalRepo = System.getProperty("maven.only.local.repo", "false");
-        if (StringUtils.isNotBlank(mavenOnlyLocalRepo))
-            args.add("maven.only.local.repo=" + mavenOnlyLocalRepo);
+        String mavenOffline = System.getProperty("maven.offline", "false");
+        if (StringUtils.isNotBlank(mavenOffline))
+            args.add("maven.offline=" + mavenOffline);
 
         // if this JVM has `maven.repo.uri` defined, make sure to propagate it to child
         String remoteRepoUri = System.getProperty("maven.repo.uri");

--- a/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/JettyHomeTester.java
+++ b/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/JettyHomeTester.java
@@ -155,6 +155,10 @@ public class JettyHomeTester
         if (StringUtils.isNotBlank(mavenLocalRepository))
             args.add("maven.local.repo=" + mavenLocalRepository);
 
+        String mavenOnlyLocalRepo = System.getProperty("maven.only.local.repo", "false");
+        if (StringUtils.isNotBlank(mavenOnlyLocalRepo))
+            args.add("maven.only.local.repo=" + mavenOnlyLocalRepo);
+
         // if this JVM has `maven.repo.uri` defined, make sure to propagate it to child
         String remoteRepoUri = System.getProperty("maven.repo.uri");
         if (remoteRepoUri != null)

--- a/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/JettyHomeTester.java
+++ b/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/JettyHomeTester.java
@@ -24,6 +24,7 @@ import java.nio.file.FileSystemAlreadyExistsException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -223,6 +224,20 @@ public class JettyHomeTester
 
     private void init() throws Exception
     {
+        String jettyHomeStr = System.getProperty("jetty.home");
+        if (jettyHomeStr != null && !jettyHomeStr.isEmpty())
+        {
+            Path jettyHome = Paths.get(jettyHomeStr);
+            // test path exists
+            if (Files.exists(jettyHome))
+            {
+                config.jettyHome = jettyHome;
+            }
+            else
+            {
+                throw new IllegalArgumentException("Ignore non existing Jetty home: " + jettyHomeStr);
+            }
+        }
         if (config.jettyHome == null)
             config.jettyHome = resolveHomeArtifact(config.getJettyVersion());
 

--- a/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/ProcessWrapper.java
+++ b/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/ProcessWrapper.java
@@ -199,7 +199,7 @@ public class ProcessWrapper implements AutoCloseable
         }
         catch (InterruptedException e)
         {
-            throw new RuntimeException(logs().get(), e);
+            throw new IllegalStateException(logs().get(), e);
         }
         // assert no WARN in the logs
         assertThat(logs().get(), not(containsString("WARN  :")));

--- a/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/ProcessWrapper.java
+++ b/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/ProcessWrapper.java
@@ -34,6 +34,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 
 /**
  * <p>A useful wrapper of {@link Process} instances.</p>
@@ -163,7 +166,7 @@ public class ProcessWrapper implements AutoCloseable
         {
             await()
                     //.conditionEvaluationListener(new ShowLogOnTimeout<>(this))
-                    .atMost(10, TimeUnit.SECONDS)
+                    .atMost(time, unit)
                     //.logging(s -> System.out.println("LOGS: " + logs().get()))
                     .until(() ->
                     {
@@ -178,6 +181,21 @@ public class ProcessWrapper implements AutoCloseable
             // as is surefire show logs from the run
             throw new RuntimeException(logs().get(), e);
         }
+        // assert no WARN in the logs
+        assertThat(logs().get(), not(containsString("WARN  :")));
+        return true;
+    }
+
+    public boolean awaitForStart() throws InterruptedException
+    {
+        return awaitForStart(START_TIMEOUT, TimeUnit.SECONDS);
+    }
+
+    public boolean awaitForStart(long time, TimeUnit unit) throws InterruptedException
+    {
+        getProcess().waitFor(time, unit);
+        // assert no WARN in the logs
+        assertThat(logs().get(), not(containsString("WARN  :")));
         return true;
     }
 

--- a/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/ProcessWrapper.java
+++ b/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/ProcessWrapper.java
@@ -193,7 +193,14 @@ public class ProcessWrapper implements AutoCloseable
 
     public boolean awaitForStart(long time, TimeUnit unit) throws InterruptedException
     {
-        getProcess().waitFor(time, unit);
+        try
+        {
+            getProcess().waitFor(time, unit);
+        }
+        catch (InterruptedException e)
+        {
+            throw new RuntimeException(logs().get(), e);
+        }
         // assert no WARN in the logs
         assertThat(logs().get(), not(containsString("WARN  :")));
         return true;

--- a/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/ProcessWrapper.java
+++ b/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/ProcessWrapper.java
@@ -22,10 +22,18 @@ import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
 
+import org.awaitility.core.ConditionEvaluationListener;
+import org.awaitility.core.ConditionTimeoutException;
+import org.awaitility.core.EvaluatedCondition;
+import org.awaitility.core.TimeoutEvent;
 import org.eclipse.jetty.toolchain.test.IO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.awaitility.Awaitility.await;
 
 /**
  * <p>A useful wrapper of {@link Process} instances.</p>
@@ -37,6 +45,8 @@ import org.slf4j.LoggerFactory;
 public class ProcessWrapper implements AutoCloseable
 {
     private static final Logger LOG = LoggerFactory.getLogger(ProcessWrapper.class);
+
+    public static final int START_TIMEOUT = Integer.getInteger("home.start.timeout", 30);
 
     private final Queue<String> logs = new ConcurrentLinkedQueue<>();
     private final Process process;
@@ -119,6 +129,56 @@ public class ProcessWrapper implements AutoCloseable
                 return true;
         }
         return false;
+    }
+
+    public boolean awaitForJettyStart()
+    {
+        return awaitForJettyStart(START_TIMEOUT, TimeUnit.SECONDS);
+    }
+
+    private record ShowLogOnTimeout<T>(ProcessWrapper run) implements ConditionEvaluationListener<T>
+    {
+        @Override
+        public void conditionEvaluated(EvaluatedCondition<T> condition)
+        {
+            // do nothing
+        }
+
+        @Override
+        public void onTimeout(TimeoutEvent timeoutEvent)
+        {
+            System.out.println("LOGS: " + String.join("\n", run.getLogs()));
+        }
+    }
+
+    public Supplier<String> logs()
+    {
+        return () -> String.join("\n", this.getLogs());
+    }
+
+    public boolean awaitForJettyStart(long time, TimeUnit unit)
+    {
+        // Started oejs.Server@
+        try
+        {
+            await()
+                    //.conditionEvaluationListener(new ShowLogOnTimeout<>(this))
+                    .atMost(10, TimeUnit.SECONDS)
+                    //.logging(s -> System.out.println("LOGS: " + logs().get()))
+                    .until(() ->
+                    {
+                        try (Stream<String> lines = getLogs().stream())
+                        {
+                            return lines.anyMatch(line -> line.contains("Started oejs.Server@"));
+                        }
+                    });
+        }
+        catch (ConditionTimeoutException e)
+        {
+            // as is surefire show logs from the run
+            throw new RuntimeException(logs().get(), e);
+        }
+        return true;
     }
 
     public boolean awaitConsoleLogsFor(String txt, Duration duration) throws InterruptedException

--- a/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/ProcessWrapper.java
+++ b/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/ProcessWrapper.java
@@ -56,6 +56,8 @@ public class ProcessWrapper implements AutoCloseable
     private final ConsoleStreamer stdOut;
     private final ConsoleStreamer stdErr;
 
+    public static final String JETTY_START_SEARCH = "Started oejs.Server@";
+
     public ProcessWrapper(Process process)
     {
         this.process = process;
@@ -172,7 +174,7 @@ public class ProcessWrapper implements AutoCloseable
                     {
                         try (Stream<String> lines = getLogs().stream())
                         {
-                            return lines.anyMatch(line -> line.contains("Started oejs.Server@"));
+                            return lines.anyMatch(line -> line.contains(JETTY_START_SEARCH));
                         }
                     });
         }

--- a/tests/test-distribution/pom.xml
+++ b/tests/test-distribution/pom.xml
@@ -111,6 +111,7 @@
               <distribution.debug.port>$(distribution.debug.port}</distribution.debug.port>
               <home.start.timeout>${home.start.timeout}</home.start.timeout>
               <mariadb.version>${mariadb.version}</mariadb.version>
+              <maven.only.local.repo>true</maven.only.local.repo>
               <sessionLogLevel>${sessionLogLevel}</sessionLogLevel>
               <environmentsToTest>${environmentsToTest}</environmentsToTest>
             </systemPropertyVariables>

--- a/tests/test-distribution/pom.xml
+++ b/tests/test-distribution/pom.xml
@@ -111,7 +111,7 @@
               <distribution.debug.port>$(distribution.debug.port}</distribution.debug.port>
               <home.start.timeout>${home.start.timeout}</home.start.timeout>
               <mariadb.version>${mariadb.version}</mariadb.version>
-              <maven.only.local.repo>true</maven.only.local.repo>
+              <maven.offline>true</maven.offline>
               <sessionLogLevel>${sessionLogLevel}</sessionLogLevel>
               <environmentsToTest>${environmentsToTest}</environmentsToTest>
             </systemPropertyVariables>

--- a/tests/test-distribution/test-distribution-common/pom.xml
+++ b/tests/test-distribution/test-distribution-common/pom.xml
@@ -138,41 +138,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-      <version>${logback.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-core</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <version>${log4j2.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>${log4j2.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j2-impl</artifactId>
-      <version>${log4j2.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-jdk14</artifactId>
-      <version>${slf4j.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
@@ -315,6 +280,50 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
+          <execution>
+            <id>copy-fake-deps</id>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <phase>process-test-resources</phase>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>ch.qos.logback</groupId>
+                  <artifactId>logback-classic</artifactId>
+                  <version>${logback.version}</version>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>ch.qos.logback</groupId>
+                  <artifactId>logback-core</artifactId>
+                  <version>${logback.version}</version>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.apache.logging.log4j</groupId>
+                  <artifactId>log4j-api</artifactId>
+                  <version>${log4j2.version}</version>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.apache.logging.log4j</groupId>
+                  <artifactId>log4j-core</artifactId>
+                  <version>${log4j2.version}</version>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.apache.logging.log4j</groupId>
+                  <artifactId>log4j-slf4j2-impl</artifactId>
+                  <version>${log4j2.version}</version>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.slf4j</groupId>
+                  <artifactId>slf4j-jdk14</artifactId>
+                  <version>${slf4j.version}</version>
+                </artifactItem>
+              </artifactItems>
+              <outputDirectory>${project.build.directory}/fake-deps</outputDirectory>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>true</overWriteSnapshots>
+            </configuration>
+          </execution>
           <execution>
             <id>unpack</id>
             <goals>

--- a/tests/test-distribution/test-distribution-common/pom.xml
+++ b/tests/test-distribution/test-distribution-common/pom.xml
@@ -149,6 +149,18 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
+      <version>${log4j2.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
@@ -190,12 +202,6 @@
       <version>${project.version}</version>
       <type>war</type>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-jdk14</artifactId>
-      <version>${slf4j.version}</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.ee9</groupId>

--- a/tests/test-distribution/test-distribution-common/pom.xml
+++ b/tests/test-distribution/test-distribution-common/pom.xml
@@ -13,6 +13,7 @@
 
   <properties>
     <bundle-symbolic-name>${project.groupId}.tests.distribution.common</bundle-symbolic-name>
+    <jetty.home>${project.build.directory}/jetty-home</jetty.home>
     <!--    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>-->
     <junit.jupiter.execution.parallel.config.fixed.parallelism>2</junit.jupiter.execution.parallel.config.fixed.parallelism>
     <testcontainers-keycloak.version>3.4.0</testcontainers-keycloak.version>
@@ -301,9 +302,35 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>unpack</id>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <phase>process-test-resources</phase>
+            <configuration>
+              <ignorePermissions>true</ignorePermissions>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.eclipse.jetty</groupId>
+                  <artifactId>jetty-home</artifactId>
+                  <type>zip</type>
+                  <overWrite>true</overWrite>
+                  <outputDirectory>${jetty.home}</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <systemPropertyVariables combine.children="append">
+            <jetty.home>${jetty.home}/jetty-home-${project.version}</jetty.home>
             <infinispan.docker.image.version>${infinispan.docker.image.version}</infinispan.docker.image.version>
             <infinispan.docker.image.name>${infinispan.docker.image.name}</infinispan.docker.image.name>
           </systemPropertyVariables>

--- a/tests/test-distribution/test-distribution-common/pom.xml
+++ b/tests/test-distribution/test-distribution-common/pom.xml
@@ -138,6 +138,17 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>${logback.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
       <version>${log4j2.version}</version>

--- a/tests/test-distribution/test-distribution-common/pom.xml
+++ b/tests/test-distribution/test-distribution-common/pom.xml
@@ -281,6 +281,7 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>
+            <!-- we want to be sure all dependencies are available in the local repo -->
             <id>copy-fake-deps</id>
             <goals>
               <goal>copy</goal>

--- a/tests/test-distribution/test-distribution-common/pom.xml
+++ b/tests/test-distribution/test-distribution-common/pom.xml
@@ -165,7 +165,6 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-slf4j-impl</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/tests/test-distribution/test-distribution-common/pom.xml
+++ b/tests/test-distribution/test-distribution-common/pom.xml
@@ -192,6 +192,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty.ee9</groupId>
       <artifactId>jetty-ee9-test-openid-webapp</artifactId>
       <version>${project.version}</version>

--- a/tests/test-distribution/test-distribution-common/pom.xml
+++ b/tests/test-distribution/test-distribution-common/pom.xml
@@ -137,6 +137,18 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${log4j2.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j2.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/AbstractJettyHomeTest.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/AbstractJettyHomeTest.java
@@ -20,6 +20,7 @@ import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.transport.HttpClientTransportOverHTTP;
 import org.eclipse.jetty.io.ClientConnector;
+import org.eclipse.jetty.tests.testers.ProcessWrapper;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
@@ -31,7 +32,7 @@ public class AbstractJettyHomeTest
 {
     protected HttpClient client;
 
-    public static final int START_TIMEOUT = Integer.getInteger("home.start.timeout", 30);
+    public static final int START_TIMEOUT = ProcessWrapper.START_TIMEOUT;
 
     public static String toEnvironment(String module, String environment)
     {

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -429,8 +429,7 @@ public class DistributionTests extends AbstractJettyHomeTest
             int port = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + port))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS),
-                    () -> String.join("\n", run2.getLogs()));
+                assertTrue(run2.awaitForJettyStart());
 
                 startHttpClient();
                 ContentResponse response = client.GET("http://localhost:" + port + "/test/index.jsp");
@@ -733,15 +732,7 @@ public class DistributionTests extends AbstractJettyHomeTest
             {
                 Path logFile = distribution.getJettyBase().resolve("logs").resolve("jetty.log");
                 await().atMost(10, TimeUnit.SECONDS).until(() -> Files.exists(logFile));
-                await()
-                    .conditionEvaluationListener(new ShowLogOnTimeout(run2))
-                    .atMost(10, TimeUnit.SECONDS).until(() ->
-                {
-                    try (Stream<String> lines = Files.lines(logFile))
-                    {
-                        return lines.anyMatch(line -> line.contains("Started oejs.Server@"));
-                    }
-                });
+                run2.awaitForJettyStart();
 
                 startHttpClient();
                 ContentResponse response = client.GET("http://localhost:" + port);
@@ -2101,25 +2092,6 @@ public class DistributionTests extends AbstractJettyHomeTest
                     .send();
                 assertEquals(HttpStatus.OK_200, ee10Response.getStatus());
             }
-        }
-    }
-
-    /**
-     * Awaitility feature to show the JettyHomeTester.Run logs if a timeout occurs.
-     * TODO: move this to org.eclipse.jetty.tests.testers and use in ProcessWrapper.awaitConsoleLogsFor too (in a different PR)
-     */
-    private record ShowLogOnTimeout<T>(JettyHomeTester.Run run) implements ConditionEvaluationListener<T>
-    {
-        @Override
-        public void conditionEvaluated(EvaluatedCondition<T> condition)
-        {
-            // do nothing
-        }
-
-        @Override
-        public void onTimeout(TimeoutEvent timeoutEvent)
-        {
-            System.err.println(String.join("\n", run.getLogs()));
         }
     }
 }

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -77,6 +77,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.awaitility.Awaitility.await;
+import static org.eclipse.jetty.tests.testers.ProcessWrapper.JETTY_START_SEARCH;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -727,7 +728,9 @@ public class DistributionTests extends AbstractJettyHomeTest
             {
                 Path logFile = distribution.getJettyBase().resolve("logs").resolve("jetty.log");
                 await().atMost(10, TimeUnit.SECONDS).until(() -> Files.exists(logFile));
-                assertTrue(run2.awaitForJettyStart(), run2.logs());
+
+                await().atMost(10, TimeUnit.SECONDS)
+                        .until(() -> Files.readAllLines(logFile).stream().anyMatch(l -> l.contains(JETTY_START_SEARCH)));
 
                 startHttpClient();
                 ContentResponse response = client.GET("http://localhost:" + port);

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -714,7 +714,7 @@ public class DistributionTests extends AbstractJettyHomeTest
             .jettyBase(jettyBase)
             .build();
 
-        try (JettyHomeTester.Run run1 = distribution.start("--debug", "--approve-all-licenses", "--add-modules=http,logging-log4j2"))
+        try (JettyHomeTester.Run run1 = distribution.start("--approve-all-licenses", "--add-modules=http,logging-log4j2"))
         {
             assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue(), run1.logs());

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -428,7 +428,6 @@ public class DistributionTests extends AbstractJettyHomeTest
             try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + port))
             {
                 assertTrue(run2.awaitForJettyStart());
-
                 startHttpClient();
                 ContentResponse response = client.GET("http://localhost:" + port + "/test/index.jsp");
                 assertEquals(HttpStatus.OK_200, response.getStatus());

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -38,6 +38,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
+import org.awaitility.core.ConditionEvaluationListener;
+import org.awaitility.core.EvaluatedCondition;
+import org.awaitility.core.TimeoutEvent;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.transport.HttpClientConnectionFactory;
@@ -426,7 +429,8 @@ public class DistributionTests extends AbstractJettyHomeTest
             int port = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + port))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS),
+                    () -> String.join("\n", run2.getLogs()));
 
                 startHttpClient();
                 ContentResponse response = client.GET("http://localhost:" + port + "/test/index.jsp");
@@ -716,7 +720,8 @@ public class DistributionTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start("--approve-all-licenses", "--add-modules=http,logging-log4j2"))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS),
+                () -> String.join("\n", run1.getLogs()));
             assertEquals(0, run1.getExitValue());
 
             Files.copy(Paths.get("src/test/resources/log4j2.xml"),
@@ -728,7 +733,9 @@ public class DistributionTests extends AbstractJettyHomeTest
             {
                 Path logFile = distribution.getJettyBase().resolve("logs").resolve("jetty.log");
                 await().atMost(10, TimeUnit.SECONDS).until(() -> Files.exists(logFile));
-                await().atMost(10, TimeUnit.SECONDS).until(() ->
+                await()
+                    .conditionEvaluationListener(new ShowLogOnTimeout(run2))
+                    .atMost(10, TimeUnit.SECONDS).until(() ->
                 {
                     try (Stream<String> lines = Files.lines(logFile))
                     {
@@ -768,7 +775,8 @@ public class DistributionTests extends AbstractJettyHomeTest
             int port = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + port))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS),
+                    () -> String.join("\n", run2.getLogs()));
                 assertThat(run2.getLogs().stream()
                     // Check that the level formatting is that of the j.u.l. configuration file.
                     .filter(log -> log.contains("[FINE]"))
@@ -2093,6 +2101,25 @@ public class DistributionTests extends AbstractJettyHomeTest
                     .send();
                 assertEquals(HttpStatus.OK_200, ee10Response.getStatus());
             }
+        }
+    }
+
+    /**
+     * Awaitility feature to show the JettyHomeTester.Run logs if a timeout occurs.
+     * TODO: move this to org.eclipse.jetty.tests.testers and use in ProcessWrapper.awaitConsoleLogsFor too (in a different PR)
+     */
+    private record ShowLogOnTimeout<T>(JettyHomeTester.Run run) implements ConditionEvaluationListener<T>
+    {
+        @Override
+        public void conditionEvaluated(EvaluatedCondition<T> condition)
+        {
+            // do nothing
+        }
+
+        @Override
+        public void onTimeout(TimeoutEvent timeoutEvent)
+        {
+            System.err.println(String.join("\n", run.getLogs()));
         }
     }
 }

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -576,8 +576,8 @@ public class DistributionTests extends AbstractJettyHomeTest
         );
         try (JettyHomeTester.Run run1 = distribution.start("--add-modules=" + mods))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
-            assertEquals(0, run1.getExitValue());
+            assertTrue(run1.awaitForStart());
+            assertEquals(0, run1.getExitValue(), run1.logs());
 
             Path war = distribution.resolveArtifact("org.eclipse.jetty." + env + ".demos:jetty-" + env + "-demo-proxy-webapp:war:" + jettyVersion);
             distribution.installWar(war, "proxy");
@@ -787,8 +787,8 @@ public class DistributionTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start("--approve-all-licenses", "--add-modules=http,logging-jul-capture"))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
-            assertEquals(0, run1.getExitValue());
+            assertTrue(run1.awaitForStart());
+            assertEquals(0, run1.getExitValue(), run1.logs());
 
             //Path jettyBase = run1.getConfig().getJettyBase();
 
@@ -937,8 +937,8 @@ public class DistributionTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution1.start("--approve-all-licenses", "--add-modules=logging-logback,http"))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
-            assertEquals(0, run1.getExitValue());
+            assertTrue(run1.awaitForStart());
+            assertEquals(0, run1.getExitValue(), run1.logs());
 
             //Path jettyBase = run1.getConfig().getJettyBase();
 

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -714,7 +714,7 @@ public class DistributionTests extends AbstractJettyHomeTest
             .jettyBase(jettyBase)
             .build();
 
-        try (JettyHomeTester.Run run1 = distribution.start("--approve-all-licenses", "--add-modules=http,logging-log4j2"))
+        try (JettyHomeTester.Run run1 = distribution.start("--debug", "--approve-all-licenses", "--add-modules=http,logging-log4j2"))
         {
             assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue(), run1.logs());

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -716,10 +716,8 @@ public class DistributionTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start("--approve-all-licenses", "--add-modules=http,logging-log4j2"))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS),
-                () -> String.join("\n", run1.getLogs()));
-            assertEquals(0, run1.getExitValue());
-
+            assertTrue(run1.awaitForStart());
+            assertEquals(0, run1.getExitValue(), run1.logs());
             Files.copy(Paths.get("src/test/resources/log4j2.xml"),
                 distribution.getJettyBase().resolve("resources").resolve("log4j2.xml"),
                 StandardCopyOption.REPLACE_EXISTING);
@@ -753,8 +751,8 @@ public class DistributionTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start("--approve-all-licenses", "--add-modules=http,logging-jul"))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
-            assertEquals(0, run1.getExitValue());
+            assertTrue(run1.awaitForStart());
+            assertEquals(0, run1.getExitValue(), run1.logs());
 
             Path julConfig = run1.getConfig().getJettyBase().resolve("resources/java-util-logging.properties");
             assertTrue(Files.exists(julConfig));

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -38,9 +38,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
-import org.awaitility.core.ConditionEvaluationListener;
-import org.awaitility.core.EvaluatedCondition;
-import org.awaitility.core.TimeoutEvent;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.transport.HttpClientConnectionFactory;
@@ -419,8 +416,9 @@ public class DistributionTests extends AbstractJettyHomeTest
         );
         try (JettyHomeTester.Run run1 = distribution.start("--approve-all-licenses", "--add-modules=" + mods))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue());
+            LOG.atInfo().setMessage(run1.logs().get()).log();
             assertTrue(Files.exists(distribution.getJettyBase().resolve("resources/log4j2.xml")));
 
             Path war = distribution.resolveArtifact("org.eclipse.jetty." + env + ".demos:jetty-" + env + "-demo-jsp-webapp:war:" + jettyVersion);

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -727,7 +727,7 @@ public class DistributionTests extends AbstractJettyHomeTest
             {
                 Path logFile = distribution.getJettyBase().resolve("logs").resolve("jetty.log");
                 await().atMost(10, TimeUnit.SECONDS).until(() -> Files.exists(logFile));
-                run2.awaitForJettyStart();
+                assertTrue(run2.awaitForJettyStart(), run2.logs());
 
                 startHttpClient();
                 ContentResponse response = client.GET("http://localhost:" + port);

--- a/tests/test-distribution/test-distribution-common/src/test/resources/log4j2.xml
+++ b/tests/test-distribution/test-distribution-common/src/test/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="warn" name="Jetty" >
 
   <properties>
-    <property name="logging.dir">${sys:jetty.logging.dir:-target/logs}</property>
+    <property name="logging.dir">${sys:jetty.logging.dir:-logs}</property>
   </properties>
 
   <Appenders>

--- a/tests/test-distribution/test-distribution-common/src/test/resources/log4j2.xml
+++ b/tests/test-distribution/test-distribution-common/src/test/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="warn" name="Jetty" >
 
   <properties>
-    <property name="logging.dir">${sys:jetty.logging.dir:-logs}</property>
+    <property name="logging.dir">${sys:jetty.logging.dir:-target/logs}</property>
   </properties>
 
   <Appenders>


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>
