### PR TITLE
Issue #13213 - review of WebSocketClient.connect API

### DIFF
--- a/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/client/websocket/WebSocketClientDocs.java
+++ b/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/client/websocket/WebSocketClientDocs.java
@@ -151,7 +151,7 @@ public class WebSocketClientDocs
         URI serverURI = URI.create("ws://domain.com/path");
 
         // Create a custom HTTP request.
-        ClientUpgradeRequest customRequest = new ClientUpgradeRequest();
+        ClientUpgradeRequest customRequest = new ClientUpgradeRequest(serverURI);
         // Specify a cookie.
         customRequest.getCookies().add(new HttpCookie("name", "value"));
         // Specify a custom header.
@@ -160,7 +160,7 @@ public class WebSocketClientDocs
         customRequest.setSubProtocols("chat");
 
         // Connect the client EndPoint to the server with a custom HTTP request.
-        CompletableFuture<Session> clientSessionPromise = webSocketClient.connect(clientEndPoint, serverURI, customRequest);
+        CompletableFuture<Session> clientSessionPromise = webSocketClient.connect(clientEndPoint, customRequest);
         // end::customHTTPRequest[]
     }
 
@@ -184,7 +184,7 @@ public class WebSocketClientDocs
         };
 
         // Connect the client EndPoint to the server with a custom HTTP request.
-        CompletableFuture<Session> clientSessionPromise = webSocketClient.connect(clientEndPoint, serverURI, null, listener);
+        CompletableFuture<Session> clientSessionPromise = webSocketClient.connect(clientEndPoint, serverURI, listener);
         // end::inspectHTTPResponse[]
     }
 

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/ClientUpgradeRequest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/ClientUpgradeRequest.java
@@ -43,16 +43,16 @@ public final class ClientUpgradeRequest implements UpgradeRequest
     private long timeout;
     private String httpVersion;
 
+    /**
+     * @deprecated use {@link #ClientUpgradeRequest(URI)} instead.
+     */
+    @Deprecated(forRemoval = true, since = "12.1.0")
     public ClientUpgradeRequest()
     {
         /* anonymous, no requestURI, upgrade request */
         this.requestURI = null;
     }
 
-    /**
-     * @deprecated use {@link #ClientUpgradeRequest()} instead.
-     */
-    @Deprecated
     public ClientUpgradeRequest(URI uri)
     {
         this.requestURI = uri;
@@ -84,22 +84,14 @@ public final class ClientUpgradeRequest implements UpgradeRequest
     public int getHeaderInt(String name)
     {
         List<String> values = headers.get(name);
-        // no value list
         if (values == null)
-        {
             return -1;
-        }
+
         int size = values.size();
-        // empty value list
-        if (size <= 0)
-        {
+        if (size == 0)
             return -1;
-        }
-        // simple return
         if (size == 1)
-        {
             return Integer.parseInt(values.get(0));
-        }
         throw new NumberFormatException("Cannot convert multi-value header into int");
     }
 

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
@@ -19,6 +19,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
@@ -84,9 +85,56 @@ public class WebSocketClient extends ContainerLifeCycle implements Configurable,
         installBean(sessionTracker);
     }
 
+    /**
+     * Connect to remote websocket endpoint
+     *
+     * @param websocket the websocket object
+     * @param toUri the websocket uri to connect to
+     * @return the future for the session, available on success of connect
+     * @throws IOException if unable to connect
+     */
     public CompletableFuture<Session> connect(Object websocket, URI toUri) throws IOException
     {
-        return connect(websocket, toUri, null);
+        return connect(websocket, toUri, (JettyUpgradeListener)null);
+    }
+
+    /**
+     * Connect to remote websocket endpoint
+     *
+     * @param websocket the websocket object
+     * @param toUri the websocket uri to connect to
+     * @return the future for the session, available on success of connect
+     * @throws IOException if unable to connect
+     */
+    public CompletableFuture<Session> connect(Object websocket, URI toUri, JettyUpgradeListener upgradeListener) throws IOException
+    {
+        return connect(websocket, toUri, null, upgradeListener);
+    }
+
+    /**
+     * Connect to remote websocket endpoint
+     *
+     * @param websocket the websocket object
+     * @param request the upgrade request information
+     * @return the future for the session, available on success of connect
+     * @throws IOException if unable to connect
+     */
+    public CompletableFuture<Session> connect(Object websocket, ClientUpgradeRequest request) throws IOException
+    {
+        return connect(websocket, request, null);
+    }
+
+    /**
+     * Connect to remote websocket endpoint
+     *
+     * @param websocket the websocket object
+     * @param request the upgrade request information
+     * @return the future for the session, available on success of connect
+     * @throws IOException if unable to connect
+     */
+    public CompletableFuture<Session> connect(Object websocket, ClientUpgradeRequest request, JettyUpgradeListener upgradeListener) throws IOException
+    {
+        return connect(websocket, Objects.requireNonNull(request).getRequestURI(), request, upgradeListener);
     }
 
     /**
@@ -98,6 +146,7 @@ public class WebSocketClient extends ContainerLifeCycle implements Configurable,
      * @return the future for the session, available on success of connect
      * @throws IOException if unable to connect
      */
+    @Deprecated(forRemoval = true, since = "12.1.0")
     public CompletableFuture<Session> connect(Object websocket, URI toUri, ClientUpgradeRequest request) throws IOException
     {
         return connect(websocket, toUri, request, null);
@@ -112,7 +161,9 @@ public class WebSocketClient extends ContainerLifeCycle implements Configurable,
      * @param upgradeListener the upgrade listener
      * @return the future for the session, available on success of connect
      * @throws IOException if unable to connect
+     * @deprecated use {@link #connect(Object, ClientUpgradeRequest, JettyUpgradeListener)} or {@link #connect(Object, URI, JettyUpgradeListener)}.
      */
+    @Deprecated(forRemoval = true, since = "12.1.0")
     public CompletableFuture<Session> connect(Object websocket, URI toUri, ClientUpgradeRequest request, JettyUpgradeListener upgradeListener) throws IOException
     {
         for (Connection.Listener listener : getBeans(Connection.Listener.class))

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/test/java/examples/ClientDemo.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/test/java/examples/ClientDemo.java
@@ -271,11 +271,11 @@ public class ClientDemo
     private void open() throws Exception
     {
         client.setIdleTimeout(Duration.ofMillis(timeout));
-        ClientUpgradeRequest request = new ClientUpgradeRequest();
+        URI wsUri = new URI("ws://" + host + ":" + port + "/");
+        ClientUpgradeRequest request = new ClientUpgradeRequest(wsUri);
         request.setSubProtocols(protocol);
         socket = new TestSocket();
-        URI wsUri = new URI("ws://" + host + ":" + port + "/");
-        client.connect(socket, wsUri, request).get(10, TimeUnit.SECONDS);
+        client.connect(socket, request).get(10, TimeUnit.SECONDS);
     }
 
     private void send(byte op, byte[] data, int fragment)

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/test/java/examples/SimpleEchoClient.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/test/java/examples/SimpleEchoClient.java
@@ -39,8 +39,8 @@ public class SimpleEchoClient
             client.start();
 
             URI echoUri = new URI(destUri);
-            ClientUpgradeRequest request = new ClientUpgradeRequest();
-            client.connect(socket, echoUri, request);
+            ClientUpgradeRequest request = new ClientUpgradeRequest(echoUri);
+            client.connect(socket, request);
             System.out.printf("Connecting to : %s%n", echoUri);
 
             // wait for closed socket connection.

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/ConnectionHeaderTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/ConnectionHeaderTest.java
@@ -84,7 +84,7 @@ public class ConnectionHeaderTest
         };
 
         EventSocket clientEndpoint = new EventSocket();
-        try (Session session = client.connect(clientEndpoint, uri, null, upgradeListener).get(5, TimeUnit.SECONDS))
+        try (Session session = client.connect(clientEndpoint, uri, upgradeListener).get(5, TimeUnit.SECONDS))
         {
             // Generate text frame
             String msg = "this is an echo ... cho ... ho ... o";

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/JettyWebSocketExtensionConfigTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/JettyWebSocketExtensionConfigTest.java
@@ -95,7 +95,7 @@ public class JettyWebSocketExtensionConfigTest
         URI uri = URI.create("ws://localhost:" + connector.getLocalPort() + "/filterPath");
         EventSocket socket = new EventSocket();
 
-        ClientUpgradeRequest request = new ClientUpgradeRequest();
+        ClientUpgradeRequest request = new ClientUpgradeRequest(uri);
         request.addExtensions(ExtensionConfig.parse("permessage-deflate"));
 
         CountDownLatch correctResponseExtensions = new CountDownLatch(1);
@@ -113,7 +113,7 @@ public class JettyWebSocketExtensionConfigTest
             }
         };
 
-        CompletableFuture<Session> connect = client.connect(socket, uri, request, listener);
+        CompletableFuture<Session> connect = client.connect(socket, request, listener);
         try (Session session = connect.get(5, TimeUnit.SECONDS))
         {
             session.sendText("hello world", Callback.NOOP);

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/JettyWebSocketNegotiationTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/JettyWebSocketNegotiationTest.java
@@ -77,10 +77,10 @@ public class JettyWebSocketNegotiationTest
         URI uri = URI.create("ws://localhost:" + connector.getLocalPort() + "/filterPath");
         EventSocket socket = new EventSocket();
 
-        ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest();
+        ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest(uri);
         upgradeRequest.addExtensions("permessage-deflate;invalidParameter");
 
-        CompletableFuture<Session> connect = client.connect(socket, uri, upgradeRequest);
+        CompletableFuture<Session> connect = client.connect(socket, upgradeRequest);
         Throwable t = assertThrows(ExecutionException.class, () -> connect.get(5, TimeUnit.SECONDS));
         assertThat(t.getMessage(), containsString("Failed to upgrade to websocket:"));
         assertThat(t.getMessage(), containsString("400 Bad Request"));
@@ -126,7 +126,7 @@ public class JettyWebSocketNegotiationTest
         URI uri = URI.create("ws://localhost:" + connector.getLocalPort() + "/filterPath");
         EventSocket socket = new EventSocket();
         AtomicReference<Response> responseReference = new AtomicReference<>();
-        ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest();
+        ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest(uri);
         upgradeRequest.addExtensions("permessage-deflate;client_no_context_takeover");
         JettyUpgradeListener upgradeListener = new JettyUpgradeListener()
         {
@@ -137,7 +137,7 @@ public class JettyWebSocketNegotiationTest
             }
         };
 
-        client.connect(socket, uri, upgradeRequest, upgradeListener).get(5, TimeUnit.SECONDS);
+        client.connect(socket, upgradeRequest, upgradeListener).get(5, TimeUnit.SECONDS);
         Response response = responseReference.get();
         String extensions = response.getHeaders().get("Sec-WebSocket-Extensions");
         assertThat(extensions, is("permessage-deflate"));

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/LargeDeflateTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/LargeDeflateTest.java
@@ -75,11 +75,11 @@ public class LargeDeflateTest
     @Test
     public void testDeflate() throws Exception
     {
-        ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest();
+        ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest(URI.create("ws://localhost:" + _connector.getLocalPort() + "/ws"));
         upgradeRequest.addExtensions("permessage-deflate");
 
         EventSocket clientSocket = new EventSocket();
-        Session session = _client.connect(clientSocket, URI.create("ws://localhost:" + _connector.getLocalPort() + "/ws"), upgradeRequest).get();
+        Session session = _client.connect(clientSocket, upgradeRequest).get();
         ByteBuffer sentMessage = largePayloads();
         session.sendBinary(sentMessage, Callback.NOOP);
         session.close(StatusCode.NORMAL, "close from test", Callback.NOOP);

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/MaxOutgoingFramesTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/MaxOutgoingFramesTest.java
@@ -137,9 +137,9 @@ public class MaxOutgoingFramesTest
 
         URI uri = URI.create("ws://localhost:" + connector.getLocalPort() + "/");
         EventSocket socket = new EventSocket();
-        ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest();
+        ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest(uri);
         upgradeRequest.addExtensions(BlockingOutgoingExtension.class.getName());
-        client.connect(socket, uri, upgradeRequest).get(5, TimeUnit.SECONDS);
+        client.connect(socket, upgradeRequest).get(5, TimeUnit.SECONDS);
         assertTrue(socket.openLatch.await(5, TimeUnit.SECONDS));
 
         int numFrames = 30;

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/UpgradeRequestResponseTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/UpgradeRequestResponseTest.java
@@ -64,10 +64,10 @@ public class UpgradeRequestResponseTest
     {
         URI uri = URI.create("ws://localhost:" + connector.getLocalPort());
         EventSocket socket = new EventSocket();
-        ClientUpgradeRequest request = new ClientUpgradeRequest();
+        ClientUpgradeRequest request = new ClientUpgradeRequest(uri);
         request.addExtensions("permessage-deflate");
 
-        CompletableFuture<Session> connect = client.connect(socket, uri, request);
+        CompletableFuture<Session> connect = client.connect(socket, request);
         Session session = connect.get(5, TimeUnit.SECONDS);
         UpgradeRequest upgradeRequest = session.getUpgradeRequest();
         UpgradeResponse upgradeResponse = session.getUpgradeResponse();
@@ -94,10 +94,10 @@ public class UpgradeRequestResponseTest
     {
         URI uri = URI.create("ws://localhost:" + connector.getLocalPort());
         EventSocket socket = new EventSocket();
-        ClientUpgradeRequest request = new ClientUpgradeRequest();
+        ClientUpgradeRequest request = new ClientUpgradeRequest(uri);
         request.addExtensions("permessage-deflate");
 
-        CompletableFuture<Session> connect = client.connect(socket, uri, request);
+        CompletableFuture<Session> connect = client.connect(socket, request);
         Session session = connect.get(5, TimeUnit.SECONDS);
         assertTrue(serverSocket.openLatch.await(5, TimeUnit.SECONDS));
         UpgradeRequest upgradeRequest = serverSocket.session.getUpgradeRequest();

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/WebSocketStopTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/WebSocketStopTest.java
@@ -94,9 +94,9 @@ public class WebSocketStopTest
         URI uri = new URI("ws://localhost:" + connector.getLocalPort() + "/");
         EventSocket clientSocket = new EventSocket();
 
-        ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest();
+        ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest(uri);
         upgradeRequest.addExtensions("permessage-deflate");
-        Session session = client.connect(clientSocket, uri, upgradeRequest).get(5, TimeUnit.SECONDS);
+        Session session = client.connect(clientSocket, upgradeRequest).get(5, TimeUnit.SECONDS);
         clientSocket.session.sendText("init deflater", Callback.NOOP);
         assertThat(serverSocket.textMessages.poll(5, TimeUnit.SECONDS), is("init deflater"));
         session.close(StatusCode.NORMAL, null, Callback.NOOP);

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientConnectTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientConnectTest.java
@@ -224,12 +224,12 @@ public class ClientConnectTest
         CloseTrackingEndpoint cliSock = new CloseTrackingEndpoint();
 
         URI wsUri = WSURI.toWebsocket(server.getURI().resolve("/get-auth-header"));
-        ClientUpgradeRequest request = new ClientUpgradeRequest();
+        ClientUpgradeRequest request = new ClientUpgradeRequest(wsUri);
         // actual value for this test is irrelevant, its important that this
         // header actually be sent with a value (the value specified)
         String authHeaderValue = "Basic YWxhZGRpbjpvcGVuc2VzYW1l";
         request.setHeader("Authorization", authHeaderValue);
-        Future<Session> future = client.connect(cliSock, wsUri, request);
+        Future<Session> future = client.connect(cliSock, request);
 
         try (Session sess = future.get(5, TimeUnit.SECONDS))
         {

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientResponseTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientResponseTest.java
@@ -90,7 +90,7 @@ public class ClientResponseTest
 
         EchoSocket clientEndpoint = new EchoSocket();
         URI uri = URI.create("ws://localhost:" + _connector.getLocalPort());
-        ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest();
+        ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest(uri);
 
         CompletableFuture<Response> responseFuture = new CompletableFuture<>();
         CompletableFuture<String> contentFuture = new CompletableFuture<>();
@@ -111,7 +111,7 @@ public class ClientResponseTest
         };
 
         Throwable t = assertThrows(Throwable.class, () ->
-            _client.connect(clientEndpoint, uri, upgradeRequest, upgradeListener).get(5, TimeUnit.SECONDS));
+            _client.connect(clientEndpoint, upgradeRequest, upgradeListener).get(5, TimeUnit.SECONDS));
         assertThat(t, instanceOf(ExecutionException.class));
         assertThat(t.getCause(), instanceOf(UpgradeException.class));
         assertThat(t.getCause().getMessage(), containsString("Failed to upgrade to websocket: Unexpected HTTP Response Status Code: 418"));
@@ -135,7 +135,7 @@ public class ClientResponseTest
 
         EchoSocket clientEndpoint = new EchoSocket();
         URI uri = URI.create("ws://localhost:" + _connector.getLocalPort());
-        ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest();
+        ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest(uri);
 
         CompletableFuture<Void> onHandShakeRequest = new CompletableFuture<>();
         CompletableFuture<Void> onHandShakeResponse = new CompletableFuture<>();
@@ -155,7 +155,7 @@ public class ClientResponseTest
         };
 
         Throwable t = assertThrows(Throwable.class, () ->
-            _client.connect(clientEndpoint, uri, upgradeRequest, upgradeListener).get(5, TimeUnit.SECONDS));
+            _client.connect(clientEndpoint, upgradeRequest, upgradeListener).get(5, TimeUnit.SECONDS));
         assertThat(t, instanceOf(ExecutionException.class));
         assertThat(t.getCause(), instanceOf(EOFException.class));
 

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientSessionsTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientSessionsTest.java
@@ -99,9 +99,9 @@ public class ClientSessionsTest
             client.setIdleTimeout(Duration.ofSeconds(10));
 
             URI wsUri = WSURI.toWebsocket(server.getURI().resolve("/ws"));
-            ClientUpgradeRequest request = new ClientUpgradeRequest();
+            ClientUpgradeRequest request = new ClientUpgradeRequest(wsUri);
             request.setSubProtocols("echo");
-            Future<Session> future = client.connect(cliSock, wsUri, request);
+            Future<Session> future = client.connect(cliSock, request);
 
             try (Session sess = future.get(30000, TimeUnit.MILLISECONDS))
             {

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientTimeoutTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientTimeoutTest.java
@@ -108,9 +108,9 @@ public class ClientTimeoutTest
     {
         EventSocket clientSocket = new EventSocket();
         long timeout = 1000;
-        ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest();
+        ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest(WSURI.toWebsocket(server.getURI()));
         upgradeRequest.setTimeout(timeout, TimeUnit.MILLISECONDS);
-        Future<Session> connect = client.connect(clientSocket, WSURI.toWebsocket(server.getURI()), upgradeRequest);
+        Future<Session> connect = client.connect(clientSocket, upgradeRequest);
 
         ExecutionException executionException = assertThrows(ExecutionException.class, () -> connect.get(timeout * 2, TimeUnit.MILLISECONDS));
         assertThat(executionException.getCause(), instanceOf(UpgradeException.class));

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ConnectFutureTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ConnectFutureTest.java
@@ -186,8 +186,8 @@ public class ConnectFutureTest
         };
 
         CloseTrackingEndpoint clientSocket = new CloseTrackingEndpoint();
-        ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest();
-        Future<Session> connect = client.connect(clientSocket, WSURI.toWebsocket(server.getURI()), upgradeRequest, upgradeListener);
+        ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest(WSURI.toWebsocket(server.getURI()));
+        Future<Session> connect = client.connect(clientSocket, upgradeRequest, upgradeListener);
 
         // Abort after handshake response, this is during the connection upgrade.
         assertTrue(enteredListener.await(5, TimeUnit.SECONDS));

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/WebSocketClientTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/WebSocketClientTest.java
@@ -169,14 +169,14 @@ public class WebSocketClientTest
         client.setIdleTimeout(Duration.ofSeconds(10));
 
         URI wsUri = WSURI.toWebsocket(server.getURI().resolve("/echo"));
-        ClientUpgradeRequest request = new ClientUpgradeRequest();
+        ClientUpgradeRequest request = new ClientUpgradeRequest(wsUri);
         request.setSubProtocols("echo");
         request.addExtensions("x-bad");
 
         assertThrows(IllegalArgumentException.class, () ->
         {
             // Should trigger failure on bad extension
-            client.connect(cliSock, wsUri, request);
+            client.connect(cliSock, request);
         });
     }
 
@@ -188,9 +188,9 @@ public class WebSocketClientTest
         client.setIdleTimeout(Duration.ofSeconds(10));
 
         URI wsUri = WSURI.toWebsocket(server.getURI().resolve("/echo"));
-        ClientUpgradeRequest request = new ClientUpgradeRequest();
+        ClientUpgradeRequest request = new ClientUpgradeRequest(wsUri);
         request.setSubProtocols("echo");
-        Future<Session> future = client.connect(cliSock, wsUri, request);
+        Future<Session> future = client.connect(cliSock, request);
 
         try (Session sess = future.get(30, TimeUnit.SECONDS))
         {
@@ -218,9 +218,9 @@ public class WebSocketClientTest
         client.setIdleTimeout(Duration.ofSeconds(10));
 
         URI wsUri = WSURI.toWebsocket(server.getURI().resolve("/echo"));
-        ClientUpgradeRequest request = new ClientUpgradeRequest();
+        ClientUpgradeRequest request = new ClientUpgradeRequest(wsUri);
         request.setSubProtocols("echo");
-        Future<Session> future = client.connect(cliSock, wsUri, request);
+        Future<Session> future = client.connect(cliSock, request);
 
         try (Session sess = future.get(30, TimeUnit.SECONDS))
         {
@@ -250,9 +250,9 @@ public class WebSocketClientTest
         client.setIdleTimeout(Duration.ofSeconds(10));
 
         URI wsUri = WSURI.toWebsocket(server.getURI().resolve("/echo"));
-        ClientUpgradeRequest request = new ClientUpgradeRequest();
+        ClientUpgradeRequest request = new ClientUpgradeRequest(wsUri);
         request.setSubProtocols("echo");
-        Future<Session> future = client.connect(cliSock, wsUri, request);
+        Future<Session> future = client.connect(cliSock, request);
 
         try (Session sess = future.get(30, TimeUnit.SECONDS))
         {
@@ -303,9 +303,9 @@ public class WebSocketClientTest
         client.setIdleTimeout(Duration.ofSeconds(10));
 
         URI wsUri = WSURI.toWebsocket(server.getURI().resolve("/echo"));
-        ClientUpgradeRequest request = new ClientUpgradeRequest();
+        ClientUpgradeRequest request = new ClientUpgradeRequest(wsUri);
         request.setSubProtocols("echo");
-        Future<Session> future = client.connect(cliSock, wsUri, request);
+        Future<Session> future = client.connect(cliSock, request);
 
         try (Session sess = future.get(5, TimeUnit.SECONDS))
         {
@@ -360,9 +360,9 @@ public class WebSocketClientTest
         client.setIdleTimeout(Duration.ofSeconds(10));
 
         URI wsUri = WSURI.toWebsocket(server.getURI().resolve("/echo"));
-        ClientUpgradeRequest request = new ClientUpgradeRequest();
+        ClientUpgradeRequest request = new ClientUpgradeRequest(wsUri);
         request.setSubProtocols("echo");
-        Future<Session> future = client.connect(cliSock, wsUri, request);
+        Future<Session> future = client.connect(cliSock, request);
 
         try (Session ignored = future.get(5, TimeUnit.SECONDS))
         {
@@ -430,8 +430,8 @@ public class WebSocketClientTest
         client.setIdleTimeout(Duration.ofSeconds(10));
 
         URI wsUri = WSURI.toWebsocket(server.getURI().resolve("/get-params?snack=cashews&amount=handful&brand=off"));
-        ClientUpgradeRequest request = new ClientUpgradeRequest();
-        Future<Session> future = client.connect(cliSock, wsUri, request);
+        ClientUpgradeRequest request = new ClientUpgradeRequest(wsUri);
+        Future<Session> future = client.connect(cliSock, request);
 
         try (Session sess = future.get(5, TimeUnit.SECONDS))
         {

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/proxy/WebSocketProxy.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/proxy/WebSocketProxy.java
@@ -91,10 +91,10 @@ public class WebSocketProxy
             try
             {
                 this.session = session;
-                ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest();
+                ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest(serverUri);
                 upgradeRequest.setSubProtocols(session.getUpgradeRequest().getSubProtocols());
                 upgradeRequest.setExtensions(session.getUpgradeRequest().getExtensions());
-                client.connect(proxyToServer, serverUri, upgradeRequest)
+                client.connect(proxyToServer, upgradeRequest)
                     // Only demand for frames after the connect() is successful.
                     .thenAccept(ignored -> session.demand());
             }

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/proxy/WebSocketProxyTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/proxy/WebSocketProxyTest.java
@@ -148,12 +148,12 @@ public class WebSocketProxyTest
     public void testFailServerUpgrade() throws Exception
     {
         EventSocket clientSocket = new EventSocket();
-        ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest();
+        ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest(proxyUri);
         upgradeRequest.setSubProtocols("fail");
 
         try (StacklessLogging ignored = new StacklessLogging(HttpChannelState.class, Response.class))
         {
-            client.connect(clientSocket, proxyUri, upgradeRequest);
+            client.connect(clientSocket, upgradeRequest);
             assertTrue(clientSocket.closeLatch.await(5, TimeUnit.SECONDS));
         }
 

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/server/FrameAnnotationTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/server/FrameAnnotationTest.java
@@ -104,11 +104,10 @@ public class FrameAnnotationTest
     @Test
     public void testPartialText() throws Exception
     {
-        ClientUpgradeRequest request = new ClientUpgradeRequest();
-        CloseTrackingEndpoint clientEndpoint = new CloseTrackingEndpoint();
-
         URI wsUri = WSURI.toWebsocket(server.getURI().resolve("/ws"));
-        Future<Session> futSession = client.connect(clientEndpoint, wsUri, request);
+        ClientUpgradeRequest request = new ClientUpgradeRequest(wsUri);
+        CloseTrackingEndpoint clientEndpoint = new CloseTrackingEndpoint();
+        Future<Session> futSession = client.connect(clientEndpoint, request);
 
         Session session = null;
         try (StacklessLogging ignore = new StacklessLogging(WebSocketSession.class))

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/server/FrameListenerTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/server/FrameListenerTest.java
@@ -99,11 +99,10 @@ public class FrameListenerTest
     @Test
     public void testPartialText() throws Exception
     {
-        ClientUpgradeRequest request = new ClientUpgradeRequest();
-        CloseTrackingEndpoint clientEndpoint = new CloseTrackingEndpoint();
-
         URI wsUri = WSURI.toWebsocket(server.getURI().resolve("/ws"));
-        Future<Session> futSession = client.connect(clientEndpoint, wsUri, request);
+        ClientUpgradeRequest request = new ClientUpgradeRequest(wsUri);
+        CloseTrackingEndpoint clientEndpoint = new CloseTrackingEndpoint();
+        Future<Session> futSession = client.connect(clientEndpoint, request);
 
         Session session = null;
         try (StacklessLogging ignore = new StacklessLogging(WebSocketSession.class))

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/server/PartialListenerTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/server/PartialListenerTest.java
@@ -99,11 +99,10 @@ public class PartialListenerTest
     @Test
     public void testPartialText() throws Exception
     {
-        ClientUpgradeRequest request = new ClientUpgradeRequest();
-        CloseTrackingEndpoint clientEndpoint = new CloseTrackingEndpoint();
-
         URI wsUri = WSURI.toWebsocket(server.getURI().resolve("/ws"));
-        Future<Session> futSession = client.connect(clientEndpoint, wsUri, request);
+        ClientUpgradeRequest request = new ClientUpgradeRequest(wsUri);
+        CloseTrackingEndpoint clientEndpoint = new CloseTrackingEndpoint();
+        Future<Session> futSession = client.connect(clientEndpoint, request);
 
         Session session = null;
         try (StacklessLogging ignore = new StacklessLogging(WebSocketSession.class))
@@ -130,11 +129,10 @@ public class PartialListenerTest
     @Test
     public void testPartialBinary() throws Exception
     {
-        ClientUpgradeRequest request = new ClientUpgradeRequest();
         CloseTrackingEndpoint clientEndpoint = new CloseTrackingEndpoint();
-
         URI wsUri = WSURI.toWebsocket(server.getURI().resolve("/ws"));
-        Future<Session> futSession = client.connect(clientEndpoint, wsUri, request);
+        ClientUpgradeRequest request = new ClientUpgradeRequest(wsUri);
+        Future<Session> futSession = client.connect(clientEndpoint, request);
 
         Session session = null;
         try (StacklessLogging ignore = new StacklessLogging(WebSocketSession.class))
@@ -164,11 +162,10 @@ public class PartialListenerTest
     @Test
     public void testPartialTextBinaryText() throws Exception
     {
-        ClientUpgradeRequest request = new ClientUpgradeRequest();
-        CloseTrackingEndpoint clientEndpoint = new CloseTrackingEndpoint();
-
         URI wsUri = WSURI.toWebsocket(server.getURI().resolve("/ws"));
-        Future<Session> futSession = client.connect(clientEndpoint, wsUri, request);
+        ClientUpgradeRequest request = new ClientUpgradeRequest(wsUri);
+        CloseTrackingEndpoint clientEndpoint = new CloseTrackingEndpoint();
+        Future<Session> futSession = client.connect(clientEndpoint, request);
 
         Session session = null;
         try (StacklessLogging ignore = new StacklessLogging(WebSocketSession.class))

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/server/ServerCloseTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/server/ServerCloseTest.java
@@ -110,12 +110,11 @@ public class ServerCloseTest
     @Test
     public void fastClose() throws Exception
     {
-        ClientUpgradeRequest request = new ClientUpgradeRequest();
+        URI wsUri = WSURI.toWebsocket(server.getURI().resolve("/ws"));
+        ClientUpgradeRequest request = new ClientUpgradeRequest(wsUri);
         request.setSubProtocols("fastclose");
         CloseTrackingEndpoint clientEndpoint = new CloseTrackingEndpoint();
-
-        URI wsUri = WSURI.toWebsocket(server.getURI().resolve("/ws"));
-        Future<Session> futSession = client.connect(clientEndpoint, wsUri, request);
+        Future<Session> futSession = client.connect(clientEndpoint, request);
 
         Session session = null;
         try
@@ -144,12 +143,11 @@ public class ServerCloseTest
     @Test
     public void fastFail() throws Exception
     {
-        ClientUpgradeRequest request = new ClientUpgradeRequest();
+        URI wsUri = WSURI.toWebsocket(server.getURI().resolve("/ws"));
+        ClientUpgradeRequest request = new ClientUpgradeRequest(wsUri);
         request.setSubProtocols("fastfail");
         CloseTrackingEndpoint clientEndpoint = new CloseTrackingEndpoint();
-
-        URI wsUri = WSURI.toWebsocket(server.getURI().resolve("/ws"));
-        Future<Session> futSession = client.connect(clientEndpoint, wsUri, request);
+        Future<Session> futSession = client.connect(clientEndpoint, request);
 
         Session session = null;
         try (StacklessLogging ignore = new StacklessLogging(WebSocketCoreSession.class))
@@ -183,12 +181,11 @@ public class ServerCloseTest
     @Test
     public void dropConnection() throws Exception
     {
-        ClientUpgradeRequest request = new ClientUpgradeRequest();
+        URI wsUri = WSURI.toWebsocket(server.getURI().resolve("/ws"));
+        ClientUpgradeRequest request = new ClientUpgradeRequest(wsUri);
         request.setSubProtocols("container");
         CloseTrackingEndpoint clientEndpoint = new CloseTrackingEndpoint();
-
-        URI wsUri = WSURI.toWebsocket(server.getURI().resolve("/ws"));
-        Future<Session> futSession = client.connect(clientEndpoint, wsUri, request);
+        Future<Session> futSession = client.connect(clientEndpoint, request);
 
         Session session = null;
         try (StacklessLogging ignore = new StacklessLogging(WebSocketSession.class))
@@ -223,12 +220,11 @@ public class ServerCloseTest
         //fastClose();
         //dropConnection();
 
-        ClientUpgradeRequest request = new ClientUpgradeRequest();
+        URI wsUri = WSURI.toWebsocket(server.getURI().resolve("/ws"));
+        ClientUpgradeRequest request = new ClientUpgradeRequest(wsUri);
         request.setSubProtocols("container");
         CloseTrackingEndpoint clientEndpoint = new CloseTrackingEndpoint();
-
-        URI wsUri = WSURI.toWebsocket(server.getURI().resolve("/ws"));
-        Future<Session> futSession = client.connect(clientEndpoint, wsUri, request);
+        Future<Session> futSession = client.connect(clientEndpoint, request);
 
         Session session = null;
         try (StacklessLogging ignore = new StacklessLogging(WebSocketSession.class))
@@ -260,12 +256,11 @@ public class ServerCloseTest
     public void testSecondCloseFromOnClosed() throws Exception
     {
         // Testing WebSocketSession.close() in onClosed() does not cause deadlock.
-        ClientUpgradeRequest request = new ClientUpgradeRequest();
+        URI wsUri = WSURI.toWebsocket(server.getURI().resolve("/ws"));
+        ClientUpgradeRequest request = new ClientUpgradeRequest(wsUri);
         request.setSubProtocols("closeInOnClose");
         CloseTrackingEndpoint clientEndpoint = new CloseTrackingEndpoint();
-
-        URI wsUri = WSURI.toWebsocket(server.getURI().resolve("/ws"));
-        client.connect(clientEndpoint, wsUri, request).get(5, SECONDS);
+        client.connect(clientEndpoint, request).get(5, SECONDS);
 
         // Hard close from the server. Server onClosed() will try to close again which should be a NOOP.
         AbstractCloseEndpoint serverEndpoint = serverEndpointCreator.pollLastCreated();
@@ -285,12 +280,11 @@ public class ServerCloseTest
     public void testSecondCloseFromOnClosedInNewThread() throws Exception
     {
         // Testing WebSocketSession.close() in onClosed() does not cause deadlock.
-        ClientUpgradeRequest request = new ClientUpgradeRequest();
+        URI wsUri = WSURI.toWebsocket(server.getURI().resolve("/ws"));
+        ClientUpgradeRequest request = new ClientUpgradeRequest(wsUri);
         request.setSubProtocols("closeInOnCloseNewThread");
         CloseTrackingEndpoint clientEndpoint = new CloseTrackingEndpoint();
-
-        URI wsUri = WSURI.toWebsocket(server.getURI().resolve("/ws"));
-        client.connect(clientEndpoint, wsUri, request).get(5, SECONDS);
+        client.connect(clientEndpoint, request).get(5, SECONDS);
 
         // Hard close from the server. Server onClosed() will try to close again which should be a NOOP.
         AbstractCloseEndpoint serverEndpoint = serverEndpointCreator.pollLastCreated();

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/java/org/eclipse/jetty/ee10/osgi/test/TestJettyOSGiBootWithWebSocket.java
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/java/org/eclipse/jetty/ee10/osgi/test/TestJettyOSGiBootWithWebSocket.java
@@ -92,9 +92,9 @@ public class TestJettyOSGiBootWithWebSocket
         {
             client.start();
             SimpleEchoSocket socket = new SimpleEchoSocket();
-            ClientUpgradeRequest request = new ClientUpgradeRequest();
+            ClientUpgradeRequest request = new ClientUpgradeRequest(uri);
             request.setSubProtocols("chat");
-            client.connect(socket, uri, request);
+            client.connect(socket, request);
             // wait for closed socket connection.
             assertTrue(socket.awaitClose(5, TimeUnit.SECONDS));
         }

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/websocket/JettyWebSocketTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/websocket/JettyWebSocketTest.java
@@ -71,9 +71,9 @@ public class JettyWebSocketTest
 
             client.start();
 
-            ClientUpgradeRequest request = new ClientUpgradeRequest();
+            ClientUpgradeRequest request = new ClientUpgradeRequest(uri);
             request.setSubProtocols("chat");
-            client.connect(socket, uri, request);
+            client.connect(socket, request);
             // wait for closed socket connection.
             assertTrue(socket.awaitClose(5, TimeUnit.SECONDS));
         }

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee10/websocket/tests/PermessageDeflateBufferTest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee10/websocket/tests/PermessageDeflateBufferTest.java
@@ -146,11 +146,10 @@ public class PermessageDeflateBufferTest
     public void testPermessageDeflateAggregation() throws Exception
     {
         EventSocket socket = new EventSocket();
-        ClientUpgradeRequest clientUpgradeRequest = new ClientUpgradeRequest();
-        clientUpgradeRequest.addExtensions("permessage-deflate");
-
         URI uri = URI.create("ws://localhost:" + connector.getLocalPort());
-        Session session = client.connect(socket, uri, clientUpgradeRequest).get(5, TimeUnit.SECONDS);
+        ClientUpgradeRequest clientUpgradeRequest = new ClientUpgradeRequest(uri);
+        clientUpgradeRequest.addExtensions("permessage-deflate");
+        Session session = client.connect(socket, clientUpgradeRequest).get(5, TimeUnit.SECONDS);
 
         String s = randomText();
         session.sendText(s, Callback.NOOP);
@@ -165,11 +164,10 @@ public class PermessageDeflateBufferTest
     public void testPermessageDeflateFragmentedBinaryMessage() throws Exception
     {
         EventSocket socket = new EventSocket();
-        ClientUpgradeRequest clientUpgradeRequest = new ClientUpgradeRequest();
-        clientUpgradeRequest.addExtensions("permessage-deflate");
-
         URI uri = URI.create("ws://localhost:" + connector.getLocalPort());
-        Session session = client.connect(socket, uri, clientUpgradeRequest).get(5, TimeUnit.SECONDS);
+        ClientUpgradeRequest clientUpgradeRequest = new ClientUpgradeRequest(uri);
+        clientUpgradeRequest.addExtensions("permessage-deflate");
+        Session session = client.connect(socket, clientUpgradeRequest).get(5, TimeUnit.SECONDS);
 
         ByteBuffer message = randomBytes(1024);
         session.setMaxFrameSize(64);
@@ -187,12 +185,11 @@ public class PermessageDeflateBufferTest
         Duration idleTimeout = Duration.ofMillis(1000);
         serverContainer.setIdleTimeout(idleTimeout);
 
-        ClientUpgradeRequest clientUpgradeRequest = new ClientUpgradeRequest();
-        clientUpgradeRequest.addExtensions("permessage-deflate");
-
-        EventSocket socket = new EventSocket();
         URI uri = URI.create("ws://localhost:" + connector.getLocalPort() + "/incomingFail");
-        Session session = client.connect(socket, uri, clientUpgradeRequest).get(5, TimeUnit.SECONDS);
+        ClientUpgradeRequest clientUpgradeRequest = new ClientUpgradeRequest(uri);
+        clientUpgradeRequest.addExtensions("permessage-deflate");
+        EventSocket socket = new EventSocket();
+        Session session = client.connect(socket, clientUpgradeRequest).get(5, TimeUnit.SECONDS);
 
         session.sendPartialText("partial", false, Callback.NOOP);
 
@@ -210,12 +207,11 @@ public class PermessageDeflateBufferTest
     @Test
     public void testClientPartialMessageThenClientClose() throws Exception
     {
-        ClientUpgradeRequest clientUpgradeRequest = new ClientUpgradeRequest();
-        clientUpgradeRequest.addExtensions("permessage-deflate");
-
-        PartialTextSocket socket = new PartialTextSocket();
         URI uri = URI.create("ws://localhost:" + connector.getLocalPort() + "/incomingFail");
-        Session session = client.connect(socket, uri, clientUpgradeRequest).get(5, TimeUnit.SECONDS);
+        ClientUpgradeRequest clientUpgradeRequest = new ClientUpgradeRequest(uri);
+        clientUpgradeRequest.addExtensions("permessage-deflate");
+        PartialTextSocket socket = new PartialTextSocket();
+        Session session = client.connect(socket, clientUpgradeRequest).get(5, TimeUnit.SECONDS);
 
         session.sendPartialText("partial", false, Callback.NOOP);
         // Wait for the server to process the partial message.
@@ -241,12 +237,11 @@ public class PermessageDeflateBufferTest
         Duration idleTimeout = Duration.ofMillis(1000);
         serverContainer.setIdleTimeout(idleTimeout);
 
-        ClientUpgradeRequest clientUpgradeRequest = new ClientUpgradeRequest();
-        clientUpgradeRequest.addExtensions("permessage-deflate");
-
-        EventSocket socket = new EventSocket();
         URI uri = URI.create("ws://localhost:" + connector.getLocalPort() + "/outgoingFail");
-        Session session = client.connect(socket, uri, clientUpgradeRequest).get(5, TimeUnit.SECONDS);
+        ClientUpgradeRequest clientUpgradeRequest = new ClientUpgradeRequest(uri);
+        clientUpgradeRequest.addExtensions("permessage-deflate");
+        EventSocket socket = new EventSocket();
+        Session session = client.connect(socket, clientUpgradeRequest).get(5, TimeUnit.SECONDS);
 
         session.sendText("hello", Callback.NOOP);
 
@@ -264,12 +259,11 @@ public class PermessageDeflateBufferTest
     @Test
     public void testServerPartialMessageThenClientClose() throws Exception
     {
-        ClientUpgradeRequest clientUpgradeRequest = new ClientUpgradeRequest();
-        clientUpgradeRequest.addExtensions("permessage-deflate");
-
-        PartialTextSocket socket = new PartialTextSocket();
         URI uri = URI.create("ws://localhost:" + connector.getLocalPort() + "/outgoingFail");
-        Session session = client.connect(socket, uri, clientUpgradeRequest).get(5, TimeUnit.SECONDS);
+        ClientUpgradeRequest clientUpgradeRequest = new ClientUpgradeRequest(uri);
+        clientUpgradeRequest.addExtensions("permessage-deflate");
+        PartialTextSocket socket = new PartialTextSocket();
+        Session session = client.connect(socket, clientUpgradeRequest).get(5, TimeUnit.SECONDS);
 
         session.sendText("hello", Callback.NOOP);
         // Wait for the server to process the message.

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee10/websocket/tests/UpgradeHeadersTest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee10/websocket/tests/UpgradeHeadersTest.java
@@ -88,7 +88,7 @@ public class UpgradeHeadersTest
         EventSocket clientEndpoint = new EventSocket();
         URI uri = URI.create("ws://localhost:" + _connector.getLocalPort());
 
-        ClientUpgradeRequest clientUpgradeRequest = new ClientUpgradeRequest();
+        ClientUpgradeRequest clientUpgradeRequest = new ClientUpgradeRequest(uri);
         clientUpgradeRequest.getHeaders().put("sentHeader", List.of("value123"));
         if (clientUpgradeRequest.getHeaders().get("SenTHeaDer") == null)
             throw new IllegalStateException("No custom Header on ClientUpgradeRequest");
@@ -116,7 +116,7 @@ public class UpgradeHeadersTest
         };
 
         // If any of the above throw it would fail to upgrade to websocket.
-        assertNotNull(_client.connect(clientEndpoint, uri, clientUpgradeRequest, upgradeListener).get(5, TimeUnit.SECONDS));
+        assertNotNull(_client.connect(clientEndpoint, clientUpgradeRequest, upgradeListener).get(5, TimeUnit.SECONDS));
         assertTrue(clientEndpoint.openLatch.await(5, TimeUnit.SECONDS));
         clientEndpoint.session.close();
         assertTrue(clientEndpoint.closeLatch.await(5, TimeUnit.SECONDS));

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee10/websocket/tests/WebSocketOverHTTP2Test.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee10/websocket/tests/WebSocketOverHTTP2Test.java
@@ -421,9 +421,9 @@ public class WebSocketOverHTTP2Test
 
         // Connect with HTTP/1.1 and verify version in the Session's UpgradeRequest.
         EventSocket wsEndPoint = new EventSocket();
-        ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest();
+        ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest(uri);
         upgradeRequest.setHttpVersion(HttpVersion.HTTP_1_1.asString());
-        Session session = wsClient.connect(wsEndPoint, uri, upgradeRequest).get(5, TimeUnit.SECONDS);
+        Session session = wsClient.connect(wsEndPoint, upgradeRequest).get(5, TimeUnit.SECONDS);
         assertThat(session.getUpgradeRequest().getHttpVersion(), equalTo(HttpVersion.HTTP_1_1.asString()));
         assertThat(wsEndPoint.textMessages.poll(5, TimeUnit.SECONDS), equalTo("version: " + HttpVersion.HTTP_1_1.asString()));
 
@@ -435,9 +435,9 @@ public class WebSocketOverHTTP2Test
 
         // Connect with HTTP/2 and verify version in the Session's UpgradeRequest.
         wsEndPoint = new EventSocket();
-        upgradeRequest = new ClientUpgradeRequest();
+        upgradeRequest = new ClientUpgradeRequest(uri);
         upgradeRequest.setHttpVersion(HttpVersion.HTTP_2.asString());
-        session = wsClient.connect(wsEndPoint, uri, upgradeRequest).get(5, TimeUnit.SECONDS);
+        session = wsClient.connect(wsEndPoint, upgradeRequest).get(5, TimeUnit.SECONDS);
         assertThat(session.getUpgradeRequest().getHttpVersion(), equalTo(HttpVersion.HTTP_2.asString()));
         assertThat(wsEndPoint.textMessages.poll(5, TimeUnit.SECONDS), equalTo("version: " + HttpVersion.HTTP_2.asString()));
 

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee10/websocket/tests/WebSocketServletExamplesTest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee10/websocket/tests/WebSocketServletExamplesTest.java
@@ -131,9 +131,9 @@ public class WebSocketServletExamplesTest
         URI uri = URI.create("ws://localhost:" + connector.getLocalPort() + "/advancedEcho");
         EventSocket socket = new EventSocket();
 
-        ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest();
+        ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest(uri);
         upgradeRequest.setSubProtocols("text");
-        CompletableFuture<Session> connect = client.connect(socket, uri, upgradeRequest);
+        CompletableFuture<Session> connect = client.connect(socket, upgradeRequest);
         try (Session session = connect.get(5, TimeUnit.SECONDS))
         {
             String message = "hello world";

--- a/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/java/org/eclipse/jetty/ee11/osgi/test/TestJettyOSGiBootWithWebSocket.java
+++ b/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/java/org/eclipse/jetty/ee11/osgi/test/TestJettyOSGiBootWithWebSocket.java
@@ -92,9 +92,9 @@ public class TestJettyOSGiBootWithWebSocket
         {
             client.start();
             SimpleEchoSocket socket = new SimpleEchoSocket();
-            ClientUpgradeRequest request = new ClientUpgradeRequest();
+            ClientUpgradeRequest request = new ClientUpgradeRequest(uri);
             request.setSubProtocols("chat");
-            client.connect(socket, uri, request);
+            client.connect(socket, request);
             // wait for closed socket connection.
             assertTrue(socket.awaitClose(5, TimeUnit.SECONDS));
         }

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/java/org/eclipse/jetty/ee11/test/websocket/JettyWebSocketTest.java
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/java/org/eclipse/jetty/ee11/test/websocket/JettyWebSocketTest.java
@@ -71,9 +71,9 @@ public class JettyWebSocketTest
 
             client.start();
 
-            ClientUpgradeRequest request = new ClientUpgradeRequest();
+            ClientUpgradeRequest request = new ClientUpgradeRequest(uri);
             request.setSubProtocols("chat");
-            client.connect(socket, uri, request);
+            client.connect(socket, request);
             // wait for closed socket connection.
             assertTrue(socket.awaitClose(5, TimeUnit.SECONDS));
         }

--- a/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee11/websocket/tests/PermessageDeflateBufferTest.java
+++ b/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee11/websocket/tests/PermessageDeflateBufferTest.java
@@ -146,11 +146,10 @@ public class PermessageDeflateBufferTest
     public void testPermessageDeflateAggregation() throws Exception
     {
         EventSocket socket = new EventSocket();
-        ClientUpgradeRequest clientUpgradeRequest = new ClientUpgradeRequest();
-        clientUpgradeRequest.addExtensions("permessage-deflate");
-
         URI uri = URI.create("ws://localhost:" + connector.getLocalPort());
-        Session session = client.connect(socket, uri, clientUpgradeRequest).get(5, TimeUnit.SECONDS);
+        ClientUpgradeRequest clientUpgradeRequest = new ClientUpgradeRequest(uri);
+        clientUpgradeRequest.addExtensions("permessage-deflate");
+        Session session = client.connect(socket, clientUpgradeRequest).get(5, TimeUnit.SECONDS);
 
         String s = randomText();
         session.sendText(s, Callback.NOOP);
@@ -165,11 +164,10 @@ public class PermessageDeflateBufferTest
     public void testPermessageDeflateFragmentedBinaryMessage() throws Exception
     {
         EventSocket socket = new EventSocket();
-        ClientUpgradeRequest clientUpgradeRequest = new ClientUpgradeRequest();
-        clientUpgradeRequest.addExtensions("permessage-deflate");
-
         URI uri = URI.create("ws://localhost:" + connector.getLocalPort());
-        Session session = client.connect(socket, uri, clientUpgradeRequest).get(5, TimeUnit.SECONDS);
+        ClientUpgradeRequest clientUpgradeRequest = new ClientUpgradeRequest(uri);
+        clientUpgradeRequest.addExtensions("permessage-deflate");
+        Session session = client.connect(socket, clientUpgradeRequest).get(5, TimeUnit.SECONDS);
 
         ByteBuffer message = randomBytes(1024);
         session.setMaxFrameSize(64);
@@ -187,12 +185,12 @@ public class PermessageDeflateBufferTest
         Duration idleTimeout = Duration.ofMillis(1000);
         serverContainer.setIdleTimeout(idleTimeout);
 
-        ClientUpgradeRequest clientUpgradeRequest = new ClientUpgradeRequest();
+        URI uri = URI.create("ws://localhost:" + connector.getLocalPort() + "/incomingFail");
+        ClientUpgradeRequest clientUpgradeRequest = new ClientUpgradeRequest(uri);
         clientUpgradeRequest.addExtensions("permessage-deflate");
 
         EventSocket socket = new EventSocket();
-        URI uri = URI.create("ws://localhost:" + connector.getLocalPort() + "/incomingFail");
-        Session session = client.connect(socket, uri, clientUpgradeRequest).get(5, TimeUnit.SECONDS);
+        Session session = client.connect(socket, clientUpgradeRequest).get(5, TimeUnit.SECONDS);
 
         session.sendPartialText("partial", false, Callback.NOOP);
 
@@ -210,12 +208,11 @@ public class PermessageDeflateBufferTest
     @Test
     public void testClientPartialMessageThenClientClose() throws Exception
     {
-        ClientUpgradeRequest clientUpgradeRequest = new ClientUpgradeRequest();
-        clientUpgradeRequest.addExtensions("permessage-deflate");
-
-        PartialTextSocket socket = new PartialTextSocket();
         URI uri = URI.create("ws://localhost:" + connector.getLocalPort() + "/incomingFail");
-        Session session = client.connect(socket, uri, clientUpgradeRequest).get(5, TimeUnit.SECONDS);
+        ClientUpgradeRequest clientUpgradeRequest = new ClientUpgradeRequest(uri);
+        clientUpgradeRequest.addExtensions("permessage-deflate");
+        PartialTextSocket socket = new PartialTextSocket();
+        Session session = client.connect(socket, clientUpgradeRequest).get(5, TimeUnit.SECONDS);
 
         session.sendPartialText("partial", false, Callback.NOOP);
         // Wait for the server to process the partial message.
@@ -241,12 +238,11 @@ public class PermessageDeflateBufferTest
         Duration idleTimeout = Duration.ofMillis(1000);
         serverContainer.setIdleTimeout(idleTimeout);
 
-        ClientUpgradeRequest clientUpgradeRequest = new ClientUpgradeRequest();
-        clientUpgradeRequest.addExtensions("permessage-deflate");
-
-        EventSocket socket = new EventSocket();
         URI uri = URI.create("ws://localhost:" + connector.getLocalPort() + "/outgoingFail");
-        Session session = client.connect(socket, uri, clientUpgradeRequest).get(5, TimeUnit.SECONDS);
+        ClientUpgradeRequest clientUpgradeRequest = new ClientUpgradeRequest(uri);
+        clientUpgradeRequest.addExtensions("permessage-deflate");
+        EventSocket socket = new EventSocket();
+        Session session = client.connect(socket, clientUpgradeRequest).get(5, TimeUnit.SECONDS);
 
         session.sendText("hello", Callback.NOOP);
 
@@ -264,12 +260,11 @@ public class PermessageDeflateBufferTest
     @Test
     public void testServerPartialMessageThenClientClose() throws Exception
     {
-        ClientUpgradeRequest clientUpgradeRequest = new ClientUpgradeRequest();
-        clientUpgradeRequest.addExtensions("permessage-deflate");
-
-        PartialTextSocket socket = new PartialTextSocket();
         URI uri = URI.create("ws://localhost:" + connector.getLocalPort() + "/outgoingFail");
-        Session session = client.connect(socket, uri, clientUpgradeRequest).get(5, TimeUnit.SECONDS);
+        ClientUpgradeRequest clientUpgradeRequest = new ClientUpgradeRequest(uri);
+        clientUpgradeRequest.addExtensions("permessage-deflate");
+        PartialTextSocket socket = new PartialTextSocket();
+        Session session = client.connect(socket, clientUpgradeRequest).get(5, TimeUnit.SECONDS);
 
         session.sendText("hello", Callback.NOOP);
         // Wait for the server to process the message.

--- a/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee11/websocket/tests/UpgradeHeadersTest.java
+++ b/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee11/websocket/tests/UpgradeHeadersTest.java
@@ -88,7 +88,7 @@ public class UpgradeHeadersTest
         EventSocket clientEndpoint = new EventSocket();
         URI uri = URI.create("ws://localhost:" + _connector.getLocalPort());
 
-        ClientUpgradeRequest clientUpgradeRequest = new ClientUpgradeRequest();
+        ClientUpgradeRequest clientUpgradeRequest = new ClientUpgradeRequest(uri);
         clientUpgradeRequest.getHeaders().put("sentHeader", List.of("value123"));
         if (clientUpgradeRequest.getHeaders().get("SenTHeaDer") == null)
             throw new IllegalStateException("No custom Header on ClientUpgradeRequest");
@@ -116,7 +116,7 @@ public class UpgradeHeadersTest
         };
 
         // If any of the above throw it would fail to upgrade to websocket.
-        assertNotNull(_client.connect(clientEndpoint, uri, clientUpgradeRequest, upgradeListener).get(5, TimeUnit.SECONDS));
+        assertNotNull(_client.connect(clientEndpoint, clientUpgradeRequest, upgradeListener).get(5, TimeUnit.SECONDS));
         assertTrue(clientEndpoint.openLatch.await(5, TimeUnit.SECONDS));
         clientEndpoint.session.close();
         assertTrue(clientEndpoint.closeLatch.await(5, TimeUnit.SECONDS));

--- a/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee11/websocket/tests/WebSocketServletExamplesTest.java
+++ b/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee11/websocket/tests/WebSocketServletExamplesTest.java
@@ -131,9 +131,9 @@ public class WebSocketServletExamplesTest
         URI uri = URI.create("ws://localhost:" + connector.getLocalPort() + "/advancedEcho");
         EventSocket socket = new EventSocket();
 
-        ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest();
+        ClientUpgradeRequest upgradeRequest = new ClientUpgradeRequest(uri);
         upgradeRequest.setSubProtocols("text");
-        CompletableFuture<Session> connect = client.connect(socket, uri, upgradeRequest);
+        CompletableFuture<Session> connect = client.connect(socket, upgradeRequest);
         try (Session session = connect.get(5, TimeUnit.SECONDS))
         {
             String message = "hello world";


### PR DESCRIPTION
closes #13213

Change the API of xxx to accept either `URI` or `ClientUpgradeRequest` but not both, because `ClientUpgradeRequest` already contains the `URI`.