### PR TITLE
Improve javadoc documentation for core API methods

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractAuthentication.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractAuthentication.java
@@ -15,11 +15,21 @@ package org.eclipse.jetty.client;
 
 import java.net.URI;
 
+/**
+ * <p>Abstract base class for authentication implementations.
+ * Provides common functionality for URI and realm matching.</p>
+ */
 public abstract class AbstractAuthentication implements Authentication
 {
     private final URI uri;
     private final String realm;
 
+    /**
+     * Creates an authentication for the given URI and realm.
+     *
+     * @param uri the URI this authentication applies to
+     * @param realm the authentication realm
+     */
     public AbstractAuthentication(URI uri, String realm)
     {
         this.uri = uri;
@@ -28,11 +38,17 @@ public abstract class AbstractAuthentication implements Authentication
 
     public abstract String getType();
 
+    /**
+     * @return the URI this authentication applies to
+     */
     public URI getURI()
     {
         return uri;
     }
 
+    /**
+     * @return the authentication realm
+     */
     public String getRealm()
     {
         return realm;

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/DuplexConnectionPool.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/DuplexConnectionPool.java
@@ -16,9 +16,19 @@ package org.eclipse.jetty.client;
 import org.eclipse.jetty.util.ConcurrentPool;
 import org.eclipse.jetty.util.annotation.ManagedObject;
 
+/**
+ * <p>A connection pool that provides connections for both directions of communication.
+ * This pool uses a concurrent pool with FIRST strategy to manage connections efficiently.</p>
+ */
 @ManagedObject
 public class DuplexConnectionPool extends AbstractConnectionPool
 {
+    /**
+     * Creates a duplex connection pool for the given destination.
+     *
+     * @param destination the destination for which this pool provides connections
+     * @param maxConnections the maximum number of connections in the pool
+     */
     public DuplexConnectionPool(Destination destination, int maxConnections)
     {
         super(destination, () -> new ConcurrentPool<>(ConcurrentPool.StrategyType.FIRST, maxConnections), 1);

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/Origin.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/Origin.java
@@ -94,26 +94,41 @@ public class Origin
         this.transport = transport;
     }
 
+    /**
+     * @return the URI scheme (http, https, etc.)
+     */
     public String getScheme()
     {
         return scheme;
     }
 
+    /**
+     * @return the network address (host and port)
+     */
     public Address getAddress()
     {
         return address;
     }
 
+    /**
+     * @return the tag object that distinguishes destinations with the same scheme, host, port and protocol
+     */
     public Object getTag()
     {
         return tag;
     }
 
+    /**
+     * @return the network protocol, or null if not specified
+     */
     public Protocol getProtocol()
     {
         return protocol;
     }
 
+    /**
+     * @return the transport mechanism (TCP/IP, Unix domain socket, etc.)
+     */
     public Transport getTransport()
     {
         return transport;
@@ -140,6 +155,9 @@ public class Origin
                Objects.equals(transport, that.transport);
     }
 
+    /**
+     * @return a string representation of this origin as a URI
+     */
     public String asString()
     {
         return HttpURI.from(scheme, address.host, address.port, null).asString();
@@ -171,11 +189,17 @@ public class Origin
             this.address = InetSocketAddress.createUnresolved(getHost(), getPort());
         }
 
+        /**
+         * @return the host name or IP address
+         */
         public String getHost()
         {
             return host;
         }
 
+        /**
+         * @return the port number
+         */
         public int getPort()
         {
             return port;
@@ -198,11 +222,17 @@ public class Origin
             return Objects.hash(host, port);
         }
 
+        /**
+         * @return a string representation of this address as host:port
+         */
         public String asString()
         {
             return String.format("%s:%d", host, port);
         }
 
+        /**
+         * @return the socket address for this host and port
+         */
         public SocketAddress getSocketAddress()
         {
             return address;
@@ -241,11 +271,17 @@ public class Origin
             this.negotiate = negotiate;
         }
 
+        /**
+         * @return the list of protocol names associated with this protocol
+         */
         public List<String> getProtocols()
         {
             return protocols;
         }
 
+        /**
+         * @return true if this protocol should be negotiated, false otherwise
+         */
         public boolean isNegotiate()
         {
             return negotiate;
@@ -268,6 +304,9 @@ public class Origin
             return Objects.hash(protocols, negotiate);
         }
 
+        /**
+         * @return a string representation of this protocol
+         */
         public String asString()
         {
             return String.format("proto=%s,nego=%b", protocols, negotiate);

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/HashLoginService.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/HashLoginService.java
@@ -40,21 +40,38 @@ public class HashLoginService extends AbstractLoginService
     private UserStore _userStore;
     private boolean _userStoreAutoCreate = false;
 
+    /**
+     * Creates a hash login service with no name or configuration.
+     */
     public HashLoginService()
     {
     }
 
+    /**
+     * Creates a hash login service with the specified name.
+     *
+     * @param name the name of this login service
+     */
     public HashLoginService(String name)
     {
         setName(name);
     }
 
+    /**
+     * Creates a hash login service with the specified name and configuration.
+     *
+     * @param name the name of this login service
+     * @param config the resource containing user configuration
+     */
     public HashLoginService(String name, Resource config)
     {
         setName(name);
         setConfig(config);
     }
 
+    /**
+     * @return the configuration resource containing user data
+     */
     public Resource getConfig()
     {
         return _config;

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/ServerAuthException.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/ServerAuthException.java
@@ -21,20 +21,39 @@ import java.security.GeneralSecurityException;
 public class ServerAuthException extends GeneralSecurityException
 {
 
+    /**
+     * Creates a server authentication exception with no message.
+     */
     public ServerAuthException()
     {
     }
 
+    /**
+     * Creates a server authentication exception with the given message.
+     *
+     * @param s the exception message
+     */
     public ServerAuthException(String s)
     {
         super(s);
     }
 
+    /**
+     * Creates a server authentication exception with the given message and cause.
+     *
+     * @param s the exception message
+     * @param throwable the underlying cause
+     */
     public ServerAuthException(String s, Throwable throwable)
     {
         super(s, throwable);
     }
 
+    /**
+     * Creates a server authentication exception with the given cause.
+     *
+     * @param throwable the underlying cause
+     */
     public ServerAuthException(Throwable throwable)
     {
         super(throwable);

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Attachable.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Attachable.java
@@ -25,9 +25,9 @@ public interface Attachable
     Object getAttachment();
 
     /**
-     * Attaches the given object to this stream for later retrieval.
+     * Attaches the given object for later retrieval.
      *
-     * @param attachment the object to attach to this instance
+     * @param attachment the object to attach
      */
     void setAttachment(Object attachment);
 }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Fields.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Fields.java
@@ -47,7 +47,7 @@ public class Fields implements Iterable<Fields.Field>
     }
 
     /**
-     * <p>Creates an empty, modifiable, case insensitive {@code Fields} instance.</p>**
+     * <p>Creates an empty, modifiable {@code Fields} instance.</p>
      *
      * @param caseSensitive whether this {@code Fields} instance must be case sensitive
      */
@@ -56,16 +56,31 @@ public class Fields implements Iterable<Fields.Field>
         this(caseSensitive ? new LinkedHashMap<>() : new TreeMap<>(String::compareToIgnoreCase));
     }
 
+    /**
+     * Creates a {@code Fields} instance from a MultiMap.
+     *
+     * @param params the multimap to convert to fields
+     */
     public Fields(MultiMap<String> params)
     {
         this(multiMapToMapOfFields(params));
     }
 
+    /**
+     * Creates a {@code Fields} instance from a map of fields.
+     *
+     * @param fields the map of fields to use
+     */
     public Fields(Map<String, Field> fields)
     {
         this.fields = fields;
     }
 
+    /**
+     * Creates a copy of the given {@code Fields} instance.
+     *
+     * @param fields the fields to copy
+     */
     public Fields(Fields fields)
     {
         if (fields.fields instanceof TreeMap<String, Field>)
@@ -87,6 +102,9 @@ public class Fields implements Iterable<Fields.Field>
         }
     }
 
+    /**
+     * @return an immutable view of this fields instance
+     */
     public Fields asImmutable()
     {
         Map<String, Field> unmodifiable = Collections.unmodifiableMap(fields);

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/SocketAddressResolver.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/SocketAddressResolver.java
@@ -123,11 +123,17 @@ public interface SocketAddressResolver
             this.timeout = timeout;
         }
 
+        /**
+         * @return the executor used for DNS resolution
+         */
         public Executor getExecutor()
         {
             return executor;
         }
 
+        /**
+         * @return the scheduler used for timeout operations
+         */
         public Scheduler getScheduler()
         {
             return scheduler;

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/SocketAddressResolver.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/SocketAddressResolver.java
@@ -109,8 +109,8 @@ public interface SocketAddressResolver
         private final long timeout;
 
         /**
-         * Creates a new instance with the given executor (to perform DNS resolution in a separate thread),
-         * the given scheduler (to cancel the operation if it takes too long) and the given timeout, in milliseconds.
+         * Creates a new instance with the specified executor (to perform DNS resolution in a separate thread),
+         * scheduler (to cancel the operation if it takes too long) and timeout, in milliseconds.
          *
          * @param executor the thread pool to use to perform DNS resolution in pooled threads
          * @param scheduler the scheduler to schedule tasks to cancel DNS resolution if it takes too long

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/security/SecurityUtils.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/security/SecurityUtils.java
@@ -154,7 +154,7 @@ public class SecurityUtils
     }
 
     /**
-     * <p>Runs the given action as the given subject.</p>
+     * <p>Runs the action as the specified subject.</p>
      *
      * @param subject the subject this action runs as
      * @param action the action to run

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/DefaultServletTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/DefaultServletTest.java
@@ -1242,7 +1242,7 @@ public class DefaultServletTest
         assertThat(response.toString(), response.getStatus(), is(HttpStatus.OK_200));
         assertThat(response.getContent(), containsString("<h1>Alt Index</h1>"));
 
-        // Let's try deleting the `index.html` and accesing the welcome file at `index.htm`
+        // Let's try deleting the `index.html` and accessing the welcome file at `index.htm`
         // We skip this section of the test if the OS or filesystem doesn't support instantaneous delete
         // such as what happens on Microsoft Windows.
         if (deleteFile(altIndex))

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/DispatcherTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/DispatcherTest.java
@@ -173,7 +173,7 @@ public class DispatcherTest
     }
 
     @Test
-    public void testFowardThenForward() throws Exception
+    public void testForwardThenForward() throws Exception
     {
         _contextHandler.addServlet(ForwardServlet.class, "/ForwardServlet/*");
         _contextHandler.addServlet(AlwaysForwardServlet.class, "/AlwaysForwardServlet/*");

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ResourceServletTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ResourceServletTest.java
@@ -1306,7 +1306,7 @@ public class ResourceServletTest
         assertThat(response.toString(), response.getStatus(), is(HttpStatus.OK_200));
         assertThat(response.getContent(), containsString("<h1>Alt Index</h1>"));
 
-        // Let's try deleting the `index.html` and accesing the welcome file at `index.htm`
+        // Let's try deleting the `index.html` and accessing the welcome file at `index.htm`
         // We skip this section of the test if the OS or filesystem doesn't support instantaneous delete
         // such as what happens on Microsoft Windows.
         if (deleteFile(altIndex))

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ServletUpgradeTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ServletUpgradeTest.java
@@ -334,7 +334,7 @@ public class ServletUpgradeTest
             }
 
             LOG.debug("[ServletTestUtil] Found search string: '" + search + "' at index '" + searchIdx + "' in the server's " + "response");
-            // the new searchIdx is the old index plus the lenght of the
+            // the new searchIdx is the old index plus the length of the
             // search string.
             startIdx = searchIdx + search.length();
         }

--- a/jetty-ee9/jetty-ee9-jaspi/src/main/java/org/eclipse/jetty/ee9/security/jaspi/callback/CredentialValidationCallback.java
+++ b/jetty-ee9/jetty-ee9-jaspi/src/main/java/org/eclipse/jetty/ee9/security/jaspi/callback/CredentialValidationCallback.java
@@ -38,6 +38,9 @@ public class CredentialValidationCallback implements Callback
         _credential = credential;
     }
 
+    /**
+     * @return the credential for validation
+     */
     public Credential getCredential()
     {
         return _credential;
@@ -48,16 +51,25 @@ public class CredentialValidationCallback implements Callback
         _credential = null;
     }
 
+    /**
+     * @return true if validation was successful, false otherwise
+     */
     public boolean getResult()
     {
         return _result;
     }
 
+    /**
+     * @return the subject associated with this credential validation
+     */
     public javax.security.auth.Subject getSubject()
     {
         return _subject;
     }
 
+    /**
+     * @return the username associated with the credential
+     */
     public java.lang.String getUsername()
     {
         return _userName;

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ServletUpgradeTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ServletUpgradeTest.java
@@ -334,7 +334,7 @@ public class ServletUpgradeTest
             }
 
             LOG.debug("[ServletTestUtil] Found search string: '" + search + "' at index '" + searchIdx + "' in the server's " + "response");
-            // the new searchIdx is the old index plus the lenght of the
+            // the new searchIdx is the old index plus the length of the
             // search string.
             startIdx = searchIdx + search.length();
         }

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-api/src/main/java/org/eclipse/jetty/ee9/websocket/api/WebSocketConnectionListener.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-api/src/main/java/org/eclipse/jetty/ee9/websocket/api/WebSocketConnectionListener.java
@@ -44,7 +44,7 @@ public interface WebSocketConnectionListener
     /**
      * A WebSocket exception has occurred.
      * <p>
-     * This is a way for the internal implementation to notify of exceptions occured during the processing of websocket.
+     * This is a way for the internal implementation to notify of exceptions occurred during the processing of websocket.
      * <p>
      * Usually this occurs from bad / malformed incoming packets. (example: bad UTF8 data, frames that are too big, violations of the spec)
      * <p>

--- a/jetty-integrations/jetty-gcloud/jetty-gcloud-session-manager/src/main/java/org/eclipse/jetty/gcloud/session/GCloudSessionDataStoreFactory.java
+++ b/jetty-integrations/jetty-gcloud/jetty-gcloud-session-manager/src/main/java/org/eclipse/jetty/gcloud/session/GCloudSessionDataStoreFactory.java
@@ -29,6 +29,9 @@ public class GCloudSessionDataStoreFactory extends AbstractSessionDataStoreFacto
     private String _host;
     private String _projectId;
 
+    /**
+     * @return the entity data model for Google Cloud Datastore
+     */
     public GCloudSessionDataStore.EntityDataModel getEntityDataModel()
     {
         return _model;
@@ -39,6 +42,9 @@ public class GCloudSessionDataStoreFactory extends AbstractSessionDataStoreFacto
         _model = model;
     }
 
+    /**
+     * @return the maximum number of retries for Google Cloud operations
+     */
     public int getMaxRetries()
     {
         return _maxRetries;
@@ -49,6 +55,9 @@ public class GCloudSessionDataStoreFactory extends AbstractSessionDataStoreFacto
         _maxRetries = maxRetries;
     }
 
+    /**
+     * @return the backoff time in milliseconds between retries
+     */
     public int getBackoffMs()
     {
         return _backoffMs;
@@ -82,6 +91,9 @@ public class GCloudSessionDataStoreFactory extends AbstractSessionDataStoreFacto
         _host = host;
     }
 
+    /**
+     * @return the host for the Google Cloud Datastore connection
+     */
     public String getHost()
     {
         return _host;
@@ -92,6 +104,9 @@ public class GCloudSessionDataStoreFactory extends AbstractSessionDataStoreFacto
         _projectId = projectId;
     }
 
+    /**
+     * @return the Google Cloud project ID
+     */
     public String getProjectId()
     {
         return _projectId;

--- a/jetty-integrations/jetty-nosql/src/main/java/org/eclipse/jetty/nosql/mongodb/MongoUtils.java
+++ b/jetty-integrations/jetty-nosql/src/main/java/org/eclipse/jetty/nosql/mongodb/MongoUtils.java
@@ -35,6 +35,9 @@ import org.eclipse.jetty.util.URIUtil;
 public class MongoUtils
 {
 
+    /**
+     * @return the decoded object value from MongoDB binary data
+     */
     public static Object decodeValue(final Object valueToDecode) throws IOException, ClassNotFoundException
     {
         if (valueToDecode == null || valueToDecode instanceof Number || valueToDecode instanceof String || valueToDecode instanceof Boolean || valueToDecode instanceof Date)
@@ -71,16 +74,25 @@ public class MongoUtils
         }
     }
 
+    /**
+     * @return the decoded name with special characters unescaped
+     */
     public static String decodeName(String name)
     {
         return URIUtil.decodeSpecific(name, ".%");
     }
 
+    /**
+     * @return the encoded name with special characters escaped for MongoDB
+     */
     public static String encodeName(String name)
     {
         return URIUtil.encodeSpecific(name, ".%");
     }
 
+    /**
+     * @return the encoded object value suitable for MongoDB storage
+     */
     public static Object encodeName(Object value) throws IOException
     {
         if (value instanceof Number || value instanceof String || value instanceof Boolean || value instanceof Date)


### PR DESCRIPTION
- Fix typos and improve wording in comments across multiple modules
- Add missing @return documentation for methods with return values
- Add javadoc for public API constructors and methods in core modules
