### PR TITLE
Fixes #13217 - Deployment of XML only with ServletContextHandler sets wrong baseResource.

### DIFF
--- a/jetty-core/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/StandardContextHandlerFactory.java
+++ b/jetty-core/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/StandardContextHandlerFactory.java
@@ -150,26 +150,7 @@ public class StandardContextHandlerFactory implements ContextHandlerFactory
 
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {
-            XmlConfiguration xmlConfiguration = new XmlConfiguration(resourceFactory.newResource(xml), null, asProperties(attributes))
-            {
-                @Override
-                public void initializeDefaults(Object context)
-                {
-                    super.initializeDefaults(context);
-                    ContextHandler contextHandler = getContextHandler(context);
-                    if (contextHandler == null)
-                    {
-                        if (LOG.isDebugEnabled())
-                            LOG.debug("Not a ContextHandler: Not initializing Context {}", context);
-                    }
-                    else
-                    {
-                        StandardContextHandlerFactory.this.initializeContextPath(contextHandler, xml, attributes);
-                        StandardContextHandlerFactory.this.initializeContextHandler(contextHandler, xml, attributes);
-                    }
-                }
-            };
-
+            XmlConfiguration xmlConfiguration = new XmlConfiguration(resourceFactory.newResource(xml), null, asProperties(attributes));
             xmlConfiguration.getIdMap().put("Environment", environment.getName());
             xmlConfiguration.setJettyStandardIdsAndProperties(server, xml);
 


### PR DESCRIPTION
Removed override of `XmlConfiguration.initializeDefaults()`. 
The same functionality has been replaced by the environments/*.xml files.