### PR TITLE
Issue #13234 - empty query entries should be retained for Fields and Servlet Parameters

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/UrlParameterDecoder.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/UrlParameterDecoder.java
@@ -37,7 +37,6 @@ class UrlParameterDecoder
     private final boolean allowTruncatedEncoding;
     private final CharsetStringBuilder builder;
     private String name;
-    private boolean seenEqualsDelim;
     private int keyCount;
     private int charCount;
 
@@ -183,7 +182,7 @@ class UrlParameterDecoder
             case '&' ->
             {
                 String str = takeBuiltString();
-                if (seenEqualsDelim)
+                if (name != null)
                 {
                     onNewField(name, str);
                     name = null;
@@ -192,14 +191,12 @@ class UrlParameterDecoder
                 {
                     onNewField(str, "");
                 }
-                seenEqualsDelim = false;
             }
             case '=' ->
             {
                 if (name == null)
                 {
                     name = takeBuiltString();
-                    seenEqualsDelim = true;
                 }
                 else
                     builder.append(c);
@@ -300,7 +297,7 @@ class UrlParameterDecoder
 
     private void complete() throws CharacterCodingException
     {
-        if (seenEqualsDelim)
+        if (name != null)
         {
             String value = takeBuiltString();
             onNewField(name, value);
@@ -311,7 +308,6 @@ class UrlParameterDecoder
             if (!StringUtil.isEmpty(name))
                 onNewField(name, "");
         }
-        seenEqualsDelim = false;
     }
 
     private String notValidPctEncoding(char hi, char lo)

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/UrlParameterDecoder.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/UrlParameterDecoder.java
@@ -37,6 +37,7 @@ class UrlParameterDecoder
     private final boolean allowTruncatedEncoding;
     private final CharsetStringBuilder builder;
     private String name;
+    private boolean seenEqualsDelim;
     private int keyCount;
     private int charCount;
 
@@ -182,20 +183,24 @@ class UrlParameterDecoder
             case '&' ->
             {
                 String str = takeBuiltString();
-                if (name == null)
-                {
-                    onNewField(str, "");
-                }
-                else
+                if (seenEqualsDelim)
                 {
                     onNewField(name, str);
                     name = null;
                 }
+                else if (!StringUtil.isEmpty(str))
+                {
+                    onNewField(str, "");
+                }
+                seenEqualsDelim = false;
             }
             case '=' ->
             {
                 if (name == null)
+                {
                     name = takeBuiltString();
+                    seenEqualsDelim = true;
+                }
                 else
                     builder.append(c);
             }
@@ -295,7 +300,7 @@ class UrlParameterDecoder
 
     private void complete() throws CharacterCodingException
     {
-        if (name != null)
+        if (seenEqualsDelim)
         {
             String value = takeBuiltString();
             onNewField(name, value);
@@ -303,8 +308,10 @@ class UrlParameterDecoder
         else if (builder.length() > 0)
         {
             name = takeBuiltString();
-            onNewField(name, "");
+            if (!StringUtil.isEmpty(name))
+                onNewField(name, "");
         }
+        seenEqualsDelim = false;
     }
 
     private String notValidPctEncoding(char hi, char lo)

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/UrlParameterDecoder.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/UrlParameterDecoder.java
@@ -339,10 +339,10 @@ class UrlParameterDecoder
 
     private void onNewField(String name, String value)
     {
-        if (name == null || name.isEmpty())
+        if (name == null && value == null)
             return;
         keyCount++;
-        newFieldAdder.accept(name, value);
+        newFieldAdder.accept(name == null ? "" : name, value == null ? "" : value);
         if (maxKeys >= 0 && keyCount > maxKeys)
             throw new IllegalStateException(String.format("Form with too many keys [%d > %d]", keyCount, maxKeys));
     }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/UrlParameterDecoderTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/UrlParameterDecoderTest.java
@@ -106,6 +106,42 @@ public class UrlParameterDecoderTest
     }
 
     @Test
+    public void testEmptyKeyName()
+        throws Exception
+    {
+        Fields fields = new Fields();
+
+        CharsetStringBuilder charsetStringBuilder = CharsetStringBuilder.forCharset(UTF_8);
+        UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add);
+
+        String input = "=";
+        decoder.parse(input);
+
+        assertThat(fields.getSize(), is(1));
+        assertEquals("", fields.getValue(""));
+    }
+
+    @Test
+    public void testDualEmptyKeyName()
+        throws Exception
+    {
+        Fields fields = new Fields();
+
+        CharsetStringBuilder charsetStringBuilder = CharsetStringBuilder.forCharset(UTF_8);
+        UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add);
+
+        String input = "=&=";
+        decoder.parse(input);
+
+        assertThat(fields.getSize(), is(1));
+        List<String> values = fields.getValues("");
+        assertNotNull(values);
+        assertThat(values.size(), is(2));
+        assertEquals("", values.get(0));
+        assertEquals("", values.get(1));
+    }
+
+    @Test
     public void testManyPctEncoding()
         throws Exception
     {
@@ -303,10 +339,10 @@ public class UrlParameterDecoderTest
         cases.add(Arguments.of("param=%£&other=foo", Map.of("param", "%£", "other", "foo")));
 
         // Extra ampersands
-        cases.add(Arguments.of("param=aaa&&&", Map.of("param", "aaa")));
-        cases.add(Arguments.of("&&&param=aaa", Map.of("param", "aaa")));
-        cases.add(Arguments.of("&&param=aaa&&other=foo", Map.of("param", "aaa", "other", "foo")));
-        cases.add(Arguments.of("param=aaa&&other=foo&&", Map.of("param", "aaa", "other", "foo")));
+        cases.add(Arguments.of("param=aaa&&&", Map.of("param", "aaa", "", "")));
+        cases.add(Arguments.of("&&&param=aaa", Map.of("param", "aaa", "", "")));
+        cases.add(Arguments.of("&&param=aaa&&other=foo", Map.of("param", "aaa", "other", "foo", "", "")));
+        cases.add(Arguments.of("param=aaa&&other=foo&&", Map.of("param", "aaa", "other", "foo", "", "")));
 
         // Encoded ampersands
         cases.add(Arguments.of("param=aaa%26&other=foo", Map.of("param", "aaa&", "other", "foo")));
@@ -382,10 +418,10 @@ public class UrlParameterDecoderTest
         cases.add(Arguments.of("param=f_%e0%b8&other=foo", Map.of("param", "f_�", "other", "foo")));
 
         // Extra ampersands
-        cases.add(Arguments.of("param=aaa&&&", Map.of("param", "aaa")));
-        cases.add(Arguments.of("&&&param=aaa", Map.of("param", "aaa")));
-        cases.add(Arguments.of("&&param=aaa&&other=foo", Map.of("param", "aaa", "other", "foo")));
-        cases.add(Arguments.of("param=aaa&&other=foo&&", Map.of("param", "aaa", "other", "foo")));
+        cases.add(Arguments.of("param=aaa&&&", Map.of("param", "aaa", "", "")));
+        cases.add(Arguments.of("&&&param=aaa", Map.of("param", "aaa", "", "")));
+        cases.add(Arguments.of("&&param=aaa&&other=foo", Map.of("param", "aaa", "other", "foo", "", "")));
+        cases.add(Arguments.of("param=aaa&&other=foo&&", Map.of("param", "aaa", "other", "foo", "", "")));
 
         // Encoded ampersands
         cases.add(Arguments.of("param=aaa%26&other=foo", Map.of("param", "aaa&", "other", "foo")));

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/UrlParameterDecoderTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/UrlParameterDecoderTest.java
@@ -106,7 +106,7 @@ public class UrlParameterDecoderTest
     }
 
     @Test
-    public void testEmptyKeyName()
+    public void testEmptyKeyAndEmptyValue()
         throws Exception
     {
         Fields fields = new Fields();
@@ -118,11 +118,33 @@ public class UrlParameterDecoderTest
         decoder.parse(input);
 
         assertThat(fields.getSize(), is(1));
-        assertEquals("", fields.getValue(""));
+        List<String> values = fields.getValues("");
+        assertNotNull(values);
+        assertThat(values.size(), is(1));
+        assertEquals("", values.get(0));
     }
 
     @Test
-    public void testDualEmptyKeyName()
+    public void testEmptyKeyWithValue()
+        throws Exception
+    {
+        Fields fields = new Fields();
+
+        CharsetStringBuilder charsetStringBuilder = CharsetStringBuilder.forCharset(UTF_8);
+        UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add);
+
+        String input = "=foo";
+        decoder.parse(input);
+
+        assertThat(fields.getSize(), is(1));
+        List<String> values = fields.getValues("");
+        assertNotNull(values);
+        assertThat(values.size(), is(1));
+        assertEquals("foo", values.get(0));
+    }
+
+    @Test
+    public void testDualEmptyKeysAndEmptyValues()
         throws Exception
     {
         Fields fields = new Fields();
@@ -139,6 +161,89 @@ public class UrlParameterDecoderTest
         assertThat(values.size(), is(2));
         assertEquals("", values.get(0));
         assertEquals("", values.get(1));
+    }
+
+    @Test
+    public void testDualEmptyKeysWithValues()
+        throws Exception
+    {
+        Fields fields = new Fields();
+
+        CharsetStringBuilder charsetStringBuilder = CharsetStringBuilder.forCharset(UTF_8);
+        UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add);
+
+        String input = "=foo&=bar";
+        decoder.parse(input);
+
+        assertThat(fields.getSize(), is(1));
+        List<String> values = fields.getValues("");
+        assertNotNull(values);
+        assertThat(values.size(), is(2));
+        assertEquals("foo", values.get(0));
+        assertEquals("bar", values.get(1));
+    }
+
+    @Test
+    public void testOneAmpersand()
+        throws Exception
+    {
+        Fields fields = new Fields();
+
+        CharsetStringBuilder charsetStringBuilder = CharsetStringBuilder.forCharset(UTF_8);
+        UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add);
+
+        String input = "&";
+        decoder.parse(input);
+
+        assertThat(fields.getSize(), is(1));
+        List<String> values = fields.getValues("");
+        assertNotNull(values);
+        assertThat(values.size(), is(1));
+        assertEquals("", values.get(0));
+    }
+
+    @Test
+    public void testTwoAmpersands()
+        throws Exception
+    {
+        Fields fields = new Fields();
+
+        CharsetStringBuilder charsetStringBuilder = CharsetStringBuilder.forCharset(UTF_8);
+        UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add);
+
+        String input = "&&";
+        decoder.parse(input);
+
+        assertThat(fields.getSize(), is(1));
+        List<String> values = fields.getValues("");
+        assertNotNull(values);
+        assertThat(values.size(), is(2));
+        assertEquals("", values.get(0));
+        assertEquals("", values.get(1));
+    }
+
+    @Test
+    public void testValueBetweenTwoAmpersands()
+        throws Exception
+    {
+        Fields fields = new Fields();
+
+        CharsetStringBuilder charsetStringBuilder = CharsetStringBuilder.forCharset(UTF_8);
+        UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add);
+
+        String input = "&foo&";
+        decoder.parse(input);
+
+        assertThat(fields.getSize(), is(2));
+        List<String> values = fields.getValues("");
+        assertNotNull(values);
+        assertThat(values.size(), is(1));
+        assertEquals("", values.get(0));
+
+        values = fields.getValues("foo");
+        assertNotNull(values);
+        assertThat(values.size(), is(1));
+        assertEquals("", values.get(0));
     }
 
     @Test

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/UrlParameterDecoderTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/UrlParameterDecoderTest.java
@@ -105,145 +105,60 @@ public class UrlParameterDecoderTest
         assertEquals("d", fields.getValue("c"));
     }
 
-    @Test
-    public void testEmptyKeyAndEmptyValue()
-        throws Exception
+    /**
+     * List of parsing behaviors from Browser {@code URLSearchParams} implementations.
+     * @see <a href="https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams">URLSearchParams</a>
+     */
+    public static Stream<Arguments> browserParsingCases()
     {
-        Fields fields = new Fields();
+        List<Arguments> cases = new ArrayList<>();
 
-        CharsetStringBuilder charsetStringBuilder = CharsetStringBuilder.forCharset(UTF_8);
-        UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add);
+        cases.add(Arguments.of("a=b&c=d", Map.of("a", List.of("b"), "c", List.of("d"))));
+        cases.add(Arguments.of("a=b?c=d", Map.of("a", List.of("b?c=d"))));
+        cases.add(Arguments.of("=", Map.of("", List.of(""))));
+        cases.add(Arguments.of("a=b&a=c&a=d", Map.of("a", List.of("b", "c", "d"))));
+        cases.add(Arguments.of("&", Map.of()));
+        cases.add(Arguments.of("&&&", Map.of()));
+        cases.add(Arguments.of("a=b&&&", Map.of("a", List.of("b"))));
+        cases.add(Arguments.of("&&&a=b", Map.of("a", List.of("b"))));
+        cases.add(Arguments.of("=&=", Map.of("", List.of("", ""))));
+        cases.add(Arguments.of("&=&", Map.of("", List.of(""))));
+        cases.add(Arguments.of("foo", Map.of("foo", List.of(""))));
+        cases.add(Arguments.of("foo&bar", Map.of("foo", List.of(""), "bar", List.of(""))));
+        cases.add(Arguments.of("foo=", Map.of("foo", List.of(""))));
+        cases.add(Arguments.of("foo=&", Map.of("foo", List.of(""))));
+        cases.add(Arguments.of("=foo", Map.of("", List.of("foo"))));
+        cases.add(Arguments.of("=foo&=bar", Map.of("", List.of("foo", "bar"))));
+        cases.add(Arguments.of("foo==", Map.of("foo", List.of("="))));
+        cases.add(Arguments.of("foo===", Map.of("foo", List.of("=="))));
+        cases.add(Arguments.of("a===b", Map.of("a", List.of("==b"))));
+        cases.add(Arguments.of("a=\"b\"", Map.of("a", List.of("\"b\""))));
+        cases.add(Arguments.of("\"a=b\"", Map.of("\"a", List.of("b\""))));
+        cases.add(Arguments.of("a=b& =foo", Map.of("a", List.of("b"), " ", List.of("foo"))));
+        cases.add(Arguments.of("===foo", Map.of("", List.of("==foo"))));
 
-        String input = "=";
-        decoder.parse(input);
-
-        assertThat(fields.getSize(), is(1));
-        List<String> values = fields.getValues("");
-        assertNotNull(values);
-        assertThat(values.size(), is(1));
-        assertEquals("", values.get(0));
+        return cases.stream();
     }
 
-    @Test
-    public void testEmptyKeyWithValue()
-        throws Exception
+    @ParameterizedTest
+    @MethodSource("browserParsingCases")
+    public void testBrowserParsingBehavior(String input, Map<String, List<String>> expectedParams) throws IOException
     {
         Fields fields = new Fields();
-
         CharsetStringBuilder charsetStringBuilder = CharsetStringBuilder.forCharset(UTF_8);
         UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add);
 
-        String input = "=foo";
         decoder.parse(input);
 
-        assertThat(fields.getSize(), is(1));
-        List<String> values = fields.getValues("");
-        assertNotNull(values);
-        assertThat(values.size(), is(1));
-        assertEquals("foo", values.get(0));
-    }
+        assertThat("Field count", fields.getSize(), is(expectedParams.size()));
 
-    @Test
-    public void testDualEmptyKeysAndEmptyValues()
-        throws Exception
-    {
-        Fields fields = new Fields();
-
-        CharsetStringBuilder charsetStringBuilder = CharsetStringBuilder.forCharset(UTF_8);
-        UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add);
-
-        String input = "=&=";
-        decoder.parse(input);
-
-        assertThat(fields.getSize(), is(1));
-        List<String> values = fields.getValues("");
-        assertNotNull(values);
-        assertThat(values.size(), is(2));
-        assertEquals("", values.get(0));
-        assertEquals("", values.get(1));
-    }
-
-    @Test
-    public void testDualEmptyKeysWithValues()
-        throws Exception
-    {
-        Fields fields = new Fields();
-
-        CharsetStringBuilder charsetStringBuilder = CharsetStringBuilder.forCharset(UTF_8);
-        UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add);
-
-        String input = "=foo&=bar";
-        decoder.parse(input);
-
-        assertThat(fields.getSize(), is(1));
-        List<String> values = fields.getValues("");
-        assertNotNull(values);
-        assertThat(values.size(), is(2));
-        assertEquals("foo", values.get(0));
-        assertEquals("bar", values.get(1));
-    }
-
-    @Test
-    public void testOneAmpersand()
-        throws Exception
-    {
-        Fields fields = new Fields();
-
-        CharsetStringBuilder charsetStringBuilder = CharsetStringBuilder.forCharset(UTF_8);
-        UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add);
-
-        String input = "&";
-        decoder.parse(input);
-
-        assertThat(fields.getSize(), is(1));
-        List<String> values = fields.getValues("");
-        assertNotNull(values);
-        assertThat(values.size(), is(1));
-        assertEquals("", values.get(0));
-    }
-
-    @Test
-    public void testTwoAmpersands()
-        throws Exception
-    {
-        Fields fields = new Fields();
-
-        CharsetStringBuilder charsetStringBuilder = CharsetStringBuilder.forCharset(UTF_8);
-        UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add);
-
-        String input = "&&";
-        decoder.parse(input);
-
-        assertThat(fields.getSize(), is(1));
-        List<String> values = fields.getValues("");
-        assertNotNull(values);
-        assertThat(values.size(), is(2));
-        assertEquals("", values.get(0));
-        assertEquals("", values.get(1));
-    }
-
-    @Test
-    public void testValueBetweenTwoAmpersands()
-        throws Exception
-    {
-        Fields fields = new Fields();
-
-        CharsetStringBuilder charsetStringBuilder = CharsetStringBuilder.forCharset(UTF_8);
-        UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add);
-
-        String input = "&foo&";
-        decoder.parse(input);
-
-        assertThat(fields.getSize(), is(2));
-        List<String> values = fields.getValues("");
-        assertNotNull(values);
-        assertThat(values.size(), is(1));
-        assertEquals("", values.get(0));
-
-        values = fields.getValues("foo");
-        assertNotNull(values);
-        assertThat(values.size(), is(1));
-        assertEquals("", values.get(0));
+        for (String key : expectedParams.keySet())
+        {
+            Fields.Field field = fields.get(key);
+            String message = "Fields[%s]".formatted(key);
+            assertNotNull(field, message);
+            assertEquals(expectedParams.get(key), field.getValues(), message);
+        }
     }
 
     @Test
@@ -444,10 +359,10 @@ public class UrlParameterDecoderTest
         cases.add(Arguments.of("param=%£&other=foo", Map.of("param", "%£", "other", "foo")));
 
         // Extra ampersands
-        cases.add(Arguments.of("param=aaa&&&", Map.of("param", "aaa", "", "")));
-        cases.add(Arguments.of("&&&param=aaa", Map.of("param", "aaa", "", "")));
-        cases.add(Arguments.of("&&param=aaa&&other=foo", Map.of("param", "aaa", "other", "foo", "", "")));
-        cases.add(Arguments.of("param=aaa&&other=foo&&", Map.of("param", "aaa", "other", "foo", "", "")));
+        cases.add(Arguments.of("param=aaa&&&", Map.of("param", "aaa")));
+        cases.add(Arguments.of("&&&param=aaa", Map.of("param", "aaa")));
+        cases.add(Arguments.of("&&param=aaa&&other=foo", Map.of("param", "aaa", "other", "foo")));
+        cases.add(Arguments.of("param=aaa&&other=foo&&", Map.of("param", "aaa", "other", "foo")));
 
         // Encoded ampersands
         cases.add(Arguments.of("param=aaa%26&other=foo", Map.of("param", "aaa&", "other", "foo")));
@@ -523,10 +438,10 @@ public class UrlParameterDecoderTest
         cases.add(Arguments.of("param=f_%e0%b8&other=foo", Map.of("param", "f_�", "other", "foo")));
 
         // Extra ampersands
-        cases.add(Arguments.of("param=aaa&&&", Map.of("param", "aaa", "", "")));
-        cases.add(Arguments.of("&&&param=aaa", Map.of("param", "aaa", "", "")));
-        cases.add(Arguments.of("&&param=aaa&&other=foo", Map.of("param", "aaa", "other", "foo", "", "")));
-        cases.add(Arguments.of("param=aaa&&other=foo&&", Map.of("param", "aaa", "other", "foo", "", "")));
+        cases.add(Arguments.of("param=aaa&&&", Map.of("param", "aaa")));
+        cases.add(Arguments.of("&&&param=aaa", Map.of("param", "aaa")));
+        cases.add(Arguments.of("&&param=aaa&&other=foo", Map.of("param", "aaa", "other", "foo")));
+        cases.add(Arguments.of("param=aaa&&other=foo&&", Map.of("param", "aaa", "other", "foo")));
 
         // Encoded ampersands
         cases.add(Arguments.of("param=aaa%26&other=foo", Map.of("param", "aaa&", "other", "foo")));


### PR DESCRIPTION
Fix regression in 12.0.21, where empty query parameters should still produce a Field or Servlet Parameter.

That means ..

1. `?=` is a single parameter with key name of empty string (`""`), with a single value of empty string (`""`).
2. `?=&=` is a single parameter with key name of empty string (`""`), with a two values of empty string (`""`).
3. `?&` has no parameters.
4. `?&&` has no parameters.

Closes #13234