### PR TITLE
Rework locked fields accesses in `SslConnection`

### DIFF
--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
@@ -338,16 +338,14 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
 
     private void lockedAcquireEncryptedInput()
     {
-        if (!_lock.isHeldByCurrentThread())
-            throw new IllegalStateException();
+        assert _lock.isHeldByCurrentThread();
         if (_encryptedInput == null)
             _encryptedInput = _bufferPool.acquire(getPacketBufferSize(), _encryptedDirectBuffers);
     }
 
     private void lockedAcquireEncryptedOutput()
     {
-        if (!_lock.isHeldByCurrentThread())
-            throw new IllegalStateException();
+        assert _lock.isHeldByCurrentThread();
         // TODO: before the output was done with the BBP only.
         if (_encryptedOutput == null)
             _encryptedOutput = _bufferPool.acquire(getPacketBufferSize(), _encryptedDirectBuffers);
@@ -356,7 +354,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
     @Override
     public void onUpgradeTo(ByteBuffer buffer)
     {
-        try (AutoLock l = _lock.lock())
+        try (AutoLock ignored = _lock.lock())
         {
             lockedAcquireEncryptedInput();
             BufferUtil.append(_encryptedInput.getByteBuffer(), buffer);
@@ -376,7 +374,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
     {
         _open = false;
         getSslEndPoint().getConnection().onClose(cause);
-        try (AutoLock l = _lock.lock())
+        try (AutoLock ignored = _lock.lock())
         {
             lockedDiscardInputBuffers();
             lockedDiscardEncryptedOutputBuffer();
@@ -444,7 +442,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
         FlushState flushState;
         try (AutoLock l = _lock.tryLock())
         {
-            if (_lock.isHeldByCurrentThread())
+            if (l.isHeldByCurrentThread())
             {
                 fillState = _fillState;
                 flushState = _flushState;
@@ -476,8 +474,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
 
     private void lockedReleaseEmptyEncryptedInputBuffer()
     {
-        if (!_lock.isHeldByCurrentThread())
-            throw new IllegalStateException();
+        assert _lock.isHeldByCurrentThread();
         if (_encryptedInput != null && !_encryptedInput.hasRemaining())
         {
             _encryptedInput.release();
@@ -487,8 +484,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
 
     private void lockedReleaseEmptyDecryptedInputBuffer()
     {
-        if (!_lock.isHeldByCurrentThread())
-            throw new IllegalStateException();
+        assert _lock.isHeldByCurrentThread();
         if (_decryptedInput != null && !_decryptedInput.hasRemaining())
         {
             _decryptedInput.release();
@@ -498,8 +494,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
 
     private void lockedDiscardInputBuffers()
     {
-        if (!_lock.isHeldByCurrentThread())
-            throw new IllegalStateException();
+        assert _lock.isHeldByCurrentThread();
         if (_encryptedInput != null)
             _encryptedInput.clear();
         if (_decryptedInput != null)
@@ -515,8 +510,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
 
     private void lockedDiscardEncryptedOutputBuffer()
     {
-        if (!_lock.isHeldByCurrentThread())
-            throw new IllegalStateException();
+        assert _lock.isHeldByCurrentThread();
         if (_encryptedOutput != null)
             _encryptedOutput.clear();
         lockedReleaseEmptyEncryptedOutputBuffer();
@@ -524,8 +518,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
 
     private void lockedReleaseEmptyEncryptedOutputBuffer()
     {
-        if (!_lock.isHeldByCurrentThread())
-            throw new IllegalStateException();
+        assert _lock.isHeldByCurrentThread();
         if (_encryptedOutput != null && !_encryptedOutput.hasRemaining())
         {
             _encryptedOutput.release();
@@ -607,7 +600,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
             {
                 // If we are handshaking, then wake up any waiting write as well as it may have been blocked on the read
                 boolean waitingForFill;
-                try (AutoLock l = _lock.lock())
+                try (AutoLock ignored = _lock.lock())
                 {
                     if (LOG.isDebugEnabled())
                         LOG.debug("onFillable {}", SslConnection.this);
@@ -620,7 +613,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
 
                 if (waitingForFill)
                 {
-                    try (AutoLock l = _lock.lock())
+                    try (AutoLock ignored = _lock.lock())
                     {
                         waitingForFill = _flushState == FlushState.WAIT_FOR_FILL;
                     }
@@ -638,7 +631,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
         {
             // If we are handshaking, then wake up any waiting write as well as it may have been blocked on the read
             boolean fail = false;
-            try (AutoLock l = _lock.lock())
+            try (AutoLock ignored = _lock.lock())
             {
                 if (LOG.isDebugEnabled())
                     LOG.debug("onFillableFail {}", SslConnection.this, failure);
@@ -665,11 +658,10 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
         @Override
         public void setConnection(Connection connection)
         {
-            if (connection instanceof AbstractConnection)
+            if (connection instanceof AbstractConnection c)
             {
                 // This is an optimization to avoid that upper layer connections use small
                 // buffers and we need to copy decrypted data rather than decrypting in place.
-                AbstractConnection c = (AbstractConnection)connection;
                 int appBufferSize = getApplicationBufferSize();
                 if (c.getInputBufferSize() < appBufferSize)
                     c.setInputBufferSize(appBufferSize);
@@ -687,7 +679,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
         {
             try
             {
-                try (AutoLock l = _lock.lock())
+                try (AutoLock ignored = _lock.lock())
                 {
                     if (LOG.isDebugEnabled())
                         LOG.debug(">fill {}", SslConnection.this);
@@ -924,7 +916,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
                 boolean fillable;
                 ByteBuffer write = null;
                 boolean interest = false;
-                try (AutoLock l = _lock.lock())
+                try (AutoLock ignored = _lock.lock())
                 {
                     if (LOG.isDebugEnabled())
                         LOG.debug(">needFillInterest s={}/{} uf={} ei={} di={} {}",
@@ -1001,9 +993,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
 
         private void lockedHandshakeSucceeded() throws SSLException
         {
-            if (!_lock.isHeldByCurrentThread())
-                throw new IllegalStateException();
-
+            assert _lock.isHeldByCurrentThread();
             if (_handshake.compareAndSet(HandshakeState.HANDSHAKE, HandshakeState.SUCCEEDED))
             {
                 if (LOG.isDebugEnabled())
@@ -1024,7 +1014,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
             if (_handshake.compareAndSet(HandshakeState.HANDSHAKE, HandshakeState.FAILED))
             {
                 if (LOG.isDebugEnabled())
-                    LOG.debug("handshake failed {} {}", SslConnection.this, failure);
+                    LOG.debug("handshake failed {}", SslConnection.this, failure);
                 if (!(failure instanceof SSLHandshakeException))
                     failure = new SSLHandshakeException(failure.getMessage()).initCause(failure);
                 notifyHandshakeFailed(_sslEngine, failure);
@@ -1071,7 +1061,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
         {
             try
             {
-                try (AutoLock l = _lock.lock())
+                try (AutoLock ignored = _lock.lock())
                 {
                     if (LOG.isDebugEnabled())
                     {
@@ -1278,7 +1268,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
             {
                 boolean fillInterest = false;
                 ByteBuffer write = null;
-                try (AutoLock l = _lock.lock())
+                try (AutoLock ignored = _lock.lock())
                 {
                     if (LOG.isDebugEnabled())
                         LOG.debug(">onIncompleteFlush {} {}", SslConnection.this, _encryptedOutput);
@@ -1376,7 +1366,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
             try
             {
                 boolean flush = false;
-                try (AutoLock l = _lock.lock())
+                try (AutoLock ignored = _lock.lock())
                 {
                     boolean ishut = endPoint.isInputShutdown();
                     boolean oshut = endPoint.isOutputShutdown();
@@ -1403,7 +1393,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
                         // If we still can't flush, but we are not closing the endpoint,
                         // let's just flush the encrypted output in the background.
                         ByteBuffer write = null;
-                        try (AutoLock l = _lock.lock())
+                        try (AutoLock ignored = _lock.lock())
                         {
                             if (_encryptedOutput != null && _encryptedOutput.hasRemaining())
                             {
@@ -1415,7 +1405,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
                         {
                             endPoint.write(Callback.from(() ->
                             {
-                                try (AutoLock l = _lock.lock())
+                                try (AutoLock ignored = _lock.lock())
                                 {
                                     _flushState = FlushState.IDLE;
                                     lockedReleaseEmptyEncryptedOutputBuffer();
@@ -1440,7 +1430,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
 
         private void disconnect()
         {
-            try (AutoLock l = _lock.lock())
+            try (AutoLock ignored = _lock.lock())
             {
                 lockedDiscardEncryptedOutputBuffer();
             }
@@ -1489,7 +1479,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
         @Override
         public void doClose()
         {
-            try (AutoLock l = _lock.lock())
+            try (AutoLock ignored = _lock.lock())
             {
                 lockedDiscardInputBuffers();
             }
@@ -1508,7 +1498,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
         public boolean isInputShutdown()
         {
             boolean inputsEmpty;
-            try (AutoLock l = _lock.lock())
+            try (AutoLock ignored = _lock.lock())
             {
                 inputsEmpty =
                     (_encryptedInput == null || !_encryptedInput.hasRemaining()) &&
@@ -1608,7 +1598,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
 
         private Throwable handleException(Throwable x, String context)
         {
-            try (AutoLock l = _lock.lock())
+            try (AutoLock ignored = _lock.lock())
             {
                 if (_failure == null)
                 {
@@ -1661,7 +1651,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
             {
                 boolean fillable;
                 boolean interested;
-                try (AutoLock l = _lock.lock())
+                try (AutoLock ignored = _lock.lock())
                 {
                     if (LOG.isDebugEnabled())
                         LOG.debug("IncompleteWriteCB succeeded {}", SslConnection.this);
@@ -1686,7 +1676,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
             public void failed(final Throwable x)
             {
                 boolean failFillInterest;
-                try (AutoLock l = _lock.lock())
+                try (AutoLock ignored = _lock.lock())
                 {
                     if (LOG.isDebugEnabled())
                         LOG.debug("IncompleteWriteCB failed {}", SslConnection.this, x);

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
@@ -121,13 +121,16 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
     private RetainableByteBuffer _decryptedInput;
     private RetainableByteBuffer _encryptedInput;
     private RetainableByteBuffer _encryptedOutput;
-    private boolean _renegotiationAllowed;
-    private int _renegotiationLimit = -1;
     private boolean _closedOutbound;
-    private boolean _requireCloseMessage;
     private FlushState _flushState = FlushState.IDLE;
     private FillState _fillState = FillState.IDLE;
     private boolean _underflown;
+
+    // Those fields have getters/setters not protected by the lock.
+    private boolean _renegotiationAllowed;
+    private int _renegotiationLimit = -1;
+    private boolean _requireCloseMessage;
+
     private final Runnable _runFillable = new RunnableTask("runFillable")
     {
         @Override
@@ -327,12 +330,16 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
 
     private void acquireEncryptedInput()
     {
+        if (!_lock.isHeldByCurrentThread())
+            throw new IllegalStateException();
         if (_encryptedInput == null)
             _encryptedInput = _bufferPool.acquire(getPacketBufferSize(), _encryptedDirectBuffers);
     }
 
     private void acquireEncryptedOutput()
     {
+        if (!_lock.isHeldByCurrentThread())
+            throw new IllegalStateException();
         // TODO: before the output was done with the BBP only.
         if (_encryptedOutput == null)
             _encryptedOutput = _bufferPool.acquire(getPacketBufferSize(), _encryptedDirectBuffers);
@@ -341,8 +348,11 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
     @Override
     public void onUpgradeTo(ByteBuffer buffer)
     {
-        acquireEncryptedInput();
-        BufferUtil.append(_encryptedInput.getByteBuffer(), buffer);
+        try (AutoLock l = _lock.lock())
+        {
+            acquireEncryptedInput();
+            BufferUtil.append(_encryptedInput.getByteBuffer(), buffer);
+        }
     }
 
     @Override
@@ -412,12 +422,31 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
     @Override
     public String toConnectionString()
     {
-        ByteBuffer b = _encryptedInput == null ? null : _encryptedInput.getByteBuffer();
-        int ei = b == null ? -1 : b.remaining();
-        b = _encryptedOutput == null ? null : _encryptedOutput.getByteBuffer();
-        int eo = b == null ? -1 : b.remaining();
-        b = _decryptedInput == null ? null : _decryptedInput.getByteBuffer();
-        int di = b == null ? -1 : b.remaining();
+        int ei;
+        int eo;
+        int di;
+        FillState fillState;
+        FlushState flushState;
+        try (AutoLock l = _lock.tryLock())
+        {
+            if (_lock.isHeldByCurrentThread())
+            {
+                fillState = _fillState;
+                flushState = _flushState;
+                ByteBuffer b = _encryptedInput == null ? null : _encryptedInput.getByteBuffer();
+                ei = b == null ? -1 : b.remaining();
+                b = _encryptedOutput == null ? null : _encryptedOutput.getByteBuffer();
+                eo = b == null ? -1 : b.remaining();
+                b = _decryptedInput == null ? null : _decryptedInput.getByteBuffer();
+                di = b == null ? -1 : b.remaining();
+            }
+            else
+            {
+                fillState = null;
+                flushState = null;
+                ei = eo = di = -1;
+            }
+        }
 
         Connection connection = _sslEndPoint.getConnection();
         return String.format("%s@%x{%s,eio=%d/%d,di=%d,fill=%s,flush=%s}~>%s=>%s",
@@ -425,7 +454,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
             hashCode(),
             _sslEngine.getHandshakeStatus(),
             ei, eo, di,
-            _fillState, _flushState,
+            fillState, flushState,
             _sslEndPoint.toEndPointString(),
             connection instanceof AbstractConnection ? ((AbstractConnection)connection).toConnectionString() : connection);
     }
@@ -957,6 +986,9 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
 
         private void handshakeSucceeded() throws SSLException
         {
+            if (!_lock.isHeldByCurrentThread())
+                throw new IllegalStateException();
+
             if (_handshake.compareAndSet(HandshakeState.HANDSHAKE, HandshakeState.SUCCEEDED))
             {
                 if (LOG.isDebugEnabled())
@@ -1460,10 +1492,14 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
         @Override
         public boolean isInputShutdown()
         {
-            return
-                (_encryptedInput == null || !_encryptedInput.hasRemaining()) &&
-                (_decryptedInput == null || !_decryptedInput.hasRemaining()) &&
-                (getEndPoint().isInputShutdown() || isInboundDone());
+            boolean inputsEmpty;
+            try (AutoLock l = _lock.lock())
+            {
+                inputsEmpty =
+                    (_encryptedInput == null || !_encryptedInput.hasRemaining()) &&
+                    (_decryptedInput == null || !_decryptedInput.hasRemaining());
+            }
+            return inputsEmpty && (getEndPoint().isInputShutdown() || isInboundDone());
         }
 
         private boolean isInboundDone()

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
@@ -432,9 +432,9 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
     @Override
     public String toConnectionString()
     {
-        int ei;
-        int eo;
-        int di;
+        int encryptedInputRemainingBytes;
+        int encryptedOutputRemainingBytes;
+        int decryptedInputRemainingBytes;
         FillState fillState;
         FlushState flushState;
         try (AutoLock l = _lock.tryLock())
@@ -444,17 +444,17 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
                 fillState = _fillState;
                 flushState = _flushState;
                 ByteBuffer b = _encryptedInput == null ? null : _encryptedInput.getByteBuffer();
-                ei = b == null ? -1 : b.remaining();
+                encryptedInputRemainingBytes = b == null ? -1 : b.remaining();
                 b = _encryptedOutput == null ? null : _encryptedOutput.getByteBuffer();
-                eo = b == null ? -1 : b.remaining();
+                encryptedOutputRemainingBytes = b == null ? -1 : b.remaining();
                 b = _decryptedInput == null ? null : _decryptedInput.getByteBuffer();
-                di = b == null ? -1 : b.remaining();
+                decryptedInputRemainingBytes = b == null ? -1 : b.remaining();
             }
             else
             {
                 fillState = null;
                 flushState = null;
-                ei = eo = di = -1;
+                encryptedInputRemainingBytes = encryptedOutputRemainingBytes = decryptedInputRemainingBytes = -1;
             }
         }
 
@@ -463,7 +463,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
             getClass().getSimpleName(),
             hashCode(),
             _sslEngine.getHandshakeStatus(),
-            ei, eo, di,
+            encryptedInputRemainingBytes, encryptedOutputRemainingBytes, decryptedInputRemainingBytes,
             fillState, flushState,
             _sslEndPoint.toEndPointString(),
             connection instanceof AbstractConnection ? ((AbstractConnection)connection).toConnectionString() : connection);

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
@@ -328,7 +328,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
         return Math.max(hsSize, size);
     }
 
-    private void acquireEncryptedInput()
+    private void lockedAcquireEncryptedInput()
     {
         if (!_lock.isHeldByCurrentThread())
             throw new IllegalStateException();
@@ -336,7 +336,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
             _encryptedInput = _bufferPool.acquire(getPacketBufferSize(), _encryptedDirectBuffers);
     }
 
-    private void acquireEncryptedOutput()
+    private void lockedAcquireEncryptedOutput()
     {
         if (!_lock.isHeldByCurrentThread())
             throw new IllegalStateException();
@@ -350,7 +350,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
     {
         try (AutoLock l = _lock.lock())
         {
-            acquireEncryptedInput();
+            lockedAcquireEncryptedInput();
             BufferUtil.append(_encryptedInput.getByteBuffer(), buffer);
         }
     }
@@ -459,7 +459,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
             connection instanceof AbstractConnection ? ((AbstractConnection)connection).toConnectionString() : connection);
     }
 
-    private void releaseEmptyEncryptedInputBuffer()
+    private void lockedReleaseEmptyEncryptedInputBuffer()
     {
         if (!_lock.isHeldByCurrentThread())
             throw new IllegalStateException();
@@ -470,7 +470,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
         }
     }
 
-    private void releaseEmptyDecryptedInputBuffer()
+    private void lockedReleaseEmptyDecryptedInputBuffer()
     {
         if (!_lock.isHeldByCurrentThread())
             throw new IllegalStateException();
@@ -481,7 +481,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
         }
     }
 
-    private void discardInputBuffers()
+    private void lockedDiscardInputBuffers()
     {
         if (!_lock.isHeldByCurrentThread())
             throw new IllegalStateException();
@@ -489,25 +489,25 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
             _encryptedInput.clear();
         if (_decryptedInput != null)
             _decryptedInput.clear();
-        releaseEmptyInputBuffers();
+        lockedReleaseEmptyInputBuffers();
     }
 
-    private void releaseEmptyInputBuffers()
+    private void lockedReleaseEmptyInputBuffers()
     {
-        releaseEmptyEncryptedInputBuffer();
-        releaseEmptyDecryptedInputBuffer();
+        lockedReleaseEmptyEncryptedInputBuffer();
+        lockedReleaseEmptyDecryptedInputBuffer();
     }
 
-    private void discardEncryptedOutputBuffer()
+    private void lockedDiscardEncryptedOutputBuffer()
     {
         if (!_lock.isHeldByCurrentThread())
             throw new IllegalStateException();
         if (_encryptedOutput != null)
             _encryptedOutput.clear();
-        releaseEmptyEncryptedOutputBuffer();
+        lockedReleaseEmptyEncryptedOutputBuffer();
     }
 
-    private void releaseEmptyEncryptedOutputBuffer()
+    private void lockedReleaseEmptyEncryptedOutputBuffer()
     {
         if (!_lock.isHeldByCurrentThread())
             throw new IllegalStateException();
@@ -720,7 +720,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
                                     throw new IllegalStateException("Unexpected HandshakeStatus " + status);
                             }
 
-                            acquireEncryptedInput();
+                            lockedAcquireEncryptedInput();
 
                             // can we use the passed buffer if it is big enough
                             ByteBuffer appIn;
@@ -838,14 +838,14 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
                                     // See also system property "jsse.SSLEngine.acceptLargeFragments".
                                     if ((_decryptedInput == null || !_decryptedInput.hasRemaining()) && appBufferSize < getApplicationBufferSize())
                                     {
-                                        releaseEmptyDecryptedInputBuffer();
+                                        lockedReleaseEmptyDecryptedInputBuffer();
                                         continue;
                                     }
                                     throw new IllegalStateException("Unexpected unwrap result " + unwrap);
 
                                 case OK:
                                     if (unwrapResult.getHandshakeStatus() == HandshakeStatus.FINISHED)
-                                        handshakeSucceeded();
+                                        lockedHandshakeSucceeded();
 
                                     if (isRenegotiating() && !allowRenegotiate())
                                         return filled = -1;
@@ -869,7 +869,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
                     }
                     catch (Throwable x)
                     {
-                        discardInputBuffers();
+                        lockedDiscardInputBuffers();
                         Throwable f = handleException(x, "fill");
                         Throwable failure = handshakeFailed(f);
                         if (_flushState == FlushState.WAIT_FOR_FILL)
@@ -881,7 +881,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
                     }
                     finally
                     {
-                        releaseEmptyInputBuffers();
+                        lockedReleaseEmptyInputBuffers();
 
                         if (_flushState == FlushState.WAIT_FOR_FILL)
                         {
@@ -984,7 +984,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
             }
         }
 
-        private void handshakeSucceeded() throws SSLException
+        private void lockedHandshakeSucceeded() throws SSLException
         {
             if (!_lock.isHeldByCurrentThread())
                 throw new IllegalStateException();
@@ -1126,7 +1126,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
                             }
 
                             int packetBufferSize = getPacketBufferSize();
-                            acquireEncryptedOutput();
+                            lockedAcquireEncryptedOutput();
 
                             if (_handshake.compareAndSet(HandshakeState.INITIAL, HandshakeState.HANDSHAKE))
                             {
@@ -1199,14 +1199,14 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
                                     // See also system property "jsse.SSLEngine.acceptLargeFragments".
                                     if (packetBufferSize < getPacketBufferSize())
                                     {
-                                        releaseEmptyEncryptedOutputBuffer();
+                                        lockedReleaseEmptyEncryptedOutputBuffer();
                                         continue;
                                     }
                                     throw new IllegalStateException("Unexpected wrap result " + wrap);
 
                                 case OK:
                                     if (wrapResult.getHandshakeStatus() == HandshakeStatus.FINISHED)
-                                        handshakeSucceeded();
+                                        lockedHandshakeSucceeded();
 
                                     if (isRenegotiating() && !allowRenegotiate())
                                     {
@@ -1237,13 +1237,13 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
                     }
                     catch (Throwable x)
                     {
-                        discardEncryptedOutputBuffer();
+                        lockedDiscardEncryptedOutputBuffer();
                         Throwable failure = handleException(x, "flush");
                         throw handshakeFailed(failure);
                     }
                     finally
                     {
-                        releaseEmptyEncryptedOutputBuffer();
+                        lockedReleaseEmptyEncryptedOutputBuffer();
                         if (LOG.isDebugEnabled())
                             LOG.debug("<flush {} {}", result, SslConnection.this);
                     }
@@ -1403,7 +1403,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
                                 try (AutoLock l = _lock.lock())
                                 {
                                     _flushState = FlushState.IDLE;
-                                    releaseEmptyEncryptedOutputBuffer();
+                                    lockedReleaseEmptyEncryptedOutputBuffer();
                                 }
                             }, t -> disconnect()), write);
                         }
@@ -1427,7 +1427,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
         {
             try (AutoLock l = _lock.lock())
             {
-                discardEncryptedOutputBuffer();
+                lockedDiscardEncryptedOutputBuffer();
             }
             getEndPoint().close();
         }
@@ -1476,7 +1476,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
         {
             try (AutoLock l = _lock.lock())
             {
-                discardInputBuffers();
+                lockedDiscardInputBuffers();
             }
             // First send the TLS Close Alert, then the FIN.
             doShutdownOutput(true);
@@ -1650,7 +1650,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
                 {
                     if (LOG.isDebugEnabled())
                         LOG.debug("IncompleteWriteCB succeeded {}", SslConnection.this);
-                    releaseEmptyEncryptedOutputBuffer();
+                    lockedReleaseEmptyEncryptedOutputBuffer();
                     _flushState = FlushState.IDLE;
 
                     interested = _fillState == FillState.INTERESTED;
@@ -1676,7 +1676,7 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
                     if (LOG.isDebugEnabled())
                         LOG.debug("IncompleteWriteCB failed {}", SslConnection.this, x);
 
-                    discardEncryptedOutputBuffer();
+                    lockedDiscardEncryptedOutputBuffer();
 
                     _flushState = FlushState.IDLE;
                     failFillInterest = _fillState == FillState.WAIT_FOR_FLUSH ||

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
@@ -376,6 +376,11 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
     {
         _open = false;
         getSslEndPoint().getConnection().onClose(cause);
+        try (AutoLock l = _lock.lock())
+        {
+            lockedDiscardInputBuffers();
+            lockedDiscardEncryptedOutputBuffer();
+        }
         super.onClose(cause);
     }
 

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
@@ -126,10 +126,12 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
     private FillState _fillState = FillState.IDLE;
     private boolean _underflown;
 
-    // Those fields have getters/setters not protected by the lock.
-    private boolean _renegotiationAllowed;
-    private int _renegotiationLimit = -1;
-    private boolean _requireCloseMessage;
+    private volatile boolean _open; // Must be volatile to make the protection against modifications of the below fields effective.
+    // The following fields have getters/setters not protected by the lock
+    // so they cannot be set once the _open boolean above is set to true.
+    private boolean _renegotiationAllowed; // Effectively final, set by ClientConnectionFactory.customize() right after creation.
+    private int _renegotiationLimit = -1; // Set by ClientConnectionFactory.customize() right after creation, and updated by a single thread.
+    private boolean _requireCloseMessage; // Effectively final, set by ClientConnectionFactory.customize() right after creation.
 
     private final Runnable _runFillable = new RunnableTask("runFillable")
     {
@@ -247,6 +249,8 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
 
     public void setRenegotiationAllowed(boolean renegotiationAllowed)
     {
+        if (_open)
+            throw new IllegalStateException("Cannot set renegotiation allowed on an open connection");
         _renegotiationAllowed = renegotiationAllowed;
     }
 
@@ -266,6 +270,8 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
      */
     public void setRenegotiationLimit(int renegotiationLimit)
     {
+        if (_open)
+            throw new IllegalStateException("Cannot set renegotiation limit on an open connection");
         _renegotiationLimit = renegotiationLimit;
     }
 
@@ -288,6 +294,8 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
      */
     public void setRequireCloseMessage(boolean requireCloseMessage)
     {
+        if (_open)
+            throw new IllegalStateException("Cannot set require close message on an open connection");
         _requireCloseMessage = requireCloseMessage;
     }
 
@@ -360,11 +368,13 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
     {
         super.onOpen();
         getSslEndPoint().getConnection().onOpen();
+        _open = true;
     }
 
     @Override
     public void onClose(Throwable cause)
     {
+        _open = false;
         getSslEndPoint().getConnection().onClose(cause);
         super.onClose(cause);
     }


### PR DESCRIPTION
Not all fields are accessed under a lock in `SslEndPoint`, so in this change I reviewed all field accesses to:

 - add locking around the field accesses where that was missing
 - add `isHeldByCurrentThread()` guards in private methods that assume they're called by a method holding the lock
 - modify `toConnectionString()` to read the fields under `tryLock` as that method is eventually called by `AbstractEndPoint.toString()`
 - comment the config properties that are not protected by the lock
 - add a volatile boolean protecting against modifications after `onOpen` the fields that are not protected by the lock
 - fix a buffer leak in `SslConnection` by discarding all buffers in `onClose()`

Fixes #13263
Fixes #13280