### PR TITLE
Issue #12818 - fix potential NPE from WebSocketConnection

### DIFF
--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConnection.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConnection.java
@@ -61,6 +61,14 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
         CANCELLED
     }
 
+    private enum State
+    {
+        IDLE,
+        FILLING_AND_PARSING,
+        CLOSING,
+        CLOSED
+    }
+
     private final AutoLock lock = new AutoLock();
     private final ByteBufferPool byteBufferPool;
     private final Generator generator;
@@ -76,6 +84,8 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
     private RetainableByteBuffer networkBuffer;
     private boolean useInputDirectByteBuffers;
     private boolean useOutputDirectByteBuffers;
+    private State state = State.IDLE;
+    private Throwable closeCause;
 
     /**
      * Create a WSConnection.
@@ -205,20 +215,48 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
     {
         if (LOG.isDebugEnabled())
             LOG.debug("onClose() of physical connection");
+        super.onClose(cause);
+
+        boolean close = false;
+        try (AutoLock ignored = lock.lock())
+        {
+            closeCause = cause;
+            switch (state)
+            {
+                case IDLE:
+                {
+                    state = State.CLOSED;
+                    close = true;
+                    break;
+                }
+                case FILLING_AND_PARSING:
+                {
+                    state = State.CLOSING;
+                    break;
+                }
+                default:
+                    throw new IllegalStateException(state.name());
+            }
+        }
+
+        if (close)
+            doOnClose(cause);
+    }
+
+    private void doOnClose(Throwable cause)
+    {
+        if (LOG.isDebugEnabled())
+            LOG.debug("doOnClose() {}", String.valueOf(cause));
 
         if (!coreSession.isClosed())
             coreSession.onEof();
         flusher.onClose(cause);
 
-        try (AutoLock ignored = lock.lock())
+        if (networkBuffer != null)
         {
-            if (networkBuffer != null)
-            {
-                networkBuffer.clear();
-                releaseNetworkBuffer();
-            }
+            networkBuffer.clear();
+            releaseNetworkBuffer();
         }
-        super.onClose(cause);
     }
 
     @Override
@@ -364,10 +402,7 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
         }
 
         if (fillAndParse)
-        {
-            // TODO can we just fillAndParse();
             getExecutor().execute(this);
-        }
     }
 
     public boolean moreDemand()
@@ -429,6 +464,28 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
 
     private void fillAndParse()
     {
+        boolean doClose = false;
+        Throwable closeCause = null;
+        try (AutoLock ignored = lock.lock())
+        {
+            switch (state)
+            {
+                case IDLE -> state = State.FILLING_AND_PARSING;
+                case CLOSED ->
+                {
+                    doClose = true;
+                    closeCause = this.closeCause;
+                }
+                default -> throw new IllegalStateException(state.name());
+            }
+        }
+
+        if (doClose)
+        {
+            doOnClose(closeCause);
+            return;
+        }
+
         acquireNetworkBuffer();
 
         try
@@ -464,7 +521,9 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
                 if (networkBuffer.isRetained())
                     reacquireNetworkBuffer();
 
-                int filled = getEndPoint().fill(networkBuffer.getByteBuffer()); // TODO check if compact is possible.
+                // The parser is fully consuming so we can clear the network buffer before filling.
+                networkBuffer.clear();
+                int filled = getEndPoint().fill(networkBuffer.getByteBuffer());
 
                 if (LOG.isDebugEnabled())
                     LOG.debug("endpointFill() filled={}: {}", filled, networkBuffer);
@@ -497,6 +556,24 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
                 releaseNetworkBuffer();
             }
             coreSession.processConnectionError(t, Callback.NOOP);
+        }
+        finally
+        {
+            try (AutoLock ignored = lock.lock())
+            {
+                switch (state)
+                {
+                    case FILLING_AND_PARSING -> state = State.IDLE;
+                    case CLOSING ->
+                    {
+                        doClose = true;
+                        closeCause = this.closeCause;
+                    }
+                    default -> throw new IllegalStateException(state.name());
+                }
+            }
+            if (doClose)
+                doOnClose(closeCause);
         }
     }
 

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConnection.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConnection.java
@@ -64,13 +64,11 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
     /*
      * The state of the WebSocketConnection, used to serialize fillingAndParsing with connection close events.
      * <pre>
-     *   ┌────IDLE<───────────────┐
-     *   │      │                 │
-     *   │      V                 │
-     *   │    FILLING_AND_PARSING─┤
-     *   │                        │
-     *   │                        V
-     *   └───>CLOSED<────────CLOSING
+     *   IDLE   <------> FILLING_AND_PARSING
+     *     |                 |
+     *     |                 |
+     *     v                 v
+     *   CLOSED <-------- CLOSING
      * </pre>
      */
     private enum State

--- a/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/ParseFrameAfterCloseTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/ParseFrameAfterCloseTest.java
@@ -1,0 +1,146 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.websocket.core;
+
+import java.net.URI;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.io.Connection;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.Blocker;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.websocket.core.client.CoreClientUpgradeRequest;
+import org.eclipse.jetty.websocket.core.client.WebSocketCoreClient;
+import org.eclipse.jetty.websocket.core.server.WebSocketUpgradeHandler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ParseFrameAfterCloseTest
+{
+    private Server _server;
+    private WebSocketUpgradeHandler _upgradeHandler;
+    private WebSocketCoreClient _client;
+    private ServerConnector _serverConnector;
+
+    @BeforeEach
+    public void before() throws Exception
+    {
+        _server = new Server();
+        _serverConnector = new ServerConnector(_server);
+        _server.addConnector(_serverConnector);
+
+        _upgradeHandler = new WebSocketUpgradeHandler();
+        _server.setHandler(_upgradeHandler);
+        _server.start();
+
+        _client = new WebSocketCoreClient();
+        _client.start();
+    }
+
+    @AfterEach
+    public void after() throws Exception
+    {
+        _client.stop();
+        _server.stop();
+    }
+
+    public static class ServerFrameHandler extends TestFrameHandler
+    {
+        private final CountDownLatch connectionCloseLatch = new CountDownLatch(1);
+        private boolean first;
+
+        @Override
+        public void onOpen(CoreSession coreSession)
+        {
+            super.onOpen(coreSession);
+            first = true;
+            ((WebSocketCoreSession)coreSession).getConnection().addEventListener(new Connection.Listener()
+            {
+                @Override
+                public void onClosed(Connection connection)
+                {
+                    connectionCloseLatch.countDown();
+                }
+            });
+        }
+
+        @Override
+        public void onFrame(Frame frame, Callback callback)
+        {
+            super.onFrame(frame, callback);
+            if (first)
+            {
+                coreSession.abort();
+                awaitConnectionClose();
+                first = false;
+            }
+        }
+
+        public void awaitConnectionClose()
+        {
+            try
+            {
+                connectionCloseLatch.await();
+            }
+            catch (InterruptedException e)
+            {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    @Test
+    public void testParseFrameAfterClose() throws Exception
+    {
+        ServerFrameHandler serverFrameHandler = new ServerFrameHandler();
+        _upgradeHandler.addMapping("/", (req, resp, cb) -> serverFrameHandler);
+
+        TestMessageHandler clientHandler = new TestMessageHandler();
+        URI uri = URI.create("ws://localhost:" + _serverConnector.getLocalPort());
+        CoreClientUpgradeRequest upgradeRequest = CoreClientUpgradeRequest.from(_client, uri, clientHandler);
+        CoreSession coreSession = _client.connect(upgradeRequest).get(5, TimeUnit.SECONDS);
+
+        // Send two frames with batch mode so they are sent in the same write.
+        try (Blocker.Callback callback = Blocker.callback())
+        {
+            coreSession.sendFrame(new Frame(OpCode.TEXT, "message1"), Callback.NOOP, true);
+            coreSession.sendFrame(new Frame(OpCode.TEXT, "message2"), Callback.NOOP, true);
+            coreSession.flush(callback);
+            callback.block();
+        }
+
+        // We get first frame before abort.
+        Frame frame = Objects.requireNonNull(serverFrameHandler.getFrames().poll(5, TimeUnit.SECONDS));
+        assertThat(frame.getOpCode(), equalTo(OpCode.TEXT));
+        assertThat(frame.getPayloadAsUTF8(), equalTo("message1"));
+
+        // The connection is aborted after the first frame, but the second frame is still read as it was in the network buffer.
+        frame = Objects.requireNonNull(serverFrameHandler.getFrames().poll(5, TimeUnit.SECONDS));
+        assertThat(frame.getOpCode(), equalTo(OpCode.TEXT));
+        assertThat(frame.getPayloadAsUTF8(), equalTo("message2"));
+
+        // Close connection.
+        coreSession.close(Callback.NOOP);
+        assertTrue(clientHandler.closeLatch.await(5, TimeUnit.SECONDS));
+        assertThat(clientHandler.closeStatus.getCode(), equalTo(CloseStatus.NO_CLOSE));
+    }
+}


### PR DESCRIPTION
Fixes #12818 and #13225

If a close `WebSocketConnection.onClose` event happens during `fillAndParse()` then the network buffer is nulled out while it is still in use potentially causing NPE.

This fixes this issue by introducing a new atomic state so that onClosed() serializes the close actions with `fillAndParse()`.