### PR TITLE
Fix NPE in `HttpReceiver.responseSuccess()` when that method is called more than once

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpReceiver.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpReceiver.java
@@ -52,7 +52,7 @@ import org.slf4j.LoggerFactory;
  * is available</li>
  * <li>{@link #responseHeader(HttpExchange, HttpField)}, when an HTTP field is available</li>
  * <li>{@link #responseHeaders(HttpExchange)}, when all HTTP headers are available</li>
- * <li>{@link #responseSuccess(HttpExchange, Runnable)}, when the response is successful</li>
+ * <li>{@link #responseSuccess(Runnable)}, when the response is successful</li>
  * </ol>
  * At any time, subclasses may invoke {@link #responseFailure(Throwable, Promise)} to indicate that the response has failed
  * (for example, because of I/O exceptions).
@@ -302,7 +302,7 @@ public abstract class HttpReceiver implements Invocable
                 if (LOG.isDebugEnabled())
                     LOG.debug("Interim response status {}, succeeding", response.getStatus());
                 // The response success event will be serialized and run after this event completes.
-                responseSuccess(exchange, this::onInterim);
+                responseSuccess(this::onInterim);
                 return;
             }
 
@@ -357,17 +357,18 @@ public abstract class HttpReceiver implements Invocable
      * This method takes care of notifying {@link Response.SuccessListener}s and possibly
      * {@link Response.CompleteListener}s (if the exchange is completed).
      *
-     * @param exchange the HTTP exchange
      * @param afterSuccessTask an optional task to invoke afterwards
      */
-    protected void responseSuccess(HttpExchange exchange, Runnable afterSuccessTask)
+    protected void responseSuccess(Runnable afterSuccessTask)
     {
+        HttpExchange exchange = getHttpExchange();
         if (LOG.isDebugEnabled())
             LOG.debug("Invoking responseSuccess for {} on {}", exchange, this);
 
         // Mark atomically the response as completed, with respect
-        // to concurrency between response success and response failure.
-        if (!exchange.responseComplete(null))
+        // to concurrency between response success and response failure;
+        // exchange can be null if responseSuccess() has already been called.
+        if (exchange == null || !exchange.responseComplete(null))
             return;
 
         Runnable successTask = () ->

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpReceiverOverHTTP.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpReceiverOverHTTP.java
@@ -129,7 +129,7 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
             LOG.debug("ParseAndFill needFillInterest {} in {}", needFillInterest, this);
         chunk = consumeChunk();
         if (state == State.COMPLETE)
-            responseSuccess(getHttpExchange(), receiveNext);
+            responseSuccess(receiveNext);
         if (chunk != null)
             return chunk;
         if (needFillInterest && fillInterestIfNeeded)
@@ -346,7 +346,7 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
                     // Connection upgrade, bail out.
                     if (isUpgrade || isTunnel)
                     {
-                        responseSuccess(exchange, null);
+                        responseSuccess(null);
                         return true;
                     }
 
@@ -369,7 +369,7 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
                     // When notifyContentAvailable==false, this method is called from read(boolean),
                     // and the call to responseSuccess() is performed by read().
                     if (notifyContentAvailable)
-                        responseSuccess(exchange, receiveNext);
+                        responseSuccess(receiveNext);
 
                     // Reading the next response will
                     // be performed by receivedNext().

--- a/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpChannelOverFCGI.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpChannelOverFCGI.java
@@ -135,9 +135,7 @@ public class HttpChannelOverFCGI extends HttpChannel
 
     protected void responseSuccess()
     {
-        HttpExchange exchange = getHttpExchange();
-        if (exchange != null)
-            receiver.responseSuccess(exchange);
+        receiver.responseSuccess();
     }
 
     protected void responseFailure(Throwable failure, Promise<Boolean> promise)

--- a/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpReceiverOverFCGI.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpReceiverOverFCGI.java
@@ -133,9 +133,9 @@ public class HttpReceiverOverFCGI extends HttpReceiver
         chunk = Content.Chunk.EOF;
     }
 
-    void responseSuccess(HttpExchange exchange)
+    void responseSuccess()
     {
-        super.responseSuccess(exchange, this::receiveNext);
+        responseSuccess(this::receiveNext);
     }
 
     private void receiveNext()

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpReceiverOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpReceiverOverHTTP2.java
@@ -94,7 +94,7 @@ public class HttpReceiverOverHTTP2 extends HttpReceiver implements HTTP2Channel.
         }
         else
         {
-            responseSuccess(getHttpExchange(), null);
+            responseSuccess(null);
             return Content.Chunk.EOF;
         }
     }

--- a/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpReceiverOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpReceiverOverHTTP3.java
@@ -76,7 +76,7 @@ public class HttpReceiverOverHTTP3 extends HttpReceiver
         }
         else
         {
-            responseSuccess(getHttpExchange(), null);
+            responseSuccess(null);
             return Content.Chunk.EOF;
         }
     }
@@ -151,7 +151,7 @@ public class HttpReceiverOverHTTP3 extends HttpReceiver
         HttpFields trailers = frame.getMetaData().getHttpFields();
         trailers.forEach(exchange.getResponse()::trailer);
 
-        Runnable task = () -> responseSuccess(exchange, null);
+        Runnable task = () -> responseSuccess(null);
         return new Invocable.ReadyTask(getHttpConnection().getInvocationType(), task);
     }
 


### PR DESCRIPTION
`HttpReceiverOverHTTP3.read(boolean)` can call `responseSuccess()` more than once: calling `read()` again after EOF has been reached still calls `responseSuccess()` which throws NPE as the exchange has been nulled by the 1st call to `responseSuccess()`.

This change is about making `responseSuccess()` get the exchange itself instead of accepting it as a parameter and checking it for null, much like `responseFailure()` does.

This fixes `HttpClientTest.testClientUseContentSourceInSpawnedThreadWithTrailer()` introduced by #13201