### PR TITLE
Fix `IllegalStateException` when aborting a blocking write

### DIFF
--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
@@ -629,7 +629,8 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
                             break;
                         }
 
-                        // Set a close callback on the HttpOutput to make it an async callback
+                        // Set a close callback on the HttpOutput to make it an async callback;
+                        // the response may already have been completed when the callback runs if completeOutput() decides to abort.
                         _response.completeOutput(Callback.from(NON_BLOCKING, () -> _state.completed(null), _state::completed));
 
                         break;

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannelState.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannelState.java
@@ -1019,6 +1019,10 @@ public class HttpChannelState
             if (LOG.isDebugEnabled())
                 LOG.debug("completed {}", toStringLocked());
 
+            // If abort() was already called, this is a no-op.
+            if (_requestState == RequestState.COMPLETED)
+                return;
+
             if (_requestState != RequestState.COMPLETING)
                 throw new IllegalStateException(this.getStatusStringLocked(), failure);
 


### PR DESCRIPTION
Fixes #13312

Only EE9 is impacted, EE10/11 have an equivalent test that behaves properly.

The test logging the warning is `org.eclipse.jetty.ee9.nested.BlockingTest.testBlockingWriteThenNormalComplete()`.