### PR TITLE
Issue #13291 remove: old slf4j osgi compat; unneeded osgi dependency

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -148,7 +148,7 @@ def mavenBuild(jdk, cmdline, mvnName) {
           }
           sh "mkdir ~/.mimir"
           sh "cp jenkins-mimir-daemon.properties ~/.mimir/daemon.properties"
-          sh "mvn $extraArgs $dashProfile -s $GLOBAL_MVN_SETTINGS -DsettingsPath=$GLOBAL_MVN_SETTINGS -Dmaven.repo.uri=http://nexus-service.nexus.svc.cluster.local:8081/repository/maven-public/ -ntp -Dmaven.repo.local=.repository -Pci -V -B -e -U $cmdline"
+          sh "mvn $extraArgs $dashProfile -s $GLOBAL_MVN_SETTINGS -Dsettings.path=$GLOBAL_MVN_SETTINGS -DsettingsPath=$GLOBAL_MVN_SETTINGS -Dmaven.repo.uri=http://nexus-service.nexus.svc.cluster.local:8081/repository/maven-public/ -ntp -Dmaven.repo.local=.repository -Pci -V -B -e -U $cmdline"
           if(saveHome()) {
             archiveArtifacts artifacts: ".repository/org/eclipse/jetty/jetty-home/**/jetty-home-*", allowEmptyArchive: true, onlyIfSuccessful: false
           }

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/pom.xml
@@ -544,7 +544,7 @@
             <skipTests>${skipTests}</skipTests>
             <systemPropertyVariables>
               <mavenRepoPath>${session.repositorySession.localRepository.basedir.absolutePath}</mavenRepoPath>
-              <settingsFilePath>${env.GLOBAL_MVN_SETTINGS}</settingsFilePath>
+              <settingsFilePath>${settings.path}</settingsFilePath>
               <!-- uncomment to be able to use jetty logging -->
               <!-- pax.exam.system>default</pax.exam.system -->
             </systemPropertyVariables>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/java/org/eclipse/jetty/ee10/osgi/test/TestJettyOSGiBootWithBundle.java
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/java/org/eclipse/jetty/ee10/osgi/test/TestJettyOSGiBootWithBundle.java
@@ -69,8 +69,7 @@ public class TestJettyOSGiBootWithBundle
         TestOSGiUtil.coreJettyDependencies(options);
         TestOSGiUtil.coreJspDependencies(options);
         options.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-alpn-java-client").versionAsInProject().start());
-        options.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-alpn-client").versionAsInProject().start());
-        //back down version of bnd used here because tinybundles expects only this version
+        options.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-alpn-client").versionAsInProject().start());xs
         options.add(mavenBundle().groupId("biz.aQute.bnd").artifactId("biz.aQute.bndlib").versionAsInProject().start());
         options.add(mavenBundle().groupId("biz.aQute.bnd").artifactId("biz.aQute.bnd.util").versionAsInProject().start());
         options.add(mavenBundle().groupId("org.ops4j.pax.tinybundles").artifactId("tinybundles").versionAsInProject().start());

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/java/org/eclipse/jetty/ee10/osgi/test/TestJettyOSGiBootWithBundle.java
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/java/org/eclipse/jetty/ee10/osgi/test/TestJettyOSGiBootWithBundle.java
@@ -69,7 +69,7 @@ public class TestJettyOSGiBootWithBundle
         TestOSGiUtil.coreJettyDependencies(options);
         TestOSGiUtil.coreJspDependencies(options);
         options.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-alpn-java-client").versionAsInProject().start());
-        options.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-alpn-client").versionAsInProject().start());xs
+        options.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-alpn-client").versionAsInProject().start());
         options.add(mavenBundle().groupId("biz.aQute.bnd").artifactId("biz.aQute.bndlib").versionAsInProject().start());
         options.add(mavenBundle().groupId("biz.aQute.bnd").artifactId("biz.aQute.bnd.util").versionAsInProject().start());
         options.add(mavenBundle().groupId("org.ops4j.pax.tinybundles").artifactId("tinybundles").versionAsInProject().start());

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/java/org/eclipse/jetty/ee10/osgi/test/TestJettyOSGiBootWithBundle.java
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/java/org/eclipse/jetty/ee10/osgi/test/TestJettyOSGiBootWithBundle.java
@@ -69,7 +69,7 @@ public class TestJettyOSGiBootWithBundle
         TestOSGiUtil.coreJettyDependencies(options);
         TestOSGiUtil.coreJspDependencies(options);
         options.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-alpn-java-client").versionAsInProject().start());
-        options.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-alpn-client").versionAsInProject().start());)
+        options.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-alpn-client").versionAsInProject().start());
         options.add(mavenBundle().groupId("biz.aQute.bnd").artifactId("biz.aQute.bndlib").versionAsInProject().start());
         options.add(mavenBundle().groupId("biz.aQute.bnd").artifactId("biz.aQute.bnd.util").versionAsInProject().start());
         options.add(mavenBundle().groupId("org.ops4j.pax.tinybundles").artifactId("tinybundles").versionAsInProject().start());

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/java/org/eclipse/jetty/ee10/osgi/test/TestJettyOSGiBootWithBundle.java
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/java/org/eclipse/jetty/ee10/osgi/test/TestJettyOSGiBootWithBundle.java
@@ -69,7 +69,7 @@ public class TestJettyOSGiBootWithBundle
         TestOSGiUtil.coreJettyDependencies(options);
         TestOSGiUtil.coreJspDependencies(options);
         options.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-alpn-java-client").versionAsInProject().start());
-        options.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-alpn-client").versionAsInProject().start());
+        options.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-alpn-client").versionAsInProject().start());)
         options.add(mavenBundle().groupId("biz.aQute.bnd").artifactId("biz.aQute.bndlib").versionAsInProject().start());
         options.add(mavenBundle().groupId("biz.aQute.bnd").artifactId("biz.aQute.bnd.util").versionAsInProject().start());
         options.add(mavenBundle().groupId("org.ops4j.pax.tinybundles").artifactId("tinybundles").versionAsInProject().start());

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/java/org/eclipse/jetty/ee10/osgi/test/TestJettyOSGiBootWithBundle.java
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/java/org/eclipse/jetty/ee10/osgi/test/TestJettyOSGiBootWithBundle.java
@@ -71,7 +71,8 @@ public class TestJettyOSGiBootWithBundle
         options.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-alpn-java-client").versionAsInProject().start());
         options.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-alpn-client").versionAsInProject().start());
         //back down version of bnd used here because tinybundles expects only this version
-        options.add(mavenBundle().groupId("biz.aQute.bnd").artifactId("biz.aQute.bndlib").version("3.5.0").start());
+        options.add(mavenBundle().groupId("biz.aQute.bnd").artifactId("biz.aQute.bndlib").versionAsInProject().start());
+        options.add(mavenBundle().groupId("biz.aQute.bnd").artifactId("biz.aQute.bnd.util").versionAsInProject().start());
         options.add(mavenBundle().groupId("org.ops4j.pax.tinybundles").artifactId("tinybundles").versionAsInProject().start());
         TinyBundle bundle = TinyBundles.bundle();
         bundle.addClass(SomeCustomBean.class);

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/java/org/eclipse/jetty/ee10/osgi/test/TestJettyOSGiBootWithJakartaWebSocket.java
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/java/org/eclipse/jetty/ee10/osgi/test/TestJettyOSGiBootWithJakartaWebSocket.java
@@ -85,7 +85,8 @@ public class TestJettyOSGiBootWithJakartaWebSocket
     {
         List<Option> res = new ArrayList<>();
         //Need an earlier version of bndlib because of tinybundles
-        res.add(mavenBundle().groupId("biz.aQute.bnd").artifactId("biz.aQute.bndlib").version("3.5.0").start());
+        res.add(mavenBundle().groupId("biz.aQute.bnd").artifactId("biz.aQute.bndlib").versionAsInProject().start());
+        res.add(mavenBundle().groupId("biz.aQute.bnd").artifactId("biz.aQute.bnd.util").versionAsInProject().start());
         res.add(mavenBundle().groupId("org.ops4j.pax.tinybundles").artifactId("tinybundles").versionAsInProject().start());
         return res;
     }

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/java/org/eclipse/jetty/ee10/osgi/test/TestJettyOSGiBootWithJakartaWebSocket.java
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/java/org/eclipse/jetty/ee10/osgi/test/TestJettyOSGiBootWithJakartaWebSocket.java
@@ -84,7 +84,6 @@ public class TestJettyOSGiBootWithJakartaWebSocket
     public static List<Option> extraDependencies()
     {
         List<Option> res = new ArrayList<>();
-        //Need an earlier version of bndlib because of tinybundles
         res.add(mavenBundle().groupId("biz.aQute.bnd").artifactId("biz.aQute.bndlib").versionAsInProject().start());
         res.add(mavenBundle().groupId("biz.aQute.bnd").artifactId("biz.aQute.bnd.util").versionAsInProject().start());
         res.add(mavenBundle().groupId("org.ops4j.pax.tinybundles").artifactId("tinybundles").versionAsInProject().start());

--- a/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/pom.xml
+++ b/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/pom.xml
@@ -547,7 +547,7 @@
             <systemPropertyVariables>
               <bundle.debug></bundle.debug>
               <mavenRepoPath>${session.repositorySession.localRepository.basedir.absolutePath}</mavenRepoPath>
-              <settingsFilePath>${env.GLOBAL_MVN_SETTINGS}</settingsFilePath>
+              <settingsFilePath>${settings.path}</settingsFilePath>
             </systemPropertyVariables>
             <!-- TODO -->
             <excludes>

--- a/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/java/org/eclipse/jetty/ee11/osgi/test/TestJettyOSGiBootWithJakartaWebSocket.java
+++ b/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/java/org/eclipse/jetty/ee11/osgi/test/TestJettyOSGiBootWithJakartaWebSocket.java
@@ -85,7 +85,8 @@ public class TestJettyOSGiBootWithJakartaWebSocket
     {
         List<Option> res = new ArrayList<>();
         //Need an earlier version of bndlib because of tinybundles
-        res.add(mavenBundle().groupId("biz.aQute.bnd").artifactId("biz.aQute.bndlib").version("3.5.0").start());
+        res.add(mavenBundle().groupId("biz.aQute.bnd").artifactId("biz.aQute.bndlib").versionAsInProject().start());
+        res.add(mavenBundle().groupId("biz.aQute.bnd").artifactId("biz.aQute.bnd.util").versionAsInProject().start());
         res.add(mavenBundle().groupId("org.ops4j.pax.tinybundles").artifactId("tinybundles").versionAsInProject().start());
         return res;
     }

--- a/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/java/org/eclipse/jetty/ee11/osgi/test/TestJettyOSGiBootWithJakartaWebSocket.java
+++ b/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/java/org/eclipse/jetty/ee11/osgi/test/TestJettyOSGiBootWithJakartaWebSocket.java
@@ -84,7 +84,6 @@ public class TestJettyOSGiBootWithJakartaWebSocket
     public static List<Option> extraDependencies()
     {
         List<Option> res = new ArrayList<>();
-        //Need an earlier version of bndlib because of tinybundles
         res.add(mavenBundle().groupId("biz.aQute.bnd").artifactId("biz.aQute.bndlib").versionAsInProject().start());
         res.add(mavenBundle().groupId("biz.aQute.bnd").artifactId("biz.aQute.bnd.util").versionAsInProject().start());
         res.add(mavenBundle().groupId("org.ops4j.pax.tinybundles").artifactId("tinybundles").versionAsInProject().start());

--- a/jetty-ee8/jetty-ee8-maven-plugin/src/it/jetty-maven-plugin-provided-module-dep/web/src/config/jetty.xml
+++ b/jetty-ee8/jetty-ee8-maven-plugin/src/it/jetty-maven-plugin-provided-module-dep/web/src/config/jetty.xml
@@ -39,7 +39,7 @@
         <Set name="host">
           <Property name="jetty.host"/>
         </Set>
-        <Set name="port"><Property name="jetty.port" default="0"/>0
+        <Set name="port"><Property name="jetty.port" default="0"/>
         </Set>
         <Set name="idleTimeout">30000</Set>
       </New>

--- a/jetty-ee8/jetty-ee8-maven-plugin/src/it/jetty-run-mojo-jar-scan-it/MyWebApp/pom.xml
+++ b/jetty-ee8/jetty-ee8-maven-plugin/src/it/jetty-run-mojo-jar-scan-it/MyWebApp/pom.xml
@@ -49,8 +49,9 @@
                   <value>${jetty.port.file}</value>
                 </systemProperty>
               </systemProperties>
-              <nonBlocking>true</nonBlocking>
-              <jettyXml>${basedir}/src/config/jetty.xml</jettyXml>
+              <jettyXmls>
+                <jettyXml>${basedir}/src/config/jetty.xml</jettyXml>
+              </jettyXmls>
               <contextXml>${basedir}/src/config/context.xml</contextXml>
               <useTestScope>true</useTestScope>
               <supportedPackagings>

--- a/jetty-ee8/jetty-ee8-osgi/test-jetty-ee8-osgi/pom.xml
+++ b/jetty-ee8/jetty-ee8-osgi/test-jetty-ee8-osgi/pom.xml
@@ -14,7 +14,7 @@
     <annotation.groupId>jakarta.annotation</annotation.groupId>
     <assembly-directory>target/distribution</assembly-directory>
     <bundle-symbolic-name>${project.groupId}.boot.test.osgi</bundle-symbolic-name>
-    <bundle.debug>true</bundle.debug>
+    <bundle.debug>false</bundle.debug>
     <!-- too many duplicates with osgi jars... -->
     <duplicate-finder.skip>true</duplicate-finder.skip>
     <ee9.module>jetty-ee9-osgi/test-jetty-ee9-osgi</ee9.module>

--- a/jetty-ee8/jetty-ee8-osgi/test-jetty-ee8-osgi/pom.xml
+++ b/jetty-ee8/jetty-ee8-osgi/test-jetty-ee8-osgi/pom.xml
@@ -567,7 +567,7 @@
               <mavenRepoPath>${session.repositorySession.localRepository.basedir.absolutePath}</mavenRepoPath>
               <pax.exam.debug.port>${pax.exam.debug.port}</pax.exam.debug.port>
               <pax.exam.LEVEL>${pax.exam.LEVEL}</pax.exam.LEVEL>
-              <settingsFilePath>${env.GLOBAL_MVN_SETTINGS}</settingsFilePath>
+              <settingsFilePath>${settings.path}</settingsFilePath>
               <servlet.artifactId>${servlet.artifactId}</servlet.artifactId>
               <inject.groupId>${inject.groupId}</inject.groupId>
               <inject.artifactId>${inject.artifactId}</inject.artifactId>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/pom.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/pom.xml
@@ -542,7 +542,7 @@
             <skipTests>${skipTests}</skipTests>
             <systemPropertyVariables>
               <mavenRepoPath>${session.repositorySession.localRepository.basedir.absolutePath}</mavenRepoPath>
-              <settingsFilePath>${env.GLOBAL_MVN_SETTINGS}</settingsFilePath>
+              <settingsFilePath>${settings.path}</settingsFilePath>
             </systemPropertyVariables>
             <!-- TODO -->
           </configuration>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/java/org/eclipse/jetty/ee9/osgi/test/TestJettyOSGiAnnotationParser.java
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/java/org/eclipse/jetty/ee9/osgi/test/TestJettyOSGiAnnotationParser.java
@@ -52,6 +52,7 @@ public class TestJettyOSGiAnnotationParser
     {
         ArrayList<Option> options = new ArrayList<>();
         options.add(TestOSGiUtil.optionalRemoteDebug());
+        options.addAll(TestOSGiUtil.configurePaxExamLogging());
         options.add(CoreOptions.junitBundles());
         TestOSGiUtil.coreJettyDependencies(options);
         TestOSGiUtil.coreJspDependencies(options);

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/java/org/eclipse/jetty/ee9/osgi/test/TestJettyOSGiBootWithJakartaWebSocket.java
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/java/org/eclipse/jetty/ee9/osgi/test/TestJettyOSGiBootWithJakartaWebSocket.java
@@ -83,7 +83,8 @@ public class TestJettyOSGiBootWithJakartaWebSocket
     {
         List<Option> res = new ArrayList<>();
         //Need an earlier version of bndlib because of tinybundles
-        res.add(mavenBundle().groupId("biz.aQute.bnd").artifactId("biz.aQute.bndlib").version("3.5.0").start());
+        res.add(mavenBundle().groupId("biz.aQute.bnd").artifactId("biz.aQute.bndlib").versionAsInProject().start());
+        res.add(mavenBundle().groupId("biz.aQute.bnd").artifactId("biz.aQute.bnd.util").versionAsInProject().start());
         res.add(mavenBundle().groupId("org.ops4j.pax.tinybundles").artifactId("tinybundles").versionAsInProject().start());
         return res;
     }

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/java/org/eclipse/jetty/ee9/osgi/test/TestJettyOSGiBootWithJakartaWebSocket.java
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/java/org/eclipse/jetty/ee9/osgi/test/TestJettyOSGiBootWithJakartaWebSocket.java
@@ -82,7 +82,6 @@ public class TestJettyOSGiBootWithJakartaWebSocket
     public static List<Option> extraDependencies()
     {
         List<Option> res = new ArrayList<>();
-        //Need an earlier version of bndlib because of tinybundles
         res.add(mavenBundle().groupId("biz.aQute.bnd").artifactId("biz.aQute.bndlib").versionAsInProject().start());
         res.add(mavenBundle().groupId("biz.aQute.bnd").artifactId("biz.aQute.bnd.util").versionAsInProject().start());
         res.add(mavenBundle().groupId("org.ops4j.pax.tinybundles").artifactId("tinybundles").versionAsInProject().start());

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/java/org/eclipse/jetty/ee9/osgi/test/TestJettyOSGiClasspathResources.java
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/java/org/eclipse/jetty/ee9/osgi/test/TestJettyOSGiClasspathResources.java
@@ -115,8 +115,6 @@ public class TestJettyOSGiClasspathResources
         Bundle bundle = TestOSGiUtil.getBundle(bundleContext, "org.eclipse.jetty.ee9.osgi.webapp.resources.alt");
         bundle.start();
 
-
-
         try (HttpClient client = new HttpClient())
         {
             client.start();

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/java/org/eclipse/jetty/ee9/osgi/test/TestJettyOSGiClasspathResources.java
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/java/org/eclipse/jetty/ee9/osgi/test/TestJettyOSGiClasspathResources.java
@@ -115,6 +115,8 @@ public class TestJettyOSGiClasspathResources
         Bundle bundle = TestOSGiUtil.getBundle(bundleContext, "org.eclipse.jetty.ee9.osgi.webapp.resources.alt");
         bundle.start();
 
+
+
         try (HttpClient client = new HttpClient())
         {
             client.start();

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/java/org/eclipse/jetty/ee9/osgi/test/TestOSGiUtil.java
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/java/org/eclipse/jetty/ee9/osgi/test/TestOSGiUtil.java
@@ -162,30 +162,7 @@ public class TestOSGiUtil
             res.add(systemProperty("org.ops4j.pax.url.mvn.settings").value(System.getProperty("settingsFilePath")));
         }
 
-        res.add(mavenBundle().groupId("org.slf4j").artifactId("slf4j-api").version("1.7.36").startLevel(START_LEVEL_SYSTEM_BUNDLES)); //.versionAsInProject().noStart());
-
-        /*
-         * Jetty 12 uses slf4j 2.0.0 by default, however we want to test with slf4j 1.7.30 for backwards compatibility.
-         * To do that, we need to use slf4j-simple as the logging implementation. We make a simplelogger.properties
-         * file available so that jetty logging can be configured
-         */
-        // BEGIN - slf4j 1.7.x
-        /* slf4j-simple conflicts with both slf4j 1.7.x, and jetty-slf4j-impl. (but in different ways) */
-
-        //TinyBundle simpleLoggingPropertiesBundle = TinyBundles.bundle();
-        //simpleLoggingPropertiesBundle.add("simplelogger.properties", ClassLoader.getSystemResource("simplelogger.properties"));
-        //simpleLoggingPropertiesBundle.set(Constants.BUNDLE_SYMBOLICNAME, "simple-logger-properties");
-        //simpleLoggingPropertiesBundle.set(Constants.FRAGMENT_HOST, "slf4j-simple");
-        //simpleLoggingPropertiesBundle.add(FragmentActivator.class);
-        //res.add(CoreOptions.streamBundle(simpleLoggingPropertiesBundle.build()).noStart());
-        //res.add(mavenBundle().groupId("org.slf4j").artifactId("slf4j-simple").version("1.7.36").startLevel(START_LEVEL_SYSTEM_BUNDLES)); // .versionAsInProject()
-
-        // END - slf4j 1.7.x
-
-        /*
-         * When running with slf4j >= 2.0.0, remove the slf4j simple logger above and uncomment the following lines
-         */
-        // BEGIN - slf4j 2.x
+        res.add(mavenBundle().groupId("org.slf4j").artifactId("slf4j-api").versionAsInProject().noStart());
         TinyBundle loggingPropertiesBundle = TinyBundles.bundle();
         loggingPropertiesBundle.addResource("jetty-logging.properties", ClassLoader.getSystemResource("jetty-logging.properties"));
         loggingPropertiesBundle.setHeader(Constants.BUNDLE_SYMBOLICNAME, "jetty-logging-properties");
@@ -193,7 +170,6 @@ public class TestOSGiUtil
         loggingPropertiesBundle.addClass(FragmentActivator.class);
         res.add(CoreOptions.streamBundle(loggingPropertiesBundle.build()).noStart());
         res.add(mavenBundle().groupId("org.eclipse.jetty").artifactId("jetty-slf4j-impl").versionAsInProject().start());
-        // END - slf4j 2.x
 
         String servletGroupId = System.getProperty("servlet.groupId", "org.eclipse.jetty.toolchain");
         String servletArtifactId = System.getProperty("servlet.artifactId", "jetty-jakarta-servlet-api");
@@ -216,8 +192,8 @@ public class TestOSGiUtil
         res.add(mavenBundle().groupId("org.osgi").artifactId("org.osgi.util.position").versionAsInProject());
         res.add(mavenBundle().groupId("org.osgi").artifactId("org.osgi.util.tracker").versionAsInProject());
         res.add(mavenBundle().groupId("org.osgi").artifactId("org.osgi.util.xml").versionAsInProject());
-        res.add(mavenBundle().groupId("org.eclipse.platform").artifactId("org.eclipse.osgi.services").versionAsInProject());
         res.add(mavenBundle().groupId("org.osgi").artifactId("org.osgi.service.repository").versionAsInProject());
+        //Do not remove the following line! Even though it is not needed for ee9, it is needed in ee8
         res.add(mavenBundle().groupId("org.eclipse.platform").artifactId("org.eclipse.equinox.http.service.api").versionAsInProject());
         res.add(mavenBundle().groupId("org.ow2.asm").artifactId("asm").versionAsInProject().start());
         res.add(mavenBundle().groupId("org.ow2.asm").artifactId("asm-commons").versionAsInProject().start());

--- a/pom.xml
+++ b/pom.xml
@@ -327,8 +327,8 @@
     <project.build.outputTimestamp>2025-06-20T11:22:23Z</project.build.outputTimestamp>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <reactive-streams.version>1.0.4</reactive-streams.version>
+    <settings.path></settings.path>
     <settingsPath>src/it/settings.xml</settingsPath>
-    <settings.path />
     <sisu.plexus.version>0.9.0.M3</sisu.plexus.version>
     <slf4j.version>2.0.17</slf4j.version>
     <spifly.version>1.3.7</spifly.version>

--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <reactive-streams.version>1.0.4</reactive-streams.version>
     <settingsPath>src/it/settings.xml</settingsPath>
+    <settings.path />
     <sisu.plexus.version>0.9.0.M3</sisu.plexus.version>
     <slf4j.version>2.0.17</slf4j.version>
     <spifly.version>1.3.7</spifly.version>


### PR DESCRIPTION
- Removed old `slf4j` compat code in ee8/9 osgi tests as it is irrelevant.
- Reduced noise of ee8 osgi tests.
- Removed unneeded osgi dependency (which also reduced logging during tests).
