### PR TITLE
Fix `ReadPendingException` warning

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpReceiverOverHTTP.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpReceiverOverHTTP.java
@@ -55,7 +55,6 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
     private Content.Chunk chunk;
     private boolean shutdown;
     private boolean disposed;
-    private Runnable completionTask;
 
     public HttpReceiverOverHTTP(HttpChannelOverHTTP channel)
     {
@@ -127,7 +126,8 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
         if (LOG.isDebugEnabled())
             LOG.debug("ParseAndFill needFillInterest {} in {}", needFillInterest, this);
         chunk = consumeChunk();
-        runCompletionTaskIfAny();
+        if (state == State.COMPLETE)
+            responseSuccess(getHttpExchange(), receiveNext);
         if (chunk != null)
             return chunk;
         if (needFillInterest && fillInterestIfNeeded)
@@ -341,12 +341,10 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
                     boolean isUpgrade = status == HttpStatus.SWITCHING_PROTOCOLS_101;
                     boolean isTunnel = getHttpChannel().isTunnel(method, status);
 
-                    Runnable task = isUpgrade || isTunnel ? null : this.receiveNext;
-
                     // Connection upgrade, bail out.
                     if (isUpgrade || isTunnel)
                     {
-                        responseSuccess(exchange, task);
+                        responseSuccess(exchange, null);
                         return true;
                     }
 
@@ -367,9 +365,9 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
                     }
 
                     if (notifyContentAvailable)
-                        responseSuccess(exchange, task);
-                    else
-                        completionTask = () -> responseSuccess(exchange, task);
+                        responseSuccess(exchange, receiveNext);
+                    // else: Let read(boolean) call responseSuccess() so it gets a chance to read this.chunk before
+                    // responseSuccess() resets it to null.
 
                     // Continue to read from the network.
                     return false;
@@ -388,14 +386,6 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
             // and it is now driving the parsing.
             return true;
         }
-    }
-
-    void runCompletionTaskIfAny()
-    {
-        Runnable task = completionTask;
-        completionTask = null;
-        if (task != null)
-            task.run();
     }
 
     protected void fillInterested()

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpReceiverOverHTTP.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpReceiverOverHTTP.java
@@ -341,7 +341,6 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
 
                     Runnable task = isUpgrade || isTunnel ? null : this.receiveNext;
                     responseSuccess(exchange, task);
-                    chunk = Content.Chunk.EOF;
 
                     // Connection upgrade, bail out.
                     if (isUpgrade || isTunnel)

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpReceiverOverHTTP.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpReceiverOverHTTP.java
@@ -364,10 +364,10 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
                         }
                     }
 
+                    // When notifyContentAvailable==false, this method is called from read(boolean),
+                    // and the call to responseSuccess() is performed by read().
                     if (notifyContentAvailable)
                         responseSuccess(exchange, receiveNext);
-                    // else: Let read(boolean) call responseSuccess() so it gets a chance to read this.chunk before
-                    // responseSuccess() resets it to null.
 
                     // Continue to read from the network.
                     return false;

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpReceiverOverHTTP.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpReceiverOverHTTP.java
@@ -341,6 +341,7 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
 
                     Runnable task = isUpgrade || isTunnel ? null : this.receiveNext;
                     responseSuccess(exchange, task);
+                    chunk = Content.Chunk.EOF;
 
                     // Connection upgrade, bail out.
                     if (isUpgrade || isTunnel)

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpReceiverOverHTTP.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpReceiverOverHTTP.java
@@ -55,6 +55,7 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
     private Content.Chunk chunk;
     private boolean shutdown;
     private boolean disposed;
+    private Runnable completionTask;
 
     public HttpReceiverOverHTTP(HttpChannelOverHTTP channel)
     {
@@ -126,6 +127,7 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
         if (LOG.isDebugEnabled())
             LOG.debug("ParseAndFill needFillInterest {} in {}", needFillInterest, this);
         chunk = consumeChunk();
+        runCompletionTaskIfAny();
         if (chunk != null)
             return chunk;
         if (needFillInterest && fillInterestIfNeeded)
@@ -340,11 +342,13 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
                     boolean isTunnel = getHttpChannel().isTunnel(method, status);
 
                     Runnable task = isUpgrade || isTunnel ? null : this.receiveNext;
-                    responseSuccess(exchange, task);
 
                     // Connection upgrade, bail out.
                     if (isUpgrade || isTunnel)
+                    {
+                        responseSuccess(exchange, task);
                         return true;
+                    }
 
                     if (byteBuffer.hasRemaining())
                     {
@@ -359,9 +363,13 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
                             if (LOG.isDebugEnabled())
                                 LOG.debug("Discarding unexpected content after response {}: {} in {}", status, BufferUtil.toDetailString(byteBuffer), this);
                             BufferUtil.clear(byteBuffer);
-                            return false;
                         }
                     }
+
+                    if (notifyContentAvailable)
+                        responseSuccess(exchange, task);
+                    else
+                        completionTask = () -> responseSuccess(exchange, task);
 
                     // Continue to read from the network.
                     return false;
@@ -380,6 +388,14 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
             // and it is now driving the parsing.
             return true;
         }
+    }
+
+    void runCompletionTaskIfAny()
+    {
+        Runnable task = completionTask;
+        completionTask = null;
+        if (task != null)
+            task.run();
     }
 
     protected void fillInterested()

--- a/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpConnectionOverFCGI.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpConnectionOverFCGI.java
@@ -70,7 +70,6 @@ public class HttpConnectionOverFCGI extends AbstractConnection implements IConne
     private State state = State.STATUS;
     private long idleTimeout;
     private boolean shutdown;
-    private Runnable completionTask;
 
     public HttpConnectionOverFCGI(EndPoint endPoint, Destination destination, Promise<Connection> promise)
     {
@@ -251,7 +250,8 @@ public class HttpConnectionOverFCGI extends AbstractConnection implements IConne
                 // with zero or not enough bytes, so the state is reset
                 // here to avoid calling responseSuccess() again.
                 state = State.STATUS;
-                completionTask = channel::responseSuccess;
+                // Do not call channel.responseSuccess() here to give HttpReceiverOverFCGI.read(boolean) a chance to read
+                // the chunk field before channel.responseSuccess() resets it to null.
             }
             default -> throw new IllegalStateException("Invalid state " + state);
         }
@@ -259,12 +259,9 @@ public class HttpConnectionOverFCGI extends AbstractConnection implements IConne
         return handle;
     }
 
-    void runCompletionTaskIfAny()
+    void channelResponseSuccess()
     {
-        Runnable task = completionTask;
-        completionTask = null;
-        if (task != null)
-            task.run();
+        channel.responseSuccess();
     }
 
     private void shutdown()

--- a/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpConnectionOverFCGI.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpConnectionOverFCGI.java
@@ -245,11 +245,6 @@ public class HttpConnectionOverFCGI extends AbstractConnection implements IConne
             }
             case COMPLETE ->
             {
-                // For the complete event, handle==false, and cannot
-                // differentiate between a complete event and a parse()
-                // with zero or not enough bytes, so the state is reset
-                // here to avoid calling responseSuccess() again.
-                state = State.STATUS;
                 // Do not call channel.responseSuccess() here to give HttpReceiverOverFCGI.read(boolean) a chance to read
                 // the chunk field before channel.responseSuccess() resets it to null.
             }
@@ -259,8 +254,18 @@ public class HttpConnectionOverFCGI extends AbstractConnection implements IConne
         return handle;
     }
 
-    void channelResponseSuccess()
+    boolean isComplete()
     {
+        return state == State.COMPLETE;
+    }
+
+    void complete()
+    {
+        // For the complete event, handle==false, and cannot
+        // differentiate between a complete event and a parse()
+        // with zero or not enough bytes, so the state is reset
+        // here to avoid calling responseSuccess() again.
+        state = State.STATUS;
         channel.responseSuccess();
     }
 

--- a/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpConnectionOverFCGI.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpConnectionOverFCGI.java
@@ -70,6 +70,7 @@ public class HttpConnectionOverFCGI extends AbstractConnection implements IConne
     private State state = State.STATUS;
     private long idleTimeout;
     private boolean shutdown;
+    private Runnable completionTask;
 
     public HttpConnectionOverFCGI(EndPoint endPoint, Destination destination, Promise<Connection> promise)
     {
@@ -250,12 +251,20 @@ public class HttpConnectionOverFCGI extends AbstractConnection implements IConne
                 // with zero or not enough bytes, so the state is reset
                 // here to avoid calling responseSuccess() again.
                 state = State.STATUS;
-                channel.responseSuccess();
+                completionTask = channel::responseSuccess;
             }
             default -> throw new IllegalStateException("Invalid state " + state);
         }
 
         return handle;
+    }
+
+    void runCompletionTaskIfAny()
+    {
+        Runnable task = completionTask;
+        completionTask = null;
+        if (task != null)
+            task.run();
     }
 
     private void shutdown()

--- a/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpReceiverOverFCGI.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpReceiverOverFCGI.java
@@ -88,7 +88,8 @@ public class HttpReceiverOverFCGI extends HttpReceiver
         HttpConnectionOverFCGI httpConnection = getHttpConnection();
         boolean needFillInterest = httpConnection.parseAndFill(false);
         chunk = consumeChunk();
-        httpConnection.runCompletionTaskIfAny();
+        if (chunk != null && chunk.isLast())
+            httpConnection.channelResponseSuccess();
         if (chunk != null)
             return chunk;
         if (needFillInterest && fillInterestIfNeeded)

--- a/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpReceiverOverFCGI.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpReceiverOverFCGI.java
@@ -88,8 +88,8 @@ public class HttpReceiverOverFCGI extends HttpReceiver
         HttpConnectionOverFCGI httpConnection = getHttpConnection();
         boolean needFillInterest = httpConnection.parseAndFill(false);
         chunk = consumeChunk();
-        if (chunk != null && chunk.isLast())
-            httpConnection.channelResponseSuccess();
+        if (httpConnection.isComplete())
+            httpConnection.complete();
         if (chunk != null)
             return chunk;
         if (needFillInterest && fillInterestIfNeeded)

--- a/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpReceiverOverFCGI.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpReceiverOverFCGI.java
@@ -88,6 +88,7 @@ public class HttpReceiverOverFCGI extends HttpReceiver
         HttpConnectionOverFCGI httpConnection = getHttpConnection();
         boolean needFillInterest = httpConnection.parseAndFill(false);
         chunk = consumeChunk();
+        httpConnection.runCompletionTaskIfAny();
         if (chunk != null)
             return chunk;
         if (needFillInterest && fillInterestIfNeeded)

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/HTTP3Stream.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/HTTP3Stream.java
@@ -362,6 +362,7 @@ public abstract class HTTP3Stream implements Stream, CyclicTimeouts.Expirable, A
         {
             notIdle();
             notifyTrailer(frame);
+            dataRef.set(Data.EOF);
             updateClose(frame.isLast(), false);
         }
     }

--- a/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HttpStreamOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HttpStreamOverHTTP3.java
@@ -398,7 +398,7 @@ public class HttpStreamOverHTTP3 implements HttpStream
                 {
                     if (hasContent)
                     {
-                        callback.completeWith(sendDataFrame(content, lastContent, false)
+                        callback.completeWith(sendDataFrame(content, false, false)
                             .thenCompose(s -> sendTrailerFrame(trailers)));
                     }
                     else

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
@@ -138,11 +138,10 @@ public class HttpClientTest extends AbstractTest
     }
 
     @ParameterizedTest
-    @MethodSource("transports")
+    @MethodSource("transportsNoFCGI")
     public void testClientUseContentSourceInSpawnedThreadWithTrailer(Transport transport) throws Exception
     {
         assumeTrue(transport != Transport.H3); // TODO H3 should work too, but does not for some reason that must be investigated.
-        assumeTrue(transport != Transport.FCGI); // TODO FCGI should work too, but does not for some reason that must be investigated.
 
         start(transport, new Handler.Abstract()
         {

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
@@ -85,8 +85,6 @@ public class HttpClientTest extends AbstractTest
     @MethodSource("transports")
     public void testClientUseContentSourceInSpawnedThreadEmptyResponseContent(Transport transport) throws Exception
     {
-        assumeTrue(transport != Transport.H3); // TODO H3 should work too, but does not for some reason that must be investigated.
-
         start(transport, new Handler.Abstract()
         {
             @Override
@@ -113,8 +111,6 @@ public class HttpClientTest extends AbstractTest
     @MethodSource("transports")
     public void testClientUseContentSourceInSpawnedThreadWithResponseContent(Transport transport) throws Exception
     {
-        assumeTrue(transport != Transport.H3); // TODO H3 should work too, but does not for some reason that must be investigated.
-
         start(transport, new Handler.Abstract()
         {
             @Override
@@ -141,8 +137,6 @@ public class HttpClientTest extends AbstractTest
     @MethodSource("transportsNoFCGI")
     public void testClientUseContentSourceInSpawnedThreadWithTrailer(Transport transport) throws Exception
     {
-        assumeTrue(transport != Transport.H3); // TODO H3 should work too, but does not for some reason that must be investigated.
-
         start(transport, new Handler.Abstract()
         {
             @Override

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
@@ -69,6 +69,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -81,7 +82,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 public class HttpClientTest extends AbstractTest
 {
     @ParameterizedTest
-    @MethodSource("transports")
+    @MethodSource("transportsTCP")
     public void testClientUseContentSourceInSpawnedThreadEmptyResponseContent(Transport transport) throws Exception
     {
         start(transport, new Handler.Abstract()
@@ -94,42 +95,20 @@ public class HttpClientTest extends AbstractTest
             }
         });
 
-        var response = new Response.Listener()
-        {
-            final CompletableFuture<String> body = new CompletableFuture<>();
+        var listener = new OnContentSourceListener();
 
-            @Override
-            public void onContentSource(Response response, Content.Source contentSource)
-            {
-                new Thread(() ->
-                {
-                    Content.Chunk chunk = contentSource.read();
-                    if (chunk == null)
-                    {
-                        contentSource.demand(() -> onContentSource(response, contentSource));
-                        return;
-                    }
-
-                    chunk.release();
-
-                    if (!chunk.isLast())
-                        contentSource.demand(() -> onContentSource(response, contentSource));
-                    else
-                        body.complete("");
-                }
-                ).start();
-            }
-        };
-
-        client.newRequest(server.getURI())
+        client.newRequest(newURI(transport))
             .method("POST")
-            .send(response);
+            .send(listener);
 
-        response.body.get(5, TimeUnit.SECONDS);
+        OnContentSourceListener.ClientResponseContent clientResponseContent = listener.clientResponseContent.get(5, TimeUnit.SECONDS);
+        assertThat(clientResponseContent.body(), is(""));
+        assertThat(clientResponseContent.status(), is(200));
+        assertThat(clientResponseContent.trailers(), nullValue());
     }
 
     @ParameterizedTest
-    @MethodSource("transports")
+    @MethodSource("transportsTCP")
     public void testClientUseContentSourceInSpawnedThreadWithResponseContent(Transport transport) throws Exception
     {
         start(transport, new Handler.Abstract()
@@ -142,42 +121,20 @@ public class HttpClientTest extends AbstractTest
             }
         });
 
-        var response = new Response.Listener()
-        {
-            final CompletableFuture<String> body = new CompletableFuture<>();
+        var listener = new OnContentSourceListener();
 
-            @Override
-            public void onContentSource(Response response, Content.Source contentSource)
-            {
-                new Thread(() ->
-                {
-                    Content.Chunk chunk = contentSource.read();
-                    if (chunk == null)
-                    {
-                        contentSource.demand(() -> onContentSource(response, contentSource));
-                        return;
-                    }
-
-                    chunk.release();
-
-                    if (!chunk.isLast())
-                        contentSource.demand(() -> onContentSource(response, contentSource));
-                    else
-                        body.complete("");
-                }
-                ).start();
-            }
-        };
-
-        client.newRequest(server.getURI())
+        client.newRequest(newURI(transport))
             .method("POST")
-            .send(response);
+            .send(listener);
 
-        response.body.get(5, TimeUnit.SECONDS);
+        OnContentSourceListener.ClientResponseContent clientResponseContent = listener.clientResponseContent.get(5, TimeUnit.SECONDS);
+        assertThat(clientResponseContent.body(), is("some response content"));
+        assertThat(clientResponseContent.status(), is(200));
+        assertThat(clientResponseContent.trailers(), nullValue());
     }
 
     @ParameterizedTest
-    @MethodSource("transports")
+    @MethodSource("transportsTCP")
     public void testClientUseContentSourceInSpawnedThreadWithTrailer(Transport transport) throws Exception
     {
         start(transport, new Handler.Abstract()
@@ -198,38 +155,16 @@ public class HttpClientTest extends AbstractTest
             }
         });
 
-        var response = new Response.Listener()
-        {
-            final CompletableFuture<String> body = new CompletableFuture<>();
+        var listener = new OnContentSourceListener();
 
-            @Override
-            public void onContentSource(Response response, Content.Source contentSource)
-            {
-                new Thread(() ->
-                {
-                    Content.Chunk chunk = contentSource.read();
-                    if (chunk == null)
-                    {
-                        contentSource.demand(() -> onContentSource(response, contentSource));
-                        return;
-                    }
-
-                    chunk.release();
-
-                    if (!chunk.isLast())
-                        contentSource.demand(() -> onContentSource(response, contentSource));
-                    else
-                        body.complete("");
-                }
-                ).start();
-            }
-        };
-
-        client.newRequest(server.getURI())
+        client.newRequest(newURI(transport))
             .method("POST")
-            .send(response);
+            .send(listener);
 
-        response.body.get(5, TimeUnit.SECONDS);
+        OnContentSourceListener.ClientResponseContent clientResponseContent = listener.clientResponseContent.get(5, TimeUnit.SECONDS);
+        assertThat(clientResponseContent.body(), is("some response content"));
+        assertThat(clientResponseContent.status(), is(200));
+        assertThat(clientResponseContent.trailers().get("X-Trailer-test"), is("foobar"));
     }
 
     @ParameterizedTest
@@ -1306,6 +1241,47 @@ public class HttpClientTest extends AbstractTest
         public boolean await(long timeout, TimeUnit unit) throws InterruptedException
         {
             return latch.await(timeout, unit);
+        }
+    }
+
+    private static class OnContentSourceListener implements Response.Listener
+    {
+        record ClientResponseContent(int status, String body, HttpFields trailers)
+        {
+        }
+
+        final CompletableFuture<ClientResponseContent> clientResponseContent = new CompletableFuture<>();
+        final StringBuffer buffer = new StringBuffer();
+
+        @Override
+        public void onContentSource(Response response, Content.Source contentSource)
+        {
+            new Thread(() ->
+            {
+                Content.Chunk chunk = contentSource.read();
+                if (chunk == null)
+                {
+                    contentSource.demand(() -> onContentSource(response, contentSource));
+                    return;
+                }
+
+                buffer.append(BufferUtil.toString(chunk.getByteBuffer(), StandardCharsets.UTF_8));
+                chunk.release();
+
+                if (!chunk.isLast())
+                {
+                    contentSource.demand(() -> onContentSource(response, contentSource));
+                }
+                else
+                {
+                    Content.Chunk afterLastChunk = contentSource.read();
+                    if (afterLastChunk != chunk)
+                        clientResponseContent.completeExceptionally(new AssertionError("afterLastChunk != chunk"));
+                    else
+                        clientResponseContent.complete(new ClientResponseContent(response.getStatus(), buffer.toString(), response.getTrailers()));
+                }
+            }
+            ).start();
         }
     }
 }

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
@@ -40,6 +40,7 @@ import org.eclipse.jetty.client.InputStreamResponseListener;
 import org.eclipse.jetty.client.Origin;
 import org.eclipse.jetty.client.Response;
 import org.eclipse.jetty.client.Result;
+import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
@@ -81,7 +82,7 @@ public class HttpClientTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transports")
-    public void testClientUseContentSourceInSpawnedThread(Transport transport) throws Exception
+    public void testClientUseContentSourceInSpawnedThreadEmptyResponseContent(Transport transport) throws Exception
     {
         start(transport, new Handler.Abstract()
         {
@@ -89,6 +90,110 @@ public class HttpClientTest extends AbstractTest
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
             {
                 response.write(true, BufferUtil.EMPTY_BUFFER, callback);
+                return true;
+            }
+        });
+
+        var response = new Response.Listener()
+        {
+            final CompletableFuture<String> body = new CompletableFuture<>();
+
+            @Override
+            public void onContentSource(Response response, Content.Source contentSource)
+            {
+                new Thread(() ->
+                {
+                    Content.Chunk chunk = contentSource.read();
+                    if (chunk == null)
+                    {
+                        contentSource.demand(() -> onContentSource(response, contentSource));
+                        return;
+                    }
+
+                    chunk.release();
+
+                    if (!chunk.isLast())
+                        contentSource.demand(() -> onContentSource(response, contentSource));
+                    else
+                        body.complete("");
+                }
+                ).start();
+            }
+        };
+
+        client.newRequest(server.getURI())
+            .method("POST")
+            .send(response);
+
+        response.body.get(5, TimeUnit.SECONDS);
+    }
+
+    @ParameterizedTest
+    @MethodSource("transports")
+    public void testClientUseContentSourceInSpawnedThreadWithResponseContent(Transport transport) throws Exception
+    {
+        start(transport, new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
+            {
+                response.write(true, BufferUtil.toBuffer("some response content", StandardCharsets.UTF_8), callback);
+                return true;
+            }
+        });
+
+        var response = new Response.Listener()
+        {
+            final CompletableFuture<String> body = new CompletableFuture<>();
+
+            @Override
+            public void onContentSource(Response response, Content.Source contentSource)
+            {
+                new Thread(() ->
+                {
+                    Content.Chunk chunk = contentSource.read();
+                    if (chunk == null)
+                    {
+                        contentSource.demand(() -> onContentSource(response, contentSource));
+                        return;
+                    }
+
+                    chunk.release();
+
+                    if (!chunk.isLast())
+                        contentSource.demand(() -> onContentSource(response, contentSource));
+                    else
+                        body.complete("");
+                }
+                ).start();
+            }
+        };
+
+        client.newRequest(server.getURI())
+            .method("POST")
+            .send(response);
+
+        response.body.get(5, TimeUnit.SECONDS);
+    }
+
+    @ParameterizedTest
+    @MethodSource("transports")
+    public void testClientUseContentSourceInSpawnedThreadWithTrailer(Transport transport) throws Exception
+    {
+        start(transport, new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback) throws IOException
+            {
+                response.setTrailersSupplier(() -> HttpFields.build().add("X-Trailer-test", "foobar"));
+                // start chunked mode
+                try (Blocker.Callback blocker = Blocker.callback())
+                {
+                    response.write(false, BufferUtil.EMPTY_BUFFER, blocker);
+                    blocker.block();
+                }
+
+                response.write(true, BufferUtil.toBuffer("some response content", StandardCharsets.UTF_8), callback);
                 return true;
             }
         });

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
@@ -81,6 +81,54 @@ public class HttpClientTest extends AbstractTest
 {
     @ParameterizedTest
     @MethodSource("transports")
+    public void testClientUseContentSourceInSpawnedThread(Transport transport) throws Exception
+    {
+        start(transport, new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
+            {
+                response.write(true, BufferUtil.EMPTY_BUFFER, callback);
+                return true;
+            }
+        });
+
+        var response = new Response.Listener()
+        {
+            final CompletableFuture<String> body = new CompletableFuture<>();
+
+            @Override
+            public void onContentSource(Response response, Content.Source contentSource)
+            {
+                new Thread(() ->
+                {
+                    Content.Chunk chunk = contentSource.read();
+                    if (chunk == null)
+                    {
+                        contentSource.demand(() -> onContentSource(response, contentSource));
+                        return;
+                    }
+
+                    chunk.release();
+
+                    if (!chunk.isLast())
+                        contentSource.demand(() -> onContentSource(response, contentSource));
+                    else
+                        body.complete("");
+                }
+                ).start();
+            }
+        };
+
+        client.newRequest(server.getURI())
+            .method("POST")
+            .send(response);
+
+        response.body.get(5, TimeUnit.SECONDS);
+    }
+
+    @ParameterizedTest
+    @MethodSource("transports")
     public void testRequestWithoutResponseContent(Transport transport) throws Exception
     {
         final int status = HttpStatus.NO_CONTENT_204;

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
@@ -82,9 +82,11 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 public class HttpClientTest extends AbstractTest
 {
     @ParameterizedTest
-    @MethodSource("transportsTCP")
+    @MethodSource("transports")
     public void testClientUseContentSourceInSpawnedThreadEmptyResponseContent(Transport transport) throws Exception
     {
+        assumeTrue(transport != Transport.H3); // TODO H3 should work too, but does not for some reason that must be investigated.
+
         start(transport, new Handler.Abstract()
         {
             @Override
@@ -108,9 +110,11 @@ public class HttpClientTest extends AbstractTest
     }
 
     @ParameterizedTest
-    @MethodSource("transportsTCP")
+    @MethodSource("transports")
     public void testClientUseContentSourceInSpawnedThreadWithResponseContent(Transport transport) throws Exception
     {
+        assumeTrue(transport != Transport.H3); // TODO H3 should work too, but does not for some reason that must be investigated.
+
         start(transport, new Handler.Abstract()
         {
             @Override
@@ -134,9 +138,12 @@ public class HttpClientTest extends AbstractTest
     }
 
     @ParameterizedTest
-    @MethodSource("transportsTCP")
+    @MethodSource("transports")
     public void testClientUseContentSourceInSpawnedThreadWithTrailer(Transport transport) throws Exception
     {
+        assumeTrue(transport != Transport.H3); // TODO H3 should work too, but does not for some reason that must be investigated.
+        assumeTrue(transport != Transport.FCGI); // TODO FCGI should work too, but does not for some reason that must be investigated.
+
         start(transport, new Handler.Abstract()
         {
             @Override


### PR DESCRIPTION
The problem is that `HttpReceiverOverHTTP.parse()` calls `responseSuccess()` assuming that this method will queue its task into the `HttpReceiver`'s serialized executor for later execution.

Unfortunately, if `Response.Listener.onContentSource()` spawns a thread that does the usual read/demand loop on the given `Content.Source` instance, `HttpReceiverOverHTTP.parse()`'s call to `responseSuccess()` immediately executes the task which calls `HttpReceiver.reset()` before returning. This means that the `Content.Source.read()` call that initiated the `HttpReceiverOverHTTP.parse()` call does not see the `EOF` chunk but null, so it thinks it must demand while `responseSuccess()` already called `receiveNext()` which also did demand.

Fixes #13177