### PR TITLE
Issue #13432 - Skip testBindAddress if the 127.0.0.2 address is not bindable

### DIFF
--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
@@ -1945,6 +1945,18 @@ public class HttpClientTest extends AbstractHttpClientServerTest
     public void testBindAddress(Scenario scenario) throws Exception
     {
         String bindAddress = "127.0.0.2";
+
+        // Pre-check if the address is bindable (on macOS probably not)
+        try (ServerSocket testSocket = new ServerSocket())
+        {
+            testSocket.bind(new InetSocketAddress(bindAddress, 0));
+        }
+        catch (IOException e)
+        {
+            Assumptions.assumeTrue(false, 
+                "Cannot bind to " + bindAddress + " address on this system");
+        }
+
         start(scenario, new EmptyServerHandler()
         {
             @Override

--- a/jetty-core/jetty-jmx/src/test/java/org/eclipse/jetty/jmx/ConnectorServerTest.java
+++ b/jetty-core/jetty-jmx/src/test/java/org/eclipse/jetty/jmx/ConnectorServerTest.java
@@ -29,6 +29,8 @@ import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.matchesRegex;
@@ -223,6 +225,7 @@ public class ConnectorServerTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.MAC, disabledReason = "Fails on macOS due to SSL socket binding issue when RMI registry and server use same port")
     public void testJMXOverTLS() throws Exception
     {
         SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();


### PR DESCRIPTION
Fix the [jetty/jetty.project#13432](https://github.com/jetty/jetty.project/issues/13432) if the 127.0.0.2 address is not bindable, for example, on macOS