### PR TITLE
Improve JSP scratch directory creation and error message.

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletHolder.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletHolder.java
@@ -17,6 +17,8 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -679,17 +681,28 @@ public class ServletHolder extends Holder<Servlet> implements Comparable<Servlet
         }
 
         /* ensure scratch dir */
-        File scratch;
+        Path scratchDir;
         if (getInitParameter("scratchdir") == null)
         {
             File tmp = (File)getServletHandler().getServletContext().getAttribute(ServletContext.TEMPDIR);
-            scratch = new File(tmp, "jsp");
-            setInitParameter("scratchdir", scratch.getAbsolutePath());
+            scratchDir = tmp.toPath().resolve("jsp");
+            setInitParameter("scratchdir", scratchDir.toAbsolutePath().toString());
         }
 
-        scratch = new File(getInitParameter("scratchdir"));
-        if (!scratch.exists() && !scratch.mkdir())
-            throw new IllegalStateException("Could not create JSP scratch directory");
+        scratchDir = Path.of(getInitParameter("scratchdir"));
+        if (!Files.isDirectory(scratchDir))
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("Creating JSP scratch directory: {}", scratchDir);
+            try
+            {
+                Files.createDirectories(scratchDir);
+            }
+            catch (Throwable e)
+            {
+                throw new IllegalStateException("Could not create JSP scratch directory", e);
+            }
+        }
     }
 
     @ManagedAttribute(value = "role to run servlet as", readonly = true)


### PR DESCRIPTION
+ Using `Files.createDirectories(Path)` as this version does an atomic deep directory creation, and produces clear exceptions when the creation of the directory fails. (Unlike `File.mkdirs()`)