### PR TITLE
Fix the flaky testNotFileURI test

### DIFF
--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/FileSystemResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/FileSystemResourceTest.java
@@ -184,7 +184,6 @@ public class FileSystemResourceTest
     }
 
     @Test
-    @Tag("flaky")
     public void testNotFileURI()
     {
         assertThrows(IllegalArgumentException.class,

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceFactoryTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceFactoryTest.java
@@ -202,16 +202,23 @@ public class ResourceFactoryTest
     public void testCustomUriSchemeRegistered()
     {
         ResourceFactory.registerResourceFactory("custom", new CustomResourceFactory());
-        // Try as a normal String input
-        Resource resource = ResourceFactory.root().newResource("custom://foo");
-        assertThat(resource.getURI(), is(URI.create("custom://foo")));
-        assertThat(resource.getName(), is("custom-impl"));
+        try
+        {
+            // Try as a normal String input
+            Resource resource = ResourceFactory.root().newResource("custom://foo");
+            assertThat(resource.getURI(), is(URI.create("custom://foo")));
+            assertThat(resource.getName(), is("custom-impl"));
 
-        // Try as a formal URI object as input
-        URI uri = URI.create("custom://foo");
-        resource = ResourceFactory.root().newResource(uri);
-        assertThat(resource.getURI(), is(URI.create("custom://foo")));
-        assertThat(resource.getName(), is("custom-impl"));
+            // Try as a formal URI object as input
+            URI uri = URI.create("custom://foo");
+            resource = ResourceFactory.root().newResource(uri);
+            assertThat(resource.getURI(), is(URI.create("custom://foo")));
+            assertThat(resource.getName(), is("custom-impl"));
+        }
+        finally
+        {
+            ResourceFactory.unregisterResourceFactory("custom");
+        }
     }
 
     @Test
@@ -233,20 +240,27 @@ public class ResourceFactoryTest
         }
 
         ResourceFactory.registerResourceFactory("https", new URLResourceFactory());
-        // Try as a normal String input
-        Resource resource = ResourceFactory.root().newResource("https://webtide.com/");
-        assertThat(resource.getURI(), is(URI.create("https://webtide.com/")));
-        assertThat(resource.getName(), is("https://webtide.com/"));
+        try
+        {
+            // Try as a normal String input
+            Resource resource = ResourceFactory.root().newResource("https://webtide.com/");
+            assertThat(resource.getURI(), is(URI.create("https://webtide.com/")));
+            assertThat(resource.getName(), is("https://webtide.com/"));
 
-        // Try as a formal URI object as input
-        resource = ResourceFactory.root().newResource(uri);
-        assertThat(resource.getURI(), is(URI.create("https://webtide.com/")));
-        assertThat(resource.getName(), is("https://webtide.com/"));
+            // Try as a formal URI object as input
+            resource = ResourceFactory.root().newResource(uri);
+            assertThat(resource.getURI(), is(URI.create("https://webtide.com/")));
+            assertThat(resource.getName(), is("https://webtide.com/"));
 
-        // Try a sub-resource
-        Resource subResource = resource.resolve("favicon.ico");
-        assertThat(subResource.getFileName(), is("favicon.ico"));
-        assertThat(subResource.length(), greaterThan(0L));
+            // Try a sub-resource
+            Resource subResource = resource.resolve("favicon.ico");
+            assertThat(subResource.getFileName(), is("favicon.ico"));
+            assertThat(subResource.length(), greaterThan(0L));
+        }
+        finally
+        {
+            ResourceFactory.unregisterResourceFactory("https");
+        }
     }
 
     public static Stream<Arguments> newResourceCases()


### PR DESCRIPTION
Fix for the issue https://github.com/jetty/jetty.project/issues/13407

- Call `ResourceFactory.unregisterResourceFactory` to cleanup after the 2 tests registering resource factories
- Remove the flaky annotation from the `testNotFileURI` test