### PR TITLE
Issue #13341 - add async close for Jetty WebSocket API

### DIFF
--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/util/MethodHolder.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/util/MethodHolder.java
@@ -237,7 +237,7 @@ public interface MethodHolder
         }
     }
 
-    class Wrapper implements MethodHolder
+    abstract class Wrapper implements MethodHolder
     {
         public MethodHolder _methodHolder;
 
@@ -255,18 +255,6 @@ public interface MethodHolder
         public Object invoke(Object... args) throws Throwable
         {
             return getWrapped().invoke(args);
-        }
-
-        @Override
-        public MethodHolder bindTo(Object arg)
-        {
-            return getWrapped().bindTo(arg);
-        }
-
-        @Override
-        public MethodHolder bindTo(Object arg, int idx)
-        {
-            return getWrapped().bindTo(arg, idx);
         }
 
         @Override

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/util/MethodHolder.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/util/MethodHolder.java
@@ -243,7 +243,7 @@ public interface MethodHolder
 
         public Wrapper(MethodHolder methodHolder)
         {
-            _methodHolder = methodHolder;
+            _methodHolder = Objects.requireNonNull(methodHolder);
         }
 
         public MethodHolder getWrapped()
@@ -254,19 +254,31 @@ public interface MethodHolder
         @Override
         public Object invoke(Object... args) throws Throwable
         {
-            return _methodHolder.invoke(args);
+            return getWrapped().invoke(args);
+        }
+
+        @Override
+        public MethodHolder bindTo(Object arg)
+        {
+            return getWrapped().bindTo(arg);
+        }
+
+        @Override
+        public MethodHolder bindTo(Object arg, int idx)
+        {
+            return getWrapped().bindTo(arg, idx);
         }
 
         @Override
         public Class<?> parameterType(int idx)
         {
-            return _methodHolder.parameterType(idx);
+            return getWrapped().parameterType(idx);
         }
 
         @Override
         public Class<?> returnType()
         {
-            return _methodHolder.returnType();
+            return getWrapped().returnType();
         }
     }
 }

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/util/MethodHolder.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/util/MethodHolder.java
@@ -17,6 +17,7 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.WrongMethodTypeException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -56,7 +57,7 @@ public interface MethodHolder
 
     default MethodHolder bindTo(Object arg)
     {
-        throw new UnsupportedOperationException();
+        return bindTo(arg, 0);
     }
 
     default MethodHolder bindTo(Object arg, int idx)
@@ -105,7 +106,7 @@ public interface MethodHolder
 
     class Binding implements MethodHolder
     {
-        public MethodHandle _methodHandle;
+        public final MethodHandle _methodHandle;
 
         private Binding(MethodHandle methodHandle)
         {
@@ -121,15 +122,13 @@ public interface MethodHolder
         @Override
         public Binding bindTo(Object arg)
         {
-            _methodHandle = _methodHandle.bindTo(arg);
-            return this;
+            return new Binding(_methodHandle.bindTo(arg));
         }
 
         @Override
         public MethodHolder bindTo(Object arg, int idx)
         {
-            _methodHandle = MethodHandles.insertArguments(_methodHandle, idx, arg);
-            return this;
+            return new Binding(MethodHandles.insertArguments(_methodHandle, idx, arg));
         }
 
         @Override
@@ -154,17 +153,25 @@ public interface MethodHolder
     {
         private final MethodHandle _methodHandle;
         private final Object[] _parameters;
-        private final List<Integer> _unboundParamIndexes = new ArrayList<>();
+        private final List<Integer> _unboundParamIndexes;
 
         private NonBinding(MethodHandle methodHandle)
         {
             _methodHandle = Objects.requireNonNull(methodHandle);
             int numParams = methodHandle.type().parameterCount();
             _parameters = new Object[numParams];
+            _unboundParamIndexes = new ArrayList<>(numParams);
             for (int i = 0; i < numParams; i++)
             {
                 _unboundParamIndexes.add(i);
             }
+        }
+
+        private NonBinding(MethodHandle methodHandle, Object[] parameters, List<Integer> unboundParamIndexes)
+        {
+            _methodHandle = Objects.requireNonNull(methodHandle);
+            _parameters = parameters;
+            _unboundParamIndexes = unboundParamIndexes;
         }
 
         @Override
@@ -184,9 +191,11 @@ public interface MethodHolder
         @Override
         public MethodHolder bindTo(Object arg, int idx)
         {
-            _parameters[_unboundParamIndexes.get(idx)] = arg;
-            _unboundParamIndexes.remove(idx);
-            return this;
+            Object[] parameters = Arrays.copyOf(_parameters, _parameters.length);
+            List<Integer> unboundParamIndexes = new ArrayList<>(_unboundParamIndexes);
+            parameters[unboundParamIndexes.get(idx)] = arg;
+            unboundParamIndexes.remove(idx);
+            return new NonBinding(_methodHandle, parameters, unboundParamIndexes);
         }
 
         @Override
@@ -225,6 +234,39 @@ public interface MethodHolder
         public Class<?> returnType()
         {
             return _methodHandle.type().returnType();
+        }
+    }
+
+    class Wrapper implements MethodHolder
+    {
+        public MethodHolder _methodHolder;
+
+        public Wrapper(MethodHolder methodHolder)
+        {
+            _methodHolder = methodHolder;
+        }
+
+        public MethodHolder getWrapped()
+        {
+            return _methodHolder;
+        }
+
+        @Override
+        public Object invoke(Object... args) throws Throwable
+        {
+            return _methodHolder.invoke(args);
+        }
+
+        @Override
+        public Class<?> parameterType(int idx)
+        {
+            return _methodHolder.parameterType(idx);
+        }
+
+        @Override
+        public Class<?> returnType()
+        {
+            return _methodHolder.returnType();
         }
     }
 }

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/Session.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/Session.java
@@ -341,6 +341,16 @@ public interface Session extends Configurable, Closeable
         }
 
         /**
+         * <p>The WebSocket {@link Session} has been closed.</p>
+         *
+         * @param statusCode the close {@link StatusCode status code}
+         * @param reason the optional reason for the close
+         */
+        default void onWebSocketClose(int statusCode, String reason, Callback callback)
+        {
+        }
+
+        /**
          * <p>Tag interface that signals that the WebSocket endpoint
          * is demanding for WebSocket frames automatically.</p>
          *

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/Session.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/Session.java
@@ -335,7 +335,9 @@ public interface Session extends Configurable, Closeable
          *
          * @param statusCode the close {@link StatusCode status code}
          * @param reason the optional reason for the close
+         * @deprecated use {@link #onWebSocketClose(int, String, Callback)} instead.
          */
+        @Deprecated(since = "12.1.0", forRemoval = true)
         default void onWebSocketClose(int statusCode, String reason)
         {
         }
@@ -343,8 +345,10 @@ public interface Session extends Configurable, Closeable
         /**
          * <p>The WebSocket {@link Session} has been closed.</p>
          *
-         * @param statusCode the close {@link StatusCode status code}
-         * @param reason the optional reason for the close
+         * @param statusCode the close {@link StatusCode status code}.
+         * @param reason the optional reason for the close.
+         * @param callback the callback used to signal that the close processing is complete.
+         *
          */
         default void onWebSocketClose(int statusCode, String reason, Callback callback)
         {

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/annotations/OnWebSocketClose.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/annotations/OnWebSocketClose.java
@@ -25,6 +25,8 @@ import java.lang.annotation.Target;
  * <ol>
  * <li>{@code public void <methodName>(int statusCode, String reason)}</li>
  * <li>{@code public void <methodName>(Session session, int statusCode, String reason)}</li>
+ * <li>{@code public void <methodName>(int statusCode, String reason, Callback callback)}</li>
+ * <li>{@code public void <methodName>(Session session, int statusCode, String reason, Callback callback)}</li>
  * </ol>
  */
 @Documented

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandler.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandler.java
@@ -278,20 +278,7 @@ public class JettyWebSocketFrameHandler implements FrameHandler
         {
             if (closeHandle != null)
             {
-                var apiCallback = new org.eclipse.jetty.websocket.api.Callback()
-                {
-                    @Override
-                    public void succeed()
-                    {
-                        callback.succeeded();
-                    }
-
-                    @Override
-                    public void fail(Throwable x)
-                    {
-                        callback.failed(x);
-                    }
-                };
+                var apiCallback = org.eclipse.jetty.websocket.api.Callback.from(callback::succeeded, callback::failed);
                 closeHandle.invoke(closeStatus.getCode(), closeStatus.getReason(), apiCallback);
             }
             else

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandler.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandler.java
@@ -278,7 +278,7 @@ public class JettyWebSocketFrameHandler implements FrameHandler
         {
             if (closeHandle != null)
             {
-                org.eclipse.jetty.websocket.api.Callback apiCallback = new org.eclipse.jetty.websocket.api.Callback()
+                var apiCallback = new org.eclipse.jetty.websocket.api.Callback()
                 {
                     @Override
                     public void succeed()
@@ -295,7 +295,9 @@ public class JettyWebSocketFrameHandler implements FrameHandler
                 closeHandle.invoke(closeStatus.getCode(), closeStatus.getReason(), apiCallback);
             }
             else
+            {
                 callback.succeeded();
+            }
         }
         catch (Throwable cause)
         {

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandler.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandler.java
@@ -78,16 +78,16 @@ public class JettyWebSocketFrameHandler implements FrameHandler
         this.endpointInstance = endpointInstance;
         this.metadata = metadata;
 
-        this.openHandle = InvokerUtils.bindTo(MethodHolder.from(metadata.getOpenHandle()), endpointInstance);
-        this.closeHandle = InvokerUtils.bindTo(MethodHolder.from(metadata.getCloseHandle()), endpointInstance);
-        this.errorHandle = InvokerUtils.bindTo(MethodHolder.from(metadata.getErrorHandle()), endpointInstance);
-        this.textHandle = InvokerUtils.bindTo(MethodHolder.from(metadata.getTextHandle()), endpointInstance);
-        this.binaryHandle = InvokerUtils.bindTo(MethodHolder.from(metadata.getBinaryHandle()), endpointInstance);
+        this.openHandle = InvokerUtils.bindTo(metadata.getOpenHandle(), endpointInstance);
+        this.closeHandle = InvokerUtils.bindTo(metadata.getCloseHandle(), endpointInstance);
+        this.errorHandle = InvokerUtils.bindTo(metadata.getErrorHandle(), endpointInstance);
+        this.textHandle = InvokerUtils.bindTo(metadata.getTextHandle(), endpointInstance);
+        this.binaryHandle = InvokerUtils.bindTo(metadata.getBinaryHandle(), endpointInstance);
         this.textSinkClass = metadata.getTextSink();
         this.binarySinkClass = metadata.getBinarySink();
-        this.frameHandle = InvokerUtils.bindTo(MethodHolder.from(metadata.getFrameHandle()), endpointInstance);
-        this.pingHandle = InvokerUtils.bindTo(MethodHolder.from(metadata.getPingHandle()), endpointInstance);
-        this.pongHandle = InvokerUtils.bindTo(MethodHolder.from(metadata.getPongHandle()), endpointInstance);
+        this.frameHandle = InvokerUtils.bindTo(metadata.getFrameHandle(), endpointInstance);
+        this.pingHandle = InvokerUtils.bindTo(metadata.getPingHandle(), endpointInstance);
+        this.pongHandle = InvokerUtils.bindTo(metadata.getPongHandle(), endpointInstance);
     }
 
     public void setUpgradeRequest(UpgradeRequest upgradeRequest)
@@ -277,8 +277,25 @@ public class JettyWebSocketFrameHandler implements FrameHandler
         try
         {
             if (closeHandle != null)
-                closeHandle.invoke(closeStatus.getCode(), closeStatus.getReason());
-            callback.succeeded();
+            {
+                org.eclipse.jetty.websocket.api.Callback apiCallback = new org.eclipse.jetty.websocket.api.Callback()
+                {
+                    @Override
+                    public void succeed()
+                    {
+                        callback.succeeded();
+                    }
+
+                    @Override
+                    public void fail(Throwable x)
+                    {
+                        callback.failed(x);
+                    }
+                };
+                closeHandle.invoke(closeStatus.getCode(), closeStatus.getReason(), apiCallback);
+            }
+            else
+                callback.succeeded();
         }
         catch (Throwable cause)
         {

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandlerFactory.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandlerFactory.java
@@ -290,13 +290,13 @@ public class JettyWebSocketFrameHandlerFactory extends ContainerLifeCycle
         @Override
         public MethodHolder bindTo(Object arg)
         {
-            return new CallbackCompletingCloseHolder(super.bindTo(arg));
+            return new CallbackCompletingCloseHolder(getWrapped().bindTo(arg));
         }
 
         @Override
         public MethodHolder bindTo(Object arg, int idx)
         {
-            return new CallbackCompletingCloseHolder(super.bindTo(arg, idx));
+            return new CallbackCompletingCloseHolder(getWrapped().bindTo(arg, idx));
         }
     }
 

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandlerFactory.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandlerFactory.java
@@ -276,7 +276,7 @@ public class JettyWebSocketFrameHandlerFactory extends ContainerLifeCycle
 
             try
             {
-                Object value = getWrapped().invoke(args);
+                Object value = super.invoke(args);
                 callback.succeed();
                 return value;
             }
@@ -288,12 +288,17 @@ public class JettyWebSocketFrameHandlerFactory extends ContainerLifeCycle
         }
 
         @Override
+        public MethodHolder bindTo(Object arg)
+        {
+            return new CallbackCompletingCloseHolder(super.bindTo(arg));
+        }
+
+        @Override
         public MethodHolder bindTo(Object arg, int idx)
         {
-            return new CallbackCompletingCloseHolder(getWrapped().bindTo(arg, idx));
+            return new CallbackCompletingCloseHolder(super.bindTo(arg, idx));
         }
     }
-
 
     private Method findMethod(Class<?> klass, String name, Class<?>... parameters)
     {

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandlerFactory.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandlerFactory.java
@@ -22,6 +22,7 @@ import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -46,6 +47,7 @@ import org.eclipse.jetty.websocket.core.messages.PartialStringMessageSink;
 import org.eclipse.jetty.websocket.core.messages.ReaderMessageSink;
 import org.eclipse.jetty.websocket.core.messages.StringMessageSink;
 import org.eclipse.jetty.websocket.core.util.InvokerUtils;
+import org.eclipse.jetty.websocket.core.util.MethodHolder;
 import org.eclipse.jetty.websocket.core.util.ReflectUtils;
 
 /**
@@ -145,6 +147,11 @@ public class JettyWebSocketFrameHandlerFactory extends ContainerLifeCycle
         return new JettyWebSocketFrameHandler(container, endpointInstance, metadata);
     }
 
+    private MethodHolder toMethodHolder(MethodHandles.Lookup lookup, Method method)
+    {
+        return MethodHolder.from(toMethodHandle(lookup, method));
+    }
+
     private MethodHandle toMethodHandle(MethodHandles.Lookup lookup, Method method)
     {
         try
@@ -167,75 +174,126 @@ public class JettyWebSocketFrameHandlerFactory extends ContainerLifeCycle
         Method openMethod = findMethod(endpointClass, "onWebSocketOpen", Session.class);
         if (openMethod != null)
         {
-            MethodHandle connectHandle = toMethodHandle(lookup, openMethod);
+            MethodHolder connectHandle = toMethodHolder(lookup, openMethod);
             metadata.setOpenHandle(connectHandle, openMethod);
         }
 
         Method frameMethod = findMethod(endpointClass, "onWebSocketFrame", Frame.class, Callback.class);
         if (frameMethod != null)
         {
-            MethodHandle frameHandle = toMethodHandle(lookup, frameMethod);
+            MethodHolder frameHandle = toMethodHolder(lookup, frameMethod);
             metadata.setFrameHandle(frameHandle, frameMethod);
         }
 
         Method pingMethod = findMethod(endpointClass, "onWebSocketPing", ByteBuffer.class);
         if (pingMethod != null)
         {
-            MethodHandle pingHandle = toMethodHandle(lookup, pingMethod);
+            MethodHolder pingHandle = toMethodHolder(lookup, pingMethod);
             metadata.setPingHandle(pingHandle, pingMethod);
         }
 
         Method pongMethod = findMethod(endpointClass, "onWebSocketPong", ByteBuffer.class);
         if (pongMethod != null)
         {
-            MethodHandle pongHandle = toMethodHandle(lookup, pongMethod);
+            MethodHolder pongHandle = toMethodHolder(lookup, pongMethod);
             metadata.setPongHandle(pongHandle, pongMethod);
         }
 
         Method partialTextMethod = findMethod(endpointClass, "onWebSocketPartialText", String.class, boolean.class);
         if (partialTextMethod != null)
         {
-            MethodHandle partialTextHandle = toMethodHandle(lookup, partialTextMethod);
+            MethodHolder partialTextHandle = toMethodHolder(lookup, partialTextMethod);
             metadata.setTextHandle(PartialStringMessageSink.class, partialTextHandle, partialTextMethod);
         }
 
         Method partialBinaryMethod = findMethod(endpointClass, "onWebSocketPartialBinary", ByteBuffer.class, boolean.class, Callback.class);
         if (partialBinaryMethod != null)
         {
-            MethodHandle partialBinaryHandle = toMethodHandle(lookup, partialBinaryMethod);
+            MethodHolder partialBinaryHandle = toMethodHolder(lookup, partialBinaryMethod);
             metadata.setBinaryHandle(PartialByteBufferMessageSink.class, partialBinaryHandle, partialBinaryMethod);
         }
 
         Method textMethod = findMethod(endpointClass, "onWebSocketText", String.class);
         if (textMethod != null)
         {
-            MethodHandle textHandle = toMethodHandle(lookup, textMethod);
+            MethodHolder textHandle = toMethodHolder(lookup, textMethod);
             metadata.setTextHandle(StringMessageSink.class, textHandle, textMethod);
         }
 
         Method binaryMethod = findMethod(endpointClass, "onWebSocketBinary", ByteBuffer.class, Callback.class);
         if (binaryMethod != null)
         {
-            MethodHandle binaryHandle = toMethodHandle(lookup, binaryMethod);
+            MethodHolder binaryHandle = toMethodHolder(lookup, binaryMethod);
             metadata.setBinaryHandle(ByteBufferMessageSink.class, binaryHandle, binaryMethod);
         }
 
         Method errorMethod = findMethod(endpointClass, "onWebSocketError", Throwable.class);
         if (errorMethod != null)
         {
-            MethodHandle errorHandle = toMethodHandle(lookup, errorMethod);
+            MethodHolder errorHandle = toMethodHolder(lookup, errorMethod);
             metadata.setErrorHandle(errorHandle, errorMethod);
         }
 
-        Method closeMethod = findMethod(endpointClass, "onWebSocketClose", int.class, String.class);
+        Method deprecatedCloseMethod = findMethod(endpointClass, "onWebSocketClose", int.class, String.class);
+        Method closeMethod = findMethod(endpointClass, "onWebSocketClose", int.class, String.class, Callback.class);
         if (closeMethod != null)
         {
-            MethodHandle closeHandle = toMethodHandle(lookup, closeMethod);
+            if (deprecatedCloseMethod != null)
+                throw new InvalidWebSocketException("Cannot use two versions of onWebSocketClose");
+
+            MethodHolder closeHandle = toMethodHolder(lookup, closeMethod);
             metadata.setCloseHandle(closeHandle, closeMethod);
+        }
+        else if (deprecatedCloseMethod != null)
+        {
+            MethodHandle deprecatedCloseHandle = toMethodHandle(lookup, deprecatedCloseMethod);
+            deprecatedCloseHandle = MethodHandles.dropArguments(deprecatedCloseHandle, 3, Callback.class);
+            MethodHolder closeHandle = new CallbackCompletingCloseHolder(MethodHolder.from(deprecatedCloseHandle));
+            metadata.setCloseHandle(closeHandle, deprecatedCloseMethod);
         }
 
         return metadata;
     }
+
+    /**
+     * This class wraps a {@link MethodHolder} and automatically completes the callback in the signature when the
+     * call to the wrapped {@link MethodHolder} returns.
+     */
+    private static class CallbackCompletingCloseHolder extends MethodHolder.Wrapper
+    {
+        public CallbackCompletingCloseHolder(MethodHolder methodHolder)
+        {
+            super(methodHolder);
+        }
+
+        @Override
+        public Object invoke(Object... args)
+        {
+            Callback callback = (Callback)Arrays.stream(args)
+                .filter(o -> o instanceof Callback)
+                .findFirst()
+                .orElseThrow(IllegalArgumentException::new);
+
+            try
+            {
+                Object value = getWrapped().invoke(args);
+                callback.succeed();
+                return value;
+            }
+            catch (Throwable t)
+            {
+                callback.fail(t);
+            }
+            return null;
+        }
+
+        @Override
+        public MethodHolder bindTo(Object arg, int idx)
+        {
+            return new CallbackCompletingCloseHolder(getWrapped().bindTo(arg, idx));
+        }
+    }
+
 
     private Method findMethod(Class<?> klass, String name, Class<?>... parameters)
     {
@@ -268,7 +326,7 @@ public class JettyWebSocketFrameHandlerFactory extends ContainerLifeCycle
             assertSignatureValid(endpointClass, onmethod, OnWebSocketOpen.class);
             final InvokerUtils.Arg SESSION = new InvokerUtils.Arg(Session.class).required();
             MethodHandle methodHandle = InvokerUtils.mutatedInvoker(lookup, endpointClass, onmethod, SESSION);
-            metadata.setOpenHandle(methodHandle, onmethod);
+            metadata.setOpenHandle(MethodHolder.from(methodHandle), onmethod);
         }
 
         // OnWebSocketClose [0..1]
@@ -279,8 +337,24 @@ public class JettyWebSocketFrameHandlerFactory extends ContainerLifeCycle
             final InvokerUtils.Arg SESSION = new InvokerUtils.Arg(Session.class);
             final InvokerUtils.Arg STATUS_CODE = new InvokerUtils.Arg(int.class);
             final InvokerUtils.Arg REASON = new InvokerUtils.Arg(String.class);
-            MethodHandle methodHandle = InvokerUtils.mutatedInvoker(lookup, endpointClass, onmethod, SESSION, STATUS_CODE, REASON);
-            metadata.setCloseHandle(methodHandle, onmethod);
+            final InvokerUtils.Arg CALLBACK = new InvokerUtils.Arg(Callback.class);
+            MethodHandle methodHandle = InvokerUtils.mutatedInvoker(lookup, endpointClass, onmethod, SESSION, STATUS_CODE, REASON, CALLBACK);
+            MethodHolder methodHolder = MethodHolder.from(methodHandle);
+
+            // If the underlying method does not contain the callback parameter we must automatically succeed it.
+            boolean containsCallback = false;
+            for (Class<?> paramType : onmethod.getParameterTypes())
+            {
+                if (Callback.class.isAssignableFrom(paramType))
+                {
+                    containsCallback = true;
+                    break;
+                }
+            }
+            if (!containsCallback)
+                methodHolder = new CallbackCompletingCloseHolder(methodHolder);
+
+            metadata.setCloseHandle(methodHolder, onmethod);
         }
 
         // OnWebSocketError [0..1]
@@ -291,7 +365,7 @@ public class JettyWebSocketFrameHandlerFactory extends ContainerLifeCycle
             final InvokerUtils.Arg SESSION = new InvokerUtils.Arg(Session.class);
             final InvokerUtils.Arg CAUSE = new InvokerUtils.Arg(Throwable.class).required();
             MethodHandle methodHandle = InvokerUtils.mutatedInvoker(lookup, endpointClass, onmethod, SESSION, CAUSE);
-            metadata.setErrorHandle(methodHandle, onmethod);
+            metadata.setErrorHandle(MethodHolder.from(methodHandle), onmethod);
         }
 
         // OnWebSocketFrame [0..1]
@@ -303,7 +377,7 @@ public class JettyWebSocketFrameHandlerFactory extends ContainerLifeCycle
             final InvokerUtils.Arg FRAME = new InvokerUtils.Arg(Frame.class).required();
             final InvokerUtils.Arg CALLBACK = new InvokerUtils.Arg(Callback.class).required();
             MethodHandle methodHandle = InvokerUtils.mutatedInvoker(lookup, endpointClass, onmethod, SESSION, FRAME, CALLBACK);
-            metadata.setFrameHandle(methodHandle, onmethod);
+            metadata.setFrameHandle(MethodHolder.from(methodHandle), onmethod);
         }
 
         // OnWebSocketMessage [0..2]
@@ -320,7 +394,7 @@ public class JettyWebSocketFrameHandlerFactory extends ContainerLifeCycle
                 {
                     // Normal Text Message
                     assertSignatureValid(endpointClass, onMsg, OnWebSocketMessage.class);
-                    metadata.setTextHandle(StringMessageSink.class, methodHandle, onMsg);
+                    metadata.setTextHandle(StringMessageSink.class, MethodHolder.from(methodHandle), onMsg);
                     continue;
                 }
 
@@ -329,7 +403,7 @@ public class JettyWebSocketFrameHandlerFactory extends ContainerLifeCycle
                 {
                     // ByteBuffer Binary Message
                     assertSignatureValid(endpointClass, onMsg, OnWebSocketMessage.class);
-                    metadata.setBinaryHandle(ByteBufferMessageSink.class, methodHandle, onMsg);
+                    metadata.setBinaryHandle(ByteBufferMessageSink.class, MethodHolder.from(methodHandle), onMsg);
                     continue;
                 }
 
@@ -341,7 +415,7 @@ public class JettyWebSocketFrameHandlerFactory extends ContainerLifeCycle
 
                     // InputStream Binary Message
                     assertSignatureValid(endpointClass, onMsg, OnWebSocketMessage.class);
-                    metadata.setBinaryHandle(InputStreamMessageSink.class, methodHandle, onMsg);
+                    metadata.setBinaryHandle(InputStreamMessageSink.class, MethodHolder.from(methodHandle), onMsg);
                     continue;
                 }
 
@@ -353,7 +427,7 @@ public class JettyWebSocketFrameHandlerFactory extends ContainerLifeCycle
 
                     // Reader Text Message
                     assertSignatureValid(endpointClass, onMsg, OnWebSocketMessage.class);
-                    metadata.setTextHandle(ReaderMessageSink.class, methodHandle, onMsg);
+                    metadata.setTextHandle(ReaderMessageSink.class, MethodHolder.from(methodHandle), onMsg);
                     continue;
                 }
 
@@ -362,7 +436,7 @@ public class JettyWebSocketFrameHandlerFactory extends ContainerLifeCycle
                 {
                     // Partial Text Message
                     assertSignatureValid(endpointClass, onMsg, OnWebSocketMessage.class);
-                    metadata.setTextHandle(PartialStringMessageSink.class, methodHandle, onMsg);
+                    metadata.setTextHandle(PartialStringMessageSink.class, MethodHolder.from(methodHandle), onMsg);
                     continue;
                 }
 
@@ -371,7 +445,7 @@ public class JettyWebSocketFrameHandlerFactory extends ContainerLifeCycle
                 {
                     // Partial ByteBuffer Message
                     assertSignatureValid(endpointClass, onMsg, OnWebSocketMessage.class);
-                    metadata.setBinaryHandle(PartialByteBufferMessageSink.class, methodHandle, onMsg);
+                    metadata.setBinaryHandle(PartialByteBufferMessageSink.class, MethodHolder.from(methodHandle), onMsg);
                     continue;
                 }
 

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandlerMetadata.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandlerMetadata.java
@@ -13,25 +13,24 @@
 
 package org.eclipse.jetty.websocket.common;
 
-import java.lang.invoke.MethodHandle;
-
 import org.eclipse.jetty.websocket.api.exceptions.InvalidWebSocketException;
 import org.eclipse.jetty.websocket.core.Configuration;
 import org.eclipse.jetty.websocket.core.messages.MessageSink;
+import org.eclipse.jetty.websocket.core.util.MethodHolder;
 
 public class JettyWebSocketFrameHandlerMetadata extends Configuration.ConfigurationCustomizer
 {
     private boolean autoDemand;
-    private MethodHandle openHandle;
-    private MethodHandle closeHandle;
-    private MethodHandle errorHandle;
-    private MethodHandle frameHandle;
-    private MethodHandle textHandle;
+    private MethodHolder openHandle;
+    private MethodHolder closeHandle;
+    private MethodHolder errorHandle;
+    private MethodHolder frameHandle;
+    private MethodHolder textHandle;
     private Class<? extends MessageSink> textSink;
-    private MethodHandle binaryHandle;
+    private MethodHolder binaryHandle;
     private Class<? extends MessageSink> binarySink;
-    private MethodHandle pingHandle;
-    private MethodHandle pongHandle;
+    private MethodHolder pingHandle;
+    private MethodHolder pongHandle;
 
     public boolean isAutoDemand()
     {
@@ -43,7 +42,7 @@ public class JettyWebSocketFrameHandlerMetadata extends Configuration.Configurat
         this.autoDemand = autoDemand;
     }
 
-    public void setBinaryHandle(Class<? extends MessageSink> sinkClass, MethodHandle binary, Object origin)
+    public void setBinaryHandle(Class<? extends MessageSink> sinkClass, MethodHolder binary, Object origin)
     {
         assertNotSet(this.binaryHandle, "BINARY Handler", origin);
         assertNotSet(this.frameHandle, "FRAME Handler", origin);
@@ -51,7 +50,7 @@ public class JettyWebSocketFrameHandlerMetadata extends Configuration.Configurat
         this.binarySink = sinkClass;
     }
 
-    public MethodHandle getBinaryHandle()
+    public MethodHolder getBinaryHandle()
     {
         return binaryHandle;
     }
@@ -61,29 +60,29 @@ public class JettyWebSocketFrameHandlerMetadata extends Configuration.Configurat
         return binarySink;
     }
 
-    public void setCloseHandle(MethodHandle close, Object origin)
+    public void setCloseHandle(MethodHolder close, Object origin)
     {
         assertNotSet(this.closeHandle, "CLOSE Handler", origin);
         this.closeHandle = close;
     }
 
-    public MethodHandle getCloseHandle()
+    public MethodHolder getCloseHandle()
     {
         return closeHandle;
     }
 
-    public void setErrorHandle(MethodHandle error, Object origin)
+    public void setErrorHandle(MethodHolder error, Object origin)
     {
         assertNotSet(this.errorHandle, "ERROR Handler", origin);
         this.errorHandle = error;
     }
 
-    public MethodHandle getErrorHandle()
+    public MethodHolder getErrorHandle()
     {
         return errorHandle;
     }
 
-    public void setFrameHandle(MethodHandle frame, Object origin)
+    public void setFrameHandle(MethodHolder frame, Object origin)
     {
         assertNotSet(this.frameHandle, "FRAME Handler", origin);
         assertNotSet(this.textHandle, "TEXT Handler", origin);
@@ -93,47 +92,47 @@ public class JettyWebSocketFrameHandlerMetadata extends Configuration.Configurat
         this.frameHandle = frame;
     }
 
-    public MethodHandle getFrameHandle()
+    public MethodHolder getFrameHandle()
     {
         return frameHandle;
     }
 
-    public void setOpenHandle(MethodHandle openHandle, Object origin)
+    public void setOpenHandle(MethodHolder openHandle, Object origin)
     {
         assertNotSet(this.openHandle, "OPEN Handler", origin);
         this.openHandle = openHandle;
     }
 
-    public MethodHandle getOpenHandle()
+    public MethodHolder getOpenHandle()
     {
         return openHandle;
     }
 
-    public void setPingHandle(MethodHandle ping, Object origin)
+    public void setPingHandle(MethodHolder ping, Object origin)
     {
         assertNotSet(this.pingHandle, "PING Handler", origin);
         assertNotSet(this.frameHandle, "FRAME Handler", origin);
         this.pingHandle = ping;
     }
 
-    public MethodHandle getPingHandle()
+    public MethodHolder getPingHandle()
     {
         return pingHandle;
     }
 
-    public void setPongHandle(MethodHandle pong, Object origin)
+    public void setPongHandle(MethodHolder pong, Object origin)
     {
         assertNotSet(this.pongHandle, "PONG Handler", origin);
         assertNotSet(this.frameHandle, "FRAME Handler", origin);
         this.pongHandle = pong;
     }
 
-    public MethodHandle getPongHandle()
+    public MethodHolder getPongHandle()
     {
         return pongHandle;
     }
 
-    public void setTextHandle(Class<? extends MessageSink> sinkClass, MethodHandle text, Object origin)
+    public void setTextHandle(Class<? extends MessageSink> sinkClass, MethodHolder text, Object origin)
     {
         assertNotSet(this.textHandle, "TEXT Handler", origin);
         assertNotSet(this.frameHandle, "FRAME Handler", origin);
@@ -141,7 +140,7 @@ public class JettyWebSocketFrameHandlerMetadata extends Configuration.Configurat
         this.textSink = sinkClass;
     }
 
-    public MethodHandle getTextHandle()
+    public MethodHolder getTextHandle()
     {
         return textHandle;
     }

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/AsyncCloseTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/AsyncCloseTest.java
@@ -68,7 +68,7 @@ public class AsyncCloseTest
         @Override
         public void onWebSocketText(String message)
         {
-            _session.sendText(message, Callback.from(() -> _session.demand(), t-> _session.disconnect()));
+            _session.sendText(message, Callback.from(() -> _session.demand(), t -> _session.disconnect()));
         }
 
         @Override
@@ -141,9 +141,9 @@ public class AsyncCloseTest
         {
             switch (frame.getEffectiveOpCode())
             {
-                case OpCode.TEXT -> _session.sendPartialText(BufferUtil.toUTF8String(frame.getPayload()), frame.isFin(), Callback.from(callback,() -> _session.demand()));
-                case OpCode.BINARY -> _session.sendPartialBinary(frame.getPayload(), frame.isFin(), Callback.from(callback,() -> _session.demand()));
-                case OpCode.PING -> _session.sendPong(frame.getPayload(), Callback.from(callback,() -> _session.demand()));
+                case OpCode.TEXT -> _session.sendPartialText(BufferUtil.toUTF8String(frame.getPayload()), frame.isFin(), Callback.from(callback, () -> _session.demand()));
+                case OpCode.BINARY -> _session.sendPartialBinary(frame.getPayload(), frame.isFin(), Callback.from(callback, () -> _session.demand()));
+                case OpCode.PING -> _session.sendPong(frame.getPayload(), Callback.from(callback, () -> _session.demand()));
                 case OpCode.CLOSE -> new Thread(() ->
                 {
                     awaitClose(_closeLatch);

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/AsyncCloseTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/AsyncCloseTest.java
@@ -1,0 +1,304 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.websocket.tests;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.websocket.api.Callback;
+import org.eclipse.jetty.websocket.api.Frame;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.StatusCode;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketClose;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketFrame;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketOpen;
+import org.eclipse.jetty.websocket.api.annotations.WebSocket;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.eclipse.jetty.websocket.core.OpCode;
+import org.eclipse.jetty.websocket.server.WebSocketUpgradeHandler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AsyncCloseTest
+{
+    private Server _server;
+    private WebSocketClient _client;
+    private ServerConnector _connector;
+    private CloseWaitingEndpoint _serverEndpoint;
+
+    public interface CloseWaitingEndpoint
+    {
+        void close();
+    }
+
+    public static class ServerListenerMessageEndpoint implements Session.Listener, CloseWaitingEndpoint
+    {
+        private Session _session;
+        private final CountDownLatch _closeLatch = new CountDownLatch(1);
+
+        @Override
+        public void onWebSocketOpen(Session session)
+        {
+            _session = session;
+            _session.demand();
+        }
+
+        @Override
+        public void onWebSocketText(String message)
+        {
+            _session.sendText(message, Callback.from(() -> _session.demand(), t-> _session.disconnect()));
+        }
+
+        @Override
+        public void onWebSocketClose(int statusCode, String reason, Callback callback)
+        {
+            new Thread(() ->
+            {
+                awaitClose(_closeLatch);
+                _session.close(StatusCode.NORMAL, "custom close", callback);
+            }).start();
+        }
+
+        @Override
+        public void close()
+        {
+            _closeLatch.countDown();
+        }
+    }
+
+    @WebSocket(autoDemand = false)
+    public static class ServerAnnotatedMessageEndpoint implements CloseWaitingEndpoint
+    {
+        private Session _session;
+        private final CountDownLatch _closeLatch = new CountDownLatch(1);
+
+        @OnWebSocketOpen
+        public void onWebSocketOpen(Session session)
+        {
+            _session = session;
+            _session.demand();
+        }
+
+        @OnWebSocketMessage
+        public void onWebSocketText(String message)
+        {
+            _session.sendText(message, Callback.from(() -> _session.demand(), t -> _session.disconnect()));
+        }
+
+        @OnWebSocketClose
+        public void onWebSocketClose(int statusCode, String reason, Callback callback)
+        {
+            new Thread(() ->
+            {
+                awaitClose(_closeLatch);
+                _session.close(StatusCode.NORMAL, "custom close", callback);
+            }).start();
+        }
+
+        @Override
+        public void close()
+        {
+            _closeLatch.countDown();
+        }
+    }
+
+    public static class ServerListenerFrameEndpoint implements Session.Listener, CloseWaitingEndpoint
+    {
+        private Session _session;
+        private final CountDownLatch _closeLatch = new CountDownLatch(1);
+
+        @Override
+        public void onWebSocketOpen(Session session)
+        {
+            _session = session;
+            _session.demand();
+        }
+
+        @Override
+        public void onWebSocketFrame(Frame frame, Callback callback)
+        {
+            switch (frame.getEffectiveOpCode())
+            {
+                case OpCode.TEXT -> _session.sendPartialText(BufferUtil.toUTF8String(frame.getPayload()), frame.isFin(), Callback.from(callback,() -> _session.demand()));
+                case OpCode.BINARY -> _session.sendPartialBinary(frame.getPayload(), frame.isFin(), Callback.from(callback,() -> _session.demand()));
+                case OpCode.PING -> _session.sendPong(frame.getPayload(), Callback.from(callback,() -> _session.demand()));
+                case OpCode.CLOSE -> new Thread(() ->
+                {
+                    awaitClose(_closeLatch);
+                    _session.close(StatusCode.NORMAL, "custom close", callback);
+                }).start();
+            }
+        }
+
+        @Override
+        public void onWebSocketClose(int statusCode, String reason, Callback callback)
+        {
+            assertThat(_session.isOpen(), equalTo(false));
+            callback.succeed();
+        }
+
+        @Override
+        public void close()
+        {
+            _closeLatch.countDown();
+        }
+    }
+
+    @WebSocket(autoDemand = false)
+    public static class ServerAnnotatedFrameEndpoint implements CloseWaitingEndpoint
+    {
+        private Session _session;
+        private final CountDownLatch _closeLatch = new CountDownLatch(1);
+
+        @OnWebSocketOpen
+        public void onWebSocketOpen(Session session)
+        {
+            _session = session;
+            _session.demand();
+        }
+
+        @OnWebSocketFrame
+        public void onWebSocketFrame(Frame frame, Callback callback)
+        {
+            switch (frame.getEffectiveOpCode())
+            {
+                case OpCode.TEXT ->
+                    _session.sendPartialText(BufferUtil.toUTF8String(frame.getPayload()), frame.isFin(), Callback.from(callback, () -> _session.demand()));
+                case OpCode.BINARY -> _session.sendPartialBinary(frame.getPayload(), frame.isFin(), Callback.from(callback, () -> _session.demand()));
+                case OpCode.PING -> _session.sendPong(frame.getPayload(), Callback.from(callback, () -> _session.demand()));
+                case OpCode.CLOSE -> new Thread(() ->
+                {
+                    awaitClose(_closeLatch);
+                    _session.close(StatusCode.NORMAL, "custom close", callback);
+                }).start();
+            }
+        }
+
+        @OnWebSocketClose
+        public void onWebSocketClose(int statusCode, String reason, Callback callback)
+        {
+            assertThat(_session.isOpen(), equalTo(false));
+            callback.succeed();
+        }
+
+        @Override
+        public void close()
+        {
+            _closeLatch.countDown();
+        }
+    }
+
+    public void start(CloseWaitingEndpoint serverEndpoint) throws Exception
+    {
+        _server = new Server();
+        _connector = new ServerConnector(_server);
+        _server.addConnector(_connector);
+
+        WebSocketUpgradeHandler wsHandler = WebSocketUpgradeHandler.from(_server, container ->
+        {
+            container.setIdleTimeout(Duration.ZERO);
+            container.addMapping("/", (rq, rs, cb) -> serverEndpoint);
+        });
+
+        _server.setHandler(wsHandler);
+        _server.start();
+
+        _client = new WebSocketClient();
+        _client.start();
+    }
+
+    @AfterEach
+    public void stop() throws Exception
+    {
+        _client.stop();
+        _server.stop();
+    }
+
+    @Test
+    public void testListenerMessageEcho() throws Exception
+    {
+        CloseWaitingEndpoint serverEndpoint = new ServerListenerMessageEndpoint();
+        start(serverEndpoint);
+        testEchoAndClose(serverEndpoint);
+    }
+
+    @Test
+    public void testAnnotatedMessageEcho() throws Exception
+    {
+        CloseWaitingEndpoint serverEndpoint = new ServerAnnotatedMessageEndpoint();
+        start(serverEndpoint);
+        testEchoAndClose(serverEndpoint);
+    }
+
+    @Test
+    public void testListenerFrameEcho() throws Exception
+    {
+        CloseWaitingEndpoint serverEndpoint = new ServerListenerFrameEndpoint();
+        start(serverEndpoint);
+        testEchoAndClose(serverEndpoint);
+    }
+
+    @Test
+    public void testAnnotatedFrameEcho() throws Exception
+    {
+        CloseWaitingEndpoint serverEndpoint = new ServerAnnotatedFrameEndpoint();
+        start(serverEndpoint);
+        testEchoAndClose(serverEndpoint);
+    }
+
+    private void testEchoAndClose(CloseWaitingEndpoint serverEndpoint) throws Exception
+    {
+        URI uri = new URI("ws://localhost:" + _connector.getLocalPort());
+        EventSocket clientEndpoint = new EventSocket();
+        Session session = _client.connect(clientEndpoint, uri).get(5, TimeUnit.SECONDS);
+
+        String message = "hello world 1234";
+        session.sendText(message, Callback.NOOP);
+        String received = clientEndpoint.textMessages.poll(5, TimeUnit.SECONDS);
+        assertThat(received, equalTo(message));
+
+        // Initiate close from the client, test that the close is deferred.
+        session.close();
+        assertFalse(clientEndpoint.closeLatch.await(1, TimeUnit.SECONDS));
+
+        // Test the server sends the correct close response and not the automatic one.
+        serverEndpoint.close();
+        assertTrue(clientEndpoint.closeLatch.await(5, TimeUnit.SECONDS));
+        assertThat(clientEndpoint.closeCode, equalTo(StatusCode.NORMAL));
+        assertThat(clientEndpoint.closeReason, equalTo("custom close"));
+    }
+
+    private static void awaitClose(CountDownLatch countDownLatch)
+    {
+        try
+        {
+            countDownLatch.await();
+        }
+        catch (InterruptedException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
closes #13341 

- Add new close method to `Session.Listener` taking a callback `void onWebSocketClose(int statusCode, String reason, Callback callback)`.
- Also add option to use a callback with the `@OnWebSocketClose` close method.
- Fixes to `MethodHolder` to make the `bind` methods bind to a new instance and not the current one (same way that `MethodHandles` work).