### PR TITLE
Set the date/time parsing locale to match the hardcoded strings

### DIFF
--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/RolloverFileOutputStreamTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/RolloverFileOutputStreamTest.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -56,14 +57,19 @@ public class RolloverFileOutputStreamTest
 
     private static ZonedDateTime toDateTime(String timendate, ZoneId zone)
     {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd-hh:mm:ss.S a z")
-            .withZone(zone);
-        return ZonedDateTime.parse(timendate, formatter);
+        // Workaround parsing issues with different JVM implementations:
+        // Parse date/time without timezone abbreviation, then use provided zone
+        String dateTimeWithoutTz = timendate.substring(0, timendate.lastIndexOf(' '));
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd-hh:mm:ss.S a")
+            .withLocale(java.util.Locale.US);
+        LocalDateTime localDateTime = LocalDateTime.parse(dateTimeWithoutTz, formatter);
+        return localDateTime.atZone(zone);
     }
 
     private static String toString(TemporalAccessor date)
     {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd-hh:mm:ss.S a z");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd-hh:mm:ss.S a z")
+            .withLocale(java.util.Locale.US);
         return formatter.format(date);
     }
 

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/RolloverFileOutputStreamTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/RolloverFileOutputStreamTest.java
@@ -57,13 +57,10 @@ public class RolloverFileOutputStreamTest
 
     private static ZonedDateTime toDateTime(String timendate, ZoneId zone)
     {
-        // Workaround parsing issues with different JVM implementations:
-        // Parse date/time without timezone abbreviation, then use provided zone
-        String dateTimeWithoutTz = timendate.substring(0, timendate.lastIndexOf(' '));
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd-hh:mm:ss.S a")
-            .withLocale(java.util.Locale.US);
-        LocalDateTime localDateTime = LocalDateTime.parse(dateTimeWithoutTz, formatter);
-        return localDateTime.atZone(zone);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd-hh:mm:ss.S a z")
+            .withLocale(java.util.Locale.US)
+            .withZone(zone);
+        return ZonedDateTime.parse(timendate, formatter);
     }
 
     private static String toString(TemporalAccessor date)

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/RolloverFileOutputStreamTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/RolloverFileOutputStreamTest.java
@@ -18,7 +18,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;


### PR DESCRIPTION
Fix the issue https://github.com/jetty/jetty.project/issues/13411 by setting the date/time parsing locale to match the hardcoded strings