### PR TITLE
fix mod file name for inclusion

### DIFF
--- a/documentation/jetty/modules/operations-guide/pages/modules/standard.adoc
+++ b/documentation/jetty/modules/operations-guide/pages/modules/standard.adoc
@@ -92,7 +92,7 @@ For more information, refer to xref:programming-guide:server/http.adoc#connector
 The module file is `$JETTY_HOME/modules/network-connection-limit.mod`:
 
 ----
-include::{jetty-home}/modules/network-connection-limit-limit.mod[tags=documentation]
+include::{jetty-home}/modules/network-connection-limit.mod[tags=documentation]
 ----
 
 [[console-capture]]


### PR DESCRIPTION
Fix for 
```
21:26:32 [INFO] [21:26:32.919] ERROR (asciidoctor): include file not found: /root/.cache/antora/collector/jetty.project@jetty-12.0.x-0d7163d445b52d375d8067eaaebde058af22174f/documentation/jetty/target/jetty-home-12.0.24-SNAPSHOT/modules/network-connection-limit-limit.mod
21:26:32 [INFO]     file: documentation/jetty/modules/operations-guide/pages/modules/standard.adoc:95
```

Signed-off-by: Olivier Lamy <olamy@apache.org>
