### PR TITLE
Issue #13403 avoid unnecessary exception for 100 continues

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiRequest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiRequest.java
@@ -1198,8 +1198,9 @@ public class ServletApiRequest implements HttpServletRequest
 
         if (_reader != null && charset.equals(_readerCharset))
         {
-            // Try to write a 100 continue, ignoring failure result if it was not necessary.
-            _servletChannel.getResponse().writeInterim(HttpStatus.CONTINUE_100, HttpFields.EMPTY);
+            // Try to write a 100 continue if it is necessary
+            if (_inputState == ServletContextRequest.INPUT_NONE && _servletContextRequest.getHeaders().contains(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE.asString()))
+                _servletChannel.getResponse().writeInterim(HttpStatus.CONTINUE_100, HttpFields.EMPTY);
         }
         else
         {

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
@@ -1170,8 +1170,9 @@ public class Request implements HttpServletRequest
 
         if (_reader != null && encoding.equalsIgnoreCase(_readerEncoding))
         {
-            // Try to write a 100 continue, ignoring failure result if it was not necessary.
-            _channel.getCoreResponse().writeInterim(HttpStatus.CONTINUE_100, HttpFields.EMPTY);
+            // Try to write a 100 continue if it is necessary.
+            if (_inputState == INPUT_NONE && _coreRequest.getHeaders().contains(HttpHeader.EXPECT, HttpHeaderValue.CONTINUE.asString()))
+                _channel.getCoreResponse().writeInterim(HttpStatus.CONTINUE_100, HttpFields.EMPTY);
         }
         else
         {


### PR DESCRIPTION
closes #13403

Apply same fix that was done for the `getInputStream()` method to the `getReader()` method to avoid unnecessary generation of ignored exception when writing an unexpected `100 Continue`.