### PR TITLE
Issue #13409 ensure classpath Resource conversion uses full path

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
@@ -23,7 +23,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Objects;
 import java.util.StringTokenizer;
 
@@ -452,7 +451,7 @@ public interface ResourceFactory
      *     Each part of the input string could be path references (unix or windows style), string URI references, or even glob references (eg: {@code /path/to/libs/*}).
      * </p>
      * <p>
-     *     If the result of processing the input segment is a java archive, then its resulting URI will be a mountable URI as {@code jar:file:...!/}
+     *     If the result of processing the input segment is a java archive, it will not automatically be mounted, the caller must perform the mount if necessary
      * </p>
      *
      * @param str the input string of references
@@ -460,7 +459,12 @@ public interface ResourceFactory
      */
     default List<Resource> split(String str)
     {
-        return split(str, ",;|");
+        return split(str, ",;|", false);
+    }
+
+    default List<Resource> split(String str, String delim)
+    {
+        return split(str, delim, false);
     }
 
     /**
@@ -470,13 +474,15 @@ public interface ResourceFactory
      *     Note: that if you use the {@code :} character in your delims, then URI references will be impossible.
      * </p>
      * <p>
-     *     If the result of processing the input segment is a java archive, then its resulting URI will be a mountable URI as {@code jar:file:...!/}
+     *     If the result of processing the input segment is a java archive it will not be automatically mounted, the caller must mount if necessary
      * </p>
      *
      * @param str the input string of references
+     * @param delims the list of delimiters
+     * @param unwrap if true jar:file references will be unwrapped back to just the container
      * @return list of resources
      */
-    default List<Resource> split(String str, String delims)
+    default List<Resource> split(String str, String delims, boolean unwrap)
     {
         List<Resource> list = new ArrayList<>();
 
@@ -499,23 +505,32 @@ public interface ResourceFactory
                 }
                 else
                 {
-                    // Simple reference
-                    list.add(newResource(reference));
+                    // Simple reference. Could have a scheme like jar:file:, or just file:.
+                    // Or it could be a relative reference, in which case we need to
+                    // ensure it is absolute. Otherwise, comparisons between Resources
+                    // that point to the same resource but one is relative and one is absolute
+                    // will fail.
+                    if (URIUtil.hasScheme(reference) && unwrap)
+                    {
+                        // Could be a jar:file url, ensure it is unwrapped back to the file
+                        // otherwise it will be a MountedPathResource and consume a mount point
+                        // that might be unnecessary - the caller should always decide whether to mount
+                        URI uri = new URI(reference);
+                        list.add(newResource(URIUtil.unwrapContainer(uri)));
+                    }
+                    else
+                    {
+                        Path p = Paths.get(reference);
+                        if (!p.isAbsolute() && LOG.isDebugEnabled())
+                            LOG.warn("Non-absolute path: {}", reference);
+                        list.add(newResource(p.toAbsolutePath()));
+                    }
                 }
             }
             catch (Exception e)
             {
                 LOG.warn("Invalid Resource Reference: {}", reference);
-                throw e;
             }
-        }
-
-        // Perform Archive file mounting (if needed)
-        for (ListIterator<Resource> i = list.listIterator(); i.hasNext(); )
-        {
-            Resource resource = i.next();
-            if (resource.exists() && !resource.isDirectory() && FileID.isLibArchive(resource.getName()))
-                i.set(newResource(URIUtil.toJarFileUri(resource.getURI())));
         }
 
         return list;

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
@@ -510,13 +510,16 @@ public interface ResourceFactory
                     // ensure it is absolute. Otherwise, comparisons between Resources
                     // that point to the same resource but one is relative and one is absolute
                     // will fail.
-                    if (URIUtil.hasScheme(reference) && unwrap)
+                    if (URIUtil.hasScheme(reference))
                     {
                         // Could be a jar:file url, ensure it is unwrapped back to the file
                         // otherwise it will be a MountedPathResource and consume a mount point
                         // that might be unnecessary - the caller should always decide whether to mount
                         URI uri = new URI(reference);
-                        list.add(newResource(URIUtil.unwrapContainer(uri)));
+                        if (unwrap)
+                            list.add(newResource(URIUtil.unwrapContainer(uri)));
+                        else
+                            list.add(newResource(uri.toASCIIString()));
                     }
                     else
                     {
@@ -529,7 +532,10 @@ public interface ResourceFactory
             }
             catch (Exception e)
             {
-                LOG.warn("Invalid Resource Reference: {}", reference);
+                if (LOG.isDebugEnabled())
+                    LOG.warn("Invalid Resource Reference: {}", reference, e);
+                else
+                    LOG.warn("Invalid Resource Reference: {}", reference);
             }
         }
 

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/CombinedResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/CombinedResourceTest.java
@@ -24,12 +24,14 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
+import org.eclipse.jetty.util.FileID;
 import org.eclipse.jetty.util.URIUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -455,6 +457,15 @@ public class CombinedResourceTest
 
         // To use this, we need to split it (and optionally honor globs)
         List<Resource> resources = resourceFactory.split(config);
+
+        // Perform Archive file mounting (if needed)
+        for (ListIterator<Resource> i = resources.listIterator(); i.hasNext(); )
+        {
+            Resource resource = i.next();
+            if (resource.exists() && !resource.isDirectory() && FileID.isLibArchive(resource.getName()))
+                i.set(resourceFactory.newResource(URIUtil.toJarFileUri(resource.getURI())));
+        }
+
         // Now let's create a ResourceCollection from this list of URIs
         // Since this is user space, we cannot know ahead of time what
         // this list contains, so we mount because we assume there

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceFactoryTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceFactoryTest.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
@@ -50,6 +51,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -311,7 +313,7 @@ public class ResourceFactoryTest
     }
 
     @Test
-    public void testSplitSingleJar()
+    public void testSplitSingleJar() throws URISyntaxException
     {
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {
@@ -324,7 +326,7 @@ public class ResourceFactoryTest
     }
 
     @Test
-    public void testSplitSinglePath()
+    public void testSplitSinglePath() throws URISyntaxException
     {
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {
@@ -337,7 +339,25 @@ public class ResourceFactoryTest
     }
 
     @Test
-    public void testSplitOnComma()
+    public void testSplitIsAbsolute() throws Exception
+    {
+        try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
+        {
+            String config = String.format("%s,%s,%s,%s,%s,%s", "dir/a", "foo/b", "bar/c", "jar:file:///foo/bar.jar!/", "file:///foo/bar.jar", "/foo/bar.jar");
+
+            List<Resource> resources = resourceFactory.split(config, File.pathSeparator, true);
+
+            resources.stream().forEach(r ->
+            {
+                //Note: do not test the value of absolute resolution of the relative references as this is system dependent.
+                assertFalse(r instanceof MountedPathResource);
+                assertThat(r.getPath().isAbsolute(), is(true));
+            });
+        }
+    }
+
+    @Test
+    public void testSplitOnComma() throws URISyntaxException
     {
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {
@@ -365,7 +385,7 @@ public class ResourceFactoryTest
     }
 
     @Test
-    public void testSplitOnPipe()
+    public void testSplitOnPipe() throws URISyntaxException
     {
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {
@@ -393,7 +413,7 @@ public class ResourceFactoryTest
     }
 
     @Test
-    public void testSplitOnSemicolon()
+    public void testSplitOnSemicolon() throws URISyntaxException
     {
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {
@@ -421,7 +441,7 @@ public class ResourceFactoryTest
     }
 
     @Test
-    public void testSplitOnPathSeparatorWithGlob() throws IOException
+    public void testSplitOnPathSeparatorWithGlob() throws IOException, URISyntaxException
     {
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {
@@ -443,7 +463,7 @@ public class ResourceFactoryTest
             ));
 
             // Split using commas
-            List<URI> uris = resourceFactory.split(config, File.pathSeparator).stream().map(Resource::getURI).toList();
+            List<URI> uris = resourceFactory.split(config, File.pathSeparator, false).stream().map(Resource::getURI).toList();
 
             URI[] expected = new URI[]{
                 dir.toUri(),
@@ -460,7 +480,7 @@ public class ResourceFactoryTest
 
     @ParameterizedTest
     @ValueSource(strings = {";", "|", ","})
-    public void testSplitOnDelimWithGlob(String delimChar) throws IOException
+    public void testSplitOnDelimWithGlob(String delimChar) throws IOException, URISyntaxException
     {
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceFactoryTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceFactoryTest.java
@@ -50,6 +50,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -320,7 +321,7 @@ public class ResourceFactoryTest
             Path testJar = MavenPaths.findTestResourceFile("jar-file-resource.jar");
             String input = testJar.toUri().toASCIIString();
             List<Resource> resources = resourceFactory.split(input);
-            String expected = URIUtil.toJarFileUri(testJar.toUri()).toASCIIString();
+            String expected = testJar.toUri().toASCIIString();
             assertThat(resources.get(0).getURI().toString(), is(expected));
         }
     }
@@ -333,7 +334,7 @@ public class ResourceFactoryTest
             Path testJar = MavenPaths.findTestResourceFile("jar-file-resource.jar");
             String input = testJar.toString();
             List<Resource> resources = resourceFactory.split(input);
-            String expected = URIUtil.toJarFileUri(testJar.toUri()).toASCIIString();
+            String expected = testJar.toUri().toASCIIString();
             assertThat(resources.get(0).getURI().toString(), is(expected));
         }
     }
@@ -344,15 +345,23 @@ public class ResourceFactoryTest
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {
             String config = String.format("%s,%s,%s,%s,%s,%s", "dir/a", "foo/b", "bar/c", "jar:file:///foo/bar.jar!/", "file:///foo/bar.jar", "/foo/bar.jar");
-
-            List<Resource> resources = resourceFactory.split(config, File.pathSeparator, true);
-
+            List<Resource> resources = resourceFactory.split(config, ",", true);
             resources.stream().forEach(r ->
             {
                 //Note: do not test the value of absolute resolution of the relative references as this is system dependent.
-                assertFalse(r instanceof MountedPathResource);
-                assertThat(r.getPath().isAbsolute(), is(true));
+                assertThat(r, not(instanceOf(MountedPathResource.class))); //unwrapped so cannot be mounted
+                assertThat(r.getPath().isAbsolute(), is(true)); //must be absolute
             });
+
+            //test that an unwrapped jar:file will try to be mounted and fail because it isn't a real location
+            resources = resourceFactory.split("jar:file:///foo/bar.jar!/", ",", false);
+            assertThat(resources.size(), is(0));
+
+            //test that uri with a scheme, but is not unwrapped returns a Resource
+            resources = resourceFactory.split("file:///foo/bar.jar", ",", false);
+            assertThat(resources.size(), is(1));
+            assertThat(resources.get(0), not(instanceOf(MountedPathResource.class)));
+            assertThat(resources.get(0).getPath().isAbsolute(), is(true));
         }
     }
 
@@ -468,10 +477,9 @@ public class ResourceFactoryTest
             URI[] expected = new URI[]{
                 dir.toUri(),
                 foo.toUri(),
-                // Should see the two archives as `jar:file:` URI entries
-                URIUtil.toJarFileUri(bar.resolve("lib-foo.jar").toUri()),
-                URIUtil.toJarFileUri(bar.resolve("lib-zed.zip").toUri()),
-                URIUtil.toJarFileUri(exampleJar.toUri())
+                bar.resolve("lib-foo.jar").toUri(),
+                bar.resolve("lib-zed.zip").toUri(),
+                exampleJar.toUri()
             };
 
             assertThat(uris, contains(expected));
@@ -509,10 +517,9 @@ public class ResourceFactoryTest
             URI[] expected = new URI[]{
                 dir.toUri(),
                 foo.toUri(),
-                // Should see the two archives as `jar:file:` URI entries
-                URIUtil.toJarFileUri(bar.resolve("lib-foo.jar").toUri()),
-                URIUtil.toJarFileUri(bar.resolve("lib-zed.zip").toUri()),
-                URIUtil.toJarFileUri(exampleJar.toUri())
+                bar.resolve("lib-foo.jar").toUri(),
+                bar.resolve("lib-zed.zip").toUri(),
+                exampleJar.toUri()
             };
 
             assertThat(uris, contains(expected));

--- a/jetty-ee10/jetty-ee10-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-webapp/pom.xml
@@ -95,6 +95,7 @@
           <useManifestOnlyJar>false</useManifestOnlyJar>
           <additionalClasspathElements>
             <additionalClasspathElement>${basedir}/src/test/resources/mods/foo-bar-janb.jar</additionalClasspathElement>
+            <additionalClasspathElement>src/test/resources/mods/com-acme-janb.jar</additionalClasspathElement>
           </additionalClasspathElements>
           <excludes>
             <exclude>org.eclipse.jetty.ee10.webapp.WebAppClassLoaderUrlStreamTest</exclude>

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
@@ -168,6 +168,9 @@ public class MetaInfConfiguration extends AbstractConfiguration
         String classPath = System.getProperty("java.class.path");
         if (classPath != null)
         {
+            //convert classpath into Resources. Any jar:file: references will be
+            //unwrapped, because we need the location of the file, not the contents
+            //of the file
             resourceFactory.split(classPath, File.pathSeparator, true)
                 .stream()
                 .filter(Objects::nonNull)

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
@@ -20,7 +20,6 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -169,15 +168,8 @@ public class MetaInfConfiguration extends AbstractConfiguration
         String classPath = System.getProperty("java.class.path");
         if (classPath != null)
         {
-            //The classpath may contain relative paths of jar files etc. We
-            //must convert these relative paths to full paths. This is because
-            //in eg scanForFragment, the web-fragment.xml Resource is a
-            //fully qualified path. In MetaData.resolve() we compare this
-            //fully qualified path with the container Resources, and thus both
-            //must be fully qualified for a match (as per PathResource.equals() method).
-            Stream.of(classPath.split(File.pathSeparator))
-                .map(Paths::get)
-                .map(p -> resourceFactory.newResource(p.toUri().toASCIIString()))
+            resourceFactory.split(classPath, File.pathSeparator, true)
+                .stream()
                 .filter(Objects::nonNull)
                 .filter(r -> uriPatternPredicate.test(r.getURI()))
                 .forEach(addContainerResource);

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaInfConfiguration.java
@@ -20,6 +20,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -168,10 +169,17 @@ public class MetaInfConfiguration extends AbstractConfiguration
         String classPath = System.getProperty("java.class.path");
         if (classPath != null)
         {
-            resourceFactory.split(classPath, File.pathSeparator)
-                .stream()
+            //The classpath may contain relative paths of jar files etc. We
+            //must convert these relative paths to full paths. This is because
+            //in eg scanForFragment, the web-fragment.xml Resource is a
+            //fully qualified path. In MetaData.resolve() we compare this
+            //fully qualified path with the container Resources, and thus both
+            //must be fully qualified for a match (as per PathResource.equals() method).
+            Stream.of(classPath.split(File.pathSeparator))
+                .map(Paths::get)
+                .map(p -> resourceFactory.newResource(p.toUri().toASCIIString()))
                 .filter(Objects::nonNull)
-                .filter(r -> uriPatternPredicate.test(URIUtil.unwrapContainer(r.getURI())))
+                .filter(r -> uriPatternPredicate.test(r.getURI()))
                 .forEach(addContainerResource);
         }
 

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
@@ -1260,6 +1260,9 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
      */
     public void setExtraClasspath(String extraClasspath)
     {
+        //convert classpath into Resources. Any jar:file: references will be
+        //unwrapped, because we need the location of the file, not the contents
+        //of the file
         setExtraClasspath(getResourceFactory().split(extraClasspath, File.pathSeparator, true));
     }
 

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.ee10.webapp;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -1259,7 +1260,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
      */
     public void setExtraClasspath(String extraClasspath)
     {
-        setExtraClasspath(getResourceFactory().split(extraClasspath));
+        setExtraClasspath(getResourceFactory().split(extraClasspath, File.pathSeparator, true));
     }
 
     public void setExtraClasspath(List<Resource> extraClasspath)

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/MetaInfConfigurationTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/MetaInfConfigurationTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.ee10.webapp;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
@@ -21,6 +22,7 @@ import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +36,7 @@ import org.eclipse.jetty.util.TypeUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.resource.FileSystemPool;
+import org.eclipse.jetty.util.resource.MountedPathResource;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceCollators;
 import org.junit.jupiter.api.AfterEach;
@@ -46,12 +49,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(WorkDirExtension.class)
 @Isolated("Access static method of FileSystemPool")
 public class MetaInfConfigurationTest
 {
-
     @BeforeEach
     public void beforeEach()
     {
@@ -528,6 +533,48 @@ public class MetaInfConfigurationTest
         env.put("create", "true");
         URI jarUri = URIUtil.uriJarPrefix(jarFile.toUri(), "!/");
         return FileSystems.newFileSystem(jarUri, env);
+    }
+
+    @Test
+    public void testRelativeContainerPaths() throws Exception
+    {
+        // check to make sure that the test environment is set up correctly
+        // with a relative reference
+        String classPath = System.getProperty("java.class.path");
+        String[] files = classPath.split(File.pathSeparator);
+        String relativeFile = null;
+        for (String f : files)
+        {
+            if (f.endsWith("com-acme-janb.jar"))
+                relativeFile = f;
+        }
+
+        assertThat(relativeFile, notNullValue());
+        assertFalse(Paths.get(relativeFile).isAbsolute());
+
+        // test that the relative reference is converted into a resource with absolute Path
+        MetaInfConfiguration config = new MetaInfConfiguration();
+        WebAppContext context = new WebAppContext();
+        context.setServer(new Server());
+        try
+        {
+            context.setAttribute(MetaInfConfiguration.CONTAINER_JAR_PATTERN, ".*/com-acme-janb.jar");
+            WebAppClassLoader loader = new WebAppClassLoader(context);
+            context.setClassLoader(loader);
+            config.preConfigure(context);
+
+            List<Resource> resources = context.getMetaData().getContainerResources();
+            assertThat(resources.size(), is(1));
+            assertTrue(resources.get(0).getPath().isAbsolute());
+            assertFalse(resources.get(0) instanceof MountedPathResource);
+        }
+        finally
+        {
+            config.postConfigure(context);
+            // manually stop ResourceFactory.
+            // normally this would be done via WebAppContext.stop(), but we didn't start the context.
+            LifeCycle.stop(context.getResourceFactory());
+        }
     }
 
     /**

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppContextTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppContextTest.java
@@ -759,7 +759,6 @@ public class WebAppContextTest
                 .filter(FileID::isJavaArchive)
                 .sorted(Comparator.naturalOrder())
                 .map(Path::toUri)
-                .map(URIUtil::toJarFileUri)
                 .collect(Collectors.toList());
         }
         List<URI> actualURIs = new ArrayList<>();

--- a/jetty-ee8/jetty-ee8-webapp/pom.xml
+++ b/jetty-ee8/jetty-ee8-webapp/pom.xml
@@ -131,6 +131,7 @@
           <useManifestOnlyJar>false</useManifestOnlyJar>
           <additionalClasspathElements>
             <additionalClasspathElement>${project.build.testOutputDirectory}/mods/foo-bar-janb.jar</additionalClasspathElement>
+            <additionalClasspathElement>target/test-classes/mods/com-acme-janb.jar</additionalClasspathElement>
           </additionalClasspathElements>
           <excludes>
             <exclude>org.eclipse.jetty.ee8.webapp.WebAppClassLoaderUrlStreamTest</exclude>

--- a/jetty-ee9/jetty-ee9-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-webapp/pom.xml
@@ -110,6 +110,7 @@
           <useManifestOnlyJar>false</useManifestOnlyJar>
           <additionalClasspathElements>
             <additionalClasspathElement>${project.build.testOutputDirectory}/mods/foo-bar-janb.jar</additionalClasspathElement>
+            <additionalClasspathElement>src/test/resources/mods/com-acme-janb.jar</additionalClasspathElement>
           </additionalClasspathElements>
           <excludes>
             <exclude>org.eclipse.jetty.ee9.webapp.WebAppClassLoaderUrlStreamTest</exclude>

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
@@ -173,7 +173,7 @@ public class MetaInfConfiguration extends AbstractConfiguration
             resourceFactory.split(classPath, File.pathSeparator, true)
                 .stream()
                 .filter(Objects::nonNull)
-                .filter(r -> uriPatternPredicate.test(URIUtil.unwrapContainer(r.getURI())))
+                .filter(r -> uriPatternPredicate.test(r.getURI()))
                 .forEach(addContainerResource);
         }
 

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
@@ -170,7 +170,7 @@ public class MetaInfConfiguration extends AbstractConfiguration
         String classPath = System.getProperty("java.class.path");
         if (classPath != null)
         {
-            resourceFactory.split(classPath, File.pathSeparator)
+            resourceFactory.split(classPath, File.pathSeparator, true)
                 .stream()
                 .filter(Objects::nonNull)
                 .filter(r -> uriPatternPredicate.test(URIUtil.unwrapContainer(r.getURI())))

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaInfConfiguration.java
@@ -170,6 +170,9 @@ public class MetaInfConfiguration extends AbstractConfiguration
         String classPath = System.getProperty("java.class.path");
         if (classPath != null)
         {
+            //convert classpath into Resources. Any jar:file: references will be
+            //unwrapped, because we need the location of the file, not the contents
+            //of the file
             resourceFactory.split(classPath, File.pathSeparator, true)
                 .stream()
                 .filter(Objects::nonNull)

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
@@ -1267,7 +1267,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
      */
     public void setExtraClasspath(String extraClasspath) throws IOException
     {
-        setExtraClasspath(getResourceFactory().split(extraClasspath));
+        setExtraClasspath(getResourceFactory().split(extraClasspath, File.pathSeparator, true));
     }
 
     public void setExtraClasspath(List<Resource> extraClasspath)

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
@@ -1267,6 +1267,9 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
      */
     public void setExtraClasspath(String extraClasspath) throws IOException
     {
+        //convert classpath into Resources. Any jar:file: references will be
+        //unwrapped, because we need the location of the file, not the contents
+        //of the file
         setExtraClasspath(getResourceFactory().split(extraClasspath, File.pathSeparator, true));
     }
 

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/MetaInfConfigurationTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/MetaInfConfigurationTest.java
@@ -13,7 +13,9 @@
 
 package org.eclipse.jetty.ee9.webapp;
 
+import java.io.File;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -22,10 +24,15 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.component.LifeCycle;
+import org.eclipse.jetty.util.resource.MountedPathResource;
 import org.eclipse.jetty.util.resource.Resource;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -119,6 +126,48 @@ public class MetaInfConfigurationTest
         context31false.getServletContext().setEffectiveMajorVersion(3);
         context31false.getServletContext().setEffectiveMinorVersion(1);
         meta31false.preConfigure(context31false);
+    }
+
+    @Test
+    public void testRelativeContainerPaths() throws Exception
+    {
+        // check to make sure that the test environment is set up correctly
+        // with a relative reference
+        String classPath = System.getProperty("java.class.path");
+        String[] files = classPath.split(File.pathSeparator);
+        String relativeFile = null;
+        for (String f : files)
+        {
+            if (f.endsWith("com-acme-janb.jar"))
+                relativeFile = f;
+        }
+
+        assertThat(relativeFile, notNullValue());
+        assertFalse(Paths.get(relativeFile).isAbsolute());
+
+        // test that the relative reference is converted into a resource with absolute Path
+        MetaInfConfiguration config = new MetaInfConfiguration();
+        WebAppContext context = new WebAppContext();
+        context.setServer(new Server());
+        try
+        {
+            context.setAttribute(MetaInfConfiguration.CONTAINER_JAR_PATTERN, ".*/com-acme-janb.jar");
+            WebAppClassLoader loader = new WebAppClassLoader(context);
+            context.setClassLoader(loader);
+            config.preConfigure(context);
+
+            List<Resource> resources = context.getMetaData().getContainerResources();
+            assertThat(resources.size(), is(1));
+            assertTrue(resources.get(0).getPath().isAbsolute());
+            assertFalse(resources.get(0) instanceof MountedPathResource);
+        }
+        finally
+        {
+            config.postConfigure(context);
+            // manually stop ResourceFactory.
+            // normally this would be done via WebAppContext.stop(), but we didn't start the context.
+            LifeCycle.stop(context.getResourceFactory());
+        }
     }
 
     /**

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppContextTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppContextTest.java
@@ -775,7 +775,6 @@ public class WebAppContextTest
                 .filter(FileID::isLibArchive)
                 .sorted(Comparator.naturalOrder())
                 .map(Path::toUri)
-                .map(URIUtil::toJarFileUri)
                 .collect(Collectors.toList());
         }
         List<URI> actualURIs = new ArrayList<>();


### PR DESCRIPTION
closes #13409

The problem described in #13409 has 2 parts to it:

1.  #11092 converted all classpath jars into `MountedPathResource` instead of `PathResource`
2.  after the change in #10889 to use non-ephemeral `Resources` to refer to the results of scanning for `web-fragment.xml`, `*.tld` and `META-INF/resources` (so that we avoid keeping mount points around for jars that don't actually contain any of these things), whenever we compare `Resources` we must ensure that their `path`s are the same.

For example, when running with a command line like:

> java -cp target/dependency/*:target/application-1.0.jar  some.Main

and `target/dependency/library-1.0.jar` contains a `web-fragment.xml` we see the following:

The container `Resource` is a `MountedPathResource` and has:

```
path = /
uri = jar:file:///home/janb/src/tmp/application/target/dependency/library-1.0.jar!/
```
The `Resource` of the jar known to contain the `web-fragment.xml` is a `PathResource` and has:

```
path=/home/janb/src/tmp/application/target/dependency/library-1.0.jar
uri=file:///home/janb/src/tmp/application/target/dependency/library-1.0.jar
```
As can be seen, there are 2 problems:

1 A comparison of these 2 resources fails because `MountedPathResource` is not a `PathResource` 
2 Even if they were both `PathResources`, the paths are different 

Reverting the change to `MetaInfConfiguration` from #11092, we now have both `Resources` as `PathResource`, but one resource has a relative path whilst the other is fully qualified:

The container `Resource`  has:

```
path=target/dependency/library-1.0.jar
uri=file:///home/janb/src/tmp/application/target/dependency/library-1.0.jar
```

The `Resource` that represents the jar with fragment has:

```
path=/home/janb/src/tmp/application/target/dependency/library-1.0.jar
uri=file:///home/janb/src/tmp/application/target/dependency/library-1.0.jar
```

This PR reverts the change from #11092, but also ensures that _both_ the container `Resource` and jar containing the fragment `Resource` have fully qualified paths.

@joakime is there a way to modify your change from #11092 to keep some of the goodness, but ensure that it doesn't always create `MountedPathResource`? We definitely don't want to always do the mount, because we only want to mount if we are going to be keeping the resource around because it has something useful in it (ie see the changes we made in #10889). We do need to retain the fix in this PR to ensure that the paths are fully qualified.




