### PR TITLE
Fixes #12300: add null check in RewriteHandler.doStart() and unit test

### DIFF
--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RewriteHandler.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RewriteHandler.java
@@ -143,6 +143,15 @@ public class RewriteHandler extends Handler.Wrapper
         return input.handle(response, callback);
     }
 
+    @Override
+    protected void doStart() throws Exception {
+        if (getHandler() == null) {
+            throw new IllegalStateException("RewriteHandler requires a child Handler " +
+                    "before starting.");
+        }
+        super.doStart();
+    }
+
     private static class LastRuleHandler extends Rule.Handler
     {
         private final Handler _handler;

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RewriteHandler.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/RewriteHandler.java
@@ -143,15 +143,6 @@ public class RewriteHandler extends Handler.Wrapper
         return input.handle(response, callback);
     }
 
-    @Override
-    protected void doStart() throws Exception {
-        if (getHandler() == null) {
-            throw new IllegalStateException("RewriteHandler requires a child Handler " +
-                    "before starting.");
-        }
-        super.doStart();
-    }
-
     private static class LastRuleHandler extends Rule.Handler
     {
         private final Handler _handler;
@@ -165,6 +156,9 @@ public class RewriteHandler extends Handler.Wrapper
         @Override
         protected boolean handle(Response response, Callback callback) throws Exception
         {
+            if (_handler == null)
+                throw new IllegalStateException("RewriteHandler: Child handler is not set.");
+
             return _handler.handle(getWrapped(), response, callback);
         }
     }

--- a/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/RewriteHandlerMissingChildTest.java
+++ b/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/RewriteHandlerMissingChildTest.java
@@ -1,0 +1,64 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.rewrite.handler;
+
+import java.util.List;
+
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.LocalConnector;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RewriteHandlerMissingChildTest
+{
+    private final Server _server = new Server();
+    private final LocalConnector _connector =
+            new LocalConnector(_server, new HttpConnectionFactory(new HttpConfiguration()));
+    private final RewriteHandler _rewriteHandler = new RewriteHandler();
+
+    @AfterEach
+    public void tearDown()
+    {
+        LifeCycle.stop(_server);
+    }
+
+    @Test
+    public void testChildHandlerIsNullThrowsException() throws Exception
+    {
+        _rewriteHandler.setRules(List.of(new RewriteRegexRule("/xxx/(.*)", "/$1/zzz")));
+        _rewriteHandler.setOriginalPathAttribute("originalPath");
+
+        _server.addConnector(_connector);
+        _server.setHandler(_rewriteHandler);
+        _server.start();
+
+        String request = """
+            GET /xxx/bar HTTP/1.1
+            Host: localhost
+                        
+            """;
+
+        HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse(request));
+
+        assertEquals(500, response.getStatus(), "Expected HTTP 500 error from RewriteHandler");
+        assertEquals("Server Error", response.getReason());
+
+    }
+}

--- a/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/RewriteHandlerTest.java
+++ b/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/RewriteHandlerTest.java
@@ -123,21 +123,4 @@ public class RewriteHandlerTest extends AbstractRuleTest
         assertEquals("/x%20y/zzz", response.get("X-Path"));
         assertEquals("/xxx/x%20y", response.get("X-Original-Path"));
     }
-
-    @Test
-    public void testThrowsIfNoChildHandlerSet() {
-        RewriteHandler rewriteHandler = new RewriteHandler();
-        rewriteHandler.setRules(List.of(
-                new RewritePatternRule("/bug/*", "/fix")
-        ));
-
-        IllegalStateException exception = org.junit.jupiter.api.Assertions.assertThrows(
-                IllegalStateException.class,
-                rewriteHandler::start,
-                "Expected start() to throw if no child handler is set"
-        );
-
-        assertEquals("RewriteHandler requires a child Handler before starting.",
-                exception.getMessage());
-    }
 }

--- a/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/RewriteHandlerTest.java
+++ b/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/RewriteHandlerTest.java
@@ -123,4 +123,21 @@ public class RewriteHandlerTest extends AbstractRuleTest
         assertEquals("/x%20y/zzz", response.get("X-Path"));
         assertEquals("/xxx/x%20y", response.get("X-Original-Path"));
     }
+
+    @Test
+    public void testThrowsIfNoChildHandlerSet() {
+        RewriteHandler rewriteHandler = new RewriteHandler();
+        rewriteHandler.setRules(List.of(
+                new RewritePatternRule("/bug/*", "/fix")
+        ));
+
+        IllegalStateException exception = org.junit.jupiter.api.Assertions.assertThrows(
+                IllegalStateException.class,
+                rewriteHandler::start,
+                "Expected start() to throw if no child handler is set"
+        );
+
+        assertEquals("RewriteHandler requires a child Handler before starting.",
+                exception.getMessage());
+    }
 }


### PR DESCRIPTION
Added null check in RewriteHandler#doStart() to prevent misuse when no child Handler is set. included a test verifying the behavior.