### PR TITLE
Ignore bad cookie names in legacy CookieCutter

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CookieCompliance.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CookieCompliance.java
@@ -165,7 +165,8 @@ public class CookieCompliance implements ComplianceViolation.Mode
     );
 
     /**
-     * A CookieCompliance mode that allows <a href="https://tools.ietf.org/html/rfc2965">RFC 2965</a> compliance.
+     * A CookieCompliance mode that allows <a href="https://tools.ietf.org/html/rfc2965">RFC 2965</a> compliance, but with
+     * exceptions that match the behavior of legacy Jetty releases.
      */
     public static final CookieCompliance RFC2965_LEGACY = new CookieCompliance("RFC2965_LEGACY", allOf(Violation.class));
 
@@ -174,12 +175,11 @@ public class CookieCompliance implements ComplianceViolation.Mode
      * but does <b>not</b> allow:
      * <ul>
      * <li>{@link Violation#BAD_QUOTES}</li>
-     * <li>{@link Violation#COMMA_NOT_VALID_OCTET}</li>
      * <li>{@link Violation#RESERVED_NAMES_NOT_DOLLAR_PREFIXED}</li>
      * </ul>
      */
     public static final CookieCompliance RFC2965 = new CookieCompliance("RFC2965", complementOf(of(
-        Violation.BAD_QUOTES, Violation.COMMA_NOT_VALID_OCTET, Violation.RESERVED_NAMES_NOT_DOLLAR_PREFIXED)
+        Violation.BAD_QUOTES, Violation.RESERVED_NAMES_NOT_DOLLAR_PREFIXED)
     ));
 
     private static final List<CookieCompliance> KNOWN_MODES = Arrays.asList(RFC6265, RFC6265_STRICT, RFC6265_LEGACY, RFC2965, RFC2965_LEGACY);
@@ -211,9 +211,9 @@ public class CookieCompliance implements ComplianceViolation.Mode
      * with a '-' to exclude them from the mode.  Examples are:
      * </p>
      * <dl>
-     * <dt>{@code 0,RESERVED_NAMES_NOT_DOLLAR_PREFIXED}</dt><dd>Only allow {@link CookieCompliance.Violation#RESERVED_NAMES_NOT_DOLLAR_PREFIXED}</dd>
-     * <dt>{@code *,-RESERVED_NAMES_NOT_DOLLAR_PREFIXED}</dt><dd>Allow all violations, except {@link CookieCompliance.Violation#RESERVED_NAMES_NOT_DOLLAR_PREFIXED}</dd>
-     * <dt>{@code RFC2965,RESERVED_NAMES_NOT_DOLLAR_PREFIXED}</dt><dd>Same as RFC2965, but allows {@link CookieCompliance.Violation#RESERVED_NAMES_NOT_DOLLAR_PREFIXED}</dd>
+     * <dt>{@code 0,ESCAPE_IN_QUOTES}</dt><dd>Only allow {@link CookieCompliance.Violation#ESCAPE_IN_QUOTES}</dd>
+     * <dt>{@code *,-ESCAPE_IN_QUOTES}</dt><dd>Allow all violations, except {@link CookieCompliance.Violation#ESCAPE_IN_QUOTES}</dd>
+     * <dt>{@code RFC2965,ESCAPE_IN_QUOTES}</dt><dd>Same as RFC2965, but allows {@link CookieCompliance.Violation#ESCAPE_IN_QUOTES}</dd>
      * </dl>
      *
      * @param spec A string describing the compliance

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CookieCutter.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CookieCutter.java
@@ -210,6 +210,14 @@ public class CookieCutter implements CookieParser
                                         // This is a new cookie, so add the completed last cookie if we have one
                                         if (cookieName != null)
                                         {
+                                            if (!isLegacyCookieName(cookieName))
+                                            {
+                                                if (!_complianceMode.allows(INVALID_COOKIES))
+                                                    throw new InvalidCookieException("Bad Cookie Name");
+                                                reportComplianceViolation(INVALID_COOKIES, hdr);
+                                                reject = true;
+                                            }
+
                                             if (reject)
                                             {
                                                 if (_complianceMode.allows(INVALID_COOKIES))
@@ -384,5 +392,26 @@ public class CookieCutter implements CookieParser
             c == ',' || // comma
             c == ';' || // semicolon
             c == '\\';  // backslash
+    }
+
+    private boolean isLegacyCookieNameToken(char c)
+    {
+        return c >= 0x20 && c < 0x7f && "/()<>@,;:\\\"[]?={} \t".indexOf(c) == -1;
+    }
+
+    private boolean isLegacyCookieName(String name)
+    {
+        for (int i = 0; i < name.length(); i++)
+            if (!isLegacyCookieNameToken(name.charAt(i)))
+                return false;
+        return !name.equalsIgnoreCase("Comment") && // rfc2019
+            !name.equalsIgnoreCase("Discard") && // 2019++
+            !name.equalsIgnoreCase("Domain") &&
+            !name.equalsIgnoreCase("Expires") && // (old cookies)
+            !name.equalsIgnoreCase("Max-Age") && // rfc2019
+            !name.equalsIgnoreCase("Path") &&
+            !name.equalsIgnoreCase("Secure") &&
+            !name.equalsIgnoreCase("Version") &&
+            !name.startsWith("$");
     }
 }

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/CookieCutterTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/CookieCutterTest.java
@@ -26,7 +26,12 @@ public class CookieCutterTest
 {
     private Cookie[] parseCookieHeaders(CookieCompliance compliance, String... headers)
     {
-        TestCutter cutter = new TestCutter(compliance, null);
+        return parseCookieHeaders(compliance, null, headers);
+    }
+
+    private Cookie[] parseCookieHeaders(CookieCompliance compliance, ComplianceViolation.Listener listener, String... headers)
+    {
+        TestCutter cutter = new TestCutter(compliance, listener);
         for (String header : headers)
         {
             cutter.parseFields(header);
@@ -44,6 +49,20 @@ public class CookieCutterTest
         assertThat(prefix + ".value", cookie.getValue(), is(expectedValue));
         assertThat(prefix + ".version", cookie.getVersion(), is(expectedVersion));
         assertThat(prefix + ".path", cookie.getPath(), is(expectedPath));
+    }
+
+    /**
+     * Example from RFC2109 and RFC2965
+     */
+    @Test
+    public void testLEGACY()
+    {
+        String rawCookie = "a=A=,b=B=,c/u=CU=,d=D=";
+        Cookie[] cookies = parseCookieHeaders(CookieCompliance.RFC2965_LEGACY, rawCookie);
+        assertThat(cookies.length, is(3));
+        assertCookie("0", cookies[0], "a", "A=", 0, null);
+        assertCookie("1", cookies[1], "b", "B=", 0, null);
+        assertCookie("2", cookies[2], "d", "D=", 0, null);
     }
 
     /**
@@ -282,6 +301,12 @@ public class CookieCutterTest
         public String getComment()
         {
             return comment;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "Cookie: " + name + " = " + value;
         }
     }
 

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ServerHttpCookieTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ServerHttpCookieTest.java
@@ -97,6 +97,12 @@ public class ServerHttpCookieTest
         return Stream.of(
             Arguments.of(RFC6265_STRICT, "Cookie: name=value", 200, "Version=", List.of("[name=value]").toArray(new String[0])),
 
+            // LEGACY Test
+            Arguments.of(RFC2965, "Cookie: c=A==,b==,c/u==,z=f", 200, "Version=", List.of("[c=A==]", "[b==]").toArray(new String[0])),
+            Arguments.of(RFC2965_LEGACY, "Cookie: c=A==,b==,c/u==,z=f", 200, "Version=", List.of("[c=A==]", "[b==]", "[z=f]").toArray(new String[0])),
+            Arguments.of(RFC6265, "Cookie: c/u=v", 200, "Version=", new String[0]),
+            Arguments.of(RFC6265_LEGACY, "Cookie: c/u=v", 200, "Version=", new String[0]),
+
             // Attribute tests
             Arguments.of(RFC6265_STRICT, "Cookie:  $version=1; name=value", 200, "Version=", List.of("[$version=1]", "[name=value]").toArray(new String[0])),
             Arguments.of(RFC6265, "Cookie: $version=1; name=value", 200, "Version=", List.of("[$version=1]", "[name=value]").toArray(new String[0])),


### PR DESCRIPTION
Mimic the behavior of legacy jetty by ignoring cookies that would have thrown if used in the javax.servlet.http.Cookie class.
Fixes #13168 