### PR TITLE
stop throwing ISE when complete() is called after abort()

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannelState.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannelState.java
@@ -814,6 +814,8 @@ public class ServletChannelState
                     break;
 
                 case COMPLETE:
+                case COMPLETING:
+                case COMPLETED:
                     return;
                 default:
                     throw new IllegalStateException(this.getStatusStringLocked());

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannelState.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannelState.java
@@ -1019,7 +1019,7 @@ public class HttpChannelState
                 LOG.debug("completed {}", toStringLocked());
 
             if (_requestState != RequestState.COMPLETING)
-                throw new IllegalStateException(this.getStatusStringLocked());
+                throw new IllegalStateException(this.getStatusStringLocked(), failure);
 
             if (_event == null)
             {

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannelState.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannelState.java
@@ -748,6 +748,8 @@ public class HttpChannelState
                     break;
 
                 case COMPLETE:
+                case COMPLETING:
+                case COMPLETED:
                     return;
                 default:
                     throw new IllegalStateException(getStatusStringLocked());


### PR DESCRIPTION
Fixes the ISE logs of https://github.com/jetty/jetty.project/issues/13198 once merged to 12.1.x.