### PR TITLE
Remove references to old jetty-ee#-ant, as it no longer exists.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1770,18 +1770,6 @@
                 <include>**/*.adoc</include>
               </includes>
               <excludes>
-                <!-- Sabre Holdings -->
-                <exclude>jetty-ee*/jetty-ee*-ant/src/main/java/org/eclipse/jetty/ee*/ant/AntWebAppContext.java</exclude>
-                <exclude>jetty-ee*/jetty-ee*-ant/src/main/java/org/eclipse/jetty/ee*/ant/types/Connectors.java</exclude>
-                <exclude>jetty-ee*/jetty-ee*-ant/src/main/java/org/eclipse/jetty/ee*/ant/types/ContextHandlers.java</exclude>
-                <exclude>jetty-ee*/jetty-ee*-ant/src/main/java/org/eclipse/jetty/ee*/ant/types/FileMatchingConfiguration.java</exclude>
-                <exclude>jetty-ee*/jetty-ee*-ant/src/main/java/org/eclipse/jetty/ee*/ant/types/LoginServices.java</exclude>
-                <exclude>jetty-ee*/jetty-ee*-ant/src/main/java/org/eclipse/jetty/ee*/ant/types/SystemProperties.java</exclude>
-                <exclude>jetty-ee*/jetty-ee*-ant/src/main/java/org/eclipse/jetty/ee*/ant/utils/ServerProxy.java</exclude>
-                <exclude>jetty-ee*/jetty-ee*-ant/src/main/java/org/eclipse/jetty/ee*/ant/utils/TaskLog.java</exclude>
-                <exclude>jetty-ee*/jetty-ee*-ant/src/main/java/org/eclipse/jetty/ee*/ant/AntWebXmlConfiguration.java</exclude>
-                <exclude>jetty-ee*/jetty-ee*-ant/src/main/java/org/eclipse/jetty/ee*/ant/JettyRunTask.java</exclude>
-                <exclude>jetty-ee*/jetty-ee*-ant/src/main/java/org/eclipse/jetty/ee*/ant/ServerProxyImpl.java</exclude>
                 <!-- Aki Yoshida -->
                 <exclude>jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/security/UnixCrypt.java</exclude>
                 <!-- Distribution Text (no header, too noisy) -->
@@ -1990,7 +1978,6 @@
         <configuration>
           <excludes>
             <!-- build tools -->
-            <exclude>**/org/eclipse/jetty/ant/**</exclude>
             <exclude>*/org/eclipse/jetty/maven/its/**</exclude>
             <!-- example code / documentation -->
             <exclude>**/org/eclipse/jetty/embedded/**</exclude>


### PR DESCRIPTION
Now that `jetty-ant` and `jetty-ee#-ant` are no more, the older references to those maven modules should be removed too.