### PR TITLE
Race Condition in WebSocketConnection - Job failed: java.lang.IllegalStateException: FILLING_AND_PARSING

### DIFF
--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConnection.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConnection.java
@@ -489,6 +489,7 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
 
         acquireNetworkBuffer();
 
+        boolean registerFillInterested = false;
         try
         {
             while (true)
@@ -539,7 +540,7 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
                 if (filled == 0)
                 {
                     releaseNetworkBuffer();
-                    fillInterested();
+                    registerFillInterested = true;
                     return;
                 }
 
@@ -575,6 +576,8 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
             }
             if (close)
                 doOnClose(closeCause);
+            else if (registerFillInterested)
+                fillInterested();
         }
     }
 

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConnection.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConnection.java
@@ -75,6 +75,7 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
     {
         IDLE,
         FILLING_AND_PARSING,
+        MORE_FILLING_AND_PARSING,
         CLOSING,
         CLOSED
     }
@@ -240,6 +241,7 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
                     break;
                 }
                 case FILLING_AND_PARSING:
+                case MORE_FILLING_AND_PARSING:
                 {
                     state = State.CLOSING;
                     break;
@@ -470,6 +472,7 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
             switch (state)
             {
                 case IDLE -> state = State.FILLING_AND_PARSING;
+                case FILLING_AND_PARSING -> state = State.MORE_FILLING_AND_PARSING;
                 case CLOSED ->
                 {
                     return;
@@ -478,100 +481,110 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
             }
         }
 
-        acquireNetworkBuffer();
-
-        boolean registerFillInterested = false;
-        try
+        boolean fillingAndParsing = true;
+        while (fillingAndParsing)
         {
-            while (true)
+            acquireNetworkBuffer();
+
+            boolean registerFillInterested = false;
+            try
             {
-                // Parse and handle frames
-                while (networkBuffer.hasRemaining())
+                while (true)
                 {
-                    Frame.Parsed frame = parser.parse(networkBuffer.getByteBuffer());
-                    if (frame == null)
-                        break;
-
-                    messagesIn.increment();
-
-                    if (meetDemand())
-                        onFrame(frame);
-
-                    if (!moreDemand())
-                        return;
-                }
-
-                // buffer must be empty here because parser is fully consuming
-                assert (!networkBuffer.hasRemaining());
-
-                if (!getEndPoint().isOpen())
-                {
-                    releaseNetworkBuffer();
-                    return;
-                }
-
-                // If more references that 1(us), don't refill into buffer and risk compaction.
-                if (networkBuffer.isRetained())
-                    reacquireNetworkBuffer();
-
-                // The parser is fully consuming so we can clear the network buffer before filling.
-                networkBuffer.clear();
-                int filled = getEndPoint().fill(networkBuffer.getByteBuffer());
-
-                if (LOG.isDebugEnabled())
-                    LOG.debug("endpointFill() filled={}: {}", filled, networkBuffer);
-
-                if (filled < 0)
-                {
-                    releaseNetworkBuffer();
-                    coreSession.onEof();
-                    return;
-                }
-
-                if (filled == 0)
-                {
-                    releaseNetworkBuffer();
-                    registerFillInterested = true;
-                    return;
-                }
-
-                bytesIn.add(filled);
-            }
-        }
-        catch (Throwable t)
-        {
-            if (LOG.isDebugEnabled())
-                LOG.debug("Error during fillAndParse() {}", t.toString());
-
-            if (networkBuffer != null)
-            {
-                BufferUtil.clear(networkBuffer.getByteBuffer());
-                releaseNetworkBuffer();
-            }
-            coreSession.processConnectionError(t, Callback.NOOP);
-        }
-        finally
-        {
-            boolean close = false;
-            Throwable closeCause = null;
-            try (AutoLock ignored = lock.lock())
-            {
-                switch (state)
-                {
-                    case FILLING_AND_PARSING -> state = State.IDLE;
-                    case CLOSING ->
+                    // Parse and handle frames
+                    while (networkBuffer.hasRemaining())
                     {
-                        state = State.CLOSED;
-                        close = true;
-                        closeCause = this.closeCause;
+                        Frame.Parsed frame = parser.parse(networkBuffer.getByteBuffer());
+                        if (frame == null)
+                            break;
+
+                        messagesIn.increment();
+
+                        if (meetDemand())
+                            onFrame(frame);
+
+                        if (!moreDemand())
+                            return;
                     }
-                    default -> throw new IllegalStateException(state.name());
+
+                    // buffer must be empty here because parser is fully consuming
+                    assert (!networkBuffer.hasRemaining());
+
+                    if (!getEndPoint().isOpen())
+                    {
+                        releaseNetworkBuffer();
+                        return;
+                    }
+
+                    // If more references that 1(us), don't refill into buffer and risk compaction.
+                    if (networkBuffer.isRetained())
+                        reacquireNetworkBuffer();
+
+                    // The parser is fully consuming so we can clear the network buffer before filling.
+                    networkBuffer.clear();
+                    int filled = getEndPoint().fill(networkBuffer.getByteBuffer());
+
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("endpointFill() filled={}: {}", filled, networkBuffer);
+
+                    if (filled < 0)
+                    {
+                        releaseNetworkBuffer();
+                        coreSession.onEof();
+                        return;
+                    }
+
+                    if (filled == 0)
+                    {
+                        releaseNetworkBuffer();
+                        registerFillInterested = true;
+                        return;
+                    }
+
+                    bytesIn.add(filled);
                 }
             }
-            if (close)
-                doOnClose(closeCause);
-            else if (registerFillInterested)
-                fillInterested();
+            catch (Throwable t)
+            {
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Error during fillAndParse() {}", t.toString());
+
+                if (networkBuffer != null)
+                {
+                    BufferUtil.clear(networkBuffer.getByteBuffer());
+                    releaseNetworkBuffer();
+                }
+                coreSession.processConnectionError(t, Callback.NOOP);
+            }
+            finally
+            {
+                fillingAndParsing = false;
+                boolean close = false;
+                Throwable closeCause = null;
+                try (AutoLock ignored = lock.lock())
+                {
+                    switch (state)
+                    {
+                        case MORE_FILLING_AND_PARSING ->
+                        {
+                            fillingAndParsing = true;
+                            state = State.FILLING_AND_PARSING;
+                        }
+                        case FILLING_AND_PARSING -> state = State.IDLE;
+                        case CLOSING ->
+                        {
+                            state = State.CLOSED;
+                            close = true;
+                            closeCause = this.closeCause;
+                        }
+                        default -> throw new IllegalStateException(state.name());
+                    }
+                }
+                if (close)
+                    doOnClose(closeCause);
+                else if (registerFillInterested)
+                    fillInterested();
+            }
         }
     }
 

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConnection.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConnection.java
@@ -472,8 +472,12 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
             switch (state)
             {
                 case IDLE -> state = State.FILLING_AND_PARSING;
-                case FILLING_AND_PARSING -> state = State.MORE_FILLING_AND_PARSING;
-                case CLOSED ->
+                case FILLING_AND_PARSING ->
+                {
+                    state = State.MORE_FILLING_AND_PARSING;
+                    return;
+                }
+                case CLOSED, CLOSING ->
                 {
                     return;
                 }

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConnection.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConnection.java
@@ -571,8 +571,16 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
                     {
                         case MORE_FILLING_AND_PARSING ->
                         {
-                            fillingAndParsing = true;
-                            state = State.FILLING_AND_PARSING;
+                            if (registerFillInterested)
+                            {
+                                // We had no content to read, so no point looping around again.
+                                state = State.IDLE;
+                            }
+                            else
+                            {
+                                fillingAndParsing = true;
+                                state = State.FILLING_AND_PARSING;
+                            }
                         }
                         case FILLING_AND_PARSING -> state = State.IDLE;
                         case CLOSING ->

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConnection.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConnection.java
@@ -465,8 +465,6 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
 
     private void fillAndParse()
     {
-        boolean close = false;
-        Throwable closeCause = null;
         try (AutoLock ignored = lock.lock())
         {
             switch (state)
@@ -474,17 +472,10 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
                 case IDLE -> state = State.FILLING_AND_PARSING;
                 case CLOSED ->
                 {
-                    close = true;
-                    closeCause = this.closeCause;
+                    return;
                 }
                 default -> throw new IllegalStateException(state.name());
             }
-        }
-
-        if (close)
-        {
-            doOnClose(closeCause);
-            return;
         }
 
         acquireNetworkBuffer();
@@ -561,6 +552,8 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
         }
         finally
         {
+            boolean close = false;
+            Throwable closeCause = null;
             try (AutoLock ignored = lock.lock())
             {
                 switch (state)
@@ -568,6 +561,7 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
                     case FILLING_AND_PARSING -> state = State.IDLE;
                     case CLOSING ->
                     {
+                        state = State.CLOSED;
                         close = true;
                         closeCause = this.closeCause;
                     }

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConnection.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConnection.java
@@ -331,26 +331,20 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
 
     private void acquireNetworkBuffer()
     {
-        try (AutoLock l = lock.lock())
-        {
-            if (networkBuffer == null)
-                networkBuffer = newNetworkBuffer(getInputBufferSize());
-        }
+        if (networkBuffer == null)
+            networkBuffer = newNetworkBuffer(getInputBufferSize());
     }
 
     private void reacquireNetworkBuffer()
     {
-        try (AutoLock l = lock.lock())
-        {
-            if (networkBuffer == null)
-                throw new IllegalStateException();
+        if (networkBuffer == null)
+            throw new IllegalStateException();
 
-            if (networkBuffer.getByteBuffer().hasRemaining())
-                throw new IllegalStateException();
+        if (networkBuffer.getByteBuffer().hasRemaining())
+            throw new IllegalStateException();
 
-            networkBuffer.release();
-            networkBuffer = newNetworkBuffer(getInputBufferSize());
-        }
+        networkBuffer.release();
+        networkBuffer = newNetworkBuffer(getInputBufferSize());
     }
 
     private RetainableByteBuffer newNetworkBuffer(int capacity)
@@ -360,17 +354,14 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
 
     private void releaseNetworkBuffer()
     {
-        try (AutoLock l = lock.lock())
-        {
-            if (networkBuffer == null)
-                throw new IllegalStateException();
+        if (networkBuffer == null)
+            throw new IllegalStateException();
 
-            if (networkBuffer.hasRemaining())
-                throw new IllegalStateException();
+        if (networkBuffer.hasRemaining())
+            throw new IllegalStateException();
 
-            networkBuffer.release();
-            networkBuffer = null;
-        }
+        networkBuffer.release();
+        networkBuffer = null;
     }
 
     @Override
@@ -392,10 +383,10 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
     public void demand()
     {
         boolean fillAndParse = false;
-        try (AutoLock l = lock.lock())
+        try (AutoLock ignored = lock.lock())
         {
             if (LOG.isDebugEnabled())
-                LOG.debug("demand {} d={} fp={} {}", demand, fillingAndParsing, networkBuffer, this);
+                LOG.debug("demand {} fp={} {}", demand, fillingAndParsing, this);
 
             if (demand != DemandState.CANCELLED)
             {
@@ -417,7 +408,7 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
 
     public boolean moreDemand()
     {
-        try (AutoLock l = lock.lock())
+        try (AutoLock ignored = lock.lock())
         {
             if (LOG.isDebugEnabled())
                 LOG.debug("moreDemand? d={} fp={} {} {}", demand, fillingAndParsing, networkBuffer, this);
@@ -446,7 +437,7 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
 
     public boolean meetDemand()
     {
-        try (AutoLock l = lock.lock())
+        try (AutoLock ignored = lock.lock())
         {
             if (LOG.isDebugEnabled())
                 LOG.debug("meetDemand d={} fp={} {} {}", demand, fillingAndParsing, networkBuffer, this);
@@ -464,7 +455,7 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
 
     public void cancelDemand()
     {
-        try (AutoLock l = lock.lock())
+        try (AutoLock ignored = lock.lock())
         {
             if (LOG.isDebugEnabled())
                 LOG.debug("cancelDemand d={} fp={} {} {}", demand, fillingAndParsing, networkBuffer, this);
@@ -598,10 +589,7 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
     {
         if (LOG.isDebugEnabled())
             LOG.debug("Set initial buffer - {}", BufferUtil.toDetailString(initialBuffer));
-        try (AutoLock l = lock.lock())
-        {
-            networkBuffer = newNetworkBuffer(initialBuffer.remaining());
-        }
+        networkBuffer = newNetworkBuffer(initialBuffer.remaining());
         ByteBuffer buffer = networkBuffer.getByteBuffer();
         BufferUtil.clearToFill(buffer);
         BufferUtil.put(initialBuffer, buffer);

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConnection.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConnection.java
@@ -64,11 +64,11 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
     /*
      * The state of the WebSocketConnection, used to serialize fillingAndParsing with connection close events.
      * <pre>
-     *   IDLE   <------> FILLING_AND_PARSING
-     *     |                 |
-     *     |                 |
-     *     v                 v
-     *   CLOSED <-------- CLOSING
+     *   IDLE   <------> FILLING_AND_PARSING  <------> MORE_FILLING_AND_PARSING
+     *     |                 |                           |
+     *     |                 |                           |
+     *     v                 v                           |
+     *   CLOSED <-------- CLOSING <----------------------+
      * </pre>
      */
     private enum State


### PR DESCRIPTION
After PR https://github.com/jetty/jetty.project/pull/13264 there is a new race condition that can prevent a `WebSocketConnection` from completing.

```
2025-06-30 16:19:10.123:WARN :oejut.QueuedThreadPool:qtp-LocalServer-827: Job failed
java.lang.IllegalStateException: FILLING_AND_PARSING
	at org.eclipse.jetty.websocket.core.WebSocketConnection.fillAndParse(WebSocketConnection.java:489)
	at org.eclipse.jetty.websocket.core.WebSocketConnection.run(WebSocketConnection.java:389)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:981)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.doRunJob(QueuedThreadPool.java:1211)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1166)
	at java.base/java.lang.Thread.run(Thread.java:840)
```

This stacktrace can be seen in `jetty-12.0.x` HEAD on build job for JDK17 and JDK21 (doesn't happen in JDK24) -
* https://jenkins.webtide.net/blue/organizations/jenkins/jetty.project/detail/jetty-12.0.x/2565/pipeline/12