### PR TITLE
Fix `<license><name>` by using SPDX in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,11 +18,11 @@
 
   <licenses>
     <license>
-      <name>Eclipse Public License - Version 2.0</name>
+      <name>EPL-2.0</name>
       <url>https://www.eclipse.org/legal/epl-2.0/</url>
     </license>
     <license>
-      <name>Apache Software License - Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>https://www.apache.org/licenses/LICENSE-2.0</url>
     </license>
   </licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -20,10 +20,12 @@
     <license>
       <name>EPL-2.0</name>
       <url>https://www.eclipse.org/legal/epl-2.0/</url>
+      <distribution>repo</distribution>
     </license>
     <license>
       <name>Apache-2.0</name>
-      <url>https://www.apache.org/licenses/LICENSE-2.0</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
     </license>
   </licenses>
 


### PR DESCRIPTION
Automated license compliance checkers complain when the `<name>`
and the `<url>` tag of a `<license>` element in the pom.xml don't match.

Any mismatch requires manual investigation.

The current tag `<name>Apache Software License - Version 2.0</name>`
doesn't match the official license name because the official license
name is `Apache License` and not `Apache Software License`:
https://www.apache.org/licenses/LICENSE-2.0

There are two official ways to fill the `<name>` tag:
* The full legal name of the license as specified by https://maven.apache.org/ref/3.9.11/maven-model/maven.html
* The SPDX identifier as recommended by https://maven.apache.org/pom.html#Licenses

During code review the full legal name was rejected as wrong and it was requested that
the SPDX identifier must be used.

Therefore the `<name>` is changed from the full legal name to the SPDX identifier.
This fixes the issue with the wrong license name.