### PR TITLE
Issue #13190 - Add CompactPathRule support for decoding and canonicalizing paths

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -163,8 +163,6 @@ def mavenBuild(jdk, cmdline, mvnName) {
     finally
     {
       junit testResults: '**/target/surefire-reports/TEST**.xml,**/target/invoker-reports/TEST*.xml', allowEmptyResults: true
-      // temporary logs to remove
-      sh "ls -lrt ~/.mimir/"
     }
   }
 }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/CompactPathRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/CompactPathRule.java
@@ -15,27 +15,121 @@ package org.eclipse.jetty.rewrite.handler;
 
 import java.io.IOException;
 
+import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HttpURI;
-import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.util.URIUtil;
 
 /**
- * <p>Rewrites the URI by compacting to remove occurrences of {@code //}.</p>
- * <p>For example, {@code //foo/bar//baz} is compacted to {@code /foo/bar/baz}.</p>
+ * <p>Rewrites the URI by compacting to remove occurrences of {@code //} and {@code /../}.</p>
+ *
+ * <p>Optionally decode the path before compacting.</p>
+ * <p>Optionally canonicalize path before compacting.</p>
+ *
+ * <table>
+ *     <caption>Examples</caption>
+ *     <tr>
+ *       <th>isDecoding</th>
+ *       <th>isCanonicalizing</th>
+ *       <th>Input Path</th>
+ *       <th>Resulting Path</th>
+ *     </tr>
+ *     <tr>
+ *       <td>false (default)</td>
+ *       <td>false (default)</td>
+ *       <td>{@code //foo/bar//baz}</td>
+ *       <td>{@code /foo/bar/baz}</td>
+ *     </tr>
+ *     <tr>
+ *       <td>false (default)</td>
+ *       <td>false (default)</td>
+ *       <td>{@code //foo/../bar//baz}</td>
+ *       <td>{@code /bar/baz}</td>
+ *     </tr>
+ *     <tr>
+ *       <td>true</td>
+ *       <td>true</td>
+ *       <td>{@code //foo/../bar//baz}</td>
+ *       <td>{@code /bar/baz}</td>
+ *     </tr>
+ * </table>
+ *
+ * @see URIUtil#decodePath(String)
+ * @see URIUtil#canonicalPath(String)
+ * @see URIUtil#compactPath(String)
  */
 public class CompactPathRule extends Rule
 {
+    private boolean decoding = false;
+    private boolean canonicalizing = false;
+
+    public boolean isCanonicalizing()
+    {
+        return canonicalizing;
+    }
+
+    public void setCanonicalizing(boolean canonicalizing)
+    {
+        this.canonicalizing = canonicalizing;
+    }
+
+    public boolean isDecoding()
+    {
+        return decoding;
+    }
+
+    public void setDecoding(boolean decoding)
+    {
+        this.decoding = decoding;
+    }
+
     @Override
     public Handler matchAndApply(Handler input) throws IOException
     {
+        // Get the path without extra things like path parameters
         String path = input.getHttpURI().getCanonicalPath();
-        String compacted = URIUtil.compactPath(path);
+        String cleanedPath = path;
 
-        if (path.equals(compacted))
-            return null;
+        if (isDecoding())
+            cleanedPath = URIUtil.decodePath(cleanedPath);
+        if (isCanonicalizing())
+        {
+            cleanedPath = URIUtil.canonicalPath(cleanedPath);
+            if (cleanedPath == null)
+            {
+                notifyPathCompaction(input, cleanedPath, "Navigate above root URL");
 
-        HttpURI uri = Request.newHttpURIFrom(input, compacted);
+                // Attempted to navigate to above root URL
+                HttpURI uri = HttpURI.build(input.getHttpURI())
+                    .path("/")
+                    .asImmutable();
 
-        return new HttpURIHandler(input, uri);
+                return new HttpURIHandler(input, uri);
+            }
+        }
+
+        cleanedPath = URIUtil.compactPath(cleanedPath);
+
+        if (input.getHttpURI().getPath().equals(cleanedPath))
+            return null; // nothing to do, input and cleaned is the same.
+
+        notifyPathCompaction(input, cleanedPath, "Path was changed");
+
+        try
+        {
+            HttpURI uri = HttpURI.build(input.getHttpURI())
+                .path(cleanedPath)
+                .asImmutable();
+
+            return new HttpURIHandler(input, uri);
+        }
+        catch (IllegalArgumentException e)
+        {
+            throw new BadMessageException("Bad Path");
+        }
+    }
+
+    private void notifyPathCompaction(Handler input, String cleanedPath, String message)
+    {
+        // TODO: notify listener of event
     }
 }

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/CompactPathRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/CompactPathRule.java
@@ -14,6 +14,8 @@
 package org.eclipse.jetty.rewrite.handler;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HttpURI;
@@ -59,8 +61,28 @@ import org.eclipse.jetty.util.URIUtil;
  */
 public class CompactPathRule extends Rule
 {
+    public record CompactedEvent(Handler input, String changedPath, String message, CompactPathRule rule)
+    {
+    }
+
+    public interface Listener
+    {
+        void onCompactedEvent(CompactedEvent event);
+    }
+
+    private List<Listener> listeners = new ArrayList<>();
     private boolean decoding = false;
     private boolean canonicalizing = false;
+
+    public void addListener(Listener listener)
+    {
+        listeners.add(listener);
+    }
+
+    public boolean removeListener(Listener listener)
+    {
+        return listeners.remove(listener);
+    }
 
     public boolean isCanonicalizing()
     {
@@ -130,6 +152,10 @@ public class CompactPathRule extends Rule
 
     private void notifyPathCompaction(Handler input, String cleanedPath, String message)
     {
-        // TODO: notify listener of event
+        CompactedEvent event = new CompactedEvent(input, cleanedPath, message, this);
+        for (Listener listener : listeners)
+        {
+            listener.onCompactedEvent(event);
+        }
     }
 }

--- a/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/CompactPathRuleTest.java
+++ b/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/CompactPathRuleTest.java
@@ -25,14 +25,18 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.UriCompliance;
+import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CompactPathRuleTest extends AbstractRuleTest
@@ -41,29 +45,45 @@ public class CompactPathRuleTest extends AbstractRuleTest
     {
         return Stream.of(
             // shouldn't change anything
-            Arguments.of("/foo", null, "/foo", "", "/foo"),
-            Arguments.of("/", null, "/", "", "/"),
+            Arguments.of(false, false, "/foo", null, "/foo", "", "/foo"),
+            Arguments.of(false, false, "/", null, "/", "", "/"),
             // simple compact path
-            Arguments.of("////foo", null, "/foo", "", "/foo"),
+            Arguments.of(false, false, "////foo", null, "/foo", "", "/foo"),
             // with simple query
-            Arguments.of("//foo//bar", "a=b", "/foo/bar", "a=b", "/foo/bar?a=b"),
+            Arguments.of(false, false, "//foo//bar", "a=b", "/foo/bar", "a=b", "/foo/bar?a=b"),
             // with query that has double slashes (should preserve slashes in query)
-            Arguments.of("//foo//bar", "a=b//c", "/foo/bar", "a=b//c", "/foo/bar?a=b//c"),
+            Arguments.of(false, false, "//foo//bar", "a=b//c", "/foo/bar", "a=b//c", "/foo/bar?a=b//c"),
             // with ambiguous path parameter
-            Arguments.of("//foo/..;/bar", "a=b//c", "/bar", "a=b//c", "/bar?a=b//c"),
-            // with ambiguous path separator (not changed)
-            Arguments.of("//foo/b%2far", "a=b//c", "/foo/b%2Far", "a=b//c", "/foo/b%2Far?a=b//c"),
-            // with ambiguous path encoding (not changed)
-            Arguments.of("//foo/%2562ar", "a=b//c", "/foo/%2562ar", "a=b//c", "/foo/%2562ar?a=b//c")
+            Arguments.of(false, false, "//foo/..;/bar", "a=b//c", "/bar", "a=b//c", "/bar?a=b//c"),
+            // with ambiguous path separator
+            Arguments.of(false, false, "//foo/b%2far", "a=b//c", "/foo/b%2Far", "a=b//c", "/foo/b%2Far?a=b//c"),
+            Arguments.of(true, false, "//foo/b%2far", "a=b//c", "/foo/b/ar", "a=b//c", "/foo/b/ar?a=b//c"),
+            // with ambiguous path encoding
+            Arguments.of(false, false, "//foo/%2562ar", "a=b//c", "/foo/%2562ar", "a=b//c", "/foo/%2562ar?a=b//c"),
+            Arguments.of(true, false, "//foo/%2562ar", "a=b//c", "/foo/%62ar", "a=b//c", "/foo/%62ar?a=b//c"),
+            // with path above navigation
+            Arguments.of(false, false, "/..%2f../context/index.html", null, "/..%2F../context/index.html", "", "/..%2F../context/index.html"),
+            Arguments.of(false, true, "/..%2f../context/index.html", null, "/..%2F../context/index.html", "", "/..%2F../context/index.html"),
+            Arguments.of(true, true, "/..%2f../context/index.html", null, "/", "", "/"),
+            Arguments.of(false, false, "/a/%2e%2e/b/index.html", null, "/b/index.html", "", "/b/index.html"),
+            Arguments.of(true, false, "/a/%2e%2e/b/index.html", null, "/b/index.html", "", "/b/index.html"),
+            Arguments.of(false, true, "/a/%2e%2e/b/index.html", null, "/b/index.html", "", "/b/index.html"),
+            Arguments.of(true, true, "/a/%2e%2e/b/index.html", null, "/b/index.html", "", "/b/index.html"),
+            Arguments.of(false, false, "/a/%2e%2e/b/../c/index.html", null, "/c/index.html", "", "/c/index.html"),
+            Arguments.of(true, false, "/a/%2e%2e/b/../c/index.html", null, "/c/index.html", "", "/c/index.html"),
+            Arguments.of(false, true, "/a/%2e%2e/b/../c/index.html", null, "/c/index.html", "", "/c/index.html"),
+            Arguments.of(true, true, "/a/%2e%2e/b/../c/index.html", null, "/c/index.html", "", "/c/index.html")
         );
     }
 
     @ParameterizedTest
     @MethodSource("scenarios")
-    public void testCompactPathRule(String inputPath, String inputQuery, String expectedPath, String expectedQuery, String expectedPathQuery) throws Exception
+    public void testCompactPathRule(boolean decoding, boolean canonicalizing, String inputPath, String inputQuery, String expectedPath, String expectedQuery, String expectedPathQuery) throws Exception
     {
         _httpConfig.setUriCompliance(UriCompliance.UNSAFE);
         CompactPathRule rule = new CompactPathRule();
+        rule.setDecoding(decoding);
+        rule.setCanonicalizing(canonicalizing);
         _rewriteHandler.addRule(rule);
         start(new Handler.Abstract()
         {
@@ -104,12 +124,15 @@ public class CompactPathRuleTest extends AbstractRuleTest
             }
         });
 
+        String requestPath = inputPath;
+        if (inputQuery != null)
+            requestPath += "?" + inputQuery;
 
         String request = """
             GET %s HTTP/1.1
             Host: localhost
             
-            """.formatted(HttpURI.build().path(inputPath).query(inputQuery));
+            """.formatted(requestPath);
 
         HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse(request));
         assertEquals(HttpStatus.OK_200, response.getStatus());
@@ -121,16 +144,61 @@ public class CompactPathRuleTest extends AbstractRuleTest
             assertEquals(expectedQuery, props.getProperty("uri.query"));
             assertEquals(expectedPathQuery, props.getProperty("uri.pathQuery"));
 
-            boolean ambiguousPathSep = inputPath.contains("%2f");
-            boolean ambiguousPathEncoding = inputPath.contains("%25");
+            boolean expectingAmbiguousPathSep = !decoding && inputPath.contains("%2f");
+            boolean expectingAmbiguousPathEncoding = !decoding && inputPath.contains("%25");
 
-            assertEquals(Boolean.toString(ambiguousPathSep || ambiguousPathEncoding), props.getProperty("uri.isAmbiguous"));
-            assertEquals(Boolean.toString(ambiguousPathSep || ambiguousPathEncoding), props.getProperty("uri.hasViolations"));
-            assertEquals("false", props.getProperty("uri.hasAmbiguousEmptySegment"));
-            assertEquals(Boolean.toString(ambiguousPathEncoding), props.getProperty("uri.hasAmbiguousEncoding"));
-            assertEquals("false", props.getProperty("uri.hasAmbiguousParameter"));
-            assertEquals(Boolean.toString(ambiguousPathSep), props.getProperty("uri.hasAmbiguousSeparator"));
-            assertEquals("false", props.getProperty("uri.hasAmbiguousSegment"));
+            assertThat("uri.isAmbiguous", getBoolean(props, "uri.isAmbiguous"), is(expectingAmbiguousPathSep || expectingAmbiguousPathEncoding));
+            assertThat("uri.hasViolations", getBoolean(props, "uri.hasViolations"), is(expectingAmbiguousPathSep || expectingAmbiguousPathEncoding));
+            assertThat("uri.hasAmbiguousEmptySegment", getBoolean(props, "uri.hasAmbiguousEmptySegment"), is(false));
+            assertThat("uri.hasAmbiguousEncoding", getBoolean(props, "uri.hasAmbiguousEncoding"), is(expectingAmbiguousPathEncoding));
+            assertThat("uri.hasAmbiguousParameter", getBoolean(props, "uri.hasAmbiguousParameter"), is(false));
+            assertThat("uri.hasAmbiguousSeparator", getBoolean(props, "uri.hasAmbiguousSeparator"), is(expectingAmbiguousPathSep));
+            assertThat("uri.hasAmbiguousSegment", getBoolean(props, "uri.hasAmbiguousSegment"), is(false));
         }
+    }
+
+    private boolean getBoolean(Properties properties, String key)
+    {
+        return Boolean.parseBoolean(properties.getProperty(key, "false"));
+    }
+
+    /**
+     * Tests where the navigation goes up beyond the root of the URL
+     */
+    @ParameterizedTest
+    @CsvSource(delimiter = '|',
+        textBlock = """
+        # decoding | canonicalizing | inputPath
+        false | false | /../context/
+        false | false | /%2e./context/
+        false | false | /.%2e/context/
+        false | false | /%2e%2e/context/
+        true | false | /..%2fcontext/
+        """)
+    public void testCompactPathRuleResultsInBadMessage(boolean decoding, boolean canonicalizing, String inputPath) throws Exception
+    {
+        _httpConfig.setUriCompliance(UriCompliance.UNSAFE);
+        CompactPathRule rule = new CompactPathRule();
+        rule.setDecoding(decoding);
+        rule.setCanonicalizing(canonicalizing);
+        _rewriteHandler.addRule(rule);
+        start(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                Content.Sink.write(response,true, "Shouldn't reach here", callback);
+                return true;
+            }
+        });
+
+        String request = """
+            GET %s HTTP/1.1
+            Host: localhost
+            
+            """.formatted(inputPath);
+
+        HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse(request));
+        assertEquals(HttpStatus.BAD_REQUEST_400, response.getStatus());
     }
 }

--- a/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/CompactPathRuleTest.java
+++ b/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/CompactPathRuleTest.java
@@ -168,13 +168,13 @@ public class CompactPathRuleTest extends AbstractRuleTest
     @ParameterizedTest
     @CsvSource(delimiter = '|',
         textBlock = """
-        # decoding | canonicalizing | inputPath
-        false | false | /../context/
-        false | false | /%2e./context/
-        false | false | /.%2e/context/
-        false | false | /%2e%2e/context/
-        true | false | /..%2fcontext/
-        """)
+            # decoding | canonicalizing | inputPath
+            false | false | /../context/
+            false | false | /%2e./context/
+            false | false | /.%2e/context/
+            false | false | /%2e%2e/context/
+            true | false | /..%2fcontext/
+            """)
     public void testCompactPathRuleResultsInBadMessage(boolean decoding, boolean canonicalizing, String inputPath) throws Exception
     {
         _httpConfig.setUriCompliance(UriCompliance.UNSAFE);
@@ -187,7 +187,7 @@ public class CompactPathRuleTest extends AbstractRuleTest
             @Override
             public boolean handle(Request request, Response response, Callback callback)
             {
-                Content.Sink.write(response,true, "Shouldn't reach here", callback);
+                Content.Sink.write(response, true, "Shouldn't reach here", callback);
                 return true;
             }
         });


### PR DESCRIPTION
Adding methods to `CompactPathRule`

* `setDecoding(boolean)`
* `setCanonicalizing(boolean)`
* `addListener(Listener)`

