### PR TITLE
Change default stop timeout value in `WebSocketClient`

### DIFF
--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
@@ -60,7 +60,7 @@ public class WebSocketClient extends ContainerLifeCycle implements Configurable,
     private final SessionTracker sessionTracker = new SessionTracker();
     private final Configuration.ConfigurationCustomizer configurationCustomizer = new Configuration.ConfigurationCustomizer();
     private boolean stopAtShutdown = false;
-    private long _stopTimeout = Long.MAX_VALUE;
+    private long _stopTimeout = 30;
 
     /**
      * Instantiates a WebSocketClient with a default {@link HttpClient}.
@@ -398,9 +398,16 @@ public class WebSocketClient extends ContainerLifeCycle implements Configurable,
     @Override
     protected void doStop() throws Exception
     {
-        if (getStopTimeout() > 0)
-            Graceful.shutdown(this).get(getStopTimeout(), TimeUnit.MILLISECONDS);
-        super.doStop();
+        try
+        {
+            long stopTimeout = getStopTimeout();
+            if (stopTimeout > 0L)
+                Graceful.shutdown(this).get(stopTimeout, TimeUnit.MILLISECONDS);
+        }
+        finally
+        {
+            super.doStop();
+        }
     }
 
     @Override

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
@@ -60,7 +60,7 @@ public class WebSocketClient extends ContainerLifeCycle implements Configurable,
     private final SessionTracker sessionTracker = new SessionTracker();
     private final Configuration.ConfigurationCustomizer configurationCustomizer = new Configuration.ConfigurationCustomizer();
     private boolean stopAtShutdown = false;
-    private long _stopTimeout = 30;
+    private long _stopTimeout;
 
     /**
      * Instantiates a WebSocketClient with a default {@link HttpClient}.

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/WebSocketStopTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/WebSocketStopTest.java
@@ -56,6 +56,7 @@ public class WebSocketStopTest
         server.setHandler(wsHandler);
         server.start();
 
+        client.setStopTimeout(5000);
         client.start();
     }
 

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientCloseTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientCloseTest.java
@@ -95,6 +95,7 @@ public class ClientCloseTest
     {
         client = new WebSocketClient();
         client.setMaxTextMessageSize(1024);
+        client.setStopTimeout(5000);
         client.start();
     }
 

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-client/src/main/java/org/eclipse/jetty/ee9/websocket/client/WebSocketClient.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-client/src/main/java/org/eclipse/jetty/ee9/websocket/client/WebSocketClient.java
@@ -64,7 +64,7 @@ public class WebSocketClient extends ContainerLifeCycle implements WebSocketPoli
     private final Configuration.ConfigurationCustomizer configurationCustomizer = new Configuration.ConfigurationCustomizer();
     private final WebSocketComponents components = new WebSocketComponents();
     private boolean stopAtShutdown = false;
-    private long _stopTimeout = Long.MAX_VALUE;
+    private long _stopTimeout = 30;
 
     /**
      * Instantiate a WebSocketClient with defaults
@@ -394,9 +394,16 @@ public class WebSocketClient extends ContainerLifeCycle implements WebSocketPoli
     @Override
     protected void doStop() throws Exception
     {
-        if (getStopTimeout() > 0)
-            Graceful.shutdown(this).get(getStopTimeout(), TimeUnit.MILLISECONDS);
-        super.doStop();
+        try
+        {
+            long stopTimeout = getStopTimeout();
+            if (stopTimeout > 0L)
+                Graceful.shutdown(this).get(stopTimeout, TimeUnit.MILLISECONDS);
+        }
+        finally
+        {
+            super.doStop();
+        }
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-client/src/main/java/org/eclipse/jetty/ee9/websocket/client/WebSocketClient.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-client/src/main/java/org/eclipse/jetty/ee9/websocket/client/WebSocketClient.java
@@ -64,7 +64,7 @@ public class WebSocketClient extends ContainerLifeCycle implements WebSocketPoli
     private final Configuration.ConfigurationCustomizer configurationCustomizer = new Configuration.ConfigurationCustomizer();
     private final WebSocketComponents components = new WebSocketComponents();
     private boolean stopAtShutdown = false;
-    private long _stopTimeout = 30;
+    private long _stopTimeout;
 
     /**
      * Instantiate a WebSocketClient with defaults

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/WebSocketStopTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/WebSocketStopTest.java
@@ -70,6 +70,7 @@ public class WebSocketStopTest
         JettyWebSocketServletContainerInitializer.configure(contextHandler, null);
 
         server.start();
+        client.setStopTimeout(5000);
         client.start();
     }
 

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/client/ClientCloseTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/client/ClientCloseTest.java
@@ -99,6 +99,7 @@ public class ClientCloseTest
     {
         client = new WebSocketClient();
         client.setMaxTextMessageSize(1024);
+        client.setStopTimeout(5000);
         client.start();
     }
 


### PR DESCRIPTION
This should fix the graceful stop from blocking virtually forever.

Nevertheless, since only JDK24 builds reported this error, something not cleaned up was left for the graceful shutdown to clean it up. This should be identified and fixed too.

Fixes #13160