### PR TITLE
Fixes #13087 - Why doesn't SocketAddressResolver API receive the context map?

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -576,7 +576,7 @@ public class HttpClient extends ContainerLifeCycle implements AutoCloseable
         if (transport.requiresDomainNameResolution())
         {
             Origin.Address address = origin.getAddress();
-            getSocketAddressResolver().resolve(address.getHost(), address.getPort(), new Promise<>()
+            getSocketAddressResolver().resolve(address.getHost(), address.getPort(), context, new Promise<>()
             {
                 @Override
                 public void succeeded(List<InetSocketAddress> socketAddresses)

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/ConnectionPoolTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/ConnectionPoolTest.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.client;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -294,14 +295,14 @@ public class ConnectionPoolTest
         client.setSocketAddressResolver(new SocketAddressResolver.Sync()
         {
             @Override
-            public void resolve(String host, int port, Promise<List<InetSocketAddress>> promise)
+            public void resolve(String host, int port, Map<String, Object> context, Promise<List<InetSocketAddress>> promise)
             {
                 client.getExecutor().execute(() ->
                 {
                     try
                     {
                         Thread.sleep(delay);
-                        super.resolve(host, port, promise);
+                        super.resolve(host, port, context, promise);
                     }
                     catch (InterruptedException x)
                     {
@@ -362,14 +363,14 @@ public class ConnectionPoolTest
         client.setSocketAddressResolver(new SocketAddressResolver.Sync()
         {
             @Override
-            public void resolve(String host, int port, Promise<List<InetSocketAddress>> promise)
+            public void resolve(String host, int port, Map<String, Object> context, Promise<List<InetSocketAddress>> promise)
             {
                 client.getExecutor().execute(() ->
                 {
                     try
                     {
                         Thread.sleep(100);
-                        super.resolve(host, port, promise);
+                        super.resolve(host, port, context, promise);
                     }
                     catch (InterruptedException x)
                     {

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
@@ -834,9 +834,9 @@ public class HttpClientTest extends AbstractHttpClientServerTest
             client.setSocketAddressResolver(new SocketAddressResolver.Async(client.getExecutor(), client.getScheduler(), 5000)
             {
                 @Override
-                public void resolve(String host, int port, Promise<List<InetSocketAddress>> promise)
+                public void resolve(String host, int port, Map<String, Object> context, Promise<List<InetSocketAddress>> promise)
                 {
-                    super.resolve(host, port, new Promise<>()
+                    super.resolve(host, port, context, new Promise<>()
                     {
                         @Override
                         public void succeeded(List<InetSocketAddress> result)

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/SocketAddressResolver.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/SocketAddressResolver.java
@@ -19,6 +19,7 @@ import java.net.SocketAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -41,9 +42,10 @@ public interface SocketAddressResolver
      *
      * @param host the host to resolve
      * @param port the port of the resulting socket address
+     * @param context the context information
      * @param promise the callback invoked when the resolution succeeds or fails
      */
-    public void resolve(String host, int port, Promise<List<InetSocketAddress>> promise);
+    public void resolve(String host, int port, Map<String, Object> context, Promise<List<InetSocketAddress>> promise);
 
     /**
      * <p>Creates {@link InetSocketAddress} instances synchronously in the caller thread.</p>
@@ -52,7 +54,7 @@ public interface SocketAddressResolver
     public static class Sync implements SocketAddressResolver
     {
         @Override
-        public void resolve(String host, int port, Promise<List<InetSocketAddress>> promise)
+        public void resolve(String host, int port, Map<String, Object> context, Promise<List<InetSocketAddress>> promise)
         {
             try
             {
@@ -140,7 +142,7 @@ public interface SocketAddressResolver
         }
 
         @Override
-        public void resolve(final String host, final int port, final Promise<List<InetSocketAddress>> promise)
+        public void resolve(final String host, final int port, Map<String, Object> context, final Promise<List<InetSocketAddress>> promise)
         {
             executor.execute(() ->
             {


### PR DESCRIPTION
Updated `SocketAddressResolver.resolve()` signature to accept the context Map.