### PR TITLE
Fixes #13164 - ProxyServlet abort.

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpStatus.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpStatus.java
@@ -205,14 +205,12 @@ public class HttpStatus
         }
 
         /**
-         * Simple test against an code to determine if it falls into the
-         * <code>Informational</code> message category as defined in the <a
-         * href="http://tools.ietf.org/html/rfc1945">RFC 1945 - HTTP/1.0</a>,
-         * and <a href="http://tools.ietf.org/html/rfc7231">RFC 7231 -
-         * HTTP/1.1</a>.
+         * Simple test against a code to determine if it falls into the
+         * {@code Informational} message category as defined in
+         * <a href="https://www.rfc-editor.org/rfc/rfc9110.html">RFC 9110</a>.
          *
          * @return true if within range of codes that belongs to
-         * <code>Informational</code> messages.
+         * {@code Informational} codes.
          */
         public boolean isInformational()
         {
@@ -220,14 +218,12 @@ public class HttpStatus
         }
 
         /**
-         * Simple test against an code to determine if it falls into the
-         * <code>Success</code> message category as defined in the <a
-         * href="http://tools.ietf.org/html/rfc1945">RFC 1945 - HTTP/1.0</a>,
-         * and <a href="http://tools.ietf.org/html/rfc7231">RFC 7231 -
-         * HTTP/1.1</a>.
+         * Simple test against a code to determine if it falls into the
+         * {@code Successful} message category as defined in
+         * <a href="https://www.rfc-editor.org/rfc/rfc9110.html">RFC 9110</a>.
          *
          * @return true if within range of codes that belongs to
-         * <code>Success</code> messages.
+         * {@code Successful} codes.
          */
         public boolean isSuccess()
         {
@@ -235,14 +231,12 @@ public class HttpStatus
         }
 
         /**
-         * Simple test against an code to determine if it falls into the
-         * <code>Redirection</code> message category as defined in the <a
-         * href="http://tools.ietf.org/html/rfc1945">RFC 1945 - HTTP/1.0</a>,
-         * and <a href="http://tools.ietf.org/html/rfc7231">RFC 7231 -
-         * HTTP/1.1</a>.
+         * Simple test against a code to determine if it falls into the
+         * {@code Redirection} message category as defined in
+         * <a href="https://www.rfc-editor.org/rfc/rfc9110.html">RFC 9110</a>.
          *
          * @return true if within range of codes that belongs to
-         * <code>Redirection</code> messages.
+         * {@code Redirection} codes.
          */
         public boolean isRedirection()
         {
@@ -250,14 +244,12 @@ public class HttpStatus
         }
 
         /**
-         * Simple test against an code to determine if it falls into the
-         * <code>Client Error</code> message category as defined in the <a
-         * href="http://tools.ietf.org/html/rfc1945">RFC 1945 - HTTP/1.0</a>,
-         * and <a href="http://tools.ietf.org/html/rfc7231">RFC 7231 -
-         * HTTP/1.1</a>.
+         * Simple test against a code to determine if it falls into the
+         * {@code Client Error} message category as defined in
+         * <a href="https://www.rfc-editor.org/rfc/rfc9110.html">RFC 9110</a>.
          *
          * @return true if within range of codes that belongs to
-         * <code>Client Error</code> messages.
+         * {@code Client Error} codes.
          */
         public boolean isClientError()
         {
@@ -265,14 +257,12 @@ public class HttpStatus
         }
 
         /**
-         * Simple test against an code to determine if it falls into the
-         * <code>Server Error</code> message category as defined in the <a
-         * href="http://tools.ietf.org/html/rfc1945">RFC 1945 - HTTP/1.0</a>,
-         * and <a href="http://tools.ietf.org/html/rfc7231">RFC 7231 -
-         * HTTP/1.1</a>.
+         * Simple test against a code to determine if it falls into the
+         * {@code Server Error} message category as defined in
+         * <a href="https://www.rfc-editor.org/rfc/rfc9110.html">RFC 9110</a>.
          *
          * @return true if within range of codes that belongs to
-         * <code>Server Error</code> messages.
+         * {@code Server Error} codes.
          */
         public boolean isServerError()
         {
@@ -281,10 +271,10 @@ public class HttpStatus
     }
 
     /**
-     * Get the HttpStatusCode for a specific code
+     * Get the HttpStatus.Code for a specific code.
      *
      * @param code the code to lookup.
-     * @return the {@link HttpStatus} if found, or null if not found.
+     * @return the {@link HttpStatus.Code} if found, or null if not found.
      */
     public static Code getCode(int code)
     {
@@ -317,28 +307,21 @@ public class HttpStatus
 
     public static boolean hasNoBody(int status)
     {
-        switch (status)
+        return switch (status)
         {
-            case NO_CONTENT_204:
-            case RESET_CONTENT_205:
-            case PARTIAL_CONTENT_206:
-            case NOT_MODIFIED_304:
-                return true;
-
-            default:
-                return status < OK_200;
-        }
+            case NO_CONTENT_204, RESET_CONTENT_205, PARTIAL_CONTENT_206, NOT_MODIFIED_304 -> true;
+            default -> status < OK_200;
+        };
     }
 
     /**
-     * Simple test against an code to determine if it falls into the
-     * <code>Informational</code> message category as defined in the <a
-     * href="http://tools.ietf.org/html/rfc1945">RFC 1945 - HTTP/1.0</a>, and <a
-     * href="http://tools.ietf.org/html/rfc7231">RFC 7231 - HTTP/1.1</a>.
+     * Simple test against a code to determine if it falls into the
+     * {@code Informational} message category as defined in
+     * <a href="https://www.rfc-editor.org/rfc/rfc9110.html">RFC 9110</a>.
      *
      * @param code the code to test.
      * @return true if within range of codes that belongs to
-     * <code>Informational</code> messages.
+     * {@code Informational} codes.
      */
     public static boolean isInformational(int code)
     {
@@ -357,14 +340,13 @@ public class HttpStatus
     }
 
     /**
-     * Simple test against an code to determine if it falls into the
-     * <code>Success</code> message category as defined in the <a
-     * href="http://tools.ietf.org/html/rfc1945">RFC 1945 - HTTP/1.0</a>, and <a
-     * href="http://tools.ietf.org/html/rfc7231">RFC 7231 - HTTP/1.1</a>.
+     * Simple test against a code to determine if it falls into the
+     * {@code Successful} message category as defined in
+     * <a href="https://www.rfc-editor.org/rfc/rfc9110.html">RFC 9110</a>.
      *
      * @param code the code to test.
      * @return true if within range of codes that belongs to
-     * <code>Success</code> messages.
+     * {@code Successful} codes.
      */
     public static boolean isSuccess(int code)
     {
@@ -372,14 +354,13 @@ public class HttpStatus
     }
 
     /**
-     * Simple test against an code to determine if it falls into the
-     * <code>Redirection</code> message category as defined in the <a
-     * href="http://tools.ietf.org/html/rfc1945">RFC 1945 - HTTP/1.0</a>, and <a
-     * href="http://tools.ietf.org/html/rfc7231">RFC 7231 - HTTP/1.1</a>.
+     * Simple test against a code to determine if it falls into the
+     * {@code Redirection} message category as defined in
+     * <a href="https://www.rfc-editor.org/rfc/rfc9110.html">RFC 9110</a>.
      *
      * @param code the code to test.
      * @return true if within range of codes that belongs to
-     * <code>Redirection</code> messages.
+     * {@code Redirection} codes.
      */
     public static boolean isRedirection(int code)
     {
@@ -387,14 +368,26 @@ public class HttpStatus
     }
 
     /**
-     * Simple test against an code to determine if it falls into the
-     * <code>Client Error</code> message category as defined in the <a
-     * href="http://tools.ietf.org/html/rfc1945">RFC 1945 - HTTP/1.0</a>, and <a
-     * href="http://tools.ietf.org/html/rfc7231">RFC 7231 - HTTP/1.1</a>.
+     * Tests whether the status code is either a
+     * {@link #isClientError(int) client error} or a
+     * {@link #isServerError(int) server error}.
+     *
+     * @param code the code to test
+     * @return whether the status code is either a client error or a server error
+     */
+    public static boolean isError(int code)
+    {
+        return isClientError(code) || isServerError(code);
+    }
+
+    /**
+     * Simple test against a code to determine if it falls into the
+     * {@code Client Error} message category as defined in
+     * <a href="https://www.rfc-editor.org/rfc/rfc9110.html">RFC 9110</a>.
      *
      * @param code the code to test.
      * @return true if within range of codes that belongs to
-     * <code>Client Error</code> messages.
+     * {@code Client Error} codes.
      */
     public static boolean isClientError(int code)
     {
@@ -402,14 +395,13 @@ public class HttpStatus
     }
 
     /**
-     * Simple test against an code to determine if it falls into the
-     * <code>Server Error</code> message category as defined in the <a
-     * href="http://tools.ietf.org/html/rfc1945">RFC 1945 - HTTP/1.0</a>, and <a
-     * href="http://tools.ietf.org/html/rfc7231">RFC 7231 - HTTP/1.1</a>.
+     * Simple test against a code to determine if it falls into the
+     * {@code Server Error} message category as defined in
+     * <a href="https://www.rfc-editor.org/rfc/rfc9110.html">RFC 9110</a>.
      *
      * @param code the code to test.
      * @return true if within range of codes that belongs to
-     * <code>Server Error</code> messages.
+     * {@code Server Error} codes.
      */
     public static boolean isServerError(int code)
     {

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpStatus.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpStatus.java
@@ -205,7 +205,7 @@ public class HttpStatus
         }
 
         /**
-         * Simple test against a code to determine if it falls into the
+         * Tests whether the status code is of the
          * {@code Informational} message category as defined in
          * <a href="https://www.rfc-editor.org/rfc/rfc9110.html">RFC 9110</a>.
          *
@@ -218,7 +218,7 @@ public class HttpStatus
         }
 
         /**
-         * Simple test against a code to determine if it falls into the
+         * Tests whether the status code is of the
          * {@code Successful} message category as defined in
          * <a href="https://www.rfc-editor.org/rfc/rfc9110.html">RFC 9110</a>.
          *
@@ -231,7 +231,7 @@ public class HttpStatus
         }
 
         /**
-         * Simple test against a code to determine if it falls into the
+         * Tests whether the status code is of the
          * {@code Redirection} message category as defined in
          * <a href="https://www.rfc-editor.org/rfc/rfc9110.html">RFC 9110</a>.
          *
@@ -244,7 +244,7 @@ public class HttpStatus
         }
 
         /**
-         * Simple test against a code to determine if it falls into the
+         * Tests whether the status code is of the
          * {@code Client Error} message category as defined in
          * <a href="https://www.rfc-editor.org/rfc/rfc9110.html">RFC 9110</a>.
          *
@@ -257,7 +257,7 @@ public class HttpStatus
         }
 
         /**
-         * Simple test against a code to determine if it falls into the
+         * Tests whether the status code is of the
          * {@code Server Error} message category as defined in
          * <a href="https://www.rfc-editor.org/rfc/rfc9110.html">RFC 9110</a>.
          *
@@ -315,7 +315,7 @@ public class HttpStatus
     }
 
     /**
-     * Simple test against a code to determine if it falls into the
+     * Tests whether the status code is of the
      * {@code Informational} message category as defined in
      * <a href="https://www.rfc-editor.org/rfc/rfc9110.html">RFC 9110</a>.
      *
@@ -340,7 +340,7 @@ public class HttpStatus
     }
 
     /**
-     * Simple test against a code to determine if it falls into the
+     * Tests whether the status code is of the
      * {@code Successful} message category as defined in
      * <a href="https://www.rfc-editor.org/rfc/rfc9110.html">RFC 9110</a>.
      *
@@ -354,7 +354,7 @@ public class HttpStatus
     }
 
     /**
-     * Simple test against a code to determine if it falls into the
+     * Tests whether the status code is of the
      * {@code Redirection} message category as defined in
      * <a href="https://www.rfc-editor.org/rfc/rfc9110.html">RFC 9110</a>.
      *
@@ -381,7 +381,7 @@ public class HttpStatus
     }
 
     /**
-     * Simple test against a code to determine if it falls into the
+     * Tests whether the status code is of the
      * {@code Client Error} message category as defined in
      * <a href="https://www.rfc-editor.org/rfc/rfc9110.html">RFC 9110</a>.
      *
@@ -395,7 +395,7 @@ public class HttpStatus
     }
 
     /**
-     * Simple test against a code to determine if it falls into the
+     * Tests whether the status code is of the
      * {@code Server Error} message category as defined in
      * <a href="https://www.rfc-editor.org/rfc/rfc9110.html">RFC 9110</a>.
      *

--- a/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/AsyncMiddleManServlet.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/AsyncMiddleManServlet.java
@@ -67,6 +67,7 @@ import org.slf4j.LoggerFactory;
  */
 public class AsyncMiddleManServlet extends AbstractProxyServlet
 {
+    private static final String PROXY_REQUEST_SENT_ATTRIBUTE = AsyncMiddleManServlet.class.getName() + ".proxyRequestSent";
     private static final String PROXY_REQUEST_CONTENT_COMMITTED_ATTRIBUTE = AsyncMiddleManServlet.class.getName() + ".proxyRequestContentCommitted";
     private static final String CLIENT_TRANSFORMER_ATTRIBUTE = AsyncMiddleManServlet.class.getName() + ".clientTransformer";
     private static final String SERVER_TRANSFORMER_ATTRIBUTE = AsyncMiddleManServlet.class.getName() + ".serverTransformer";
@@ -137,6 +138,13 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
         {
             sendProxyRequest(clientRequest, proxyResponse, proxyRequest);
         }
+    }
+
+    @Override
+    protected void sendProxyRequest(HttpServletRequest clientRequest, HttpServletResponse proxyResponse, Request proxyRequest)
+    {
+        proxyRequest.attribute(PROXY_REQUEST_SENT_ATTRIBUTE, true);
+        super.sendProxyRequest(clientRequest, proxyResponse, proxyRequest);
     }
 
     protected AsyncRequestContent newProxyRequestContent(HttpServletRequest clientRequest, HttpServletResponse proxyResponse, Request proxyRequest)
@@ -304,6 +312,8 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
         {
             cleanup(clientRequest);
             onClientRequestFailure(clientRequest, proxyRequest, proxyResponse, t);
+            if (!proxyRequest.getAttributes().containsKey(PROXY_REQUEST_SENT_ATTRIBUTE))
+                onProxyResponseFailure(clientRequest, proxyResponse, null, t);
         }
 
         @Override

--- a/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/AsyncProxyServlet.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/AsyncProxyServlet.java
@@ -152,7 +152,7 @@ public class AsyncProxyServlet extends ProxyServlet
         @Override
         public void onError(Throwable t)
         {
-            onClientRequestFailure(request, proxyRequest, response, t);
+            content.fail(t);
         }
 
         @Override

--- a/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/ProxyServlet.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/ProxyServlet.java
@@ -31,6 +31,7 @@ import org.eclipse.jetty.client.Result;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.server.handler.ConnectHandler;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.ExceptionUtil;
 
 /**
  * <p>Servlet 3.0 asynchronous proxy servlet.</p>
@@ -92,12 +93,10 @@ public class ProxyServlet extends AbstractProxyServlet
                         Request.Content content = proxyRequestContent(request, response, proxyRequest);
                         Content.copy(content, delegate, Callback.from(
                             delegate::close,
-                            x ->
-                            {
-                                delegate.fail(x);
-                                onClientRequestFailure(request, proxyRequest, response, x);
-                            })
-                        );
+                            x -> ExceptionUtil.callAndThen(
+                                x, delegate::fail, t -> onClientRequestFailure(request, proxyRequest, response, t)
+                            )
+                        ));
                     }
                     catch (Throwable failure)
                     {

--- a/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/ProxyServlet.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/ProxyServlet.java
@@ -90,7 +90,14 @@ public class ProxyServlet extends AbstractProxyServlet
                     try
                     {
                         Request.Content content = proxyRequestContent(request, response, proxyRequest);
-                        Content.copy(content, delegate, Callback.from(delegate::close, x -> onClientRequestFailure(request, proxyRequest, response, x)));
+                        Content.copy(content, delegate, Callback.from(
+                            delegate::close,
+                            x ->
+                            {
+                                delegate.fail(x);
+                                onClientRequestFailure(request, proxyRequest, response, x);
+                            })
+                        );
                     }
                     catch (Throwable failure)
                     {
@@ -259,7 +266,6 @@ public class ProxyServlet extends AbstractProxyServlet
             {
                 if (!chunk.isLast())
                     fail(chunk.getFailure());
-                onClientRequestFailure(request, proxyRequest, response, chunk.getFailure());
             }
             else
             {

--- a/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/AsyncMiddleManServletTest.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/AsyncMiddleManServletTest.java
@@ -589,7 +589,7 @@ public class AsyncMiddleManServletTest
                 .body(content)
                 .send(result ->
                 {
-                    if (result.isSucceeded() && result.getResponse().getStatus() == 502)
+                    if (result.isSucceeded() && result.getResponse().getStatus() == HttpStatus.INTERNAL_SERVER_ERROR_500)
                         latch.countDown();
                 });
 
@@ -669,7 +669,7 @@ public class AsyncMiddleManServletTest
                 .timeout(5, TimeUnit.SECONDS)
                 .send();
 
-            assertEquals(502, response.getStatus());
+            assertEquals(HttpStatus.BAD_GATEWAY_502, response.getStatus());
         }
     }
 
@@ -870,7 +870,7 @@ public class AsyncMiddleManServletTest
             .body(content)
             .send(result ->
             {
-                if (result.getResponse().getStatus() == 502)
+                if (result.getResponse().getStatus() == HttpStatus.INTERNAL_SERVER_ERROR_500)
                     latch.countDown();
             });
         content.write(ByteBuffer.allocate(512), Callback.NOOP);
@@ -925,7 +925,7 @@ public class AsyncMiddleManServletTest
             .timeout(5, TimeUnit.SECONDS)
             .send();
 
-        assertEquals(502, response.getStatus());
+        assertEquals(HttpStatus.BAD_GATEWAY_502, response.getStatus());
     }
 
     @Test

--- a/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/AsyncMiddleManServlet.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/AsyncMiddleManServlet.java
@@ -67,6 +67,7 @@ import org.slf4j.LoggerFactory;
  */
 public class AsyncMiddleManServlet extends AbstractProxyServlet
 {
+    private static final String PROXY_REQUEST_SENT_ATTRIBUTE = AsyncMiddleManServlet.class.getName() + ".proxyRequestSent";
     private static final String PROXY_REQUEST_CONTENT_COMMITTED_ATTRIBUTE = AsyncMiddleManServlet.class.getName() + ".proxyRequestContentCommitted";
     private static final String CLIENT_TRANSFORMER_ATTRIBUTE = AsyncMiddleManServlet.class.getName() + ".clientTransformer";
     private static final String SERVER_TRANSFORMER_ATTRIBUTE = AsyncMiddleManServlet.class.getName() + ".serverTransformer";
@@ -137,6 +138,13 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
         {
             sendProxyRequest(clientRequest, proxyResponse, proxyRequest);
         }
+    }
+
+    @Override
+    protected void sendProxyRequest(HttpServletRequest clientRequest, HttpServletResponse proxyResponse, Request proxyRequest)
+    {
+        proxyRequest.attribute(PROXY_REQUEST_SENT_ATTRIBUTE, true);
+        super.sendProxyRequest(clientRequest, proxyResponse, proxyRequest);
     }
 
     protected AsyncRequestContent newProxyRequestContent(HttpServletRequest clientRequest, HttpServletResponse proxyResponse, Request proxyRequest)
@@ -304,6 +312,8 @@ public class AsyncMiddleManServlet extends AbstractProxyServlet
         {
             cleanup(clientRequest);
             onClientRequestFailure(clientRequest, proxyRequest, proxyResponse, t);
+            if (!proxyRequest.getAttributes().containsKey(PROXY_REQUEST_SENT_ATTRIBUTE))
+                onProxyResponseFailure(clientRequest, proxyResponse, null, t);
         }
 
         @Override

--- a/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/AsyncProxyServlet.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/AsyncProxyServlet.java
@@ -152,7 +152,7 @@ public class AsyncProxyServlet extends ProxyServlet
         @Override
         public void onError(Throwable t)
         {
-            onClientRequestFailure(request, proxyRequest, response, t);
+            content.fail(t);
         }
 
         @Override

--- a/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/ProxyServlet.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/ProxyServlet.java
@@ -31,6 +31,7 @@ import org.eclipse.jetty.client.Result;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.server.handler.ConnectHandler;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.ExceptionUtil;
 
 /**
  * <p>Servlet 3.0 asynchronous proxy servlet.</p>
@@ -92,12 +93,10 @@ public class ProxyServlet extends AbstractProxyServlet
                         Request.Content content = proxyRequestContent(request, response, proxyRequest);
                         Content.copy(content, delegate, Callback.from(
                             delegate::close,
-                            x ->
-                            {
-                                delegate.fail(x);
-                                onClientRequestFailure(request, proxyRequest, response, x);
-                            })
-                        );
+                            x -> ExceptionUtil.callAndThen(
+                                x, delegate::fail, t -> onClientRequestFailure(request, proxyRequest, response, t)
+                            )
+                        ));
                     }
                     catch (Throwable failure)
                     {

--- a/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/ProxyServlet.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/ProxyServlet.java
@@ -90,7 +90,14 @@ public class ProxyServlet extends AbstractProxyServlet
                     try
                     {
                         Request.Content content = proxyRequestContent(request, response, proxyRequest);
-                        Content.copy(content, delegate, Callback.from(delegate::close, x -> onClientRequestFailure(request, proxyRequest, response, x)));
+                        Content.copy(content, delegate, Callback.from(
+                            delegate::close,
+                            x ->
+                            {
+                                delegate.fail(x);
+                                onClientRequestFailure(request, proxyRequest, response, x);
+                            })
+                        );
                     }
                     catch (Throwable failure)
                     {
@@ -259,7 +266,6 @@ public class ProxyServlet extends AbstractProxyServlet
             {
                 if (!chunk.isLast())
                     fail(chunk.getFailure());
-                onClientRequestFailure(request, proxyRequest, response, chunk.getFailure());
             }
             else
             {

--- a/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/AsyncMiddleManServletTest.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/AsyncMiddleManServletTest.java
@@ -593,7 +593,7 @@ public class AsyncMiddleManServletTest
                 .body(content)
                 .send(result ->
                 {
-                    if (result.isSucceeded() && result.getResponse().getStatus() == 502)
+                    if (result.isSucceeded() && result.getResponse().getStatus() == HttpStatus.INTERNAL_SERVER_ERROR_500)
                         latch.countDown();
                 });
 
@@ -673,7 +673,7 @@ public class AsyncMiddleManServletTest
                 .timeout(5, TimeUnit.SECONDS)
                 .send();
 
-            assertEquals(502, response.getStatus());
+            assertEquals(HttpStatus.BAD_GATEWAY_502, response.getStatus());
         }
     }
 
@@ -874,7 +874,7 @@ public class AsyncMiddleManServletTest
             .body(content)
             .send(result ->
             {
-                if (result.getResponse().getStatus() == 502)
+                if (result.getResponse().getStatus() == HttpStatus.INTERNAL_SERVER_ERROR_500)
                     latch.countDown();
             });
         content.write(ByteBuffer.allocate(512), Callback.NOOP);
@@ -929,7 +929,7 @@ public class AsyncMiddleManServletTest
             .timeout(5, TimeUnit.SECONDS)
             .send();
 
-        assertEquals(502, response.getStatus());
+        assertEquals(HttpStatus.BAD_GATEWAY_502, response.getStatus());
     }
 
     @Test


### PR DESCRIPTION
* Fixed HttpStatus javadocs and added isError(int).
* Fixed double invocations of sendProxyResponseError(). For ProxyServlet and AsyncProxyServlet, the proxyRequest is always sent early, so ProxyResponseListener.onComplete() will take care of calling sendProxyResponseError(), so it is enough to cause the abortion of the proxyRequest.
* Fixed double invocations of onClientRequestFailure(), which was aborting the proxyRequest, but was calling sendProxyResponseError() if the abort was not successful. Aborting the proxyRequest was already calling sendProxyResponseError(), so no need to calling it again if the abort was not successful.
* AsyncMiddleManServlet is different, since it does not send the proxyRequest immediately. Therefore added an attribute to know whether it was sent, and acting accordingly to guarantee that sendProxyResponseError() is called even if the proxyRequest is not sent yet (since there is no ProxyResponseListener.onComplete() installed yet).