### PR TITLE
PR #12659 - allow HttpVersion to be set on WebSocket ClientUpgradeRequest

### DIFF
--- a/jetty-core/jetty-websocket/jetty-websocket-core-client/src/main/java/org/eclipse/jetty/websocket/core/client/CoreClientUpgradeRequest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-client/src/main/java/org/eclipse/jetty/websocket/core/client/CoreClientUpgradeRequest.java
@@ -128,6 +128,11 @@ public abstract class CoreClientUpgradeRequest implements Response.CompleteListe
         return request.getVersion();
     }
 
+    public void setVersion(HttpVersion httpVersion)
+    {
+        request.version(httpVersion);
+    }
+
     public void listener(Request.Listener listener)
     {
         request.onRequestListener(listener);

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/UpgradeRequest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/UpgradeRequest.java
@@ -83,8 +83,6 @@ public interface UpgradeRequest
     /**
      * The HTTP version used for this Upgrade Request
      * <p>
-     * As of <a href="http://tools.ietf.org/html/rfc6455">RFC6455 (December 2011)</a> this is always
-     * {@code HTTP/1.1}
      *
      * @return the HTTP Version used
      */
@@ -93,7 +91,6 @@ public interface UpgradeRequest
     /**
      * The HTTP method for this Upgrade Request.
      * <p>
-     * As of <a href="http://tools.ietf.org/html/rfc6455">RFC6455 (December 2011)</a> this is always {@code GET}
      *
      * @return the HTTP method used
      */

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/ClientUpgradeRequest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/ClientUpgradeRequest.java
@@ -25,6 +25,7 @@ import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.websocket.api.ExtensionConfig;
 import org.eclipse.jetty.websocket.api.UpgradeRequest;
 import org.eclipse.jetty.websocket.api.UpgradeResponse;
@@ -38,12 +39,26 @@ public final class ClientUpgradeRequest implements UpgradeRequest
     private final List<ExtensionConfig> extensions = new ArrayList<>(1);
     private final List<HttpCookie> cookies = new ArrayList<>(1);
     private final Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    private final URI requestURI;
     private long timeout;
     private String httpVersion;
 
     public ClientUpgradeRequest()
     {
         /* anonymous, no requestURI, upgrade request */
+        this.requestURI = null;
+    }
+
+    /**
+     * @deprecated use {@link #ClientUpgradeRequest()} instead.
+     */
+    @Deprecated
+    public ClientUpgradeRequest(URI uri)
+    {
+        this.requestURI = uri;
+        String scheme = uri.getScheme();
+        if (!HttpScheme.WS.is(scheme) && !HttpScheme.WSS.is(scheme))
+            throw new IllegalArgumentException("URI scheme must be 'ws' or 'wss'");
     }
 
     @Override
@@ -103,7 +118,7 @@ public final class ClientUpgradeRequest implements UpgradeRequest
     @Override
     public String getHost()
     {
-        return null;
+        return (requestURI == null) ? null : requestURI.getHost();
     }
 
     @Override
@@ -134,13 +149,13 @@ public final class ClientUpgradeRequest implements UpgradeRequest
     @Override
     public String getQueryString()
     {
-        return null;
+        return requestURI == null ? null : requestURI.getQuery();
     }
 
     @Override
     public URI getRequestURI()
     {
-        return null;
+        return requestURI;
     }
 
     @Override
@@ -289,8 +304,6 @@ public final class ClientUpgradeRequest implements UpgradeRequest
 
     /**
      * Set the HTTP Version to use for the websocket upgrade.
-     * <p>
-     * Currently only HTTP/1.1 (with RFC6455) and HTTP/2 (with RFC8441) are supported.
      *
      * @param httpVersion the HTTP version to use.
      */

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/ClientUpgradeRequest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/ClientUpgradeRequest.java
@@ -25,7 +25,6 @@ import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jetty.http.HttpHeader;
-import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.websocket.api.ExtensionConfig;
 import org.eclipse.jetty.websocket.api.UpgradeRequest;
 import org.eclipse.jetty.websocket.api.UpgradeResponse;
@@ -39,28 +38,12 @@ public final class ClientUpgradeRequest implements UpgradeRequest
     private final List<ExtensionConfig> extensions = new ArrayList<>(1);
     private final List<HttpCookie> cookies = new ArrayList<>(1);
     private final Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-    private final URI requestURI;
-    private final String host;
     private long timeout;
+    private String httpVersion;
 
     public ClientUpgradeRequest()
     {
         /* anonymous, no requestURI, upgrade request */
-        this.requestURI = null;
-        this.host = null;
-    }
-
-    /**
-     * @deprecated use {@link #ClientUpgradeRequest()} instead.
-     */
-    @Deprecated
-    public ClientUpgradeRequest(URI uri)
-    {
-        this.requestURI = uri;
-        String scheme = uri.getScheme();
-        if (!HttpScheme.WS.is(scheme) && !HttpScheme.WSS.is(scheme))
-            throw new IllegalArgumentException("URI scheme must be 'ws' or 'wss'");
-        this.host = this.requestURI.getHost();
     }
 
     @Override
@@ -120,13 +103,7 @@ public final class ClientUpgradeRequest implements UpgradeRequest
     @Override
     public String getHost()
     {
-        return host;
-    }
-
-    @Override
-    public String getHttpVersion()
-    {
-        throw new UnsupportedOperationException("HttpVersion not available on ClientUpgradeRequest");
+        return null;
     }
 
     @Override
@@ -157,13 +134,13 @@ public final class ClientUpgradeRequest implements UpgradeRequest
     @Override
     public String getQueryString()
     {
-        return requestURI == null ? null : requestURI.getQuery();
+        return null;
     }
 
     @Override
     public URI getRequestURI()
     {
-        return requestURI;
+        return null;
     }
 
     @Override
@@ -302,6 +279,24 @@ public final class ClientUpgradeRequest implements UpgradeRequest
             List<String> values = entry.getValue();
             setHeader(name, values);
         }
+    }
+
+    @Override
+    public String getHttpVersion()
+    {
+        return httpVersion;
+    }
+
+    /**
+     * Set the HTTP Version to use for the websocket upgrade.
+     * <p>
+     * Currently only HTTP/1.1 (with RFC6455) and HTTP/2 (with RFC8441) are supported.
+     *
+     * @param httpVersion the HTTP version to use.
+     */
+    public void setHttpVersion(String httpVersion)
+    {
+        this.httpVersion = httpVersion;
     }
 
     /**

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/internal/JettyClientUpgradeRequest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/internal/JettyClientUpgradeRequest.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 
 import org.eclipse.jetty.client.Response;
 import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.common.JettyWebSocketFrameHandler;
@@ -49,6 +50,11 @@ public class JettyClientUpgradeRequest extends CoreClientUpgradeRequest
             setExtensions(request.getExtensions().stream()
                 .map(c -> new ExtensionConfig(c.getName(), c.getParameters()))
                 .collect(Collectors.toList()));
+
+            // Copy the HttpVersion if it exists.
+            String httpVersionString = request.getHttpVersion();
+            if (httpVersionString != null)
+                setVersion(HttpVersion.fromString(httpVersionString));
 
             timeout(request.getTimeout(), TimeUnit.MILLISECONDS);
         }

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee10/websocket/tests/WebSocketOverHTTP2Test.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee10/websocket/tests/WebSocketOverHTTP2Test.java
@@ -66,6 +66,8 @@ import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.websocket.api.Callback;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.StatusCode;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketOpen;
+import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 import org.eclipse.jetty.websocket.api.exceptions.UpgradeException;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
@@ -415,7 +417,7 @@ public class WebSocketOverHTTP2Test
 
         CountDownLatch latch = new CountDownLatch(2);
         onComplete = latch::countDown;
-        URI uri = URI.create("ws://localhost:" + connector.getLocalPort() + "/ws/echo");
+        URI uri = URI.create("ws://localhost:" + connector.getLocalPort() + "/ws/version");
 
         // Connect with HTTP/1.1 and verify version in the Session's UpgradeRequest.
         EventSocket wsEndPoint = new EventSocket();
@@ -423,6 +425,7 @@ public class WebSocketOverHTTP2Test
         upgradeRequest.setHttpVersion(HttpVersion.HTTP_1_1.asString());
         Session session = wsClient.connect(wsEndPoint, uri, upgradeRequest).get(5, TimeUnit.SECONDS);
         assertThat(session.getUpgradeRequest().getHttpVersion(), equalTo(HttpVersion.HTTP_1_1.asString()));
+        assertThat(wsEndPoint.textMessages.poll(5, TimeUnit.SECONDS), equalTo("version: " + HttpVersion.HTTP_1_1.asString()));
 
         // Verify we can do a normal close of the websocket connection.
         session.close(StatusCode.NORMAL, "normal close from test", Callback.NOOP);
@@ -436,6 +439,7 @@ public class WebSocketOverHTTP2Test
         upgradeRequest.setHttpVersion(HttpVersion.HTTP_2.asString());
         session = wsClient.connect(wsEndPoint, uri, upgradeRequest).get(5, TimeUnit.SECONDS);
         assertThat(session.getUpgradeRequest().getHttpVersion(), equalTo(HttpVersion.HTTP_2.asString()));
+        assertThat(wsEndPoint.textMessages.poll(5, TimeUnit.SECONDS), equalTo("version: " + HttpVersion.HTTP_2.asString()));
 
         // Verify we can do a normal close of the websocket connection.
         session.close(StatusCode.NORMAL, "normal close from test", Callback.NOOP);
@@ -447,12 +451,23 @@ public class WebSocketOverHTTP2Test
         assertTrue(latch.await(5, TimeUnit.SECONDS));
     }
 
+    @WebSocket
+    public static class VersionServerEndpoint
+    {
+        @OnWebSocketOpen
+        public void onOpen(Session session)
+        {
+            session.sendText("version: " + session.getUpgradeRequest().getHttpVersion(), Callback.NOOP);
+        }
+    }
+
     private static class TestJettyWebSocketServlet extends JettyWebSocketServlet
     {
         @Override
         protected void configure(JettyWebSocketServletFactory factory)
         {
             factory.addMapping("/ws/echo", (request, response) -> new EchoSocket());
+            factory.addMapping("/ws/version", (request, response) -> new VersionServerEndpoint());
             factory.addMapping("/ws/echo/query", (request, response) ->
             {
                 assertNotNull(request.getQueryString());

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee10/websocket/tests/WebSocketOverHTTP2Test.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee10/websocket/tests/WebSocketOverHTTP2Test.java
@@ -40,6 +40,7 @@ import org.eclipse.jetty.ee10.websocket.server.config.JettyWebSocketServletConta
 import org.eclipse.jetty.ee10.websocket.server.internal.DelegatedServerUpgradeRequest;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http2.ErrorCode;
 import org.eclipse.jetty.http2.HTTP2Cipher;
 import org.eclipse.jetty.http2.client.HTTP2Client;
@@ -66,6 +67,7 @@ import org.eclipse.jetty.websocket.api.Callback;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.StatusCode;
 import org.eclipse.jetty.websocket.api.exceptions.UpgradeException;
+import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -149,6 +151,19 @@ public class WebSocketOverHTTP2Test
         clientThreads.setName("client");
         clientConnector.setExecutor(clientThreads);
         HttpClient httpClient = new HttpClient(new HttpClientTransportDynamic(clientConnector, protocolFn.apply(clientConnector)));
+        wsClient = new WebSocketClient(httpClient);
+        wsClient.start();
+    }
+
+    private void startClient(Function<ClientConnector, ClientConnectionFactory.Info> protocolFn1,
+                             Function<ClientConnector, ClientConnectionFactory.Info> protocolFn2) throws Exception
+    {
+        ClientConnector clientConnector = new ClientConnector();
+        clientConnector.setSslContextFactory(new SslContextFactory.Client(true));
+        QueuedThreadPool clientThreads = new QueuedThreadPool();
+        clientThreads.setName("client");
+        clientConnector.setExecutor(clientThreads);
+        HttpClient httpClient = new HttpClient(new HttpClientTransportDynamic(clientConnector, protocolFn1.apply(clientConnector), protocolFn2.apply(clientConnector)));
         wsClient = new WebSocketClient(httpClient);
         wsClient.start();
     }
@@ -389,6 +404,47 @@ public class WebSocketOverHTTP2Test
         assertThat(clientEndpoint.closeCode, equalTo(StatusCode.SHUTDOWN));
         assertThat(clientEndpoint.closeReason, containsStringIgnoringCase("timeout"));
         assertNull(clientEndpoint.error);
+    }
+
+    @Test
+    public void testUpgradeRequestSetHttpVersion() throws Exception
+    {
+        startServer();
+        startClient(clientConnector -> HttpClientConnectionFactory.HTTP11,
+            clientConnector -> new ClientConnectionFactoryOverHTTP2.HTTP2(new HTTP2Client(clientConnector)));
+
+        CountDownLatch latch = new CountDownLatch(2);
+        onComplete = latch::countDown;
+        URI uri = URI.create("ws://localhost:" + connector.getLocalPort() + "/ws/echo");
+
+        // Connect with HTTP/1.1 and verify version in the Session's UpgradeRequest.
+        EventSocket wsEndPoint = new EventSocket();
+        ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest();
+        upgradeRequest.setHttpVersion(HttpVersion.HTTP_1_1.asString());
+        Session session = wsClient.connect(wsEndPoint, uri, upgradeRequest).get(5, TimeUnit.SECONDS);
+        assertThat(session.getUpgradeRequest().getHttpVersion(), equalTo(HttpVersion.HTTP_1_1.asString()));
+
+        // Verify we can do a normal close of the websocket connection.
+        session.close(StatusCode.NORMAL, "normal close from test", Callback.NOOP);
+        assertTrue(wsEndPoint.closeLatch.await(5, TimeUnit.SECONDS));
+        assertThat(wsEndPoint.closeCode, equalTo(StatusCode.NORMAL));
+        assertThat(wsEndPoint.closeReason, equalTo("normal close from test"));
+
+        // Connect with HTTP/2 and verify version in the Session's UpgradeRequest.
+        wsEndPoint = new EventSocket();
+        upgradeRequest = new ClientUpgradeRequest();
+        upgradeRequest.setHttpVersion(HttpVersion.HTTP_2.asString());
+        session = wsClient.connect(wsEndPoint, uri, upgradeRequest).get(5, TimeUnit.SECONDS);
+        assertThat(session.getUpgradeRequest().getHttpVersion(), equalTo(HttpVersion.HTTP_2.asString()));
+
+        // Verify we can do a normal close of the websocket connection.
+        session.close(StatusCode.NORMAL, "normal close from test", Callback.NOOP);
+        assertTrue(wsEndPoint.closeLatch.await(5, TimeUnit.SECONDS));
+        assertThat(wsEndPoint.closeCode, equalTo(StatusCode.NORMAL));
+        assertThat(wsEndPoint.closeReason, equalTo("normal close from test"));
+
+        // Wait for the request to complete on server before stopping.
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
     }
 
     private static class TestJettyWebSocketServlet extends JettyWebSocketServlet


### PR DESCRIPTION
closes #12659

Implement `setHttpVersion` method on `ClientUpgradeRequest` so that `WebSocketClients` supporting both HTTP/1.1 and HTTP/2 websocket upgrades can select which one to use.