### PR TITLE
Fixes #13131 - Surface received GOAWAY in HttpClient.

### DIFF
--- a/documentation/jetty/modules/programming-guide/pages/client/http.adoc
+++ b/documentation/jetty/modules/programming-guide/pages/client/http.adoc
@@ -983,6 +983,8 @@ include::code:example$src/main/java/org/eclipse/jetty/docs/programming/client/ht
 
 `HttpClientTransportOverHTTP2` uses `HTTP2Client` to format high-level semantic HTTP requests into the HTTP/2 specific format.
 
+When the HTTP/2 server closes the connection (see xref:client/http2.adoc#goaway[this section]), ``RetryableStreamException``s are converted into ``RetryableRequestException``s, so that the high-level APIs do not depend on the transport.
+
 See also xref:client/http2.adoc#listeners[this section] to be able to interact with the low-level HTTP/2 APIs while using the high-level APIs.
 
 [[transport-http3]]
@@ -998,6 +1000,8 @@ include::code:example$src/main/java/org/eclipse/jetty/docs/programming/client/ht
 `HTTP3Client` is the lower-level client that provides an API based on HTTP/3 concepts such as _sessions_, _streams_ and _frames_ that are specific to HTTP/3. See xref:client/http3.adoc[the HTTP/3 client section] for more information.
 
 `HttpClientTransportOverHTTP3` uses `HTTP3Client` to format high-level semantic HTTP requests into the HTTP/3 specific format.
+
+When the HTTP/3 server closes the connection (see xref:client/http3.adoc#goaway[this section]), ``RetryableStreamException``s are converted into ``RetryableRequestException``s, so that the high-level APIs do not depend on the transport.
 
 [[transport-fcgi]]
 === FastCGI Transport

--- a/documentation/jetty/modules/programming-guide/pages/client/http2.adoc
+++ b/documentation/jetty/modules/programming-guide/pages/client/http2.adoc
@@ -237,6 +237,30 @@ If a client application does not want to handle a particular HTTP/2 push, it can
 include::code:example$src/main/java/org/eclipse/jetty/docs/programming/client/http2/HTTP2ClientDocs.java[tags=pushReset]
 ----
 
+[[goaway]]
+== Session Closing
+
+Once a `Session` has been established (see <<connect,here>>), it may be closed in the following way, providing an error code and a short textual reason:
+
+[,java,indent=0]
+----
+include::code:example$src/main/java/org/eclipse/jetty/docs/programming/client/http2/HTTP2ClientDocs.java[tags=close]
+----
+
+Closing a `Session` will send a `GOAWAY` frame to the server.
+
+When the server closes the `Session`, the `GOAWAY` frame received by the client carries the identifier of the last stream that was processed by the server.
+Streams that have an identifier higher than the one specified in the `GOAWAY` frame are not processed by the server.
+
+A client application may be sending requests while the server is closing the `Session`, so it is possible that the client opens a stream that will not be processed by the server, because it has an identifier that is greater than the one specified in the `GOAWAY` frame sent by the server.
+
+In this case the stream is failed on the client with a `RetryableStreamException`, and client applications may decide whether to retry the request (if the request can be retried):
+
+[,java,indent=0]
+----
+include::code:example$src/main/java/org/eclipse/jetty/docs/programming/client/http2/HTTP2ClientDocs.java[tags=retryStream]
+----
+
 [[listeners]]
 == Listening to HTTP/2 Events
 

--- a/documentation/jetty/modules/programming-guide/pages/client/http3.adoc
+++ b/documentation/jetty/modules/programming-guide/pages/client/http3.adoc
@@ -153,3 +153,28 @@ The `HTTP3Client` APIs allow client applications to send and receive this "reset
 ----
 include::code:example$src/main/java/org/eclipse/jetty/docs/programming/client/http3/HTTP3ClientDocs.java[tags=reset]
 ----
+
+[[goaway]]
+== Session Closing
+
+Once a `Session` has been established (see <<connect,here>>), it may be closed in the following way:
+
+[,java,indent=0]
+----
+include::code:example$src/main/java/org/eclipse/jetty/docs/programming/client/http3/HTTP3ClientDocs.java[tags=close]
+----
+
+Closing a `Session` will send a `GOAWAY` frame to the server.
+
+When the server closes the `Session`, the `GOAWAY` frame received by the client carries the identifier of the last stream that was processed by the server.
+Streams that have an identifier higher than the one specified in the `GOAWAY` frame are not processed by the server.
+
+A client application may be sending requests while the server is closing the `Session`, so it is possible that the client opens a stream that will not be processed by the server, because it has an identifier that is greater than the one specified in the `GOAWAY` frame sent by the server.
+
+In this case the stream is failed on the client with a `RetryableStreamException`, and client applications may decide whether to retry the request (if the request can be retried):
+
+[,java,indent=0]
+----
+include::code:example$src/main/java/org/eclipse/jetty/docs/programming/client/http3/HTTP3ClientDocs.java[tags=retryStream]
+----
+

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/RetryRequestException.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/RetryRequestException.java
@@ -1,0 +1,26 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.client;
+
+/**
+ * <p>Exception indicating that the HTTP request was not handled
+ * by the server, and can therefore be retried, if possible.</p>
+ */
+public class RetryRequestException extends RuntimeException
+{
+    public RetryRequestException(Throwable failure)
+    {
+        super(failure);
+    }
+}

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/RetryableRequestException.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/RetryableRequestException.java
@@ -1,0 +1,26 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.client;
+
+/**
+ * <p>Exception indicating that the HTTP request was not handled
+ * by the server, and can therefore be retried, if possible.</p>
+ */
+public class RetryableRequestException extends RuntimeException
+{
+    public RetryableRequestException(Throwable failure)
+    {
+        super(failure);
+    }
+}

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpChannelOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpChannelOverHTTP2.java
@@ -17,12 +17,14 @@ import java.util.concurrent.TimeoutException;
 
 import org.eclipse.jetty.client.Connection;
 import org.eclipse.jetty.client.Result;
+import org.eclipse.jetty.client.RetryRequestException;
 import org.eclipse.jetty.client.transport.HttpChannel;
 import org.eclipse.jetty.client.transport.HttpExchange;
 import org.eclipse.jetty.client.transport.HttpReceiver;
 import org.eclipse.jetty.client.transport.HttpSender;
 import org.eclipse.jetty.http2.ErrorCode;
 import org.eclipse.jetty.http2.HTTP2Channel;
+import org.eclipse.jetty.http2.HTTP2Session;
 import org.eclipse.jetty.http2.HTTP2Stream;
 import org.eclipse.jetty.http2.api.Session;
 import org.eclipse.jetty.http2.api.Stream;
@@ -218,6 +220,8 @@ public class HttpChannelOverHTTP2 extends HttpChannel
         public void onFailure(Stream stream, int error, String reason, Throwable failure, Callback callback)
         {
             HTTP2Channel.Client channel = (HTTP2Channel.Client)((HTTP2Stream)stream).getAttachment();
+            if (failure instanceof HTTP2Session.RetryStreamException)
+                failure = new RetryRequestException(failure);
             connection.offerTask(channel.onFailure(failure, callback), false);
         }
     }

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpChannelOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpChannelOverHTTP2.java
@@ -17,15 +17,15 @@ import java.util.concurrent.TimeoutException;
 
 import org.eclipse.jetty.client.Connection;
 import org.eclipse.jetty.client.Result;
-import org.eclipse.jetty.client.RetryRequestException;
+import org.eclipse.jetty.client.RetryableRequestException;
 import org.eclipse.jetty.client.transport.HttpChannel;
 import org.eclipse.jetty.client.transport.HttpExchange;
 import org.eclipse.jetty.client.transport.HttpReceiver;
 import org.eclipse.jetty.client.transport.HttpSender;
 import org.eclipse.jetty.http2.ErrorCode;
 import org.eclipse.jetty.http2.HTTP2Channel;
-import org.eclipse.jetty.http2.HTTP2Session;
 import org.eclipse.jetty.http2.HTTP2Stream;
+import org.eclipse.jetty.http2.RetryableStreamException;
 import org.eclipse.jetty.http2.api.Session;
 import org.eclipse.jetty.http2.api.Stream;
 import org.eclipse.jetty.http2.frames.HeadersFrame;
@@ -220,8 +220,8 @@ public class HttpChannelOverHTTP2 extends HttpChannel
         public void onFailure(Stream stream, int error, String reason, Throwable failure, Callback callback)
         {
             HTTP2Channel.Client channel = (HTTP2Channel.Client)((HTTP2Stream)stream).getAttachment();
-            if (failure instanceof HTTP2Session.RetryStreamException)
-                failure = new RetryRequestException(failure);
+            if (failure instanceof RetryableStreamException)
+                failure = new RetryableRequestException(failure);
             connection.offerTask(channel.onFailure(failure, callback), false);
         }
     }

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -1480,14 +1480,6 @@ public abstract class HTTP2Session extends AbstractLifeCycle implements Session,
         }
     }
 
-    /**
-     * <p>Exception indicating that the HTTP/2 stream was not handled
-     * by the server, and can therefore be retried, if possible.</p>
-     */
-    public static class RetryStreamException extends RuntimeException
-    {
-    }
-
     public abstract static class Entry extends Callback.Nested
     {
         protected final Frame frame;
@@ -2068,7 +2060,7 @@ public abstract class HTTP2Session extends AbstractLifeCycle implements Session,
                 // The lastStreamId carried by the GOAWAY is that of a local stream,
                 // so the lastStreamId must be compared only to local streams ids.
                 Predicate<Stream> failIf = stream -> stream.isLocal() && stream.getId() > frame.getLastStreamId();
-                failStreams(failIf, new RetryStreamException(), false);
+                failStreams(failIf, new RetryableStreamException(), false);
             }
 
             if (tryRunZeroStreamsAction)

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -696,6 +696,16 @@ public abstract class HTTP2Session extends AbstractLifeCycle implements Session,
     {
         int error = ErrorCode.CANCEL_STREAM_ERROR.code;
         Throwable failure = toFailure(error, reason);
+        failStreams(matcher, error, failure, reset);
+    }
+
+    private void failStreams(Predicate<Stream> matcher, Throwable failure, boolean reset)
+    {
+        failStreams(matcher, ErrorCode.CANCEL_STREAM_ERROR.code, failure, reset);
+    }
+
+    private void failStreams(Predicate<Stream> matcher, int error, Throwable failure, boolean reset)
+    {
         for (Stream stream : getStreams())
         {
             if (stream.isClosed())
@@ -704,7 +714,7 @@ public abstract class HTTP2Session extends AbstractLifeCycle implements Session,
                 continue;
             if (LOG.isDebugEnabled())
                 LOG.debug("Failing stream {} of {}", stream, this);
-            failStream(stream, error, reason, failure, Callback.NOOP);
+            failStream(stream, error, failure.getMessage(), failure, Callback.NOOP);
             if (reset)
                 stream.reset(new ResetFrame(stream.getId(), error), Callback.NOOP);
         }
@@ -1470,6 +1480,14 @@ public abstract class HTTP2Session extends AbstractLifeCycle implements Session,
         }
     }
 
+    /**
+     * <p>Exception indicating that the HTTP/2 stream was not handled
+     * by the server, and can therefore be retried, if possible.</p>
+     */
+    public static class RetryStreamException extends RuntimeException
+    {
+    }
+
     public abstract static class Entry extends Callback.Nested
     {
         protected final Frame frame;
@@ -2050,7 +2068,7 @@ public abstract class HTTP2Session extends AbstractLifeCycle implements Session,
                 // The lastStreamId carried by the GOAWAY is that of a local stream,
                 // so the lastStreamId must be compared only to local streams ids.
                 Predicate<Stream> failIf = stream -> stream.isLocal() && stream.getId() > frame.getLastStreamId();
-                failStreams(failIf, "closing", false);
+                failStreams(failIf, new RetryStreamException(), false);
             }
 
             if (tryRunZeroStreamsAction)

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/RetryableStreamException.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/RetryableStreamException.java
@@ -1,0 +1,22 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.http2;
+
+/**
+ * <p>Exception indicating that the HTTP/2 stream was not handled
+ * by the server, and can therefore be retried, if possible.</p>
+ */
+public class RetryableStreamException extends RuntimeException
+{
+}

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/RetryRequestTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/RetryRequestTest.java
@@ -1,0 +1,77 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.http2.tests;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.jetty.client.Result;
+import org.eclipse.jetty.client.RetryRequestException;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.http2.ErrorCode;
+import org.eclipse.jetty.http2.api.Session;
+import org.eclipse.jetty.http2.api.Stream;
+import org.eclipse.jetty.http2.api.server.ServerSessionListener;
+import org.eclipse.jetty.http2.frames.HeadersFrame;
+import org.eclipse.jetty.util.Callback;
+import org.junit.jupiter.api.Test;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RetryRequestTest extends AbstractTest
+{
+    @Test
+    public void testRetryRequest() throws Exception
+    {
+        AtomicReference<Session> serverSessionRef = new AtomicReference<>();
+        start(new ServerSessionListener()
+        {
+            @Override
+            public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
+            {
+                serverSessionRef.set(stream.getSession());
+                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
+                stream.headers(new HeadersFrame(stream.getId(), response, null, true));
+                return null;
+            }
+        });
+
+        AtomicReference<Result> resultRef = new AtomicReference<>();
+        httpClient.newRequest("localhost", connector.getLocalPort())
+            .path("/one")
+            .timeout(5, TimeUnit.SECONDS)
+            .send(result ->
+            {
+                // No HTTP/2 frames are processed until returning from this method.
+                serverSessionRef.get().close(ErrorCode.NO_ERROR.code, "retry_next", Callback.NOOP);
+                // Send a second request, should be failed by the client.
+                httpClient.newRequest("localhost", connector.getLocalPort())
+                    .path("/two")
+                    .timeout(5, TimeUnit.SECONDS)
+                    .send(resultRef::set);
+            });
+
+        Result result = await().atMost(5, TimeUnit.SECONDS).until(resultRef::get, Objects::nonNull);
+
+        assertTrue(result.isFailed());
+        assertThat(result.getFailure(), instanceOf(RetryRequestException.class));
+    }
+}

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/RetryRequestTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/RetryRequestTest.java
@@ -18,7 +18,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.jetty.client.Result;
-import org.eclipse.jetty.client.RetryRequestException;
+import org.eclipse.jetty.client.RetryableRequestException;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpVersion;
@@ -72,6 +72,6 @@ public class RetryRequestTest extends AbstractTest
         Result result = await().atMost(5, TimeUnit.SECONDS).until(resultRef::get, Objects::nonNull);
 
         assertTrue(result.isFailed());
-        assertThat(result.getFailure(), instanceOf(RetryRequestException.class));
+        assertThat(result.getFailure(), instanceOf(RetryableRequestException.class));
     }
 }

--- a/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpReceiverOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpReceiverOverHTTP3.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.http3.client.transport.internal;
 import java.io.EOFException;
 import java.nio.ByteBuffer;
 
+import org.eclipse.jetty.client.RetryRequestException;
 import org.eclipse.jetty.client.transport.HttpExchange;
 import org.eclipse.jetty.client.transport.HttpReceiver;
 import org.eclipse.jetty.client.transport.HttpResponse;
@@ -23,6 +24,7 @@ import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.http3.HTTP3ErrorCode;
+import org.eclipse.jetty.http3.HTTP3Session;
 import org.eclipse.jetty.http3.api.Stream;
 import org.eclipse.jetty.http3.frames.HeadersFrame;
 import org.eclipse.jetty.io.Content;
@@ -156,6 +158,8 @@ public class HttpReceiverOverHTTP3 extends HttpReceiver implements Stream.Client
     @Override
     public void onFailure(Stream.Client stream, long error, Throwable failure)
     {
+        if (failure instanceof HTTP3Session.RetryStreamException)
+            failure = new RetryRequestException(failure);
         responseFailure(failure, Promise.noop());
     }
 }

--- a/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpReceiverOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpReceiverOverHTTP3.java
@@ -16,7 +16,7 @@ package org.eclipse.jetty.http3.client.transport.internal;
 import java.io.EOFException;
 import java.nio.ByteBuffer;
 
-import org.eclipse.jetty.client.RetryRequestException;
+import org.eclipse.jetty.client.RetryableRequestException;
 import org.eclipse.jetty.client.transport.HttpExchange;
 import org.eclipse.jetty.client.transport.HttpReceiver;
 import org.eclipse.jetty.client.transport.HttpResponse;
@@ -24,7 +24,7 @@ import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.http3.HTTP3ErrorCode;
-import org.eclipse.jetty.http3.HTTP3Session;
+import org.eclipse.jetty.http3.RetryableStreamException;
 import org.eclipse.jetty.http3.api.Stream;
 import org.eclipse.jetty.http3.frames.HeadersFrame;
 import org.eclipse.jetty.io.Content;
@@ -158,8 +158,8 @@ public class HttpReceiverOverHTTP3 extends HttpReceiver implements Stream.Client
     @Override
     public void onFailure(Stream.Client stream, long error, Throwable failure)
     {
-        if (failure instanceof HTTP3Session.RetryStreamException)
-            failure = new RetryRequestException(failure);
+        if (failure instanceof RetryableStreamException)
+            failure = new RetryableRequestException(failure);
         responseFailure(failure, Promise.noop());
     }
 }

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/HTTP3Session.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/HTTP3Session.java
@@ -545,7 +545,7 @@ public abstract class HTTP3Session extends ContainerLifeCycle implements Session
             // The other peer sent us a GOAWAY with the last processed streamId,
             // so we must fail the streams that have a bigger streamId.
             Predicate<HTTP3Stream> predicate = stream -> stream.isLocal() && stream.getId() > frame.getLastId();
-            failStreams(predicate, HTTP3ErrorCode.REQUEST_CANCELLED_ERROR.code(), true, new RetryStreamException());
+            failStreams(predicate, HTTP3ErrorCode.REQUEST_CANCELLED_ERROR.code(), true, new RetryableStreamException());
         }
 
         tryRunZeroStreamsAction();
@@ -855,14 +855,6 @@ public abstract class HTTP3Session extends ContainerLifeCycle implements Session
     public String toString()
     {
         return String.format("%s@%x[streams=%d,%s]", getClass().getSimpleName(), hashCode(), streamCount.get(), closeState);
-    }
-
-    /**
-     * <p>Exception indicating that the HTTP/2 stream was not handled
-     * by the server, and can therefore be retried, if possible.</p>
-     */
-    public static class RetryStreamException extends RuntimeException
-    {
     }
 
     private enum CloseState

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/HTTP3Session.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/HTTP3Session.java
@@ -217,7 +217,7 @@ public abstract class HTTP3Session extends ContainerLifeCycle implements Session
             {
                 long error = HTTP3ErrorCode.REQUEST_CANCELLED_ERROR.code();
                 String reason = "go_away";
-                failStreams(stream -> true, error, reason, true, new ClosedChannelException());
+                failStreams(stream -> true, error, true, new ClosedChannelException());
                 terminateAndDisconnect(error, reason);
             }
             return CompletableFuture.completedFuture(null);
@@ -545,7 +545,7 @@ public abstract class HTTP3Session extends ContainerLifeCycle implements Session
             // The other peer sent us a GOAWAY with the last processed streamId,
             // so we must fail the streams that have a bigger streamId.
             Predicate<HTTP3Stream> predicate = stream -> stream.isLocal() && stream.getId() > frame.getLastId();
-            failStreams(predicate, HTTP3ErrorCode.REQUEST_CANCELLED_ERROR.code(), "go_away", true, new EofException());
+            failStreams(predicate, HTTP3ErrorCode.REQUEST_CANCELLED_ERROR.code(), true, new RetryStreamException());
         }
 
         tryRunZeroStreamsAction();
@@ -625,7 +625,7 @@ public abstract class HTTP3Session extends ContainerLifeCycle implements Session
             }
         }
 
-        failStreams(stream -> true, error, reason, true, new IOException(reason));
+        failStreams(stream -> true, error, true, new IOException(reason));
 
         if (goAwayFrame != null)
             writeControlFrame(goAwayFrame, Callback.from(() -> terminateAndDisconnect(error, reason)));
@@ -672,7 +672,7 @@ public abstract class HTTP3Session extends ContainerLifeCycle implements Session
         getProtocolSession().outwardClose(error, reason);
     }
 
-    private void failStreams(Predicate<HTTP3Stream> predicate, long error, String reason, boolean close, Throwable failure)
+    private void failStreams(Predicate<HTTP3Stream> predicate, long error, boolean close, Throwable failure)
     {
         streams.values().stream()
             .filter(predicate)
@@ -680,8 +680,6 @@ public abstract class HTTP3Session extends ContainerLifeCycle implements Session
             {
                 if (close)
                     stream.reset(error, failure);
-                // Since the stream failure was generated
-                // by a GOAWAY, notify the application.
                 stream.onFailure(error, failure);
             });
     }
@@ -793,7 +791,7 @@ public abstract class HTTP3Session extends ContainerLifeCycle implements Session
 
         // No point in closing the streams, as QUIC frames cannot be sent.
         Throwable failure = new EofException(reason);
-        failStreams(stream -> true, error, reason, false, failure);
+        failStreams(stream -> true, error, false, failure);
 
         if (notifyFailure)
             onSessionFailure(error, reason, failure);
@@ -857,6 +855,14 @@ public abstract class HTTP3Session extends ContainerLifeCycle implements Session
     public String toString()
     {
         return String.format("%s@%x[streams=%d,%s]", getClass().getSimpleName(), hashCode(), streamCount.get(), closeState);
+    }
+
+    /**
+     * <p>Exception indicating that the HTTP/2 stream was not handled
+     * by the server, and can therefore be retried, if possible.</p>
+     */
+    public static class RetryStreamException extends RuntimeException
+    {
     }
 
     private enum CloseState

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/RetryableStreamException.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/RetryableStreamException.java
@@ -14,7 +14,7 @@
 package org.eclipse.jetty.http3;
 
 /**
- * <p>Exception indicating that the HTTP/2 stream was not handled
+ * <p>Exception indicating that the HTTP/3 stream was not handled
  * by the server, and can therefore be retried, if possible.</p>
  */
 public class RetryableStreamException extends RuntimeException

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/RetryableStreamException.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/RetryableStreamException.java
@@ -11,16 +11,12 @@
 // ========================================================================
 //
 
-package org.eclipse.jetty.client;
+package org.eclipse.jetty.http3;
 
 /**
- * <p>Exception indicating that the HTTP request was not handled
+ * <p>Exception indicating that the HTTP/2 stream was not handled
  * by the server, and can therefore be retried, if possible.</p>
  */
-public class RetryRequestException extends RuntimeException
+public class RetryableStreamException extends RuntimeException
 {
-    public RetryRequestException(Throwable failure)
-    {
-        super(failure);
-    }
 }

--- a/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/HttpClientTransportOverHTTP3Test.java
+++ b/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/HttpClientTransportOverHTTP3Test.java
@@ -338,5 +338,4 @@ public class HttpClientTransportOverHTTP3Test extends AbstractClientServerTest
     {
         assertThat(response.getHeaders().getValuesList(header), equalTo(Arrays.asList(values)));
     }
-
 }

--- a/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/RetryRequestTest.java
+++ b/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/RetryRequestTest.java
@@ -1,0 +1,77 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.http3.tests;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.jetty.client.Result;
+import org.eclipse.jetty.client.RetryRequestException;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpScheme;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.http3.api.Session;
+import org.eclipse.jetty.http3.api.Stream;
+import org.eclipse.jetty.http3.frames.HeadersFrame;
+import org.junit.jupiter.api.Test;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RetryRequestTest extends AbstractClientServerTest
+{
+    @Test
+    public void testRetryRequest() throws Exception
+    {
+        AtomicReference<Session> serverSessionRef = new AtomicReference<>();
+        start(new Session.Server.Listener()
+        {
+            @Override
+            public Stream.Server.Listener onRequest(Stream.Server stream, HeadersFrame frame)
+            {
+                serverSessionRef.set(stream.getSession());
+                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
+                stream.respond(new HeadersFrame(response, true));
+                return null;
+            }
+        });
+
+        AtomicReference<Result> resultRef = new AtomicReference<>();
+        httpClient.newRequest("localhost", connector.getLocalPort())
+            .scheme(HttpScheme.HTTPS.asString())
+            .path("/one")
+            .timeout(5, TimeUnit.SECONDS)
+            .send(result ->
+            {
+                // No HTTP/3 frames are processed until returning from this method.
+                serverSessionRef.get().goAway(false);
+                // Send a second request, should be failed by the client.
+                httpClient.newRequest("localhost", connector.getLocalPort())
+                    .scheme(HttpScheme.HTTPS.asString())
+                    .path("/two")
+                    .timeout(5, TimeUnit.SECONDS)
+                    .send(resultRef::set);
+            });
+
+        Result result = await().atMost(5, TimeUnit.SECONDS).until(resultRef::get, Objects::nonNull);
+
+        assertTrue(result.isFailed());
+        assertThat(result.getFailure(), instanceOf(RetryRequestException.class));
+    }
+}

--- a/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/RetryRequestTest.java
+++ b/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/RetryRequestTest.java
@@ -18,7 +18,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.jetty.client.Result;
-import org.eclipse.jetty.client.RetryRequestException;
+import org.eclipse.jetty.client.RetryableRequestException;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.http.HttpStatus;
@@ -72,6 +72,6 @@ public class RetryRequestTest extends AbstractClientServerTest
         Result result = await().atMost(5, TimeUnit.SECONDS).until(resultRef::get, Objects::nonNull);
 
         assertTrue(result.isFailed());
-        assertThat(result.getFailure(), instanceOf(RetryRequestException.class));
+        assertThat(result.getFailure(), instanceOf(RetryableRequestException.class));
     }
 }


### PR DESCRIPTION
* Introduced RetryRequestException for the high-level APIs.
* Low-level HTTP/2 and HTTP/3 now fail local streams with id > goaway.last-stream-id with a RetryStreamException.
* When linking with the high-level APIs, RetryStreamException is converted to RetryRequestException, so applications can decide whether to retry the request.