### PR TITLE
Issue #13411 - Use Locale.ROOT with DateTimeFormatter to have a consistent behavior.

### DIFF
--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpDateTimeTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpDateTimeTest.java
@@ -95,7 +95,7 @@ public class HttpDateTimeTest
     {
         ZonedDateTime actual = HttpDateTime.parse(input);
         String actualStr = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss O")
-            .withLocale(Locale.ENGLISH)
+            .withLocale(Locale.ROOT)
             .format(actual);
         assertEquals(expected, actualStr);
     }

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpDateTimeTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpDateTimeTest.java
@@ -17,9 +17,9 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -94,8 +94,9 @@ public class HttpDateTimeTest
     public void testParseValid(String input, String expected)
     {
         ZonedDateTime actual = HttpDateTime.parse(input);
-        DateTimeFormatterBuilder formatter = new DateTimeFormatterBuilder();
-        String actualStr = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss O").format(actual);
+        String actualStr = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss O")
+            .withLocale(Locale.ENGLISH)
+            .format(actual);
         assertEquals(expected, actualStr);
     }
 

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/fileinits/MavenMetadata.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/fileinits/MavenMetadata.java
@@ -129,7 +129,7 @@ public class MavenMetadata
     {
         ZoneId utc = ZoneId.of("UTC");
         LocalDate today = LocalDate.now(utc);
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss").withLocale(Locale.ENGLISH).withZone(utc);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss").withLocale(Locale.ROOT).withZone(utc);
 
         try
         {

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/fileinits/MavenMetadata.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/fileinits/MavenMetadata.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
@@ -128,7 +129,7 @@ public class MavenMetadata
     {
         ZoneId utc = ZoneId.of("UTC");
         LocalDate today = LocalDate.now(utc);
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss").withZone(utc);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss").withLocale(Locale.ENGLISH).withZone(utc);
 
         try
         {

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/fileinits/MavenMetadataTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/fileinits/MavenMetadataTest.java
@@ -18,6 +18,7 @@ import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
@@ -86,6 +87,6 @@ public class MavenMetadataTest
 
     private DateTimeFormatter getTimestampFormatter()
     {
-        return DateTimeFormatter.ofPattern("yyyyMMddHHmmss").withZone(ZoneId.of("UTC"));
+        return DateTimeFormatter.ofPattern("yyyyMMddHHmmss").withLocale(Locale.ENGLISH).withZone(ZoneId.of("UTC"));
     }
 }

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/fileinits/MavenMetadataTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/fileinits/MavenMetadataTest.java
@@ -87,6 +87,6 @@ public class MavenMetadataTest
 
     private DateTimeFormatter getTimestampFormatter()
     {
-        return DateTimeFormatter.ofPattern("yyyyMMddHHmmss").withLocale(Locale.ENGLISH).withZone(ZoneId.of("UTC"));
+        return DateTimeFormatter.ofPattern("yyyyMMddHHmmss").withLocale(Locale.ROOT).withZone(ZoneId.of("UTC"));
     }
 }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/RolloverFileOutputStreamTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/RolloverFileOutputStreamTest.java
@@ -58,7 +58,7 @@ public class RolloverFileOutputStreamTest
     private static ZonedDateTime toDateTime(String timendate, ZoneId zone)
     {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd-hh:mm:ss.S a z")
-            .withLocale(Locale.ENGLISH)
+            .withLocale(Locale.ROOT)
             .withZone(zone);
         return ZonedDateTime.parse(timendate, formatter);
     }
@@ -66,7 +66,7 @@ public class RolloverFileOutputStreamTest
     private static String toString(TemporalAccessor date)
     {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd-hh:mm:ss.S a z")
-            .withLocale(Locale.ENGLISH);
+            .withLocale(Locale.ROOT);
         return formatter.format(date);
     }
 

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/RolloverFileOutputStreamTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/RolloverFileOutputStreamTest.java
@@ -24,6 +24,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAccessor;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -57,13 +58,15 @@ public class RolloverFileOutputStreamTest
     private static ZonedDateTime toDateTime(String timendate, ZoneId zone)
     {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd-hh:mm:ss.S a z")
+            .withLocale(Locale.ENGLISH)
             .withZone(zone);
         return ZonedDateTime.parse(timendate, formatter);
     }
 
     private static String toString(TemporalAccessor date)
     {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd-hh:mm:ss.S a z");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd-hh:mm:ss.S a z")
+            .withLocale(Locale.ENGLISH);
         return formatter.format(date);
     }
 

--- a/tests/jetty-jmh/src/main/java/org/eclipse/jetty/util/jmh/DateCacheBenchmark.java
+++ b/tests/jetty-jmh/src/main/java/org/eclipse/jetty/util/jmh/DateCacheBenchmark.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.util.jmh;
 
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
@@ -40,7 +41,7 @@ import org.openjdk.jmh.runner.options.TimeValue;
 public class DateCacheBenchmark
 {
     TimeZone timeZone = TimeZone.getDefault();
-    DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DateCache.DEFAULT_FORMAT + " SSS").withZone(timeZone.toZoneId());
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DateCache.DEFAULT_FORMAT + " SSS").withLocale(Locale.ENGLISH).withZone(timeZone.toZoneId());
     DateCache dateCache = new DateCache(DateCache.DEFAULT_FORMAT + " SSS", null, timeZone, true);
 
     @Benchmark

--- a/tests/jetty-jmh/src/main/java/org/eclipse/jetty/util/jmh/DateCacheBenchmark.java
+++ b/tests/jetty-jmh/src/main/java/org/eclipse/jetty/util/jmh/DateCacheBenchmark.java
@@ -41,7 +41,7 @@ import org.openjdk.jmh.runner.options.TimeValue;
 public class DateCacheBenchmark
 {
     TimeZone timeZone = TimeZone.getDefault();
-    DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DateCache.DEFAULT_FORMAT + " SSS").withLocale(Locale.ENGLISH).withZone(timeZone.toZoneId());
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DateCache.DEFAULT_FORMAT + " SSS").withLocale(Locale.ROOT).withZone(timeZone.toZoneId());
     DateCache dateCache = new DateCache(DateCache.DEFAULT_FORMAT + " SSS", null, timeZone, true);
 
     @Benchmark


### PR DESCRIPTION
When parsing a Date Time string, the Locale is important.

Closes: #13411 