### PR TITLE
Issue #13419 - Fix locale formatting: add Locale.ROOT to %f and DecimalFormat init

### DIFF
--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/ConnectionPoolTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/ConnectionPoolTest.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.client;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -222,7 +223,7 @@ public class ConnectionPoolTest
         }
         long elapsed = NanoTime.millisSince(begin);
         if (LOG.isInfoEnabled())
-            LOG.info("%d requests in %d ms, %.3f req/s".formatted(iterations, elapsed, elapsed > 0 ? iterations * 1000D / elapsed : -1D));
+            LOG.info(String.format(Locale.ROOT, "%d requests in %d ms, %.3f req/s", iterations, elapsed, elapsed > 0 ? iterations * 1000D / elapsed : -1D));
         latch.countDown();
     }
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/QuotedQualityCSV.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/QuotedQualityCSV.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.http;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.function.ToIntFunction;
 import java.util.stream.Collectors;
@@ -258,7 +259,7 @@ public class QuotedQualityCSV extends QuotedCSV implements Iterable<String>
         @Override
         public String toString()
         {
-            return String.format("%s@%x[%s,q=%f,i=%d]",
+            return String.format(Locale.ROOT, "%s@%x[%s,q=%f,i=%d]",
                 getClass().getSimpleName(),
                 hashCode(),
                 _value,

--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HpackPerfTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HpackPerfTest.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.http2.hpack;
 import java.io.File;
 import java.io.FileReader;
 import java.nio.ByteBuffer;
+import java.util.Locale;
 import java.util.Map;
 
 import org.eclipse.jetty.http.HttpFields;
@@ -46,7 +47,7 @@ public class HpackPerfTest
     @AfterEach
     public void after()
     {
-        System.err.printf("dynamictable=%d unencoded=%d encoded=%d p=%3.1f%%%n", _tableCapacity, _unencodedSize, _encodedSize, 100.0 * _encodedSize / _unencodedSize);
+        System.err.printf(Locale.ROOT, "dynamictable=%d unencoded=%d encoded=%d p=%3.1f%%%n", _tableCapacity, _unencodedSize, _encodedSize, 100.0 * _encodedSize / _unencodedSize);
     }
 
     @Test

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -683,7 +683,7 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
             @Override
             public String toString()
             {
-                return "capacity=%d,in-use=%d/%d,pooled/acquires/releases=%d/%d/%d(%.3f%%),non-pooled/evicts/removes=%d/%d/%d".formatted(
+                return String.format(java.util.Locale.ROOT, "capacity=%d,in-use=%d/%d,pooled/acquires/releases=%d/%d/%d(%.3f%%),non-pooled/evicts/removes=%d/%d/%d",
                     capacity,
                     inUseEntries,
                     totalEntries,

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -22,6 +22,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -683,7 +684,7 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
             @Override
             public String toString()
             {
-                return String.format(java.util.Locale.ROOT, "capacity=%d,in-use=%d/%d,pooled/acquires/releases=%d/%d/%d(%.3f%%),non-pooled/evicts/removes=%d/%d/%d",
+                return String.format(Locale.ROOT, "capacity=%d,in-use=%d/%d,pooled/acquires/releases=%d/%d/%d(%.3f%%),non-pooled/evicts/removes=%d/%d/%d",
                     capacity,
                     inUseEntries,
                     totalEntries,

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/statistic/SampleStatistic.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/statistic/SampleStatistic.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.util.statistic;
 
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAccumulator;
 import java.util.concurrent.atomic.LongAdder;
@@ -125,6 +126,6 @@ public class SampleStatistic
     @Override
     public String toString()
     {
-        return String.format("%s@%x{count=%d,max=%d,mean=%f,total=%d,variance=%f,stddev=%f}", getClass().getSimpleName(), hashCode(), getCount(), getMax(), getMean(), getTotal(), getVariance(), getStdDev());
+        return String.format(Locale.ROOT, "%s@%x{count=%d,max=%d,mean=%f,total=%d,variance=%f,stddev=%f}", getClass().getSimpleName(), hashCode(), getCount(), getMax(), getMean(), getTotal(), getVariance(), getStdDev());
     }
 }

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/coders/ValidDualDecoder.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/coders/ValidDualDecoder.java
@@ -15,7 +15,9 @@ package org.eclipse.jetty.ee10.websocket.jakarta.tests.coders;
 
 import java.nio.ByteBuffer;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.ParseException;
+import java.util.Locale;
 
 import jakarta.websocket.DecodeException;
 import jakarta.websocket.Decoder;
@@ -40,7 +42,7 @@ public class ValidDualDecoder implements Decoder.Text<Integer>, Decoder.Binary<L
     @Override
     public Integer decode(String s) throws DecodeException
     {
-        DecimalFormat numberFormat = new DecimalFormat("[#,###]");
+        DecimalFormat numberFormat = new DecimalFormat("[#,###]", DecimalFormatSymbols.getInstance(Locale.ROOT));
         try
         {
             Number number = numberFormat.parse(s);

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/coders/ValidDualDecoder.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/coders/ValidDualDecoder.java
@@ -15,7 +15,9 @@ package org.eclipse.jetty.ee9.websocket.jakarta.tests.coders;
 
 import java.nio.ByteBuffer;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.ParseException;
+import java.util.Locale;
 
 import jakarta.websocket.DecodeException;
 import jakarta.websocket.Decoder;
@@ -40,7 +42,7 @@ public class ValidDualDecoder implements Decoder.Text<Integer>, Decoder.Binary<L
     @Override
     public Integer decode(String s) throws DecodeException
     {
-        DecimalFormat numberFormat = new DecimalFormat("[#,###]");
+        DecimalFormat numberFormat = new DecimalFormat("[#,###]", DecimalFormatSymbols.getInstance(Locale.ROOT));
         try
         {
             Number number = numberFormat.parse(s);

--- a/tests/jetty-jmh/src/main/java/org/eclipse/jetty/util/thread/jmh/ReservedThreadPoolBenchmark.java
+++ b/tests/jetty-jmh/src/main/java/org/eclipse/jetty/util/thread/jmh/ReservedThreadPoolBenchmark.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.util.thread.jmh;
 
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
 
@@ -113,7 +114,7 @@ public class ReservedThreadPoolBenchmark
         qtp = null;
         System.err.println("Stopped");
         long hits = hit.sum();
-        System.err.printf("hit:miss = %.1f%% (%d:%d)", 100.0D * hits / (hits + miss.sum()), hits, miss.sum());
+        System.err.printf(Locale.ROOT, "hit:miss = %.1f%% (%d:%d)", 100.0D * hits / (hits + miss.sum()), hits, miss.sum());
     }
 
     @Benchmark


### PR DESCRIPTION
Fix https://github.com/jetty/jetty.project/issues/13419 and other potential formatting issues by using Locale.ROOT for:

- Percentage formatting in ArrayByteBufferPool statistics dump
- HTTP quality values in QuotedQualityCSV
- Statistics formatting in SampleStatistic
- Test logging in connection pool tests
- Benchmark output formatting
  