### PR TITLE
Fix Typo in http.adoc

### DIFF
--- a/documentation/jetty/modules/programming-guide/pages/server/http.adoc
+++ b/documentation/jetty/modules/programming-guide/pages/server/http.adoc
@@ -148,7 +148,7 @@ The default request/response log line format is the https://en.wikipedia.org/wik
 
 [NOTE]
 ====
-Typically, the extended NCSA format is the is enough and it's the standard used and understood by most log parsing tools and monitoring tools.
+Typically, the extended NCSA format is enough and it's the standard used and understood by most log parsing tools and monitoring tools.
 
 To customize the request/response log line format see the link:{javadoc-url}/org/eclipse/jetty/server/CustomRequestLog.html[`CustomRequestLog` javadocs].
 ====


### PR DESCRIPTION
Encountered a small grammatical mistake while going over the documentation.
This PR fixes this mistake.