### PR TITLE
Cleanup remaining accumulators usage

### DIFF
--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractRetainableByteBuffer.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/AbstractRetainableByteBuffer.java
@@ -20,7 +20,7 @@ import java.nio.ByteBuffer;
  * reference counting.</p>
  * @deprecated
  */
-@Deprecated(forRemoval = true)
+@Deprecated(forRemoval = true, since = "12.1.0")
 public abstract class AbstractRetainableByteBuffer extends RetainableByteBuffer.FixedCapacity
 {
     private final ReferenceCounter _refCount;

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferAccumulator.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferAccumulator.java
@@ -31,7 +31,7 @@ import org.eclipse.jetty.util.BufferUtil;
  * @see #ensureBuffer(int, int)
  * @deprecated Use {@link RetainableByteBuffer.DynamicCapacity}
  */
-@Deprecated(forRemoval = true)
+@Deprecated(forRemoval = true, since = "12.1.0")
 public class ByteBufferAccumulator implements AutoCloseable
 {
     private final List<RetainableByteBuffer> _buffers = new ArrayList<>();

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferAggregator.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ByteBufferAggregator.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  * <p>The buffers are taken from the supplied {@link ByteBufferPool} or freshly allocated if one is not supplied.</p>
  * @deprecated Use {@link RetainableByteBuffer.DynamicCapacity}
  */
-@Deprecated(forRemoval = true)
+@Deprecated(forRemoval = true, since = "12.1.0")
 public class ByteBufferAggregator
 {
     private static final Logger LOG = LoggerFactory.getLogger(ByteBufferAggregator.class);

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ByteBufferAccumulatorTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ByteBufferAccumulatorTest.java
@@ -28,7 +28,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@Deprecated(forRemoval = true)
+@Deprecated(forRemoval = true, since = "12.1.0")
 public class ByteBufferAccumulatorTest
 {
     private CountingBufferPool bufferPool;

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ByteBufferAggregatorTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ByteBufferAggregatorTest.java
@@ -23,7 +23,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@Deprecated
+@Deprecated(forRemoval = true, since = "12.1.0")
 public class ByteBufferAggregatorTest
 {
     private ArrayByteBufferPool.Tracking bufferPool;

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ChunkAccumulatorTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ChunkAccumulatorTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@Deprecated(forRemoval = true, since = "12.1.0")
 public class ChunkAccumulatorTest
 {
     @Test

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ConnectorTimeoutTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ConnectorTimeoutTest.java
@@ -23,7 +23,6 @@ import java.util.concurrent.Exchanger;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLHandshakeException;
 
-import org.eclipse.jetty.io.ByteBufferAccumulator;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.io.RetainableByteBuffer;
@@ -581,7 +580,7 @@ public abstract class ConnectorTimeoutTest extends HttpServerTestFixture
      * A handler that will echo the request body to the response body, but only
      * once the entire body content has been received.
      */
-    public static class EchoWholeHandler extends Handler.Abstract
+    public class EchoWholeHandler extends Handler.Abstract
     {
         @Override
         public boolean handle(Request request, Response response, Callback callback) throws Exception
@@ -601,19 +600,19 @@ public abstract class ConnectorTimeoutTest extends HttpServerTestFixture
          * Accumulate the Request body until it's entirely received,
          * then write the body back to the response body.
          */
-        private static class WholeProcess implements Runnable
+        private class WholeProcess implements Runnable
         {
             Request request;
             Response response;
             Callback callback;
-            ByteBufferAccumulator bufferAccumulator;
+            RetainableByteBuffer.DynamicCapacity bufferAccumulator;
 
             public WholeProcess(Request request, Response response, Callback callback)
             {
                 this.request = request;
                 this.response = response;
                 this.callback = callback;
-                this.bufferAccumulator = new ByteBufferAccumulator();
+                this.bufferAccumulator = new RetainableByteBuffer.DynamicCapacity(_bufferPool);
             }
 
             @Override
@@ -629,17 +628,17 @@ public abstract class ConnectorTimeoutTest extends HttpServerTestFixture
                     }
                     if (Content.Chunk.isFailure(chunk))
                     {
+                        bufferAccumulator.release();
                         callback.failed(chunk.getFailure());
                         return;
                     }
                     // copy buffer
-                    bufferAccumulator.copyBuffer(chunk.getByteBuffer().slice());
+                    bufferAccumulator.append(chunk);
                     chunk.release();
                     if (chunk.isLast())
                     {
                         // write accumulated buffers
-                        RetainableByteBuffer buffer = bufferAccumulator.toRetainableByteBuffer();
-                        response.write(true, buffer.getByteBuffer(), Callback.from(buffer::release, callback));
+                        response.write(true, bufferAccumulator.getByteBuffer(), Callback.from(bufferAccumulator::release, callback));
                         return;
                     }
                 }

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/messages/ByteBufferMessageSink.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/messages/ByteBufferMessageSink.java
@@ -15,8 +15,6 @@ package org.eclipse.jetty.websocket.core.messages;
 
 import java.nio.ByteBuffer;
 
-import org.eclipse.jetty.io.ByteBufferCallbackAccumulator;
-import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.RetainableByteBuffer;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.websocket.core.CoreSession;
@@ -31,7 +29,7 @@ import org.eclipse.jetty.websocket.core.util.MethodHolder;
  */
 public class ByteBufferMessageSink extends AbstractMessageSink
 {
-    private ByteBufferCallbackAccumulator accumulator;
+    private RetainableByteBuffer.DynamicCapacity accumulator;
 
     /**
      * Creates a new {@link ByteBufferMessageSink}.
@@ -50,7 +48,7 @@ public class ByteBufferMessageSink extends AbstractMessageSink
     {
         try
         {
-            long size = (accumulator == null ? 0 : accumulator.getLength()) + frame.getPayloadLength();
+            long size = (accumulator == null ? 0 : accumulator.size()) + frame.getPayloadLength();
             long maxSize = getCoreSession().getMaxBinaryMessageSize();
             if (maxSize > 0 && size > maxSize)
             {
@@ -60,7 +58,7 @@ public class ByteBufferMessageSink extends AbstractMessageSink
 
             // If the frame is fin and no accumulator has been
             // created or used, then we don't need to aggregate.
-            if (frame.isFin() && (accumulator == null || accumulator.getLength() == 0))
+            if (frame.isFin() && (accumulator == null || accumulator.isEmpty()))
             {
                 invoke(getMethodHolder(), frame.getPayload(), callback);
                 autoDemand();
@@ -75,17 +73,16 @@ public class ByteBufferMessageSink extends AbstractMessageSink
             }
 
             if (accumulator == null)
-                accumulator = new ByteBufferCallbackAccumulator();
-            accumulator.addEntry(frame.getPayload(), callback);
+                accumulator = new RetainableByteBuffer.DynamicCapacity(getCoreSession().getByteBufferPool(), frame.getPayload().isDirect(), -1L);
+            RetainableByteBuffer.Mutable rbb = RetainableByteBuffer.wrap(frame.getPayload(), callback::succeeded);
+            if (accumulator.append(rbb))
+                rbb.release();
 
             if (frame.isFin())
             {
-                ByteBufferPool bufferPool = getCoreSession().getByteBufferPool();
-                RetainableByteBuffer buffer = bufferPool.acquire(accumulator.getLength(), false);
-                ByteBuffer byteBuffer = buffer.getByteBuffer();
-                accumulator.writeTo(byteBuffer);
+                RetainableByteBuffer buffer = accumulator.take();
                 callback = Callback.from(buffer::release);
-                invoke(getMethodHolder(), byteBuffer, callback);
+                invoke(getMethodHolder(), buffer.getByteBuffer(), callback);
                 autoDemand();
             }
             else
@@ -105,7 +102,10 @@ public class ByteBufferMessageSink extends AbstractMessageSink
     public void fail(Throwable failure)
     {
         if (accumulator != null)
-            accumulator.fail(failure);
+        {
+            accumulator.release();
+            accumulator = null;
+        }
     }
 
     protected void invoke(MethodHolder methodHolder, ByteBuffer byteBuffer, Callback callback) throws Throwable

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/messages/ByteBufferMessageSink.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/messages/ByteBufferMessageSink.java
@@ -52,7 +52,9 @@ public class ByteBufferMessageSink extends AbstractMessageSink
             long maxSize = getCoreSession().getMaxBinaryMessageSize();
             if (maxSize > 0 && size > maxSize)
             {
-                callback.failed(new MessageTooLargeException(String.format("Binary message too large: %,d > %,d", size, maxSize)));
+                MessageTooLargeException failure = new MessageTooLargeException(String.format("Binary message too large: %,d > %,d", size, maxSize));
+                fail(failure);
+                callback.failed(failure);
                 return;
             }
 
@@ -75,8 +77,10 @@ public class ByteBufferMessageSink extends AbstractMessageSink
             if (accumulator == null)
                 accumulator = new RetainableByteBuffer.DynamicCapacity(getCoreSession().getByteBufferPool(), frame.getPayload().isDirect(), -1L);
             RetainableByteBuffer.Mutable rbb = RetainableByteBuffer.wrap(frame.getPayload(), callback::succeeded);
-            if (accumulator.append(rbb))
-                rbb.release();
+            // Since the accumulator has an unlimited max size, append() will never return false
+            // so there is no need to check its return value.
+            accumulator.append(rbb);
+            rbb.release();
 
             if (frame.isFin())
             {

--- a/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/extensions/PermessageDeflateDemandTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/extensions/PermessageDeflateDemandTest.java
@@ -20,7 +20,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jetty.io.ArrayByteBufferPool;
-import org.eclipse.jetty.io.ByteBufferCallbackAccumulator;
+import org.eclipse.jetty.io.RetainableByteBuffer;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.BlockingArrayQueue;
@@ -118,14 +118,14 @@ public class PermessageDeflateDemandTest
         return BufferUtil.toBuffer(bytes);
     }
 
-    public static class ServerHandler implements FrameHandler
+    public class ServerHandler implements FrameHandler
     {
         private CoreSession _coreSession;
         private byte _messageType;
         public BlockingQueue<String> textMessages = new BlockingArrayQueue<>();
         public BlockingQueue<ByteBuffer> binaryMessages = new BlockingArrayQueue<>();
         private StringBuilder _stringBuilder = new StringBuilder();
-        private ByteBufferCallbackAccumulator _byteBuilder = new ByteBufferCallbackAccumulator();
+        private RetainableByteBuffer.DynamicCapacity _byteBuilder = new RetainableByteBuffer.DynamicCapacity();
 
         @Override
         public void onOpen(CoreSession coreSession, Callback callback)
@@ -166,11 +166,13 @@ public class PermessageDeflateDemandTest
                         }
                         break;
                     case OpCode.BINARY:
-                        _byteBuilder.addEntry(frame.getPayload(), callback);
+                        RetainableByteBuffer.Mutable rbb = RetainableByteBuffer.wrap(frame.getPayload(), callback::succeeded);
+                        if (_byteBuilder.append(rbb))
+                            rbb.release();
                         if (frame.isFin())
                         {
                             binaryMessages.add(BufferUtil.toBuffer(_byteBuilder.takeByteArray()));
-                            _byteBuilder = new ByteBufferCallbackAccumulator();
+                            _byteBuilder = new RetainableByteBuffer.DynamicCapacity(_bufferPool);
                         }
                         break;
                     default:


### PR DESCRIPTION
Remove the last few usages of `ByteBufferAccumulator` we have left (2 in tests, 1 in WebSocket code) and properly mark all legacy accumulators/aggregators and their tests as deprecated with a `since` tag.

Closes #11952