### PR TITLE
Jetty 10.0.x release script configuration for central portal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,14 +181,12 @@
 
   <distributionManagement>
     <repository>
-      <id>oss.sonatype.org</id>
-      <name>Jetty Staging Repository</name>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <id>sonatype-cp</id>
+      <url>https://repo.maven.apache.org/maven2</url>
     </repository>
     <snapshotRepository>
-      <id>oss.sonatype.org</id>
-      <name>Jetty Snapshot Repository</name>
-      <url>https://oss.sonatype.org/content/repositories/jetty-snapshots/</url>
+      <id>sonatype-cp</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots</url>
     </snapshotRepository>
   </distributionManagement>
 
@@ -325,6 +323,7 @@
     <mongo.docker.version>3.2.20</mongo.docker.version>
     <mongodb.version>3.12.14</mongodb.version>
     <openpojo.version>0.9.1</openpojo.version>
+    <njord.version>0.5.5</njord.version>
     <org.osgi.annotation.version>8.1.0</org.osgi.annotation.version>
     <org.osgi.core.version>6.0.0</org.osgi.core.version>
     <org.osgi.util.function.version>1.2.0</org.osgi.util.function.version>
@@ -1501,6 +1500,11 @@
           <version>${license.maven.plugin.version}</version>
         </plugin>
         <plugin>
+          <groupId>eu.maveniverse.maven.plugins</groupId>
+          <artifactId>njord</artifactId>
+          <version>${njord.version}</version>
+        </plugin>
+        <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
           <version>${maven.bundle.plugin.version}</version>
@@ -2132,6 +2136,13 @@
         </executions>
       </plugin>
     </plugins>
+    <extensions>
+      <extension>
+        <groupId>eu.maveniverse.maven.njord</groupId>
+        <artifactId>extension</artifactId>
+        <version>${njord.version}</version>
+      </extension>
+    </extensions>
   </build>
 
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -322,8 +322,8 @@
     <!-- if changing this version please update default in MongoTestHelper you will get thanks from Eclipse IDE users -->
     <mongo.docker.version>3.2.20</mongo.docker.version>
     <mongodb.version>3.12.14</mongodb.version>
-    <openpojo.version>0.9.1</openpojo.version>
     <njord.version>0.5.5</njord.version>
+    <openpojo.version>0.9.1</openpojo.version>
     <org.osgi.annotation.version>8.1.0</org.osgi.annotation.version>
     <org.osgi.core.version>6.0.0</org.osgi.core.version>
     <org.osgi.util.function.version>1.2.0</org.osgi.util.function.version>

--- a/scripts/release-jetty.sh
+++ b/scripts/release-jetty.sh
@@ -163,6 +163,7 @@ if proceedyn "Are you sure you want to release using above? (y/N)" n; then
     # This is equivalent to 'mvn release:perform'
     if proceedyn "Build/Deploy from tag $TAG_NAME? (Y/n)" y; then
         mvn clean deploy -Peclipse-release $DEPLOY_OPTS
+        mvn njord:publish -Ddrop=false $DEPLOY_OPTS
     fi
     if proceedyn "Update working directory for $VER_NEXT? (Y/n)" y; then
         echo "Update VERSION.txt for $VER_NEXT"
@@ -185,6 +186,7 @@ if proceedyn "Are you sure you want to release using above? (y/N)" n; then
         git push $GIT_REMOTE_ID $GIT_BRANCH_ID
         git push $GIT_REMOTE_ID $TAG_NAME
     fi
+    echo "you can now eventually deploy to staging repo using mvn njord:publish  -Ddrop=false -Dpublisher=deploy -DaltDeploymentRepository=jetty-staging::http://localhost:8081/repository/release-staging"
 else
     echo "Not performing release"
 fi


### PR DESCRIPTION
Will need locally in `~/.m2/settings.xml`

```
    <server>
      <!-- central tokens -->
      <username></username>
      <password></password>
      <id>sonatype-cp</id>
      <configuration>
        <njord.publisher>sonatype-cp</njord.publisher>
        <njord.releaseUrl>njord:template:release-sca</njord.releaseUrl>
      </configuration>
    </server>
    <server>
      <id>jetty-staging</id>
      <username></username>
      <password></password>
   </server>

.................

  <pluginGroups>
    ....
    <pluginGroup>eu.maveniverse.maven.plugins</pluginGroup>
    .....
  </pluginGroups>


```