### PR TITLE
Issue #13366 - Introduce MimeTypes.Mutable.clear()

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MimeTypes.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MimeTypes.java
@@ -588,6 +588,29 @@ public class MimeTypes
         }
 
         /**
+         * <p>
+         * Clear the MimeTypes references.
+         * </p>
+         * 
+         * <p>
+         * Once you have cleared out the MimeTypes object, make sure to properly
+         * set it up with extension to mime-type maps, along with inferred and
+         * assumed charsets for the relevant mime-types (eg: html, text, json, etc).
+         * </p>
+         *
+         * @see #addMimeMapping(String, String) 
+         * @see #addAssumed(String, String) 
+         * @see #addInferred(String, String)
+         */
+        public void clear()
+        {
+            _mimeMap.clear();
+            _assumedEncodings.clear();
+            _assumedNoEncodings.clear();
+            _inferredEncodings.clear();
+        }
+
+        /**
          * Set a mime mapping
          *
          * @param extension the extension
@@ -735,13 +758,10 @@ public class MimeTypes
          */
         public void setFrom(MimeTypes other)
         {
-            _mimeMap.clear();
+            clear();
             _mimeMap.putAll(other.getMimeMap());
-            _assumedEncodings.clear();
             _assumedEncodings.putAll(other._assumedEncodings);
-            _inferredEncodings.clear();
             _inferredEncodings.putAll(other._inferredEncodings);
-            _assumedNoEncodings.clear();
             _assumedNoEncodings.addAll(other._assumedNoEncodings);
         }
 

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/MimeTypesTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/MimeTypesTest.java
@@ -21,7 +21,9 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class MimeTypesTest
@@ -147,5 +149,39 @@ public class MimeTypesTest
     public void testMimeTypesGetBaseType(String contentTypeWithCharset, MimeTypes.Type expectedType)
     {
         assertThat(MimeTypes.getBaseType(contentTypeWithCharset), is(expectedType));
+    }
+
+    /**
+     * Test of a use case where the webapp wants a specific set of mime types,
+     * no defaults. This is accomplished by replacing getting the MimeTypes.Mutable
+     * associated with the webapp, calling clear, and then setting the values you want.
+     */
+    @Test
+    public void testMimeTypesMutableClear()
+    {
+        MimeTypes.Mutable webappMimeTypes = new MimeTypes.Mutable();
+
+        // Verify that "defaults" behavior is still there.
+        assertEquals("UTF-8", webappMimeTypes.getAssumedCharsetName("application/json"));
+        assertThat(webappMimeTypes._mimeMap.size(), greaterThan(100));
+
+        // Clear out the mime-types
+        webappMimeTypes.clear();
+        assertThat(webappMimeTypes._mimeMap.size(), is(0));
+        assertThat(webappMimeTypes._assumedEncodings.size(), is(0));
+        assertThat(webappMimeTypes._assumedNoEncodings.size(), is(0));
+        assertThat(webappMimeTypes._inferredEncodings.size(), is(0));
+
+        // Set a few new values
+        webappMimeTypes.addMimeMapping("html", "text/html");
+        // HTML is inferred to be UTF-8, and will always have a 'charset' on the content-type header
+        webappMimeTypes.addInferred("text/html", "utf-8");
+
+        webappMimeTypes.addMimeMapping("json", "application/json");
+        // JSON is always UTF-8, and is never represented as a 'charset' on the content-type header
+        webappMimeTypes.addAssumed("application/json", "utf-8");
+
+        // Images never have a 'charset' on the content-type field
+        webappMimeTypes.addAssumed("image/*", null);
     }
 }


### PR DESCRIPTION
Introduce new `MimeTypes.Mutable.clear()` method.

Closes #13366