### PR TITLE
Merge Jetty 12.1.x Support `maven.offline` property in jetty-start, to control of download of maven files from remote repos during `--add-modules` (#13147)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -157,14 +157,14 @@ def mavenBuild(jdk, cmdline, mvnName) {
           if(saveHome()) {
             archiveArtifacts artifacts: ".repository/org/eclipse/jetty/jetty-home/**/jetty-home-*", allowEmptyArchive: true, onlyIfSuccessful: false
           }
-          // temporary logs to remove
-          sh "ls -lrt ~/.mimir/"
         }
       }
     }
     finally
     {
       junit testResults: '**/target/surefire-reports/TEST**.xml,**/target/invoker-reports/TEST*.xml', allowEmptyResults: true
+      // temporary logs to remove
+      sh "ls -lrt ~/.mimir/"
     }
   }
 }

--- a/jetty-core/jetty-compression/jetty-compression-brotli/pom.xml
+++ b/jetty-core/jetty-compression/jetty-compression-brotli/pom.xml
@@ -13,7 +13,6 @@
   <description>Jetty Core Compression :: Brotli Support</description>
 
   <properties>
-    <brotli4j.version>1.17.0</brotli4j.version>
     <bundle-symbolic-name>${project.groupId}.brotli</bundle-symbolic-name>
   </properties>
 

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/BaseBuilder.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/BaseBuilder.java
@@ -93,7 +93,7 @@ public class BaseBuilder
                 // Use provided local repo directory
                 fileInitializers.add(new MavenLocalRepoFileInitializer(baseHome, localRepoDir,
                     args.getMavenLocalRepoDir() == null,
-                    startArgs.getMavenBaseUri()));
+                    startArgs.getMavenBaseUri()).offline(args.useMavenOffline()));
             }
             else
             {

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
@@ -670,6 +670,18 @@ public class StartArgs
         return mainClass;
     }
 
+    public boolean useMavenOffline()
+    {
+        String offline = getJettyEnvironment().getProperties().getString("maven.offline");
+        if (Utils.isBlank(offline))
+            offline = System.getenv("JETTY_MAVEN_OFFLINE");
+
+        if (Utils.isBlank(offline))
+            offline = System.getenv("MAVEN_OFFLINE");
+
+        return Boolean.parseBoolean(offline);
+    }
+
     public String getMavenLocalRepoDir()
     {
         String localRepo = getJettyEnvironment().getProperties().getString("maven.local.repo");

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/fileinits/MavenLocalRepoFileInitializerTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/fileinits/MavenLocalRepoFileInitializerTest.java
@@ -86,72 +86,72 @@ public class MavenLocalRepoFileInitializerTest
     public void testGetCoordinateNormal()
     {
         MavenLocalRepoFileInitializer repo = new MavenLocalRepoFileInitializer(baseHome);
-        String ref = "maven://org.eclipse.jetty/jetty-start/9.3.x";
+        String ref = "maven://org.eclipse.jetty/jetty-start/12.0.x";
         Coordinates coords = repo.getCoordinates(URI.create(ref));
         assertThat("Coordinates", coords, notNullValue());
 
         assertThat("coords.groupId", coords.groupId, is("org.eclipse.jetty"));
         assertThat("coords.artifactId", coords.artifactId, is("jetty-start"));
-        assertThat("coords.version", coords.version, is("9.3.x"));
+        assertThat("coords.version", coords.version, is("12.0.x"));
         assertThat("coords.type", coords.type, is("jar"));
         assertThat("coords.classifier", coords.classifier, nullValue());
 
         assertThat("coords.toCentralURI", coords.toCentralURI().toASCIIString(),
-            is(repo.getRemoteUri() + "org/eclipse/jetty/jetty-start/9.3.x/jetty-start-9.3.x.jar"));
+            is(repo.getRemoteUri() + "org/eclipse/jetty/jetty-start/12.0.x/jetty-start-12.0.x.jar"));
     }
 
     @Test
     public void testGetCoordinateZip()
     {
         MavenLocalRepoFileInitializer repo = new MavenLocalRepoFileInitializer(baseHome);
-        String ref = "maven://org.eclipse.jetty/jetty-home/11.0.0/zip";
+        String ref = "maven://org.eclipse.jetty/jetty-home/12.0.21/zip";
         Coordinates coords = repo.getCoordinates(URI.create(ref));
         assertThat("Coordinates", coords, notNullValue());
 
         assertThat("coords.groupId", coords.groupId, is("org.eclipse.jetty"));
         assertThat("coords.artifactId", coords.artifactId, is("jetty-home"));
-        assertThat("coords.version", coords.version, is("11.0.0"));
+        assertThat("coords.version", coords.version, is("12.0.21"));
         assertThat("coords.type", coords.type, is("zip"));
         assertThat("coords.classifier", coords.classifier, nullValue());
 
         assertThat("coords.toCentralURI", coords.toCentralURI().toASCIIString(),
-                   is(repo.getRemoteUri() + "org/eclipse/jetty/jetty-home/11.0.0/jetty-home-11.0.0.zip"));
+                   is(repo.getRemoteUri() + "org/eclipse/jetty/jetty-home/12.0.21/jetty-home-12.0.21.zip"));
     }
 
     @Test
     public void testGetCoordinateTestJar()
     {
         MavenLocalRepoFileInitializer repo = new MavenLocalRepoFileInitializer(baseHome);
-        String ref = "maven://org.eclipse.jetty/jetty-http/9.3.x/jar/tests";
+        String ref = "maven://org.eclipse.jetty/jetty-http/12.0.x/jar/tests";
         Coordinates coords = repo.getCoordinates(URI.create(ref));
         assertThat("Coordinates", coords, notNullValue());
 
         assertThat("coords.groupId", coords.groupId, is("org.eclipse.jetty"));
         assertThat("coords.artifactId", coords.artifactId, is("jetty-http"));
-        assertThat("coords.version", coords.version, is("9.3.x"));
+        assertThat("coords.version", coords.version, is("12.0.x"));
         assertThat("coords.type", coords.type, is("jar"));
         assertThat("coords.classifier", coords.classifier, is("tests"));
 
         assertThat("coords.toCentralURI", coords.toCentralURI().toASCIIString(),
-            is(repo.getRemoteUri() + "org/eclipse/jetty/jetty-http/9.3.x/jetty-http-9.3.x-tests.jar"));
+            is(repo.getRemoteUri() + "org/eclipse/jetty/jetty-http/12.0.x/jetty-http-12.0.x-tests.jar"));
     }
 
     @Test
     public void testGetCoordinateTestUnspecifiedType()
     {
         MavenLocalRepoFileInitializer repo = new MavenLocalRepoFileInitializer(baseHome);
-        String ref = "maven://org.eclipse.jetty/jetty-http/9.3.x//tests";
+        String ref = "maven://org.eclipse.jetty/jetty-http/12.0.x//tests";
         Coordinates coords = repo.getCoordinates(URI.create(ref));
         assertThat("Coordinates", coords, notNullValue());
 
         assertThat("coords.groupId", coords.groupId, is("org.eclipse.jetty"));
         assertThat("coords.artifactId", coords.artifactId, is("jetty-http"));
-        assertThat("coords.version", coords.version, is("9.3.x"));
+        assertThat("coords.version", coords.version, is("12.0.x"));
         assertThat("coords.type", coords.type, is("jar"));
         assertThat("coords.classifier", coords.classifier, is("tests"));
 
         assertThat("coords.toCentralURI", coords.toCentralURI().toASCIIString(),
-            is(repo.getRemoteUri() + "org/eclipse/jetty/jetty-http/9.3.x/jetty-http-9.3.x-tests.jar"));
+            is(repo.getRemoteUri() + "org/eclipse/jetty/jetty-http/12.0.x/jetty-http-12.0.x-tests.jar"));
     }
 
     @Test
@@ -160,18 +160,18 @@ public class MavenLocalRepoFileInitializerTest
         MavenLocalRepoFileInitializer repo =
             new MavenLocalRepoFileInitializer(baseHome, null, false,
                 "https://repo1.maven.org/maven2/");
-        String ref = "maven://org.eclipse.jetty/jetty-http/9.3.x/jar/tests";
+        String ref = "maven://org.eclipse.jetty/jetty-http/12.0.x/jar/tests";
         Coordinates coords = repo.getCoordinates(URI.create(ref));
         assertThat("Coordinates", coords, notNullValue());
 
         assertThat("coords.groupId", coords.groupId, is("org.eclipse.jetty"));
         assertThat("coords.artifactId", coords.artifactId, is("jetty-http"));
-        assertThat("coords.version", coords.version, is("9.3.x"));
+        assertThat("coords.version", coords.version, is("12.0.x"));
         assertThat("coords.type", coords.type, is("jar"));
         assertThat("coords.classifier", coords.classifier, is("tests"));
 
         assertThat("coords.toCentralURI", coords.toCentralURI().toASCIIString(),
-            is(repo.getRemoteUri() + "org/eclipse/jetty/jetty-http/9.3.x/jetty-http-9.3.x-tests.jar"));
+            is(repo.getRemoteUri() + "org/eclipse/jetty/jetty-http/12.0.x/jetty-http-12.0.x-tests.jar"));
     }
 
     @Test
@@ -181,24 +181,24 @@ public class MavenLocalRepoFileInitializerTest
     {
         MavenLocalRepoFileInitializer repo =
             new MavenLocalRepoFileInitializer(baseHome, null, false);
-        String ref = "maven://org.eclipse.jetty/jetty-http/9.4.31.v20200723/jar/tests";
+        String ref = "maven://org.eclipse.jetty/jetty-session/12.0.21/jar/tests";
         Coordinates coords = repo.getCoordinates(URI.create(ref));
         assertThat("Coordinates", coords, notNullValue());
 
         assertThat("coords.groupId", coords.groupId, is("org.eclipse.jetty"));
-        assertThat("coords.artifactId", coords.artifactId, is("jetty-http"));
-        assertThat("coords.version", coords.version, is("9.4.31.v20200723"));
+        assertThat("coords.artifactId", coords.artifactId, is("jetty-session"));
+        assertThat("coords.version", coords.version, is("12.0.21"));
         assertThat("coords.type", coords.type, is("jar"));
         assertThat("coords.classifier", coords.classifier, is("tests"));
 
         assertThat("coords.toCentralURI", coords.toCentralURI().toASCIIString(),
-                   is(repo.getRemoteUri() + "org/eclipse/jetty/jetty-http/9.4.31.v20200723/jetty-http-9.4.31.v20200723-tests.jar"));
+                   is(repo.getRemoteUri() + "org/eclipse/jetty/jetty-session/12.0.21/jetty-session-12.0.21-tests.jar"));
 
-        Path destination = testdir.resolve("jetty-http-9.4.31.v20200723-tests.jar");
+        Path destination = testdir.resolve("jetty-session-12.0.21-tests.jar");
         Files.deleteIfExists(destination);
         repo.download(coords.toCentralURI(), destination);
         assertThat(Files.exists(destination), is(true));
-        assertThat(Files.size(destination), is(986193L));
+        assertThat(Files.size(destination), is(89867L));
     }
 
     @Test
@@ -211,20 +211,20 @@ public class MavenLocalRepoFileInitializerTest
 
         MavenLocalRepoFileInitializer repo =
             new MavenLocalRepoFileInitializer(baseHome, snapshotLocalRepoDir, false, "https://oss.sonatype.org/content/repositories/jetty-snapshots/");
-        String ref = "maven://org.eclipse.jetty/jetty-rewrite/11.0.14-SNAPSHOT/jar";
+        String ref = "maven://org.eclipse.jetty/jetty-rewrite/12.0.22-SNAPSHOT/jar";
         Coordinates coords = repo.getCoordinates(URI.create(ref));
         assertThat("Coordinates", coords, notNullValue());
 
         assertThat("coords.groupId", coords.groupId, is("org.eclipse.jetty"));
         assertThat("coords.artifactId", coords.artifactId, is("jetty-rewrite"));
-        assertThat("coords.version", coords.version, is("11.0.14-SNAPSHOT"));
+        assertThat("coords.version", coords.version, is("12.0.22-SNAPSHOT"));
         assertThat("coords.type", coords.type, is("jar"));
         assertThat("coords.classifier", coords.classifier, is(nullValue()));
 
         assertThat("coords.toCentralURI", coords.toCentralURI().toASCIIString(),
-            is("https://oss.sonatype.org/content/repositories/jetty-snapshots/org/eclipse/jetty/jetty-rewrite/11.0.14-SNAPSHOT/jetty-rewrite-11.0.14-SNAPSHOT.jar"));
+            is("https://oss.sonatype.org/content/repositories/jetty-snapshots/org/eclipse/jetty/jetty-rewrite/12.0.22-SNAPSHOT/jetty-rewrite-12.0.22-SNAPSHOT.jar"));
 
-        Path destination = baseHome.getBasePath().resolve("jetty-rewrite-11.0.14-SNAPSHOT.jar");
+        Path destination = baseHome.getBasePath().resolve("jetty-rewrite-12.0.22-SNAPSHOT.jar");
         repo.download(coords, destination);
         assertThat(Files.exists(destination), is(true));
         assertThat("Snapshot File size", Files.size(destination), greaterThan(10_000L));
@@ -241,11 +241,11 @@ public class MavenLocalRepoFileInitializerTest
         MavenLocalRepoFileInitializer repo =
             new MavenLocalRepoFileInitializer(baseHome, snapshotLocalRepoDir, false,
                 "https://oss.sonatype.org/content/repositories/jetty-snapshots/");
-        String ref = "maven://org.eclipse.jetty.demos/demo-simple-webapp/11.0.14-SNAPSHOT/jar/config";
+        String ref = "maven://org.eclipse.jetty.ee10.demos/jetty-ee10-demo-simple-webapp/12.0.22-SNAPSHOT/jar/config";
         Path baseDir = baseHome.getBasePath();
         repo.create(URI.create(ref), "extract:company/");
 
-        assertThat(Files.exists(baseDir.resolve("company/modules/demo-simple.mod")), is(true));
+        assertThat(Files.exists(baseDir.resolve("company/modules/ee10-demo-simple.mod")), is(true));
     }
 
     @Test
@@ -259,10 +259,28 @@ public class MavenLocalRepoFileInitializerTest
         MavenLocalRepoFileInitializer repo =
             new MavenLocalRepoFileInitializer(baseHome, snapshotLocalRepoDir, false,
                 "https://oss.sonatype.org/content/repositories/jetty-snapshots/");
-        String ref = "maven://org.eclipse.jetty.demos/demo-simple-webapp/11.0.14-SNAPSHOT/jar/config";
+        String ref = "maven://org.eclipse.jetty.ee10.demos/jetty-ee10-demo-simple-webapp/12.0.22-SNAPSHOT/jar/config";
         Path baseDir = baseHome.getBasePath();
         repo.create(URI.create(ref), "extract:/");
 
-        assertThat(Files.exists(baseDir.resolve("modules/demo-simple.mod")), is(true));
+        assertThat(Files.exists(baseDir.resolve("modules/ee10-demo-simple.mod")), is(true));
+    }
+
+    @Test
+    @Tag("external")
+    public void testDownloadButOffline()
+        throws Exception
+    {
+        Path snapshotLocalRepoDir = testdir.resolve("snapshot-repo");
+        FS.ensureEmpty(snapshotLocalRepoDir);
+
+        MavenLocalRepoFileInitializer repo =
+            new MavenLocalRepoFileInitializer(baseHome, snapshotLocalRepoDir, false,
+                "https://oss.sonatype.org/content/repositories/jetty-snapshots/").offline(true);
+        String ref = "maven://org.eclipse.jetty.ee10.demos/jetty-ee10-demo-simple-webapp/12.0.22-SNAPSHOT/jar/config";
+        Path baseDir = baseHome.getBasePath();
+        repo.create(URI.create(ref), "extract:/");
+
+        assertThat(Files.exists(baseDir.resolve("modules/ee10-demo-simple.mod")), is(false));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,7 @@
     -->
     <bndlib.version>6.4.1</bndlib.version>
     <bouncycastle.version>1.80</bouncycastle.version>
+    <brotli4j.version>1.17.0</brotli4j.version>
     <build-helper.maven.plugin.version>3.6.0</build-helper.maven.plugin.version>
     <build-support.version>1.5</build-support.version>
     <buildnumber.maven.plugin.version>3.2.1</buildnumber.maven.plugin.version>

--- a/tests/jetty-testers/pom.xml
+++ b/tests/jetty-testers/pom.xml
@@ -25,12 +25,20 @@
       <artifactId>maven-resolver-supplier</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-xml</artifactId>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.toolchain</groupId>
       <artifactId>jetty-test-helper</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/JettyHomeTester.java
+++ b/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/JettyHomeTester.java
@@ -24,6 +24,7 @@ import java.nio.file.FileSystemAlreadyExistsException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -155,6 +156,10 @@ public class JettyHomeTester
         if (StringUtils.isNotBlank(mavenLocalRepository))
             args.add("maven.local.repo=" + mavenLocalRepository);
 
+        String mavenOffline = System.getProperty("maven.offline", "false");
+        if (StringUtils.isNotBlank(mavenOffline))
+            args.add("maven.offline=" + mavenOffline);
+
         // if this JVM has `maven.repo.uri` defined, make sure to propagate it to child
         String remoteRepoUri = System.getProperty("maven.repo.uri");
         if (remoteRepoUri != null)
@@ -219,6 +224,20 @@ public class JettyHomeTester
 
     private void init() throws Exception
     {
+        String jettyHomeStr = System.getProperty("jetty.home");
+        if (jettyHomeStr != null && !jettyHomeStr.isEmpty())
+        {
+            Path jettyHome = Paths.get(jettyHomeStr);
+            // test path exists
+            if (Files.exists(jettyHome))
+            {
+                config.jettyHome = jettyHome;
+            }
+            else
+            {
+                throw new IllegalArgumentException("Ignore non existing Jetty home: " + jettyHomeStr);
+            }
+        }
         if (config.jettyHome == null)
             config.jettyHome = resolveHomeArtifact(config.getJettyVersion());
 

--- a/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/JettyHomeTester.java
+++ b/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/JettyHomeTester.java
@@ -25,10 +25,6 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-<<<<<<< HEAD
-import java.nio.file.StandardCopyOption;
-=======
->>>>>>> jetty-12.0.x
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/ProcessWrapper.java
+++ b/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/ProcessWrapper.java
@@ -207,7 +207,7 @@ public class ProcessWrapper implements AutoCloseable
 
     public boolean awaitForStart(boolean ignoreWarn) throws InterruptedException
     {
-        return awaitForStart(START_TIMEOUT, TimeUnit.SECONDS, false);
+        return awaitForStart(START_TIMEOUT, TimeUnit.SECONDS, ignoreWarn);
     }
 
     public boolean awaitForStart(long time, TimeUnit unit) throws InterruptedException

--- a/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/ProcessWrapper.java
+++ b/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/ProcessWrapper.java
@@ -136,11 +136,6 @@ public class ProcessWrapper implements AutoCloseable
         return false;
     }
 
-    public boolean awaitForJettyStart()
-    {
-        return awaitForJettyStart(START_TIMEOUT, TimeUnit.SECONDS);
-    }
-
     private record ShowLogOnTimeout<T>(ProcessWrapper run) implements ConditionEvaluationListener<T>
     {
         @Override
@@ -161,7 +156,22 @@ public class ProcessWrapper implements AutoCloseable
         return () -> String.join("\n", this.getLogs());
     }
 
+    public boolean awaitForJettyStart(boolean ignoreWarn)
+    {
+        return awaitForJettyStart(START_TIMEOUT, TimeUnit.SECONDS, ignoreWarn);
+    }
+
+    public boolean awaitForJettyStart()
+    {
+        return awaitForJettyStart(START_TIMEOUT, TimeUnit.SECONDS);
+    }
+
     public boolean awaitForJettyStart(long time, TimeUnit unit)
+    {
+        return awaitForJettyStart(time, unit, false);
+    }
+
+    public boolean awaitForJettyStart(long time, TimeUnit unit, boolean ignoreWarn)
     {
         // Started oejs.Server@
         try
@@ -183,8 +193,10 @@ public class ProcessWrapper implements AutoCloseable
             // as is surefire show logs from the run
             throw new RuntimeException(logs().get(), e);
         }
-        // assert no WARN in the logs
-        assertThat(logs().get(), not(containsString("WARN  :")));
+        if (!ignoreWarn)
+        {
+            assertThat(logs().get(), not(containsString("WARN  :")));
+        }
         return true;
     }
 
@@ -193,7 +205,17 @@ public class ProcessWrapper implements AutoCloseable
         return awaitForStart(START_TIMEOUT, TimeUnit.SECONDS);
     }
 
+    public boolean awaitForStart(boolean ignoreWarn) throws InterruptedException
+    {
+        return awaitForStart(START_TIMEOUT, TimeUnit.SECONDS, false);
+    }
+
     public boolean awaitForStart(long time, TimeUnit unit) throws InterruptedException
+    {
+        return awaitForStart(time, unit, false);
+    }
+
+    public boolean awaitForStart(long time, TimeUnit unit, boolean ignoreWarn) throws InterruptedException
     {
         try
         {
@@ -203,8 +225,10 @@ public class ProcessWrapper implements AutoCloseable
         {
             throw new IllegalStateException(logs().get(), e);
         }
-        // assert no WARN in the logs
-        // assertThat(logs().get(), not(containsString("WARN  :")));
+        if (!ignoreWarn)
+        {
+            assertThat(logs().get(), not(containsString("WARN  :")));
+        }
         return true;
     }
 

--- a/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/ProcessWrapper.java
+++ b/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/ProcessWrapper.java
@@ -204,7 +204,7 @@ public class ProcessWrapper implements AutoCloseable
             throw new IllegalStateException(logs().get(), e);
         }
         // assert no WARN in the logs
-        assertThat(logs().get(), not(containsString("WARN  :")));
+        // assertThat(logs().get(), not(containsString("WARN  :")));
         return true;
     }
 

--- a/tests/test-distribution/pom.xml
+++ b/tests/test-distribution/pom.xml
@@ -111,6 +111,7 @@
               <distribution.debug.port>$(distribution.debug.port}</distribution.debug.port>
               <home.start.timeout>${home.start.timeout}</home.start.timeout>
               <mariadb.version>${mariadb.version}</mariadb.version>
+              <maven.offline>true</maven.offline>
               <sessionLogLevel>${sessionLogLevel}</sessionLogLevel>
               <environmentsToTest>${environmentsToTest}</environmentsToTest>
             </systemPropertyVariables>

--- a/tests/test-distribution/test-distribution-common/pom.xml
+++ b/tests/test-distribution/test-distribution-common/pom.xml
@@ -13,6 +13,7 @@
 
   <properties>
     <bundle-symbolic-name>${project.groupId}.tests.distribution.common</bundle-symbolic-name>
+    <jetty.home>${project.build.directory}/jetty-home</jetty.home>
     <!--    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>-->
     <junit.jupiter.execution.parallel.config.fixed.parallelism>2</junit.jupiter.execution.parallel.config.fixed.parallelism>
     <testcontainers-keycloak.version>3.4.0</testcontainers-keycloak.version>
@@ -165,7 +166,6 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-slf4j-impl</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -278,9 +278,80 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- we want to be sure all dependencies are available in the local repo -->
+            <id>copy-fake-deps</id>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <phase>process-test-resources</phase>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>ch.qos.logback</groupId>
+                  <artifactId>logback-classic</artifactId>
+                  <version>${logback.version}</version>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>ch.qos.logback</groupId>
+                  <artifactId>logback-core</artifactId>
+                  <version>${logback.version}</version>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.apache.logging.log4j</groupId>
+                  <artifactId>log4j-api</artifactId>
+                  <version>${log4j2.version}</version>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.apache.logging.log4j</groupId>
+                  <artifactId>log4j-core</artifactId>
+                  <version>${log4j2.version}</version>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.apache.logging.log4j</groupId>
+                  <artifactId>log4j-slf4j2-impl</artifactId>
+                  <version>${log4j2.version}</version>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.slf4j</groupId>
+                  <artifactId>slf4j-jdk14</artifactId>
+                  <version>${slf4j.version}</version>
+                </artifactItem>
+              </artifactItems>
+              <outputDirectory>${project.build.directory}/fake-deps</outputDirectory>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>true</overWriteSnapshots>
+            </configuration>
+          </execution>
+          <execution>
+            <id>unpack</id>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <phase>process-test-resources</phase>
+            <configuration>
+              <ignorePermissions>true</ignorePermissions>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.eclipse.jetty</groupId>
+                  <artifactId>jetty-home</artifactId>
+                  <type>zip</type>
+                  <overWrite>true</overWrite>
+                  <outputDirectory>${jetty.home}</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <systemPropertyVariables combine.children="append">
+            <jetty.home>${jetty.home}/jetty-home-${project.version}</jetty.home>
             <infinispan.docker.image.version>${infinispan.docker.image.version}</infinispan.docker.image.version>
             <infinispan.docker.image.name>${infinispan.docker.image.name}</infinispan.docker.image.name>
           </systemPropertyVariables>

--- a/tests/test-distribution/test-distribution-common/pom.xml
+++ b/tests/test-distribution/test-distribution-common/pom.xml
@@ -411,6 +411,26 @@
                   <artifactId>slf4j-jdk14</artifactId>
                   <version>${slf4j.version}</version>
                 </artifactItem>
+                <artifactItem>
+                  <groupId>com.aayushatharva.brotli4j</groupId>
+                  <artifactId>brotli4j</artifactId>
+                  <version>${brotli4j.version}</version>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>com.aayushatharva.brotli4j</groupId>
+                  <artifactId>service</artifactId>
+                  <version>${brotli4j.version}</version>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>com.aayushatharva.brotli4j</groupId>
+                  <artifactId>native-linux-x86_64</artifactId>
+                  <version>${brotli4j.version}</version>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>com.aayushatharva.brotli4j</groupId>
+                  <artifactId>native-windows-x86_64</artifactId>
+                  <version>${brotli4j.version}</version>
+                </artifactItem>
               </artifactItems>
               <outputDirectory>${project.build.directory}/fake-deps</outputDirectory>
               <overWriteReleases>false</overWriteReleases>

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/AbstractJettyHomeTest.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/AbstractJettyHomeTest.java
@@ -20,6 +20,7 @@ import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.transport.HttpClientTransportOverHTTP;
 import org.eclipse.jetty.io.ClientConnector;
+import org.eclipse.jetty.tests.testers.ProcessWrapper;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
@@ -31,7 +32,7 @@ public class AbstractJettyHomeTest
 {
     protected HttpClient client;
 
-    public static final int START_TIMEOUT = Integer.getInteger("home.start.timeout", 30);
+    public static final int START_TIMEOUT = ProcessWrapper.START_TIMEOUT;
 
     public static String toEnvironment(String module, String environment)
     {

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/BadAppTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/BadAppTests.java
@@ -59,7 +59,7 @@ public class BadAppTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start("--add-modules=http," + toEnvironment("deploy", env)))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertThat(run1.getExitValue(), is(0));
 
             Path war = distribution.resolveArtifact("org.eclipse.jetty." + env + ":jetty-" + env + "-test-badinit-webapp:war:" + jettyVersion);
@@ -100,7 +100,7 @@ public class BadAppTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start("--add-modules=http," + toEnvironment("deploy", env)))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertThat(run1.getExitValue(), is(0));
 
             Path war = distribution.resolveArtifact("org.eclipse.jetty." + env + ":jetty-" + env + "-test-badinit-webapp:war:" + jettyVersion);
@@ -112,7 +112,7 @@ public class BadAppTests extends AbstractJettyHomeTest
             int port = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + port))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(run2.awaitForJettyStart());
 
                 startHttpClient();
                 ContentResponse response = client.GET("http://localhost:" + port + "/badapp/");
@@ -144,7 +144,7 @@ public class BadAppTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start("--add-modules=http," + toEnvironment("deploy", env)))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertThat(run1.getExitValue(), is(0));
 
             Path war = distribution.resolveArtifact("org.eclipse.jetty." + env + ":jetty-" + env + "-test-badinit-webapp:war:" + jettyVersion);
@@ -153,7 +153,7 @@ public class BadAppTests extends AbstractJettyHomeTest
             int port = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + port, "jetty.server.dumpAfterStart=true"))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(run2.awaitForJettyStart());
 
                 startHttpClient();
                 //ContentResponse response = client.GET("http://localhost:" + port + "/badapp/bad/x");
@@ -189,7 +189,7 @@ public class BadAppTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start(args1))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS), logs(run1));
+            assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue(), logs(run1));
             Path badWebApp = distribution.resolveArtifact("org.eclipse.jetty." + env + ":" + "jetty-" + env + "-test-bad-websocket-webapp:war:" + jettyVersion);
             distribution.installWar(badWebApp, "test");
@@ -199,7 +199,7 @@ public class BadAppTests extends AbstractJettyHomeTest
 
             try (JettyHomeTester.Run run2 = distribution.start(args2))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS), logs(run2));
+                assertTrue(run2.awaitForJettyStart());
                 assertFalse(run2.getLogs().stream().anyMatch(s -> s.contains("LinkageError")));
 
                 startHttpClient();

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/BouncyCastleModuleTest.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/BouncyCastleModuleTest.java
@@ -41,13 +41,13 @@ public class BouncyCastleModuleTest
 
         try (JettyHomeTester.Run configRun = distribution.start("--approve-all-licenses", "--add-modules=https,bouncycastle,test-keystore"))
         {
-            assertTrue(configRun.awaitFor(30, TimeUnit.SECONDS));
+            assertTrue(configRun.awaitForStart());
             assertEquals(0, configRun.getExitValue());
 
             int httpsPort = Tester.freePort();
             try (JettyHomeTester.Run startRun = distribution.start(List.of("jetty.ssl.selectors=1", "jetty.ssl.port=" + httpsPort)))
             {
-                assertTrue(startRun.awaitConsoleLogsFor("Started oejs.Server@", 10, TimeUnit.SECONDS));
+                assertTrue(startRun.awaitForJettyStart());
                 assertTrue(startRun.getLogs().stream().anyMatch(line -> line.contains("provider=BCJSSE")));
 
                 try (HttpClient httpClient = new HttpClient())

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/CDITests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/CDITests.java
@@ -103,7 +103,7 @@ public class CDITests extends AbstractJettyHomeTest
         };
         try (JettyHomeTester.Run run1 = distribution.start(args1))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue());
 
             Path war = distribution.resolveArtifact("org.eclipse.jetty." + env + ":jetty-" + env + "-test-" + integration + "-cdi-webapp:war:" + jettyVersion);
@@ -116,7 +116,7 @@ public class CDITests extends AbstractJettyHomeTest
             int port = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + port))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(run2.awaitForJettyStart());
 
                 startHttpClient();
                 ContentResponse response = client.GET("http://localhost:" + port + "/demo/greetings");

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/ConscryptModuleTest.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/ConscryptModuleTest.java
@@ -41,13 +41,13 @@ public class ConscryptModuleTest
 
         try (JettyHomeTester.Run configRun = distribution.start("--approve-all-licenses", "--add-modules=https,conscrypt,test-keystore"))
         {
-            assertTrue(configRun.awaitFor(30, TimeUnit.SECONDS));
+            assertTrue(configRun.awaitForStart());
             assertEquals(0, configRun.getExitValue());
 
             int httpsPort = Tester.freePort();
             try (JettyHomeTester.Run startRun = distribution.start(List.of("jetty.ssl.selectors=1", "jetty.ssl.port=" + httpsPort)))
             {
-                assertTrue(startRun.awaitConsoleLogsFor("Started oejs.Server@", 10, TimeUnit.SECONDS));
+                assertTrue(startRun.awaitForJettyStart());
                 assertTrue(startRun.getLogs().stream().anyMatch(line -> line.contains("provider=Conscrypt")));
 
                 try (HttpClient httpClient = new HttpClient())

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DemoModulesTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DemoModulesTests.java
@@ -68,7 +68,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
         String baseURI = "http://localhost:%d/%s-test".formatted(httpPort, env);
         try (JettyHomeTester.Run runConfig = distribution.start(argsConfig))
         {
-            assertTrue(runConfig.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(runConfig.awaitForStart());
             assertEquals(0, runConfig.getExitValue());
 
             String[] argsStart =
@@ -79,7 +79,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
 
             try (JettyHomeTester.Run runStart = distribution.start(argsStart))
             {
-                assertTrue(runStart.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(runStart.awaitForJettyStart());
 
                 startHttpClient();
                 ContentResponse response = client.GET(baseURI + "/dump/auth/admin/info");
@@ -112,12 +112,12 @@ public class DemoModulesTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run runConfig = distribution.start(argsConfig))
         {
-            assertTrue(runConfig.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(runConfig.awaitForStart());
             assertEquals(0, runConfig.getExitValue(), "Exit value");
 
             try (JettyHomeTester.Run runListConfig = distribution.start("--list-config"))
             {
-                assertTrue(runListConfig.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(runListConfig.awaitForStart());
                 assertEquals(0, runListConfig.getExitValue(), "Exit value");
                 // Example of what we expect
                 // jetty.webapp.addHiddenClasses = org.eclipse.jetty.logging.,${jetty.home.uri}/lib/logging/,org.slf4j.,${jetty.base.uri}/lib/bouncycastle/
@@ -156,7 +156,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run runConfig = distribution.start(argsConfig))
         {
-            assertTrue(runConfig.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(runConfig.awaitForStart());
             assertEquals(0, runConfig.getExitValue());
 
             String[] argsStart = {
@@ -166,7 +166,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
 
             try (JettyHomeTester.Run runStart = distribution.start(argsStart))
             {
-                assertTrue(runStart.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(runStart.awaitForJettyStart());
 
                 startHttpClient();
                 ContentResponse response = client.GET(baseURI + "/dump.jsp");
@@ -202,7 +202,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run runConfig = distribution.start(argsConfig))
         {
-            assertTrue(runConfig.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(runConfig.awaitForStart());
             assertEquals(0, runConfig.getExitValue());
 
             String[] argsStart = {
@@ -212,7 +212,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
 
             try (JettyHomeTester.Run runStart = distribution.start(argsStart))
             {
-                assertTrue(runStart.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(runStart.awaitForJettyStart());
 
                 startHttpClient();
                 ContentResponse response = client.GET(baseURI + "/dump.jsp");
@@ -248,7 +248,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run runConfig = distribution.start(argsConfig))
         {
-            assertTrue(runConfig.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(runConfig.awaitForStart());
             assertEquals(0, runConfig.getExitValue());
 
             String[] argsStart = 
@@ -259,7 +259,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
 
             try (JettyHomeTester.Run runStart = distribution.start(argsStart))
             {
-                assertTrue(runStart.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(runStart.awaitForJettyStart());
 
                 startHttpClient();
                 ContentResponse response = client.GET(baseURI + "/auth.html");
@@ -295,7 +295,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run runConfig = distribution.start(argsConfig))
         {
-            assertTrue(runConfig.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(runConfig.awaitForStart());
             assertEquals(0, runConfig.getExitValue());
 
             String[] argsStart = {
@@ -305,7 +305,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
 
             try (JettyHomeTester.Run runStart = distribution.start(argsStart))
             {
-                assertTrue(runStart.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(runStart.awaitForJettyStart());
 
                 startHttpClient();
                 ContentResponse response = client.GET(baseURI + "/jstl.jsp");
@@ -344,7 +344,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run runConfig = distribution.start(argsConfig))
         {
-            assertTrue(runConfig.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(runConfig.awaitForStart());
             assertEquals(0, runConfig.getExitValue());
 
             String[] argsStart = {
@@ -354,7 +354,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
 
             try (JettyHomeTester.Run runStart = distribution.start(argsStart))
             {
-                assertTrue(runStart.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(runStart.awaitForJettyStart());
 
                 startHttpClient();
                 ContentResponse response;
@@ -398,7 +398,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run runConfig = distribution.start(argsConfig))
         {
-            assertTrue(runConfig.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(runConfig.awaitForStart());
             assertEquals(0, runConfig.getExitValue(), logs(runConfig));
 
             String[] argsStart = {
@@ -408,8 +408,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
 
             try (JettyHomeTester.Run runStart = distribution.start(argsStart))
             {
-                assertTrue(runStart.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS),
-                    () -> String.join("\n", runStart.getLogs()));
+                assertTrue(runStart.awaitForJettyStart());
 
                 startHttpClient();
 
@@ -479,7 +478,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
         String baseURI = "http://localhost:%d/%s-test".formatted(httpPort, env);
         try (JettyHomeTester.Run runConfig = distribution.start(argsConfig))
         {
-            assertTrue(runConfig.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(runConfig.awaitForStart());
             assertEquals(0, runConfig.getExitValue());
 
             String[] argsStart =
@@ -490,7 +489,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
             };
             try (JettyHomeTester.Run runStart = distribution.start(argsStart))
             {
-                assertTrue(runStart.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(runStart.awaitForJettyStart());
 
                 startHttpClient();
                 ContentResponse response = client.GET(baseURI + "/hello");
@@ -523,7 +522,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run runConfig = distribution.start(argsConfig))
         {
-            assertTrue(runConfig.awaitFor(START_TIMEOUT, TimeUnit.SECONDS), logs(runConfig));
+            assertTrue(runConfig.awaitForStart());
             assertEquals(0, runConfig.getExitValue(), logs(runConfig));
 
             int httpPort = Tester.freePort();
@@ -534,7 +533,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
             };
             try (JettyHomeTester.Run runStart = distribution.start(argsStart))
             {
-                assertTrue(runStart.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS), logs(runStart));
+                assertTrue(runStart.awaitForJettyStart());
 
                 String baseURI = "http://localhost:%d/%s-test".formatted(httpPort, env);
 
@@ -589,7 +588,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run runConfig = distribution.start(argsConfig))
         {
-            assertTrue(runConfig.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(runConfig.awaitForStart());
             assertEquals(0, runConfig.getExitValue());
 
             int httpPort = Tester.freePort();
@@ -601,8 +600,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
             };
             try (JettyHomeTester.Run runStart = distribution.start(argsStart))
             {
-                assertTrue(runStart.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS),
-                    "LOGS: " + String.join("\n", runStart.getLogs()));
+                assertTrue(runStart.awaitForJettyStart());
 
                 String baseURI = "http://localhost:%d/%s-test".formatted(httpPort, env);
 
@@ -638,7 +636,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run runConfig = distribution.start(argsConfig))
         {
-            assertTrue(runConfig.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(runConfig.awaitForStart());
             assertEquals(0, runConfig.getExitValue());
 
             String[] argsStart = {
@@ -648,7 +646,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
 
             try (JettyHomeTester.Run runStart = distribution.start(argsStart))
             {
-                assertTrue(runStart.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(runStart.awaitForJettyStart());
 
                 startHttpClient();
                 ContentResponse response = client.GET(baseURI);
@@ -680,7 +678,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run runConfig = distribution.start(argsConfig))
         {
-            assertTrue(runConfig.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(runConfig.awaitForStart());
             assertEquals(0, runConfig.getExitValue());
 
             String[] argsStart =
@@ -690,7 +688,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
             };
             try (JettyHomeTester.Run runStart = distribution.start(argsStart))
             {
-                assertTrue(runStart.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(runStart.awaitForJettyStart());
                 startHttpClient();
 
                 String rootURI = "http://localhost:%d".formatted(httpPort);
@@ -741,7 +739,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run runConfig = distribution.start(argsConfig))
         {
-            assertTrue(runConfig.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(runConfig.awaitForStart());
             assertEquals(0, runConfig.getExitValue());
 
             String[] argsStart = {
@@ -752,7 +750,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
 
             try (JettyHomeTester.Run runStart = distribution.start(argsStart))
             {
-                assertTrue(runStart.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(runStart.awaitForJettyStart());
                 startHttpClient();
                 String baseURI = "http://localhost:%d/%s-test".formatted(httpPort, env);
 
@@ -784,7 +782,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run runConfig = distribution.start(argsConfig))
         {
-            assertTrue(runConfig.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(runConfig.awaitForStart());
             assertEquals(0, runConfig.getExitValue());
 
             String[] argsStart = {
@@ -795,7 +793,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
 
             try (JettyHomeTester.Run runStart = distribution.start(argsStart))
             {
-                assertTrue(runStart.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(runStart.awaitForJettyStart());
                 startHttpClient();
                 String baseURI = "http://localhost:%d/%s-test".formatted(httpPort, env);
 

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DemoModulesTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DemoModulesTests.java
@@ -489,7 +489,7 @@ public class DemoModulesTests extends AbstractJettyHomeTest
             };
             try (JettyHomeTester.Run runStart = distribution.start(argsStart))
             {
-                assertTrue(runStart.awaitForJettyStart());
+                assertTrue(runStart.awaitForJettyStart(true));
 
                 startHttpClient();
                 ContentResponse response = client.GET(baseURI + "/hello");

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DeployerTest.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DeployerTest.java
@@ -62,7 +62,7 @@ public class DeployerTest extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start(List.of("--add-modules=resources,http,core-deploy")))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue());
 
             Path baseResourcePath = jettyBase.resolve("work/test");
@@ -90,7 +90,7 @@ public class DeployerTest extends AbstractJettyHomeTest
             int httpPort = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + httpPort))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(run2.awaitForJettyStart());
 
                 startHttpClient();
                 ContentResponse response = client.GET("http://localhost:" + httpPort + "/test/test.txt");
@@ -112,7 +112,7 @@ public class DeployerTest extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start(List.of("--add-modules=resources,http,core-deploy")))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue());
 
             Path nominatedDir = jettyBase.resolve("webapps").resolve("test.d");
@@ -127,7 +127,7 @@ public class DeployerTest extends AbstractJettyHomeTest
             int httpPort = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + httpPort))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(run2.awaitForJettyStart());
 
                 startHttpClient();
                 ContentResponse response = client.GET("http://localhost:" + httpPort + "/test/test.txt");
@@ -149,7 +149,7 @@ public class DeployerTest extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start(List.of("--add-modules=resources,http,core-deploy")))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue());
 
             Path nominatedDir = jettyBase.resolve("webapps").resolve("test");
@@ -164,7 +164,7 @@ public class DeployerTest extends AbstractJettyHomeTest
             int httpPort = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + httpPort))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(run2.awaitForJettyStart());
 
                 startHttpClient();
                 ContentResponse response = client.GET("http://localhost:" + httpPort + "/test/test.txt");
@@ -186,7 +186,7 @@ public class DeployerTest extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start(List.of("--add-modules=resources,http,core-deploy")))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue());
 
             Path testDir = jettyBase.resolve("webapps").resolve("test");
@@ -210,7 +210,7 @@ public class DeployerTest extends AbstractJettyHomeTest
             int httpPort = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + httpPort))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS), () -> String.join(System.lineSeparator(), run2.getLogs()));
+                assertTrue(run2.awaitForJettyStart());
 
                 startHttpClient();
                 String uri = "http://localhost:" + httpPort + "/demo/test.txt";
@@ -250,7 +250,7 @@ public class DeployerTest extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start(List.of("--add-modules=resources,http,static-deploy")))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue());
 
             Path staticDir = jettyBase.resolve("webapps/test");
@@ -262,7 +262,7 @@ public class DeployerTest extends AbstractJettyHomeTest
             int httpPort = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + httpPort))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(run2.awaitForJettyStart());
 
                 startHttpClient();
                 ContentResponse response = client.GET("http://localhost:" + httpPort + "/test/test.txt");
@@ -284,7 +284,7 @@ public class DeployerTest extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start(List.of("--add-modules=resources,http,static-deploy")))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue());
 
             Path outputJar = jettyBase.resolve("webapps/test.jar");
@@ -303,7 +303,7 @@ public class DeployerTest extends AbstractJettyHomeTest
             int httpPort = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + httpPort))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(run2.awaitForJettyStart());
 
                 startHttpClient();
                 ContentResponse response = client.GET("http://localhost:" + httpPort + "/test/test.txt");
@@ -330,7 +330,7 @@ public class DeployerTest extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start(argsConfig))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue());
 
             Path wars = jettyBase.resolve("wars");
@@ -358,7 +358,7 @@ public class DeployerTest extends AbstractJettyHomeTest
             int httpPort = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + httpPort))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(run2.awaitForJettyStart());
 
                 startHttpClient();
                 ContentResponse response = client.GET("http://localhost:" + httpPort + "/test/test.txt");

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionCoreHandlerTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionCoreHandlerTests.java
@@ -373,8 +373,8 @@ public class DistributionCoreHandlerTests extends AbstractJettyHomeTest
         };
         try (JettyHomeTester.Run run1 = distribution.start("--approve-all-licenses", "--add-modules=" + String.join(",", modules)))
         {
-            assertTrue(run1.awaitFor(10, TimeUnit.SECONDS));
-            assertEquals(0, run1.getExitValue());
+            assertTrue(run1.awaitForStart());
+            assertEquals(0, run1.getExitValue(), run1.logs());
 
             Path jettyLogging = distribution.getJettyBase().resolve("resources/jetty-logging.properties");
             String loggingConfig = """

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionJSPTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionJSPTests.java
@@ -118,7 +118,7 @@ public class DistributionJSPTests extends AbstractJettyHomeTest
             int port = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("--jpms", "jetty.http.port=" + port))
             {
-                assertTrue(run2.awaitForJettyStart());
+                assertTrue(run2.awaitForJettyStart(true));
 
                 startHttpClient();
                 ContentResponse response = client.GET("http://localhost:" + port + "/test/index.jsp");

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionJSPTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionJSPTests.java
@@ -69,7 +69,7 @@ public class DistributionJSPTests extends AbstractJettyHomeTest
             // Verify that --create-start-ini works
             assertTrue(Files.exists(distribution.getJettyBase().resolve("start.ini")));
 
-            Path war = distribution.resolveArtifact("org.eclipse.jetty." + env + ".demos:jetty-" + env + "-demo-jsp-webapp:war:" + jettyVersion);
+            Path war = distribution.resolveArtifact("org.eclipse.jetty.demos:jetty-servlet5-demo-jsp-webapp:war:" + jettyVersion);
             distribution.installWar(war, "test");
 
             int port = Tester.freePort();
@@ -112,7 +112,7 @@ public class DistributionJSPTests extends AbstractJettyHomeTest
             assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue());
 
-            Path war = distribution.resolveArtifact("org.eclipse.jetty." + env + ".demos:jetty-" + env + "-demo-jsp-webapp:war:" + jettyVersion);
+            Path war = distribution.resolveArtifact("org.eclipse.jetty.demos:jetty-servlet5-demo-jsp-webapp:war:" + jettyVersion);
             distribution.installWar(war, "test");
 
             int port = Tester.freePort();
@@ -214,7 +214,7 @@ public class DistributionJSPTests extends AbstractJettyHomeTest
             LOG.atInfo().setMessage(run1.logs().get()).log();
             assertTrue(Files.exists(distribution.getJettyBase().resolve("resources/log4j2.xml")));
 
-            Path war = distribution.resolveArtifact("org.eclipse.jetty." + env + ".demos:jetty-" + env + "-demo-jsp-webapp:war:" + jettyVersion);
+            Path war = distribution.resolveArtifact("org.eclipse.jetty.demos:jetty-servlet5-demo-jsp-webapp:war:" + jettyVersion);
             distribution.installWar(war, "test");
 
             int port = Tester.freePort();

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -282,7 +282,7 @@ public class DistributionTests extends AbstractJettyHomeTest
         );
         try (JettyHomeTester.Run run1 = distribution.start("--add-modules=" + mods))
         {
-            assertTrue(run1.awaitForStart());
+            assertTrue(run1.awaitForStart(true));
             assertEquals(0, run1.getExitValue(), run1.logs());
 
             Path war = distribution.resolveArtifact("org.eclipse.jetty." + env + ".demos:jetty-" + env + "-demo-proxy-webapp:war:" + jettyVersion);
@@ -306,7 +306,7 @@ public class DistributionTests extends AbstractJettyHomeTest
             int port = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("--jpms", "jetty.http.port=" + port, "jetty.server.dumpAfterStart=true"))
             {
-                assertTrue(run2.awaitForJettyStart());
+                assertTrue(run2.awaitForJettyStart(true));
 
                 startHttpClient(() -> new HttpClient(new HttpClientTransportOverHTTP(1)));
                 ContentResponse response = client.GET("http://localhost:" + port + "/proxy/jetty-12/index.html");
@@ -472,7 +472,7 @@ public class DistributionTests extends AbstractJettyHomeTest
             int port = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + port))
             {
-                assertTrue(run2.awaitForJettyStart());
+                assertTrue(run2.awaitForJettyStart(true));
                 assertTrue(run2.getLogs().stream()
                     .anyMatch(log -> log.contains("WARN") && log.contains("Forking")));
             }
@@ -613,7 +613,7 @@ public class DistributionTests extends AbstractJettyHomeTest
             int port = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + port))
             {
-                assertTrue(run2.awaitForJettyStart());
+                assertTrue(run2.awaitForJettyStart(true));
                 assertTrue(run2.getLogs().stream()
                     .anyMatch(log -> log.contains("WARN") && log.contains(reason)));
             }
@@ -668,7 +668,7 @@ public class DistributionTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start("--add-to-start=server,logging-jetty"))
         {
-            assertTrue(run1.awaitForStart());
+            assertTrue(run1.awaitForStart(true));
             assertEquals(0, run1.getExitValue());
 
             try (JettyHomeTester.Run run2 = distribution.start("--dry-run"))
@@ -1447,7 +1447,7 @@ public class DistributionTests extends AbstractJettyHomeTest
         });
         try (JettyHomeTester.Run run1 = distribution.start("--add-modules=" + String.join(",", modules)))
         {
-            assertTrue(run1.awaitForStart());
+            assertTrue(run1.awaitForStart(true));
             assertEquals(0, run1.getExitValue());
 
             int httpPort = Tester.freePort();
@@ -1458,7 +1458,7 @@ public class DistributionTests extends AbstractJettyHomeTest
                 args.add("--jpms");
             try (JettyHomeTester.Run run2 = distribution.start(args))
             {
-                assertTrue(run2.awaitForJettyStart());
+                assertTrue(run2.awaitForJettyStart(true));
 
                 startHttpClient();
 

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -128,7 +128,7 @@ public class DistributionTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start("--add-modules=http"))
         {
-            assertTrue(run1.awaitFor(10, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue());
 
             Path pidfile = run1.getConfig().getJettyBase().resolve("jetty.pid");
@@ -151,7 +151,7 @@ public class DistributionTests extends AbstractJettyHomeTest
 
             try (JettyHomeTester.Run run2 = distribution.start(args))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", 10, TimeUnit.SECONDS));
+                assertTrue(run2.awaitForJettyStart());
 
                 assertTrue(Files.isRegularFile(pidfile), "PID file should exist");
                 assertTrue(Files.isRegularFile(statefile), "State file should exist");
@@ -210,8 +210,8 @@ public class DistributionTests extends AbstractJettyHomeTest
         );
         try (JettyHomeTester.Run run1 = distribution.start("--approve-all-licenses", "--add-modules=" + mods))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
-            assertEquals(0, run1.getExitValue());
+            assertTrue(run1.awaitForStart());
+            assertEquals(0, run1.getExitValue(), () -> logs(run1).get());
 
             Path war = distribution.resolveArtifact("org.eclipse.jetty.demos:jetty-servlet5-demo-jsp-webapp:war:" + jettyVersion);
             distribution.installWar(war, "test");
@@ -231,7 +231,7 @@ public class DistributionTests extends AbstractJettyHomeTest
 
                 try (JettyHomeTester.Run run3 = distribution.start("jetty.http.port=" + port, "jetty.quickstart.mode=QUICKSTART"))
                 {
-                    assertTrue(run3.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                    assertTrue(run3.awaitForJettyStart());
 
                     startHttpClient();
                     ContentResponse response = client.GET("http://localhost:" + port + "/test/index.jsp");
@@ -242,7 +242,6 @@ public class DistributionTests extends AbstractJettyHomeTest
             }
         }
     }
-
 
     @Test
     @Tag("external")
@@ -259,7 +258,7 @@ public class DistributionTests extends AbstractJettyHomeTest
         String outPath = "etc/maven-metadata.xml";
         try (JettyHomeTester.Run run = distribution.start("--download=" + downloadURI + "|" + outPath))
         {
-            assertTrue(run.awaitConsoleLogsFor("Base directory was modified", 120, TimeUnit.SECONDS));
+            assertTrue(run.awaitForJettyStart(120, TimeUnit.SECONDS));
             Path target = jettyBase.resolve(outPath);
             assertTrue(Files.exists(target), "could not create " + target);
         }
@@ -307,7 +306,7 @@ public class DistributionTests extends AbstractJettyHomeTest
             int port = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("--jpms", "jetty.http.port=" + port, "jetty.server.dumpAfterStart=true"))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(run2.awaitForJettyStart());
 
                 startHttpClient(() -> new HttpClient(new HttpClientTransportOverHTTP(1)));
                 ContentResponse response = client.GET("http://localhost:" + port + "/proxy/jetty-12/index.html");
@@ -337,7 +336,7 @@ public class DistributionTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start("--add-modules=https,test-keystore"))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue());
 
             //Path jettyBase = run1.getConfig().getJettyBase();
@@ -390,15 +389,14 @@ public class DistributionTests extends AbstractJettyHomeTest
 
             try (JettyHomeTester.Run run2 = distribution.start("--add-modules=ssl-patch"))
             {
-                assertTrue(run2.awaitFor(START_TIMEOUT, TimeUnit.SECONDS), logs(run2));
+                assertTrue(run2.awaitForStart());
                 assertEquals(0, run2.getExitValue());
 
                 int port = Tester.freePort();
                 int sslPort = Tester.freePort();
                 try (JettyHomeTester.Run run3 = distribution.start("jetty.http.port=" + port, "jetty.ssl.port=" + sslPort))
                 {
-                    assertTrue(run3.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS),
-                            logs(run3));
+                    assertTrue(run3.awaitForJettyStart());
 
                     // Check for the protocol order: fcgi must be after ssl and before http.
                     assertTrue(run3.getLogs().stream()
@@ -425,7 +423,7 @@ public class DistributionTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start("--add-modules=unixdomain-http"))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue());
 
             int maxUnixDomainPathLength = 108;
@@ -435,7 +433,7 @@ public class DistributionTests extends AbstractJettyHomeTest
             assertTrue(Files.deleteIfExists(path));
             try (JettyHomeTester.Run run2 = distribution.start("jetty.unixdomain.path=" + path))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(run2.awaitForJettyStart());
 
                 ClientConnector connector = new ClientConnector();
                 client = new HttpClient(new HttpClientTransportDynamic(connector, HttpClientConnectionFactory.HTTP11));
@@ -468,13 +466,13 @@ public class DistributionTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start(List.of("--add-modules=http,exec")))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue());
 
             int port = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + port))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(run2.awaitForJettyStart());
                 assertTrue(run2.getLogs().stream()
                     .anyMatch(log -> log.contains("WARN") && log.contains("Forking")));
             }
@@ -506,14 +504,14 @@ public class DistributionTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start("--add-module=https,test-keystore,ssl-ini"))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue());
 
             // Override the property on the command line with the correct password.
             int port = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start(pathProperty + "=cmdline", "jetty.ssl.port=" + port))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(run2.awaitForJettyStart());
                 assertThat("${jetty.base}/cmdline", jettyBase.resolve("cmdline"), PathMatchers.isRegularFile());
                 assertThat("${jetty.base}/modbased", jettyBase.resolve("modbased"), not(PathMatchers.exists()));
             }
@@ -532,7 +530,7 @@ public class DistributionTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start("--approve-all-licenses", "--add-modules=http,well-known"))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue());
 
             // Ensure .well-known directory exists.
@@ -552,7 +550,7 @@ public class DistributionTests extends AbstractJettyHomeTest
             int port = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + port))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(run2.awaitForJettyStart());
 
                 // Test we can access the file in the .well-known directory.
                 startHttpClient();
@@ -590,7 +588,7 @@ public class DistributionTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run listConfigRun = distribution.start(List.of("--list-modules")))
         {
-            assertTrue(listConfigRun.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(listConfigRun.awaitForStart());
             assertEquals(0, listConfigRun.getExitValue());
 
             assertTrue(listConfigRun.getLogs().stream().noneMatch(log -> log.contains("DEPRECATED")));
@@ -615,7 +613,7 @@ public class DistributionTests extends AbstractJettyHomeTest
             int port = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + port))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(run2.awaitForJettyStart());
                 assertTrue(run2.getLogs().stream()
                     .anyMatch(log -> log.contains("WARN") && log.contains(reason)));
             }
@@ -634,14 +632,14 @@ public class DistributionTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start("--approve-all-licenses", "--add-modules=http3,test-keystore"))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue());
 
             int h2Port = Tester.freePort();
             int h3Port = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start(List.of("jetty.ssl.selectors=1", "jetty.ssl.port=" + h2Port, "jetty.quic.port=" + h3Port)))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(run2.awaitForJettyStart());
 
                 QuicheClientQuicConfiguration clientQuicConfig = HTTP3ClientQuicConfiguration.configure(new QuicheClientQuicConfiguration());
                 HTTP3Client http3Client = new HTTP3Client(clientQuicConfig);
@@ -670,7 +668,7 @@ public class DistributionTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start("--add-to-start=server,logging-jetty"))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue());
 
             try (JettyHomeTester.Run run2 = distribution.start("--dry-run"))
@@ -696,7 +694,7 @@ public class DistributionTests extends AbstractJettyHomeTest
         String[] args1 = {"--add-module=server,http,requestlog"};
         try (JettyHomeTester.Run run1 = distribution.start(args1))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue());
 
             // Setup custom format string with spaces
@@ -714,7 +712,7 @@ public class DistributionTests extends AbstractJettyHomeTest
                 };
             try (JettyHomeTester.Run run2 = distribution.start(args2))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(run2.awaitForJettyStart());
                 startHttpClient(false);
 
                 String uri = "http://localhost:" + port + "/test";
@@ -747,7 +745,7 @@ public class DistributionTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start(List.of("--add-modules=resources,http,fcgi,fcgi-proxy,core-deploy")))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue());
 
             // Add a FastCGI connector to simulate, for example, php-fpm.
@@ -826,7 +824,7 @@ public class DistributionTests extends AbstractJettyHomeTest
             int httpPort = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + httpPort, "etc/fcgi-connector.xml"))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(run2.awaitForJettyStart());
 
                 startHttpClient();
                 // Make a request to the /proxy context on the httpPort; it should be converted to FastCGI
@@ -856,7 +854,7 @@ public class DistributionTests extends AbstractJettyHomeTest
         );
         try (JettyHomeTester.Run run1 = distribution.start(List.of("--add-modules=" + mods)))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue());
 
             // Add a FastCGI connector to simulate, for example, php-fpm.
@@ -949,7 +947,7 @@ public class DistributionTests extends AbstractJettyHomeTest
             int httpPort = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + httpPort, "etc/fcgi-connector.xml"))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(run2.awaitForJettyStart());
 
                 startHttpClient();
                 // Make a request to the /proxy context on the httpPort; it should be converted to FastCGI
@@ -974,13 +972,13 @@ public class DistributionTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start("--add-modules=threadpool-virtual-preview,http"))
         {
-            assertTrue(run1.awaitFor(10, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue());
 
             int httpPort = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start(List.of("jetty.http.selectors=1", "jetty.http.port=" + httpPort)))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", 10, TimeUnit.SECONDS));
+                assertTrue(run2.awaitForJettyStart());
 
                 startHttpClient();
                 ContentResponse response = client.newRequest("localhost", httpPort)
@@ -1005,13 +1003,13 @@ public class DistributionTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start("--add-modules=http," + threadPoolModule))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue());
 
             int httpPort = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start(List.of("jetty.http.selectors=1", "jetty.http.port=" + httpPort)))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(run2.awaitForJettyStart());
 
                 startHttpClient();
                 ContentResponse response = client.newRequest("localhost", httpPort)
@@ -1042,14 +1040,14 @@ public class DistributionTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start("--add-modules=" + mods))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue());
 
             int httpPort = Tester.freePort();
             String contextPath = "/" + toEnvironment("demo-simple", env);
             try (JettyHomeTester.Run run2 = distribution.start(List.of("jetty.http.selectors=1", "jetty.http.port=" + httpPort)))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(run2.awaitForJettyStart());
 
                 startHttpClient();
                 ContentResponse response = client.newRequest("localhost", httpPort)
@@ -1091,7 +1089,7 @@ public class DistributionTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run runConfig = distribution.start(argsConfig))
         {
-            assertTrue(runConfig.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(runConfig.awaitForStart());
             assertEquals(0, runConfig.getExitValue());
 
             String[] argsStart = {
@@ -1146,7 +1144,7 @@ public class DistributionTests extends AbstractJettyHomeTest
 
             try (JettyHomeTester.Run runStart = distribution.start(argsStart))
             {
-                assertTrue(runStart.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(runStart.awaitForJettyStart());
 
                 startHttpClient();
                 ContentResponse response = client.GET("http://localhost:" + httpPort + "/demo/index.html");
@@ -1167,7 +1165,7 @@ public class DistributionTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start("--add-modules=http"))
         {
-            assertTrue(run1.awaitFor(10, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue());
 
             int httpPort = Tester.freePort();
@@ -1177,7 +1175,7 @@ public class DistributionTests extends AbstractJettyHomeTest
             );
             try (JettyHomeTester.Run run2 = distribution.start(args))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(run2.awaitForJettyStart());
                 startHttpClient();
 
                 List<String> hostHeaders = new ArrayList<>();
@@ -1223,7 +1221,7 @@ public class DistributionTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start("--add-modules=http,cross-origin,demo-handler"))
         {
-            run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS);
+            assertTrue(run1.awaitForStart());
             assertThat(run1.getExitValue(), is(0));
 
             int httpPort1 = Tester.freePort();
@@ -1235,7 +1233,7 @@ public class DistributionTests extends AbstractJettyHomeTest
             );
             try (JettyHomeTester.Run run2 = distribution.start(args))
             {
-                assertThat(run2.awaitConsoleLogsFor("Started oejs.Server", START_TIMEOUT, TimeUnit.SECONDS), is(true));
+                assertThat(run2.awaitForJettyStart(), is(true));
                 startHttpClient();
 
                 ContentResponse response = client.newRequest("http://localhost:" + httpPort1 + "/demo-handler/")
@@ -1258,7 +1256,7 @@ public class DistributionTests extends AbstractJettyHomeTest
             );
             try (JettyHomeTester.Run run2 = distribution.start(args))
             {
-                assertThat(run2.awaitConsoleLogsFor("Started oejs.Server", START_TIMEOUT, TimeUnit.SECONDS), is(true));
+                assertThat(run2.awaitForJettyStart(), is(true));
                 startHttpClient();
 
                 ContentResponse response = client.newRequest("http://localhost:" + httpPort2 + "/demo-handler/")
@@ -1284,13 +1282,13 @@ public class DistributionTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start("--add-modules=state-tracking,http,demo-handler"))
         {
-            run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS);
+            run1.awaitForStart();
             assertThat(run1.getExitValue(), is(0));
 
             int httpPort = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + httpPort))
             {
-                assertThat(run2.awaitConsoleLogsFor("Started oejs.Server", START_TIMEOUT, TimeUnit.SECONDS), is(true));
+                assertThat(run2.awaitForJettyStart(), is(true));
                 startHttpClient();
 
                 ContentResponse response = client.newRequest("http://localhost:" + httpPort + "/demo-handler/")
@@ -1313,7 +1311,7 @@ public class DistributionTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start("--add-modules=http,http2-client-transport,core-deploy"))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue());
 
             String name = "test-webapp";
@@ -1335,7 +1333,7 @@ public class DistributionTests extends AbstractJettyHomeTest
             int port = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + port))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(run2.awaitForJettyStart());
 
                 startHttpClient();
                 URI serverUri = URI.create("http://localhost:" + port + "/test/");
@@ -1365,7 +1363,7 @@ public class DistributionTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start("--add-modules=" + String.join(",", modules)))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue());
             Path envExt = jettyBase.resolve("lib/" + env + "/ext");
             assertTrue(Files.isDirectory(envExt));
@@ -1377,7 +1375,7 @@ public class DistributionTests extends AbstractJettyHomeTest
         // Verify that the empty.jar is listed as being on the classpath
         try (JettyHomeTester.Run run = distribution.start(" jetty.server.dumpAfterStart=true"))
         {
-            assertThat(run.awaitConsoleLogsFor("lib/" + env + "/ext/empty.jar", START_TIMEOUT, TimeUnit.SECONDS), is(true));
+            assertThat(run.awaitForJettyStart(), is(true));
             run.stop();
             assertThat(run.awaitFor(START_TIMEOUT, TimeUnit.SECONDS), is(true));
         }
@@ -1393,13 +1391,13 @@ public class DistributionTests extends AbstractJettyHomeTest
 
         try (JettyHomeTester.Run run1 = distribution.start("--add-modules=forwarded,test-keystore,http2,requestlog"))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue());
 
             int port = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("jetty.ssl.selectors=1", "jetty.ssl.port=" + port))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(run2.awaitForJettyStart());
 
                 String forwarded = "10.1.1.1";
 
@@ -1449,7 +1447,7 @@ public class DistributionTests extends AbstractJettyHomeTest
         });
         try (JettyHomeTester.Run run1 = distribution.start("--add-modules=" + String.join(",", modules)))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue());
 
             int httpPort = Tester.freePort();
@@ -1460,7 +1458,7 @@ public class DistributionTests extends AbstractJettyHomeTest
                 args.add("--jpms");
             try (JettyHomeTester.Run run2 = distribution.start(args))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(run2.awaitForJettyStart());
 
                 startHttpClient();
 

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/session/AbstractSessionDistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/session/AbstractSessionDistributionTests.java
@@ -84,7 +84,7 @@ public abstract class AbstractSessionDistributionTests extends AbstractJettyHome
 
         try (JettyHomeTester.Run run1 = jettyHomeTester.start(argsStart))
         {
-            assertTrue(run1.awaitForStart());
+            assertTrue(run1.awaitForStart(true));
             assertEquals(0, run1.getExitValue());
 
             Path war = jettyHomeTester.resolveArtifact("org.eclipse.jetty." +  environment +
@@ -101,7 +101,7 @@ public abstract class AbstractSessionDistributionTests extends AbstractJettyHome
             
             try (JettyHomeTester.Run run2 = jettyHomeTester.start(argsStart))
             {
-                assertTrue(run2.awaitForJettyStart());
+                assertTrue(run2.awaitForJettyStart(true));
 
                 startHttpClient();
                 ContentResponse response = client.GET("http://localhost:" + port + "/test/session?action=CREATE");
@@ -122,7 +122,7 @@ public abstract class AbstractSessionDistributionTests extends AbstractJettyHome
 
             try (JettyHomeTester.Run run2 = jettyHomeTester.start(argsStart))
             {
-                assertTrue(run2.awaitForJettyStart());
+                assertTrue(run2.awaitForJettyStart(true));
 
                 ContentResponse response = client.GET("http://localhost:" + port + "/test/session?action=READ");
                 assertEquals(HttpStatus.OK_200, response.getStatus());

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/session/AbstractSessionDistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/session/AbstractSessionDistributionTests.java
@@ -84,7 +84,7 @@ public abstract class AbstractSessionDistributionTests extends AbstractJettyHome
 
         try (JettyHomeTester.Run run1 = jettyHomeTester.start(argsStart))
         {
-            assertTrue(run1.awaitFor(START_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue());
 
             Path war = jettyHomeTester.resolveArtifact("org.eclipse.jetty." +  environment +
@@ -101,7 +101,7 @@ public abstract class AbstractSessionDistributionTests extends AbstractJettyHome
             
             try (JettyHomeTester.Run run2 = jettyHomeTester.start(argsStart))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(run2.awaitForJettyStart());
 
                 startHttpClient();
                 ContentResponse response = client.GET("http://localhost:" + port + "/test/session?action=CREATE");
@@ -122,7 +122,7 @@ public abstract class AbstractSessionDistributionTests extends AbstractJettyHome
 
             try (JettyHomeTester.Run run2 = jettyHomeTester.start(argsStart))
             {
-                assertTrue(run2.awaitConsoleLogsFor("Started oejs.Server@", START_TIMEOUT, TimeUnit.SECONDS));
+                assertTrue(run2.awaitForJettyStart());
 
                 ContentResponse response = client.GET("http://localhost:" + port + "/test/session?action=READ");
                 assertEquals(HttpStatus.OK_200, response.getStatus());

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/session/FileSessionWithMemcacheDistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/session/FileSessionWithMemcacheDistributionTests.java
@@ -33,7 +33,7 @@ public class FileSessionWithMemcacheDistributionTests extends AbstractSessionDis
     private static final Logger LOGGER = LoggerFactory.getLogger(FileSessionWithMemcacheDistributionTests.class);
     private static final Logger MEMCACHED_LOG = LoggerFactory.getLogger("org.eclipse.jetty.tests.distribution.session.memcached");
 
-    private GenericContainer memcached;
+    private GenericContainer<?> memcached;
 
     private String host;
     private int port;


### PR DESCRIPTION
* add new start arg to force using file only from local repo, so test distribution builds will not download files from snapshot repo


---------

Signed-off-by: Olivier Lamy <olamy@apache.org>
Co-authored-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>