### PR TITLE
Issue #13364 change deploy WARN to DEBUG

### DIFF
--- a/jetty-core/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/ScanningAppProvider.java
+++ b/jetty-core/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/providers/ScanningAppProvider.java
@@ -181,7 +181,8 @@ public abstract class ScanningAppProvider extends ContainerLifeCycle implements 
             }
         }
 
-        LOG.warn("{} no environment for {}, ignoring", this, app);
+        if (LOG.isDebugEnabled())
+            LOG.debug("{} no matching environment for {}, ignoring", this, app);
         return null;
     }
 
@@ -449,6 +450,6 @@ public abstract class ScanningAppProvider extends ContainerLifeCycle implements 
     @Override
     public String toString()
     {
-        return String.format("%s@%x%s", this.getClass(), hashCode(), _monitored);
+        return String.format("%s@%x[%s]%s", this.getClass(), hashCode(), _environmentName, _monitored);
     }
 }


### PR DESCRIPTION
closes #13364

Whilst we have changed the deployer in jetty-12.1, these `WARN` messages in jetty-12.0 pollute the log output, making it look as if a webapp has not been deployed when it has.  The message is merely communicating that this particular `ScanningAppProvider` is not deploying the webapp because the environment doesn't match (or is missing entirely).

I've changed the `WARN` to a `DEBUG`, but also changed the log message to include the environment name so it's a little clearer. I'm happy  if we don't want to make it a `DEBUG` level, but I think `WARN` is wrong, and could maybe be `INFO` instead? Really, it's only a `WARN` if no `ScanningAppProvider` deployed the webapp, but with the 12.0.x deployer, that's too hard to tell.