### PR TITLE
Issue #13368 - Bad UrlParameterDecoder.parse() return value.

### DIFF
--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ComplianceTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ComplianceTest.java
@@ -10,6 +10,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 // ========================================================================
 //
+
 package org.eclipse.jetty.server;
 
 import java.util.ArrayList;

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ComplianceTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ComplianceTest.java
@@ -1,0 +1,153 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+package org.eclipse.jetty.server;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import org.eclipse.jetty.http.ComplianceViolation;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.http.UriCompliance;
+import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.util.BlockingArrayQueue;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.Fields;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Test various {@link org.eclipse.jetty.http.ComplianceViolation} behaviors with actual requests.
+ */
+public class ComplianceTest
+{
+    private Server server;
+    private LocalConnector localConnector;
+
+    @AfterEach
+    public void stopServer()
+    {
+        LifeCycle.stop(server);
+    }
+
+    protected void startServer(Consumer<Server> serverConsumer) throws Exception
+    {
+        server = new Server();
+        localConnector = new LocalConnector(server);
+        server.addConnector(localConnector);
+
+        if (serverConsumer != null)
+            serverConsumer.accept(server);
+
+        server.start();
+    }
+
+    public static Stream<Arguments> queryComplianceCases()
+    {
+        List<Arguments> cases = new ArrayList<>();
+        for (UriCompliance compliance : List.of(UriCompliance.DEFAULT, UriCompliance.LEGACY, UriCompliance.RFC3986))
+        {
+            cases.add(Arguments.of(compliance, "query=blocked=%2F%2F%E6%84%9B%22",
+                Map.of("query", "blocked=//愛\"")));
+            cases.add(Arguments.of(compliance, "query=buster=1752874099305",
+                Map.of("query", "buster=1752874099305")));
+            cases.add(Arguments.of(compliance, "query=startup=1",
+                Map.of("query", "startup=1")));
+        }
+        return cases.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("queryComplianceCases")
+    public void testQueryCompliance(UriCompliance compliance, String rawQuery, Map<String, String> expectedMap) throws Exception
+    {
+        Queue<ComplianceViolation.Event> events = new BlockingArrayQueue<>();
+
+        ComplianceViolation.Listener listener = new ComplianceViolation.Listener()
+        {
+            @Override
+            public void onComplianceViolation(ComplianceViolation.Event event)
+            {
+                new RuntimeException("Huh?").printStackTrace(System.err);
+                events.add(event);
+            }
+        };
+
+        startServer(server ->
+        {
+            localConnector.getContainedBeans(HttpConfiguration.class)
+                .forEach(httpConfig ->
+                {
+                    httpConfig.setUriCompliance(compliance);
+                    httpConfig.addComplianceViolationListener(listener);
+                });
+
+            server.setHandler(new Handler.Abstract()
+            {
+                @Override
+                public boolean handle(Request request, Response response, Callback callback)
+                {
+                    try
+                    {
+                        StringBuilder body = new StringBuilder();
+                        body.append("raw-path-query=").append(request.getHttpURI().getPathQuery());
+                        Fields fields = Request.getParameters(request);
+                        for (Fields.Field field : fields)
+                        {
+                            body.append("\nfield[").append(field.getName());
+                            body.append("]=").append(field.getValues());
+                        }
+                        Content.Sink.write(response, true, body.toString(), callback);
+                        return true;
+                    }
+                    catch (Exception e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                }
+            });
+        });
+
+        String rawRequest = """
+            GET /test?%s HTTP/1.1
+            Host: local
+            Connection: close
+            
+            """.formatted(rawQuery);
+
+        String rawResponse = localConnector.getResponse(rawRequest);
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertEquals(200, response.getStatus());
+        String responseBody = response.getContent();
+        assertThat(responseBody, containsString(rawQuery));
+        expectedMap.forEach((key, value) -> assertThat(responseBody, containsString("field[%s]=[%s]".formatted(key, value))));
+
+        // Shouldn't see any compliance violation events
+        assertEquals(0, events.size(), () ->
+        {
+            StringBuilder msg = new StringBuilder();
+            events.forEach(event -> msg.append("event:").append(event).append("\n"));
+            return msg.toString();
+        });
+    }
+}

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/UrlEncoded.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/UrlEncoded.java
@@ -368,7 +368,7 @@ public class UrlEncoded
         UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, adder, -1, -1, allowBadUtf8, allowBadPercent, allowTruncatedUtf8);
         try
         {
-            return decoder.parse(query, offset, length);
+            return !decoder.parse(query, offset, length);
         }
         catch (IOException e)
         {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/UrlParameterDecoder.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/UrlParameterDecoder.java
@@ -39,6 +39,7 @@ class UrlParameterDecoder
     private String name;
     private int keyCount;
     private int charCount;
+    private boolean codingError = false;
 
     public UrlParameterDecoder(CharsetStringBuilder charsetStringBuilder, BiConsumer<String, String> newFieldAdder)
     {
@@ -164,7 +165,7 @@ class UrlParameterDecoder
         }
 
         complete();
-        return builder.hasCodingErrors();
+        return codingError;
     }
 
     /**
@@ -223,6 +224,7 @@ class UrlParameterDecoder
                 }
                 catch (NumberFormatException e)
                 {
+                    codingError = true;
                     boolean replaced = builder.replaceIncomplete();
                     if (replaced && !allowBadEncoding || !allowBadPercent)
                         throw new IllegalArgumentException(notValidPctEncoding((char)hi, (char)lo));
@@ -273,12 +275,14 @@ class UrlParameterDecoder
     {
         if (builder.replaceIncomplete())
         {
+            codingError = true;
             if (!allowBadEncoding || !allowBadPercent)
                 throw new IllegalArgumentException(notValidPctEncoding((char)hi, (char)0));
             return false;
         }
         else if (allowBadPercent)
         {
+            codingError = true;
             builder.append('%');
             if (hi != -1)
                 builder.append((char)hi);
@@ -286,6 +290,7 @@ class UrlParameterDecoder
         }
         else
         {
+            codingError = true;
             throw new IllegalArgumentException(notValidPctEncoding((char)hi, (char)0));
         }
     }
@@ -295,6 +300,9 @@ class UrlParameterDecoder
         buffer.append((byte)((convertHexDigit(hi) << 4) + convertHexDigit(lo)));
     }
 
+    /**
+     * Finish up any remaining character sequences.
+     */
     private void complete() throws CharacterCodingException
     {
         if (name != null)
@@ -320,22 +328,26 @@ class UrlParameterDecoder
         if (!allowBadEncoding && !allowBadPercent && !allowTruncatedEncoding)
         {
             String result = builder.build(false);
+            codingError |= builder.hasCodingErrors();
             builder.reset();
             return result;
         }
 
-        boolean codingError = builder.hasCodingErrors();
+        codingError |= builder.hasCodingErrors();
         if (codingError && !allowBadEncoding)
         {
             return builder.build(false);
         }
 
-        if (builder.replaceIncomplete() && !allowTruncatedEncoding)
+        boolean replaced = builder.replaceIncomplete();
+        codingError |= replaced;
+        if (replaced && !allowTruncatedEncoding)
         {
             return builder.build(false);
         }
 
         String result = builder.build(true);
+        codingError |= builder.hasCodingErrors();
         builder.reset();
         return result;
     }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/UrlParameterDecoder.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/UrlParameterDecoder.java
@@ -153,6 +153,7 @@ class UrlParameterDecoder
 
     private boolean parseCompletely(CharIterator iter) throws IOException
     {
+        codingError = false;
         int i;
         while ((i = iter.next()) >= 0)
         {

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/UrlParameterDecoderTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/UrlParameterDecoderTest.java
@@ -40,8 +40,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class UrlParameterDecoderTest
@@ -99,7 +101,7 @@ public class UrlParameterDecoderTest
         UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add);
 
         String input = "a=b&c=d";
-        decoder.parse(input);
+        assertFalse(decoder.parse(input), "No coding errors");
 
         assertEquals("b", fields.getValue("a"));
         assertEquals("d", fields.getValue("c"));
@@ -148,7 +150,7 @@ public class UrlParameterDecoderTest
         CharsetStringBuilder charsetStringBuilder = CharsetStringBuilder.forCharset(UTF_8);
         UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add);
 
-        decoder.parse(input);
+        assertFalse(decoder.parse(input), "No coding errors");
 
         assertThat("Field count", fields.getSize(), is(expectedParams.size()));
 
@@ -171,7 +173,7 @@ public class UrlParameterDecoderTest
         UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add);
 
         String input = "text=%E0%B8%9F%E0%B8%AB%E0%B8%81%E0%B8%A7%E0%B8%94%E0%B8%B2%E0%B9%88%E0%B8%81%E0%B8%9F%E0%B8%A7%E0%B8%AB%E0%B8%AA%E0%B8%94%E0%B8%B2%E0%B9%88%E0%B8%AB%E0%B8%9F%E0%B8%81%E0%B8%A7%E0%B8%94%E0%B8%AA%E0%B8%B2%E0%B8%9F%E0%B8%81%E0%B8%AB%E0%B8%A3%E0%B8%94%E0%B9%89%E0%B8%9F%E0%B8%AB%E0%B8%99%E0%B8%81%E0%B8%A3%E0%B8%94%E0%B8%B5&Action=Submit";
-        decoder.parse(input);
+        assertFalse(decoder.parse(input), "No coding errors");
 
         String hex = "E0B89FE0B8ABE0B881E0B8A7E0B894E0B8B2E0B988E0B881E0B89FE0B8A7E0B8ABE0B8AAE0B894E0B8B2E0B988E0B8ABE0B89FE0B881E0B8A7E0B894E0B8AAE0B8B2E0B89FE0B881E0B8ABE0B8A3E0B894E0B989E0B89FE0B8ABE0B899E0B881E0B8A3E0B894E0B8B5";
         String expected = new String(StringUtil.fromHexString(hex), UTF_8);
@@ -186,7 +188,7 @@ public class UrlParameterDecoderTest
         UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add);
 
         String input = "text=test%C3%A4";
-        decoder.parse(input);
+        assertFalse(decoder.parse(input), "No coding errors");
 
         // http://www.ltg.ed.ac.uk/~richard/utf-8.cgi?input=00e4&mode=hex
         // Should be "testä"
@@ -234,14 +236,10 @@ public class UrlParameterDecoderTest
     @MethodSource("invalidTestData")
     public <X extends Throwable> void testInvalidDecode(Charset charset, String input, Class<X> expectedThrowableType)
     {
-        assertThrows(expectedThrowableType, () ->
-        {
-            Fields fields = new Fields();
-            CharsetStringBuilder charsetStringBuilder = CharsetStringBuilder.forCharset(charset);
-            UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add);
-            decoder.parse(input);
-            System.out.println("fields=" + fields);
-        });
+        Fields fields = new Fields();
+        CharsetStringBuilder charsetStringBuilder = CharsetStringBuilder.forCharset(charset);
+        UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add);
+        assertThrows(expectedThrowableType, () -> decoder.parse(input));
     }
 
     /**
@@ -254,7 +252,7 @@ public class UrlParameterDecoderTest
         CharsetStringBuilder charsetStringBuilder = new Utf8StringBuilder();
         UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add);
         String input = "Name=Euro-€-Symbol";
-        decoder.parse(input);
+        assertFalse(decoder.parse(input), "No coding errors");
         assertThat("Field count", fields.getSize(), is(1));
         Fields.Field field = fields.get("Name");
         assertNotNull(field, "Fields[Name]");
@@ -268,7 +266,7 @@ public class UrlParameterDecoderTest
         CharsetStringBuilder charsetStringBuilder = CharsetStringBuilder.forCharset(UTF_16);
         UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add);
         String input = "name\n=value+%FE%FF%00%30&name1=&name2&nãme3=value+3";
-        decoder.parse(input);
+        assertFalse(decoder.parse(input), "No coding errors");
 
         assertThat("Field count", fields.getSize(), is(4));
         Fields.Field field = fields.get("name\n");
@@ -288,7 +286,7 @@ public class UrlParameterDecoderTest
         assertEquals("value 3", field.getValue(), "Fields[nãme3]");
     }
 
-    public static Stream<Arguments> queryBehaviorsBadUtf8Allowed()
+    public static Stream<Arguments> queryBehaviorsBadUtf8AllowedGood()
     {
         List<Arguments> cases = new ArrayList<>();
 
@@ -299,6 +297,28 @@ public class UrlParameterDecoderTest
         cases.add(Arguments.of("param=&other=foo", Map.of("param", "", "other", "foo")));
         cases.add(Arguments.of("param=%E2%9C%94", Map.of("param", "✔")));
         cases.add(Arguments.of("param=%E2%9C%94&other=foo", Map.of("param", "✔", "other", "foo")));
+
+        // Extra ampersands
+        cases.add(Arguments.of("param=aaa&&&", Map.of("param", "aaa")));
+        cases.add(Arguments.of("&&&param=aaa", Map.of("param", "aaa")));
+        cases.add(Arguments.of("&&param=aaa&&other=foo", Map.of("param", "aaa", "other", "foo")));
+        cases.add(Arguments.of("param=aaa&&other=foo&&", Map.of("param", "aaa", "other", "foo")));
+
+        // Encoded ampersands
+        cases.add(Arguments.of("param=aaa%26&other=foo", Map.of("param", "aaa&", "other", "foo")));
+        cases.add(Arguments.of("param=aaa&%26other=foo", Map.of("param", "aaa", "&other", "foo")));
+
+        // pct-encoded parameter names ("帽子" means "hat" in japanese)
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%90=Beret", Map.of("帽子", "Beret")));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%90=Beret&other=foo", Map.of("帽子", "Beret", "other", "foo")));
+        cases.add(Arguments.of("other=foo&%E5%B8%BD%E5%AD%90=Beret", Map.of("帽子", "Beret", "other", "foo")));
+
+        return cases.stream();
+    }
+
+    public static Stream<Arguments> queryBehaviorsBadUtf8AllowedBad()
+    {
+        List<Arguments> cases = new ArrayList<>();
 
         // Truncated / Insufficient Hex cases
         cases.add(Arguments.of("param=%E2%9C%9", Map.of("param", "�")));
@@ -358,6 +378,74 @@ public class UrlParameterDecoderTest
         cases.add(Arguments.of("param=%x&other=foo", Map.of("param", "%x", "other", "foo")));
         cases.add(Arguments.of("param=%£&other=foo", Map.of("param", "%£", "other", "foo")));
 
+        // bad pct-encoded parameter names
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%9=Beret", Map.of("帽�", "Beret")));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%=Beret", Map.of("帽�", "Beret")));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD=Beret", Map.of("帽�", "Beret")));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%9=Beret&other=foo", Map.of("帽�", "Beret", "other", "foo")));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD%=Beret&other=foo", Map.of("帽�", "Beret", "other", "foo")));
+        cases.add(Arguments.of("%E5%B8%BD%E5%AD=Beret&other=foo", Map.of("帽�", "Beret", "other", "foo")));
+
+        return cases.stream();
+    }
+
+    /**
+     * Test of BAD UTF8 ALLOWED, with good input data.
+     */
+    @ParameterizedTest
+    @MethodSource("queryBehaviorsBadUtf8AllowedGood")
+    public void testQueryBehaviorsBadUtf8AllowedGood(String input, Map<String, String> expectedParams) throws IOException
+    {
+        testQueryBehaviorsBadUtf8Allowed(input, expectedParams, false);
+    }
+
+    /**
+     * Test of BAD UTF8 ALLOWED, with bad input data.
+     */
+    @ParameterizedTest
+    @MethodSource("queryBehaviorsBadUtf8AllowedBad")
+    public void testQueryBehaviorsBadUtf8AllowedBad(String input, Map<String, String> expectedParams) throws IOException
+    {
+        testQueryBehaviorsBadUtf8Allowed(input, expectedParams, true);
+    }
+
+    private void testQueryBehaviorsBadUtf8Allowed(String input, Map<String, String> expectedParams, boolean badInput) throws IOException
+    {
+        Fields fields = new Fields();
+        CharsetStringBuilder charsetStringBuilder = CharsetStringBuilder.forCharset(UTF_8, CodingErrorAction.REPLACE, CodingErrorAction.REPLACE);
+        boolean allowBadEncoding = true;
+        boolean allowBadPercent = true;
+        boolean allowTruncatedEncoding = true;
+        UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add, -1, -1, allowBadEncoding, allowBadPercent, allowTruncatedEncoding);
+
+        assertEquals(badInput, decoder.parse(input), badInput ? "Has coding errors" : "No coding errors");
+
+        assertThat("Field count", fields.getSize(), is(expectedParams.size()));
+
+        for (String key : expectedParams.keySet())
+        {
+            Fields.Field field = fields.get(key);
+            String message = "Fields[%s]".formatted(key);
+            assertNotNull(field, message);
+            assertEquals(expectedParams.get(key), field.getValue(), message);
+        }
+    }
+
+    /**
+     * The set of allowed query string behaviors collected from Jetty 11. (Good inputs)
+     */
+    public static Stream<Arguments> queryBehaviorsLegacyAllowedGood()
+    {
+        List<Arguments> cases = new ArrayList<>();
+
+        // Normal cases
+        cases.add(Arguments.of("param=aaa", Map.of("param", "aaa")));
+        cases.add(Arguments.of("param=aaa&other=foo", Map.of("param", "aaa", "other", "foo")));
+        cases.add(Arguments.of("param=", Map.of("param", "")));
+        cases.add(Arguments.of("param=&other=foo", Map.of("param", "", "other", "foo")));
+        cases.add(Arguments.of("param=%E2%9C%94", Map.of("param", "✔")));
+        cases.add(Arguments.of("param=%E2%9C%94&other=foo", Map.of("param", "✔", "other", "foo")));
+
         // Extra ampersands
         cases.add(Arguments.of("param=aaa&&&", Map.of("param", "aaa")));
         cases.add(Arguments.of("&&&param=aaa", Map.of("param", "aaa")));
@@ -373,55 +461,19 @@ public class UrlParameterDecoderTest
         cases.add(Arguments.of("%E5%B8%BD%E5%AD%90=Beret&other=foo", Map.of("帽子", "Beret", "other", "foo")));
         cases.add(Arguments.of("other=foo&%E5%B8%BD%E5%AD%90=Beret", Map.of("帽子", "Beret", "other", "foo")));
 
-        // bad pct-encoded parameter names
-        cases.add(Arguments.of("%E5%B8%BD%E5%AD%9=Beret", Map.of("帽�", "Beret")));
-        cases.add(Arguments.of("%E5%B8%BD%E5%AD%=Beret", Map.of("帽�", "Beret")));
-        cases.add(Arguments.of("%E5%B8%BD%E5%AD=Beret", Map.of("帽�", "Beret")));
-        cases.add(Arguments.of("%E5%B8%BD%E5%AD%9=Beret&other=foo", Map.of("帽�", "Beret", "other", "foo")));
-        cases.add(Arguments.of("%E5%B8%BD%E5%AD%=Beret&other=foo", Map.of("帽�", "Beret", "other", "foo")));
-        cases.add(Arguments.of("%E5%B8%BD%E5%AD=Beret&other=foo", Map.of("帽�", "Beret", "other", "foo")));
+        // raw unicode parameter names
+        cases.add(Arguments.of("€=currency", Map.of("€", "currency")));
+        cases.add(Arguments.of("帽子=Beret", Map.of("帽子", "Beret")));
 
         return cases.stream();
     }
 
-    @ParameterizedTest
-    @MethodSource("queryBehaviorsBadUtf8Allowed")
-    public void testQueryBehaviorsBadUtf8Allowed(String input, Map<String, String> expectedParams) throws IOException
-    {
-        Fields fields = new Fields();
-        CharsetStringBuilder charsetStringBuilder = CharsetStringBuilder.forCharset(UTF_8, CodingErrorAction.REPLACE, CodingErrorAction.REPLACE);
-        boolean allowBadEncoding = true;
-        boolean allowBadPercent = true;
-        boolean allowTruncatedEncoding = true;
-        UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add, -1, -1, allowBadEncoding, allowBadPercent, allowTruncatedEncoding);
-
-        decoder.parse(input);
-
-        assertThat("Field count", fields.getSize(), is(expectedParams.size()));
-
-        for (String key : expectedParams.keySet())
-        {
-            Fields.Field field = fields.get(key);
-            String message = "Fields[%s]".formatted(key);
-            assertNotNull(field, message);
-            assertEquals(expectedParams.get(key), field.getValue(), message);
-        }
-    }
-
     /**
-     * The set of allowed query string behaviors collected from Jetty 11.
+     * The set of allowed query string behaviors collected from Jetty 11. (Bad inputs)
      */
-    public static Stream<Arguments> queryBehaviorsLegacyAllowed()
+    public static Stream<Arguments> queryBehaviorsLegacyAllowedBad()
     {
         List<Arguments> cases = new ArrayList<>();
-
-        // Normal cases
-        cases.add(Arguments.of("param=aaa", Map.of("param", "aaa")));
-        cases.add(Arguments.of("param=aaa&other=foo", Map.of("param", "aaa", "other", "foo")));
-        cases.add(Arguments.of("param=", Map.of("param", "")));
-        cases.add(Arguments.of("param=&other=foo", Map.of("param", "", "other", "foo")));
-        cases.add(Arguments.of("param=%E2%9C%94", Map.of("param", "✔")));
-        cases.add(Arguments.of("param=%E2%9C%94&other=foo", Map.of("param", "✔", "other", "foo")));
 
         // Truncated / Insufficient Hex cases
         cases.add(Arguments.of("param=%E2%9C", Map.of("param", "�")));
@@ -437,35 +489,28 @@ public class UrlParameterDecoderTest
         cases.add(Arguments.of("param=f_%e0%b8", Map.of("param", "f_�")));
         cases.add(Arguments.of("param=f_%e0%b8&other=foo", Map.of("param", "f_�", "other", "foo")));
 
-        // Extra ampersands
-        cases.add(Arguments.of("param=aaa&&&", Map.of("param", "aaa")));
-        cases.add(Arguments.of("&&&param=aaa", Map.of("param", "aaa")));
-        cases.add(Arguments.of("&&param=aaa&&other=foo", Map.of("param", "aaa", "other", "foo")));
-        cases.add(Arguments.of("param=aaa&&other=foo&&", Map.of("param", "aaa", "other", "foo")));
-
-        // Encoded ampersands
-        cases.add(Arguments.of("param=aaa%26&other=foo", Map.of("param", "aaa&", "other", "foo")));
-        cases.add(Arguments.of("param=aaa&%26other=foo", Map.of("param", "aaa", "&other", "foo")));
-
-        // pct-encoded parameter names ("帽子" means "hat" in japanese)
-        cases.add(Arguments.of("%E5%B8%BD%E5%AD%90=Beret", Map.of("帽子", "Beret")));
-        cases.add(Arguments.of("%E5%B8%BD%E5%AD%90=Beret&other=foo", Map.of("帽子", "Beret", "other", "foo")));
-        cases.add(Arguments.of("other=foo&%E5%B8%BD%E5%AD%90=Beret", Map.of("帽子", "Beret", "other", "foo")));
-
         // truncated pct-encoded parameter names
         cases.add(Arguments.of("%E5%B8%BD%E5%AD=Beret", Map.of("帽�", "Beret")));
         cases.add(Arguments.of("%E5%B8%BD%E5%AD=Beret&other=foo", Map.of("帽�", "Beret", "other", "foo")));
-
-        // raw unicode parameter names (strange replacement logic here)
-        cases.add(Arguments.of("€=currency", Map.of("€", "currency")));
-        cases.add(Arguments.of("帽子=Beret", Map.of("帽子", "Beret")));
 
         return cases.stream();
     }
 
     @ParameterizedTest
-    @MethodSource("queryBehaviorsLegacyAllowed")
-    public void testQueryBehaviorsLegacyAllowed(String input, Map<String, String> expectedParams) throws IOException
+    @MethodSource("queryBehaviorsLegacyAllowedGood")
+    public void testQueryBehaviorsLegacyAllowedGood(String input, Map<String, String> expectedParams) throws IOException
+    {
+        testQueryBehaviorsLegacyAllowed(input, expectedParams, false);
+    }
+
+    @ParameterizedTest
+    @MethodSource("queryBehaviorsLegacyAllowedBad")
+    public void testQueryBehaviorsLegacyAllowedBad(String input, Map<String, String> expectedParams) throws IOException
+    {
+        testQueryBehaviorsLegacyAllowed(input, expectedParams, true);
+    }
+
+    public void testQueryBehaviorsLegacyAllowed(String input, Map<String, String> expectedParams, boolean badInput) throws IOException
     {
         Fields fields = new Fields();
         CharsetStringBuilder charsetStringBuilder = CharsetStringBuilder.forCharset(UTF_8, CodingErrorAction.REPLACE, CodingErrorAction.REPORT);
@@ -474,7 +519,7 @@ public class UrlParameterDecoderTest
         boolean allowTruncatedEncoding = true;
         UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add, -1, -1, allowBadEncoding, allowBadPercent, allowTruncatedEncoding);
 
-        decoder.parse(input);
+        assertEquals(badInput, decoder.parse(input), badInput ? "Has coding errors" : "No coding errors");
 
         assertThat("Field count", fields.getSize(), is(expectedParams.size()));
 
@@ -584,7 +629,7 @@ public class UrlParameterDecoderTest
         CharsetStringBuilder charsetStringBuilder = CharsetStringBuilder.forCharset(japaneseCharset);
         UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add);
         String input = "name=%82%B1%82%F1%82%C9%82%BF%82%CD";
-        decoder.parse(input);
+        assertFalse(decoder.parse(input), "No coding errors");
 
         String helloInJapanese = "こんにちは";
 
@@ -614,12 +659,16 @@ public class UrlParameterDecoderTest
         Fields fields = new Fields();
         CharsetStringBuilder charsetStringBuilder = CharsetStringBuilder.forCharset(UTF_8, CodingErrorAction.REPLACE, CodingErrorAction.REPLACE);
         UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add, -1, -1, true, true, true);
-        decoder.parse(query);
+        assertTrue(decoder.parse(query), "Has coding errors");
         Fields.Field field = fields.get(expectedName);
         assertThat("Name exists", field, notNullValue());
         assertThat("Value", field.getValue(), is(expectedValue));
     }
 
+    /**
+     * Tests of raw UTF-8 bytes (not pct-encoded) that arrive.
+     * These invalid bytes are automatically converted to replacement characters.
+     */
     public static Stream<Arguments> incompleteSequenceCases()
     {
         List<Arguments> cases = new ArrayList<>();
@@ -654,7 +703,7 @@ public class UrlParameterDecoderTest
     }
 
     /**
-     * Default UrlDecoder behavior with incomplete sequences.
+     * Default UrlParameterDecoder behavior with incomplete sequences, using String input.
      */
     @ParameterizedTest
     @MethodSource("incompleteSequenceCases")
@@ -664,8 +713,9 @@ public class UrlParameterDecoderTest
         CharsetStringBuilder charsetStringBuilder = CharsetStringBuilder.forCharset(UTF_8);
         UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add);
 
+        // When using new String(byte[], Charset) with invalid bytes, the UTF-8 replacement character is automatically applied.
         String s = new String(input, UTF_8);
-        decoder.parse(s);
+        assertFalse(decoder.parse(s), "No coding errors");
         assertThat("Field count", fields.getSize(), is(expected.size()));
         for (String expectedKey : expected.keySet())
         {
@@ -676,6 +726,9 @@ public class UrlParameterDecoderTest
         }
     }
 
+    /**
+     * Configured UrlParameterDecoder behavior (allowing all) with incomplete sequences, using String input.
+     */
     @ParameterizedTest
     @MethodSource("incompleteSequenceCases")
     public void testUtf8IncompleteSequenceAllowedAsString(byte[] input, Map<String, String> expected) throws Exception
@@ -684,8 +737,9 @@ public class UrlParameterDecoderTest
         CharsetStringBuilder charsetStringBuilder = CharsetStringBuilder.forCharset(UTF_8, CodingErrorAction.REPLACE, CodingErrorAction.REPLACE);
         UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add, -1, -1, true, true, true);
 
+        // When using new String(byte[], Charset) with invalid bytes, the UTF-8 replacement character is automatically applied.
         String s = new String(input, UTF_8);
-        decoder.parse(s);
+        assertFalse(decoder.parse(s), "No coding errors");
 
         assertThat("Field count", fields.getSize(), is(expected.size()));
         for (String expectedKey : expected.keySet())
@@ -697,6 +751,9 @@ public class UrlParameterDecoderTest
         }
     }
 
+    /**
+     * Configured UrlParameterDecoder behavior (allowing all) with incomplete sequences, using InputStream input.
+     */
     @ParameterizedTest
     @MethodSource("incompleteSequenceCases")
     public void testUtf8IncompleteSequenceAllowedAsInputStream(byte[] input, Map<String, String> expected) throws Exception
@@ -707,7 +764,8 @@ public class UrlParameterDecoderTest
 
         try (InputStream is = new ByteArrayInputStream(input))
         {
-            decoder.parse(is, UTF_8);
+            // Internal conversion of raw bytes to char (for parsing) results in automatic UTF-8 replacement character use.
+            assertFalse(decoder.parse(is, UTF_8), "No coding errors");
 
             assertThat("Field count", fields.getSize(), is(expected.size()));
             for (String expectedKey : expected.keySet())


### PR DESCRIPTION
* Introduce new ComplianceTest in jetty-server.
* UrlParameterDecoder.parse() had bad return value.
* UrlEncoded.decodeUtf8To() had bad return value.
* Enhancing UrlParameterDecoderTest to test for return value of parse()
* Enhancing UrlEncodedUtf8Test to also test for decodeUtf8To() return value.

Closes #13368