### PR TITLE
Remove unused `<build>/<resource>` configurations from osgi trees.

### DIFF
--- a/jetty-ee10/jetty-ee10-osgi/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/pom.xml
@@ -40,21 +40,4 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-
-  <build>
-    <resources>
-      <!-- include default resources from Super POM as we override it for src/main/java below -->
-      <resource>
-        <directory>${project.basedir}/src/main/resources</directory>
-      </resource>
-      <!-- TODO: why do we include source in src/main/java jar file? that's what -source.jar classified is for. -->
-      <resource>
-        <directory>${project.basedir}/src/main/java</directory>
-        <excludes>
-          <exclude>**/*.java</exclude>
-        </excludes>
-      </resource>
-    </resources>
-  </build>
-
 </project>

--- a/jetty-ee11/jetty-ee11-osgi/pom.xml
+++ b/jetty-ee11/jetty-ee11-osgi/pom.xml
@@ -40,21 +40,4 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-
-  <build>
-    <resources>
-      <!-- include default resources from Super POM as we override it for src/main/java below -->
-      <resource>
-        <directory>${project.basedir}/src/main/resources</directory>
-      </resource>
-      <!-- TODO: why do we include source in src/main/java jar file? that's what -source.jar classified is for. -->
-      <resource>
-        <directory>${project.basedir}/src/main/java</directory>
-        <excludes>
-          <exclude>**/*.java</exclude>
-        </excludes>
-      </resource>
-    </resources>
-  </build>
-
 </project>

--- a/jetty-ee8/jetty-ee8-osgi/pom.xml
+++ b/jetty-ee8/jetty-ee8-osgi/pom.xml
@@ -39,33 +39,4 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-
-  <build>
-    <resources>
-      <resource>
-        <filtering>true</filtering>
-        <directory>META-INF/..</directory>
-        <includes>
-          <include>META-INF/**/*</include>
-        </includes>
-        <excludes>
-          <exclude>**/.*</exclude>
-          <exclude>**/*.jar</exclude>
-          <exclude>.settings/**/*</exclude>
-          <exclude>pom.xml</exclude>
-          <!-- exclude>META-INF/**/*</exclude -->
-          <exclude>jettyhome/**/*</exclude>
-          <exclude>src/**/*</exclude>
-          <exclude>target/**/*</exclude>
-          <exclude>build.properties</exclude>
-        </excludes>
-      </resource>
-      <resource>
-        <directory>src/main/java</directory>
-        <excludes>
-          <exclude>**/*.java</exclude>
-        </excludes>
-      </resource>
-    </resources>
-  </build>
 </project>

--- a/jetty-ee9/jetty-ee9-osgi/pom.xml
+++ b/jetty-ee9/jetty-ee9-osgi/pom.xml
@@ -41,19 +41,6 @@
   </dependencyManagement>
 
   <build>
-    <resources>
-      <!-- include default resources from Super POM as we override it for src/main/java below -->
-      <resource>
-        <directory>${project.basedir}/src/main/resources</directory>
-      </resource>
-      <!-- TODO: why do we include source in src/main/java jar file? that's what -source.jar classified is for. -->
-      <resource>
-        <directory>${project.basedir}/src/main/java</directory>
-        <excludes>
-          <exclude>**/*.java</exclude>
-        </excludes>
-      </resource>
-    </resources>
     <plugins>
       <plugin>
         <groupId>org.basepom.maven</groupId>


### PR DESCRIPTION
The original purpose of these custom maven project/build/resource entries was to do META-INF/MANIFEST.MF property expansion and filtering.

That technique hasn't been in use in our builds for a very long time now, so we should just remove these custom `<build><resource>` configurations that do nothing anymore.