### PR TITLE
Issue #13232 - Ensure legacy `BadMessageException` behaviors in ee9/ee8 use of Cross Context Dispatching.

### DIFF
--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Dispatcher.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Dispatcher.java
@@ -26,6 +26,7 @@ import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletMapping;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.UriCompliance;
@@ -100,8 +101,15 @@ public class Dispatcher implements RequestDispatcher
             else
             {
                 Objects.requireNonNull(_uri);
-                // Check any URI violations against the compliance for this request
-                checkUriViolations(_uri, baseRequest);
+                try
+                {
+                    // Check any URI violations against the compliance for this request
+                    checkUriViolations(_uri, baseRequest);
+                }
+                catch (IllegalStateException e)
+                {
+                    throw new BadMessageException(e.getMessage(), e);
+                }
 
                 IncludeAttributes attr = new IncludeAttributes(
                     old_attr,
@@ -165,8 +173,15 @@ public class Dispatcher implements RequestDispatcher
             else
             {
                 Objects.requireNonNull(_uri);
-                // Check any URI violations against the compliance for this request
-                checkUriViolations(_uri, baseRequest);
+                try
+                {
+                    // Check any URI violations against the compliance for this request
+                    checkUriViolations(_uri, baseRequest);
+                }
+                catch (IllegalStateException e)
+                {
+                    throw new BadMessageException(e.getMessage(), e);
+                }
 
                 // If we have already been forwarded previously, then keep using the established
                 // original value. Otherwise, this is the first forward, and we need to establish the values.

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
@@ -2197,7 +2197,18 @@ public class Request implements HttpServletRequest
         if (newQuery != null)
         {
             newQueryParams = new Fields(true);
-            UrlEncoded.decodeTo(newQuery, newQueryParams::add, UrlEncoded.ENCODING);
+            try
+            {
+                UrlEncoded.decodeTo(newQuery, newQueryParams::add, UrlEncoded.ENCODING);
+            }
+            catch (BadMessageException e)
+            {
+                throw e;
+            }
+            catch (Throwable th)
+            {
+                throw new BadMessageException("Bad query encoding", th);
+            }
         }
 
         Fields oldQueryParams = _queryParameters;
@@ -2207,6 +2218,10 @@ public class Request implements HttpServletRequest
             try
             {
                 UrlEncoded.decodeTo(oldQuery, oldQueryParams::add, getQueryCharset());
+            }
+            catch (BadMessageException e)
+            {
+                throw e;
             }
             catch (Throwable th)
             {

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/DispatcherTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/DispatcherTest.java
@@ -424,7 +424,7 @@ public class DispatcherTest
             assertThat(response, containsString("forward"));
 
             response = _connector.getResponse("GET /context/forward/badparams?echo=badparams HTTP/1.0\n\n");
-            assertThat(response, containsString(" 500 "));
+            assertThat(response, containsString(" 400 "));
 
             response = _connector.getResponse("GET /context/forward/?echo=badclient&bad=%88%A4 HTTP/1.0\n\n");
             assertThat(response, containsString(" 400 "));
@@ -433,7 +433,7 @@ public class DispatcherTest
             assertThat(response, containsString(" 400 "));
 
             response = _connector.getResponse("GET /context/forward/badparams?echo=badclientandparam&bad=%88%A4 HTTP/1.0\n\n");
-            assertThat(response, containsString(" 500 "));
+            assertThat(response, containsString(" 400 "));
         }
     }
 


### PR DESCRIPTION
This reproduces the legacy `BadMessageException` behavior in the following situations.

* `HttpServletRequest.getRequestDispatcher(String)`
* `ServletContext.getRequestDispatcher(String)`
* `RequestDispatcher.forward(req, resp)`
* `RequestDispatcher.include(req, resp)`

On bad input paths and bad input queries.

Closes #13232