### PR TITLE
Issue #13222 - tag `ResourceFactoryTest.testRegisterHttpsUrlFactory` as external

### DIFF
--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceFactoryTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceFactoryTest.java
@@ -34,6 +34,7 @@ import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.URIUtil;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -214,6 +215,7 @@ public class ResourceFactoryTest
     }
 
     @Test
+    @Tag("external")
     public void testRegisterHttpsUrlFactory() throws MalformedURLException
     {
         URI uri = URI.create("https://webtide.com/");


### PR DESCRIPTION

Closes #13222