### PR TITLE
Fixes #13343 - Module eeN-quickstart should depend on eeN-annotations.

### DIFF
--- a/jetty-ee10/jetty-ee10-quickstart/src/main/config/modules/ee10-quickstart.mod
+++ b/jetty-ee10/jetty-ee10-quickstart/src/main/config/modules/ee10-quickstart.mod
@@ -8,6 +8,7 @@ ee10
 
 [depend]
 server
+ee10-annotations
 ee10-deploy
 
 [lib]

--- a/jetty-ee10/jetty-ee10-quickstart/src/main/config/modules/ee10-quickstart.mod
+++ b/jetty-ee10/jetty-ee10-quickstart/src/main/config/modules/ee10-quickstart.mod
@@ -9,7 +9,8 @@ ee10
 [depend]
 server
 ee10-annotations
-ee10-deploy
+ee10-webapp
+ee10-plus
 
 [lib]
 lib/jetty-ee10-quickstart-${jetty.version}.jar

--- a/jetty-ee11/jetty-ee11-quickstart/src/main/config/modules/ee11-quickstart.mod
+++ b/jetty-ee11/jetty-ee11-quickstart/src/main/config/modules/ee11-quickstart.mod
@@ -9,7 +9,8 @@ ee11
 [depend]
 server
 ee11-annotations
-ee11-deploy
+ee11-webapp
+ee11-plus
 
 [lib]
 lib/jetty-ee11-quickstart-${jetty.version}.jar

--- a/jetty-ee11/jetty-ee11-quickstart/src/main/config/modules/ee11-quickstart.mod
+++ b/jetty-ee11/jetty-ee11-quickstart/src/main/config/modules/ee11-quickstart.mod
@@ -8,6 +8,7 @@ ee11
 
 [depend]
 server
+ee11-annotations
 ee11-deploy
 
 [lib]

--- a/jetty-ee8/jetty-ee8-quickstart/src/main/config/modules/ee8-quickstart.mod
+++ b/jetty-ee8/jetty-ee8-quickstart/src/main/config/modules/ee8-quickstart.mod
@@ -9,7 +9,8 @@ ee8
 [depend]
 server
 ee8-annotations
-ee8-deploy
+ee8-webapp
+ee8-plus
 
 [lib]
 lib/jetty-ee8-quickstart-${jetty.version}.jar

--- a/jetty-ee8/jetty-ee8-quickstart/src/main/config/modules/ee8-quickstart.mod
+++ b/jetty-ee8/jetty-ee8-quickstart/src/main/config/modules/ee8-quickstart.mod
@@ -8,6 +8,7 @@ ee8
 
 [depend]
 server
+ee8-annotations
 ee8-deploy
 
 [lib]

--- a/jetty-ee9/jetty-ee9-quickstart/src/main/config/modules/ee9-quickstart.mod
+++ b/jetty-ee9/jetty-ee9-quickstart/src/main/config/modules/ee9-quickstart.mod
@@ -8,6 +8,7 @@ ee9
 
 [depend]
 server
+ee9-annotations
 ee9-deploy
 
 [lib]

--- a/jetty-ee9/jetty-ee9-quickstart/src/main/config/modules/ee9-quickstart.mod
+++ b/jetty-ee9/jetty-ee9-quickstart/src/main/config/modules/ee9-quickstart.mod
@@ -9,7 +9,8 @@ ee9
 [depend]
 server
 ee9-annotations
-ee9-deploy
+ee9-webapp
+ee9-plus
 
 [lib]
 lib/jetty-ee9-quickstart-${jetty.version}.jar

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -202,10 +202,8 @@ public class DistributionTests extends AbstractJettyHomeTest
 
         String mods = String.join(",",
             "resources", "server", "http",
-            toEnvironment("webapp", env),
             toEnvironment("deploy", env),
             toEnvironment("apache-jsp", env),
-            toEnvironment("servlet", env),
             toEnvironment("quickstart", env)
         );
         try (JettyHomeTester.Run run1 = distribution.start("--approve-all-licenses", "--add-modules=" + mods))


### PR DESCRIPTION
Added dependency on `eeN-annotations` in `eeN-quickstart.mod` files.