### PR TITLE
`SslConnection`: discard all buffers in `onClose()`

### DIFF
--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
@@ -356,6 +356,11 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
     public void onClose(Throwable cause)
     {
         getSslEndPoint().getConnection().onClose(cause);
+        try (AutoLock l = _lock.lock())
+        {
+            discardInputBuffers();
+            discardEncryptedOutputBuffer();
+        }
         super.onClose(cause);
     }
 


### PR DESCRIPTION
Fixes #13280