### PR TITLE
Issue #13395 Support async dispatch to same context

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/AsyncContextState.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/AsyncContextState.java
@@ -89,7 +89,11 @@ public class AsyncContextState implements AsyncContext
     @Override
     public void dispatch(ServletContext context, String path)
     {
-        state().dispatch(context, path);
+        //check for dispatch to current context
+        if (context != null && context == state().getContextHandler().getContext().getServletContext())
+            state().dispatch(null, path);
+        else
+            state().dispatch(context, path);
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-common/src/test/java/org/eclipse/jetty/ee10/session/AsyncTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-common/src/test/java/org/eclipse/jetty/ee10/session/AsyncTest.java
@@ -164,6 +164,127 @@ public class AsyncTest
     }
 
     @Test
+    public void testSameContextAsync() throws Exception
+    {
+        // Test for degenerate case of async dispatch to same context, not using the
+        // AsyncContext.dispatch(path) method as would be expected, but using the
+        // AsyncContext.dispatch(context, path) method, where context is the same
+        // as the current context
+        Server server = new Server();
+        ContextHandlerCollection contextHandlerCollection = new ContextHandlerCollection();
+
+        final List<String> events = new ArrayList<>();
+
+        ServletContextHandler contextA = new ServletContextHandler();
+        contextA.addEventListener(new ServletRequestListener()
+        {
+            @Override
+            public void requestDestroyed(ServletRequestEvent sre)
+            {
+                events.add("Request Destroyed: " + sre.getServletRequest().getServletContext().getContextPath());
+                ServletRequestListener.super.requestDestroyed(sre);
+            }
+
+            @Override
+            public void requestInitialized(ServletRequestEvent sre)
+            {
+                events.add("Request Initialized: " + sre.getServletRequest().getServletContext().getContextPath());
+                ServletRequestListener.super.requestInitialized(sre);
+            }
+        });
+        contextA.setContextPath("/ctxA");
+        final String ASYNC_FLAG_NAME = "async.flag";
+
+        ServletHolder serviceHolder = new ServletHolder("service-servlet", new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                if (req.getAttribute(ASYNC_FLAG_NAME) == null)
+                {
+                    AsyncContext asyncContext = req.startAsync(req, resp);
+                    req.setAttribute(ASYNC_FLAG_NAME, new Object());
+                    asyncContext.setTimeout(100);
+                    asyncContext.addListener(new AsyncListener()
+                    {
+                        @Override
+                        public void onComplete(AsyncEvent event)
+                        {
+                            events.add("ON complete");
+                        }
+
+                        @Override
+                        public void onTimeout(AsyncEvent event)
+                        {
+                            events.add("ON timeout");
+                        }
+
+                        @Override
+                        public void onError(AsyncEvent event)
+                        {
+                            events.add("ON error");
+                        }
+
+                        @Override
+                        public void onStartAsync(AsyncEvent event)
+                        {
+                            events.add("ON startasync");
+                        }
+                    });
+                    //perform dispatch to current context
+                    asyncContext.dispatch(req.getServletContext(), "/dispatched/z");
+                }
+            }
+        });
+
+        serviceHolder.setAsyncSupported(true);
+        contextA.addServlet(serviceHolder, "/dispatcher/*");
+        contextHandlerCollection.addHandler(contextA);
+
+        ServletHolder testHolder = new ServletHolder("test-servlet", new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                resp.setCharacterEncoding("utf-8");
+                resp.setContentType("text/plain");
+                resp.getWriter().println("Dispatched to ctxA in test-servlet");
+                resp.getWriter().println(req.getQueryString());
+            }
+        });
+
+        contextA.addServlet(testHolder, "/dispatched/*");
+        server.setHandler(contextHandlerCollection);
+        LocalConnector connector = new LocalConnector(server);
+        connector.getConnectionFactory(HttpConfiguration.ConnectionFactory.class).getHttpConfiguration().setSendServerVersion(false);
+        connector.getConnectionFactory(HttpConfiguration.ConnectionFactory.class).getHttpConfiguration().setSendDateHeader(false);
+        server.addConnector(connector);
+
+        server.start();
+
+        try
+        {
+
+            String rawRequest = """
+                GET /ctxA/dispatcher/x?foo=bar HTTP/1.1
+                Host: local
+                Connection: close
+                            
+                """;
+
+            HttpTester.Response response = HttpTester.parseResponse(connector.getResponse(rawRequest));
+            assertThat(response.getStatus(), is(200));
+            assertThat(events, Matchers.containsInRelativeOrder("Request Initialized: /ctxA", "Request Destroyed: /ctxA"));
+            assertThat(response.getContent(), containsString("Dispatched to ctxA in test-servlet"));
+            assertThat(response.getContent(), containsString("foo=bar"));
+        }
+        finally
+        {
+            server.stop();
+        }
+    }
+
+    @Test
     public void testSimpleCrossContextAsync() throws Exception
     {
         //Test async cross context dispatch from context A to context B

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/AsyncContextState.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/AsyncContextState.java
@@ -89,7 +89,11 @@ public class AsyncContextState implements AsyncContext
     @Override
     public void dispatch(ServletContext context, String path)
     {
-        state().dispatch(context, path);
+        //check for dispatch to current context
+        if (context != null && context == state().getContextHandler().getContext().getServletContext())
+            state().dispatch(null, path);
+        else
+            state().dispatch(context, path);
     }
 
     @Override

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-sessions/jetty-ee11-test-sessions-common/src/test/java/org/eclipse/jetty/ee11/session/AsyncTest.java
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-sessions/jetty-ee11-test-sessions-common/src/test/java/org/eclipse/jetty/ee11/session/AsyncTest.java
@@ -27,10 +27,14 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.ServletRequestEvent;
 import jakarta.servlet.ServletRequestListener;
+import jakarta.servlet.ServletRequestWrapper;
+import jakarta.servlet.ServletResponseWrapper;
 import jakarta.servlet.WriteListener;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponseWrapper;
 import jakarta.servlet.http.HttpSession;
 import org.awaitility.Awaitility;
 import org.eclipse.jetty.client.ContentResponse;
@@ -156,6 +160,127 @@ public class AsyncTest
                 .until(() -> !contextHandler.getSessionHandler().getSessionCache().contains(id));
             assertFalse(contextHandler.getSessionHandler().getSessionCache().contains(id));
 
+        }
+        finally
+        {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void testSameContextAsync() throws Exception
+    {
+        // Test for degenerate case of async dispatch to same context, not using the
+        // AsyncContext.dispatch(path) method as would be expected, but using the
+        // AsyncContext.dispatch(context, path) method, where context is the same
+        // as the current context
+        Server server = new Server();
+        ContextHandlerCollection contextHandlerCollection = new ContextHandlerCollection();
+
+        final List<String> events = new ArrayList<>();
+
+        ServletContextHandler contextA = new ServletContextHandler();
+        contextA.addEventListener(new ServletRequestListener()
+        {
+            @Override
+            public void requestDestroyed(ServletRequestEvent sre)
+            {
+                events.add("Request Destroyed: " + sre.getServletRequest().getServletContext().getContextPath());
+                ServletRequestListener.super.requestDestroyed(sre);
+            }
+
+            @Override
+            public void requestInitialized(ServletRequestEvent sre)
+            {
+                events.add("Request Initialized: " + sre.getServletRequest().getServletContext().getContextPath());
+                ServletRequestListener.super.requestInitialized(sre);
+            }
+        });
+        contextA.setContextPath("/ctxA");
+        final String ASYNC_FLAG_NAME = "async.flag";
+
+        ServletHolder serviceHolder = new ServletHolder("service-servlet", new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                if (req.getAttribute(ASYNC_FLAG_NAME) == null)
+                {
+                    AsyncContext asyncContext = req.startAsync(req, resp);
+                    req.setAttribute(ASYNC_FLAG_NAME, new Object());
+                    asyncContext.setTimeout(100);
+                    asyncContext.addListener(new AsyncListener()
+                    {
+                        @Override
+                        public void onComplete(AsyncEvent event)
+                        {
+                            events.add("ON complete");
+                        }
+
+                        @Override
+                        public void onTimeout(AsyncEvent event)
+                        {
+                            events.add("ON timeout");
+                        }
+
+                        @Override
+                        public void onError(AsyncEvent event)
+                        {
+                            events.add("ON error");
+                        }
+
+                        @Override
+                        public void onStartAsync(AsyncEvent event)
+                        {
+                            events.add("ON startasync");
+                        }
+                    });
+                    //perform dispatch to current context
+                    asyncContext.dispatch(req.getServletContext(), "/dispatched/z");
+                }
+            }
+        });
+
+        serviceHolder.setAsyncSupported(true);
+        contextA.addServlet(serviceHolder, "/dispatcher/*");
+        contextHandlerCollection.addHandler(contextA);
+
+        ServletHolder testHolder = new ServletHolder("test-servlet", new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                resp.setCharacterEncoding("utf-8");
+                resp.setContentType("text/plain");
+                resp.getWriter().println("Dispatched to ctxA in test-servlet");
+                resp.getWriter().println(req.getQueryString());
+            }
+        });
+
+        contextA.addServlet(testHolder, "/dispatched/*");
+        server.setHandler(contextHandlerCollection);
+        LocalConnector connector = new LocalConnector(server);
+        connector.getConnectionFactory(HttpConfiguration.ConnectionFactory.class).getHttpConfiguration().setSendServerVersion(false);
+        connector.getConnectionFactory(HttpConfiguration.ConnectionFactory.class).getHttpConfiguration().setSendDateHeader(false);
+        server.addConnector(connector);
+
+        server.start();
+
+        try
+        {
+
+            String rawRequest = """
+                GET /ctxA/dispatcher/x?foo=bar HTTP/1.1
+                Host: local
+                Connection: close
+                            
+                """;
+
+            HttpTester.Response response = HttpTester.parseResponse(connector.getResponse(rawRequest));
+            assertThat(response.getStatus(), is(200));
+            assertThat(events, Matchers.containsInRelativeOrder("Request Initialized: /ctxA", "Request Destroyed: /ctxA"));
+            assertThat(response.getContent(), containsString("Dispatched to ctxA in test-servlet"));
+            assertThat(response.getContent(), containsString("foo=bar"));
         }
         finally
         {

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-common/src/test/java/org/eclipse/jetty/ee9/session/AsyncTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-common/src/test/java/org/eclipse/jetty/ee9/session/AsyncTest.java
@@ -159,6 +159,127 @@ public class AsyncTest
     }
 
     @Test
+    public void testSameContextAsync() throws Exception
+    {
+        // Test for degenerate case of async dispatch to same context, not using the
+        // AsyncContext.dispatch(path) method as would be expected, but using the
+        // AsyncContext.dispatch(context, path) method, where context is the same
+        // as the current context
+        Server server = new Server();
+        ContextHandlerCollection contextHandlerCollection = new ContextHandlerCollection();
+
+        final List<String> events = new ArrayList<>();
+
+        ServletContextHandler contextA = new ServletContextHandler();
+        contextA.addEventListener(new ServletRequestListener()
+        {
+            @Override
+            public void requestDestroyed(ServletRequestEvent sre)
+            {
+                events.add("Request Destroyed: " + sre.getServletRequest().getServletContext().getContextPath());
+                ServletRequestListener.super.requestDestroyed(sre);
+            }
+
+            @Override
+            public void requestInitialized(ServletRequestEvent sre)
+            {
+                events.add("Request Initialized: " + sre.getServletRequest().getServletContext().getContextPath());
+                ServletRequestListener.super.requestInitialized(sre);
+            }
+        });
+        contextA.setContextPath("/ctxA");
+        final String ASYNC_FLAG_NAME = "async.flag";
+
+        ServletHolder serviceHolder = new ServletHolder("service-servlet", new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                if (req.getAttribute(ASYNC_FLAG_NAME) == null)
+                {
+                    AsyncContext asyncContext = req.startAsync(req, resp);
+                    req.setAttribute(ASYNC_FLAG_NAME, new Object());
+                    asyncContext.setTimeout(100);
+                    asyncContext.addListener(new AsyncListener()
+                    {
+                        @Override
+                        public void onComplete(AsyncEvent event)
+                        {
+                            events.add("ON complete");
+                        }
+
+                        @Override
+                        public void onTimeout(AsyncEvent event)
+                        {
+                            events.add("ON timeout");
+                        }
+
+                        @Override
+                        public void onError(AsyncEvent event)
+                        {
+                            events.add("ON error");
+                        }
+
+                        @Override
+                        public void onStartAsync(AsyncEvent event)
+                        {
+                            events.add("ON startasync");
+                        }
+                    });
+                    //perform dispatch to current context
+                    asyncContext.dispatch(req.getServletContext(), "/dispatched/z");
+                }
+            }
+        });
+
+        serviceHolder.setAsyncSupported(true);
+        contextA.addServlet(serviceHolder, "/dispatcher/*");
+        contextHandlerCollection.addHandler(contextA);
+
+        ServletHolder testHolder = new ServletHolder("test-servlet", new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                resp.setCharacterEncoding("utf-8");
+                resp.setContentType("text/plain");
+                resp.getWriter().println("Dispatched to ctxA in test-servlet");
+                resp.getWriter().println(req.getQueryString());
+            }
+        });
+
+        contextA.addServlet(testHolder, "/dispatched/*");
+        server.setHandler(contextHandlerCollection);
+        LocalConnector connector = new LocalConnector(server);
+        connector.getConnectionFactory(HttpConfiguration.ConnectionFactory.class).getHttpConfiguration().setSendServerVersion(false);
+        connector.getConnectionFactory(HttpConfiguration.ConnectionFactory.class).getHttpConfiguration().setSendDateHeader(false);
+        server.addConnector(connector);
+
+        server.start();
+
+        try
+        {
+
+            String rawRequest = """
+                GET /ctxA/dispatcher/x?foo=bar HTTP/1.1
+                Host: local
+                Connection: close
+                            
+                """;
+
+            HttpTester.Response response = HttpTester.parseResponse(connector.getResponse(rawRequest));
+            assertThat(response.getStatus(), is(200));
+            assertThat(events, Matchers.containsInRelativeOrder("Request Initialized: /ctxA", "Request Destroyed: /ctxA"));
+            assertThat(response.getContent(), containsString("Dispatched to ctxA in test-servlet"));
+            assertThat(response.getContent(), containsString("foo=bar"));
+        }
+        finally
+        {
+            server.stop();
+        }
+    }
+
+    @Test
     public void testSimpleCrossContextAsync() throws Exception
     {
         //Test async cross context dispatch from context A to context B


### PR DESCRIPTION
Closes #13395

Support call to `AsyncContext.dispatch(context, path)` with the current context.