### PR TITLE
Upgrade quiche to version 0.24.4

### DIFF
--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-common/src/main/java/org/eclipse/jetty/quic/quiche/Quiche.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-common/src/main/java/org/eclipse/jetty/quic/quiche/Quiche.java
@@ -92,7 +92,14 @@ public interface Quiche
         QUICHE_ERR_KEY_UPDATE = -19,
 
         // The peer sent more data in CRYPTO frames than we can buffer.
-        QUICHE_ERR_CRYPTO_BUFFER_EXCEEDED = -20;
+        QUICHE_ERR_CRYPTO_BUFFER_EXCEEDED = -20,
+
+        // The peer sent an ACK frame with an invalid range.
+        QUICHE_ERR_INVALID_ACK_RANGE = -21,
+
+        // The peer send an ACK frame for a skipped packet used for Optimistic ACK
+        // mitigation.
+        QUICHE_ERR_OPTIMISTIC_ACK_DETECTED = -22;
 
         static String errToString(long err)
         {
@@ -136,6 +143,10 @@ public interface Quiche
                 return "QUICHE_ERR_KEY_UPDATE";
             if (err == QUICHE_ERR_CRYPTO_BUFFER_EXCEEDED)
                 return "QUICHE_ERR_CRYPTO_BUFFER_EXCEEDED";
+            if (err == QUICHE_ERR_INVALID_ACK_RANGE)
+                return "QUICHE_ERR_INVALID_ACK_RANGE";
+            if (err == QUICHE_ERR_OPTIMISTIC_ACK_DETECTED)
+                return "QUICHE_ERR_OPTIMISTIC_ACK_DETECTED";
             return "?? " + err;
         }
     }

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/main/java/org/eclipse/jetty/quic/quiche/foreign/quiche_h.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/main/java/org/eclipse/jetty/quic/quiche/foreign/quiche_h.java
@@ -30,7 +30,7 @@ import static org.eclipse.jetty.quic.quiche.foreign.NativeHelper.C_POINTER;
 
 public class quiche_h
 {
-    private static final String EXPECTED_QUICHE_VERSION = "0.24.0";
+    private static final String EXPECTED_QUICHE_VERSION = "0.24.4";
     private static final Logger LOG = LoggerFactory.getLogger(quiche_h.class);
 
     static void initialize()

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/LibQuiche.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/LibQuiche.java
@@ -30,7 +30,7 @@ public interface LibQuiche extends Library
 {
     // This interface is a translation of the quiche.h header of a specific version.
     // It needs to be reviewed each time the native lib version changes.
-    String EXPECTED_QUICHE_VERSION = "0.24.0";
+    String EXPECTED_QUICHE_VERSION = "0.24.4";
 
     // The charset used to convert java.lang.String to char * and vice versa.
     Charset CHARSET = StandardCharsets.UTF_8;

--- a/pom.xml
+++ b/pom.xml
@@ -209,7 +209,7 @@
     <jboss.logging.processor.version>2.2.2.Final</jboss.logging.processor.version>
     <jboss.logging.version>3.6.1.Final</jboss.logging.version>
     <jetty-assembly-descriptors.version>1.1</jetty-assembly-descriptors.version>
-    <jetty-quiche-native.version>0.24.0</jetty-quiche-native.version>
+    <jetty-quiche-native.version>0.24.4</jetty-quiche-native.version>
     <jetty-test-policy.version>1.2</jetty-test-policy.version>
     <jetty-version.maven.plugin.version>2.7</jetty-version.maven.plugin.version>
     <jetty.perf-helper.version>1.0.7</jetty.perf-helper.version>


### PR DESCRIPTION
A couple of error constants where added to the C API, otherwise all other changes are limited to the implementation or the Rust API.

See https://github.com/cloudflare/quiche/compare/0.24.0...0.24.4 for the Quiche sources diff.

Closes https://github.com/jetty-project/jetty-quiche-native/issues/142