### PR TITLE
Make `Environment` implementation thread-safe to prevent `ConcurrentModificationException`

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/Environment.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/Environment.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
-import java.util.TreeMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 import org.eclipse.jetty.util.Attributes;
 import org.eclipse.jetty.util.TypeUtil;
@@ -82,7 +82,7 @@ public interface Environment extends Attributes
 
     class Named extends Attributes.Mapped implements Environment, Dumpable
     {
-        private static final Map<String, Environment> __environments = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        private static final Map<String, Environment> __environments = new ConcurrentSkipListMap<>(String.CASE_INSENSITIVE_ORDER);
         private final String _name;
         private final ClassLoader _classLoader;
 


### PR DESCRIPTION
Please note that 12.1.x had a proper fix that required reworking the `Environment` API, see: https://github.com/jetty/jetty.project/pull/12854

This change is about leaving the clunky 12.0.x API as-is, but just making the implementation thread-safe to avoid `ConcurrentModificationException` being thrown by tests running in parallel.

Fixes #13274