### PR TITLE
Prevent cycles/stackoverflow in dump

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/Dumpable.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/Dumpable.java
@@ -185,6 +185,7 @@ public interface Dumpable
      */
     static void dumpObjects(Appendable out, String indent, Object object, Object... extraChildren) throws IOException
     {
+        out = DumpAppendable.ensure(out);
         dumpObject(out, object);
 
         if (DumpAppendable.hasVisited(out, object))
@@ -240,6 +241,7 @@ public interface Dumpable
     
     static void dumpContainer(Appendable out, String indent, Container object, boolean last) throws IOException
     {
+        out = DumpAppendable.ensure(out);
         Container container = object;
         ContainerLifeCycle containerLifeCycle = container instanceof ContainerLifeCycle ? (ContainerLifeCycle)container : null;
         for (Iterator<Object> i = container.getBeans().iterator(); i.hasNext(); )
@@ -284,6 +286,7 @@ public interface Dumpable
 
     static void dumpIterable(Appendable out, String indent, Iterable<?> iterable, boolean last) throws IOException
     {
+        out = DumpAppendable.ensure(out);
         for (Iterator<?> i = iterable.iterator(); i.hasNext(); )
         {
             Object item = i.next();
@@ -301,6 +304,7 @@ public interface Dumpable
 
     static void dumpMapEntries(Appendable out, String indent, Map<?, ?> map, boolean last) throws IOException
     {
+        out = DumpAppendable.ensure(out);
         for (Iterator<? extends Map.Entry<?, ?>> i = map.entrySet().iterator(); i.hasNext(); )
         {
             Map.Entry entry = i.next();

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/component/DumpableTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/component/DumpableTest.java
@@ -26,20 +26,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class DumpableTest
 {
-    public static final String EXPECTED = """
-        A size=3
-        +> B size=4
-        |  +> si
-        |  +> see
-        |  +> sea
-        |  +> C size=3
-        |     +> ay
-        |     +>@ A size=3
-        |     +> ai
-        +> be
-        +> bee
-        """;
-
     @Test
     public void testNullDumpableCollection() throws Exception
     {
@@ -66,6 +52,20 @@ public class DumpableTest
     @Test
     public void testDumpableCollectionWithCycle() throws Exception
     {
+        final String EXPECTED = """
+        A size=3
+        +> B size=4
+        |  +> si
+        |  +> see
+        |  +> sea
+        |  +> C size=3
+        |     +> ay
+        |     +>@ A size=3
+        |     +> ai
+        +> be
+        +> bee
+        """;
+
         List<Object> listC = new ArrayList<>();
         DumpableCollection c = new DumpableCollection("C", listC);
         DumpableCollection b = new DumpableCollection("B", List.of("si", "see", "sea", c));

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/component/DumpableTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/component/DumpableTest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.jetty.util.component;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -24,6 +26,20 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class DumpableTest
 {
+    public static final String EXPECTED = """
+        A size=3
+        +> B size=4
+        |  +> si
+        |  +> see
+        |  +> sea
+        |  +> C size=3
+        |     +> ay
+        |     +>@ A size=3
+        |     +> ai
+        +> be
+        +> bee
+        """;
+
     @Test
     public void testNullDumpableCollection() throws Exception
     {
@@ -59,19 +75,10 @@ public class DumpableTest
         listC.add("ai");
 
         String dump = a.dump();
-        assertThat(dump, Matchers.startsWith("""
-            A size=3
-            +> B size=4
-            |  +> si
-            |  +> see
-            |  +> sea
-            |  +> C size=3
-            |     +> ay
-            |     +>@ A size=3
-            |     +> ai
-            +> be
-            +> bee
-            legend: +- bean, += managed, +~ unmanaged, +? auto, +: iterable, +] array, +} map, +> pojo; @ visited
-            JVM:"""));
+        assertThat(dump, Matchers.startsWith(EXPECTED));
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        a.dump(new PrintStream(baos), "");
+        assertThat(baos.toString(), Matchers.startsWith(EXPECTED));
     }
 }


### PR DESCRIPTION
Avoid cycles and stack overflows if dump API is called directly.