### PR TITLE
Mail archive fix for WS status code 1014

### DIFF
--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/StatusCode.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/StatusCode.java
@@ -135,7 +135,7 @@ public final class StatusCode
     /**
      * 1014 indicates that a gateway or proxy received and invalid upstream response.
      * <p>
-     * See <a href="https://www.ietf.org/mail-archive/web/hybi/current/msg10748.html">[hybi] WebSocket Subprotocol Close Code: Bad Gateway</a>
+     * See <a href="https://mailarchive.ietf.org/arch/msg/hybi/l1lK4ZImO70jmcYorRa1lsLdvzY/">[hybi] WebSocket Subprotocol Close Code: Bad Gateway</a>
      */
     public static final int INVALID_UPSTREAM_RESPONSE = 1014;
 


### PR DESCRIPTION
I noticed that the original link https://www.ietf.org/mail-archive/web/hybi/current/msg10748.html now just redirects to the whole mailing list archive, losing the message identifier. I tried to find the specific message which proposed this specific code number: https://mailarchive.ietf.org/arch/msg/hybi/l1lK4ZImO70jmcYorRa1lsLdvzY/

Note that other mailing list links in the same class are similarly bad. Not sure if there is some more official URL somewhere indicating the currently official list of codes. If so, I failed to find it.

For reference I actually came across the bad link originally in https://www.iana.org/assignments/websocket/websocket.xhtml#close-code-number and only secondarily in Jetty documentation.

I believe this is @aamelnikov in charge?