### PR TITLE
Issue #13259 - Support `javax.naming.Referenceable` from core `Transaction`

### DIFF
--- a/jetty-core/jetty-plus/src/main/java/org/eclipse/jetty/plus/jndi/Transaction.java
+++ b/jetty-core/jetty-plus/src/main/java/org/eclipse/jetty/plus/jndi/Transaction.java
@@ -19,6 +19,7 @@ import javax.naming.LinkRef;
 import javax.naming.NameNotFoundException;
 import javax.naming.NamingException;
 import javax.naming.Reference;
+import javax.naming.Referenceable;
 
 import org.eclipse.jetty.util.jndi.NamingUtil;
 import org.slf4j.Logger;
@@ -69,6 +70,17 @@ public class Transaction extends NamingEntry
         throws NamingException
     {
         this(scope, (Object)userTransactionRef);
+    }
+
+    /**
+     * @param scope the environment in which to bind the UserTransaction
+     * @param userTransactionReferenceable a {@link Referenceable} to a UserTransaction
+     * @throws NamingException if there was a problem re
+     */
+    public Transaction(String scope, Referenceable userTransactionReferenceable)
+        throws NamingException
+    {
+        this(scope, (Object)userTransactionReferenceable.getReference());
     }
 
     /**


### PR DESCRIPTION
New constructor for supporting `javax.naming.Referenceable` feature.

This would allow an XML to initialize a UserTransaction that comes from a `Referenceable`

XML Example that uses [`com.atomikos.icatch.jta.UserTransactionImp`](https://github.com/atomikos/transactions-essentials/blob/master/public/transactions-jta/src/main/java/com/atomikos/icatch/jta/UserTransactionImp.java) which would be possible with this PR.
(Without this PR, this is an invalid XML setup)

``` xml
<?xml version="1.0"?>
<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
<Configure id="Server" class="org.eclipse.jetty.server.Server">
  <New id="usertx" class="org.eclipse.jetty.plus.jndi.Transaction"> <!-- THIS REFERENCE -->
    <Arg><Property name="environment" default="ee8"/></Arg>
    <Arg>
      <New class="com.atomikos.icatch.jta.UserTransactionImp" />
    </Arg>
  </New>
</Configure>
```

Closes #13259