### PR TITLE
Issue #13432 - Skip testBindAddress if the 127.0.0.2 address is not bindable

### DIFF
--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
@@ -1945,6 +1945,18 @@ public class HttpClientTest extends AbstractHttpClientServerTest
     public void testBindAddress(Scenario scenario) throws Exception
     {
         String bindAddress = "127.0.0.2";
+
+        // Pre-check if the address is bindable (on macOS probably not)
+        try (ServerSocket testSocket = new ServerSocket())
+        {
+            testSocket.bind(new InetSocketAddress(bindAddress, 0));
+        }
+        catch (IOException e)
+        {
+            Assumptions.assumeTrue(false, 
+                "Cannot bind to " + bindAddress + " address on this system");
+        }
+
         start(scenario, new EmptyServerHandler()
         {
             @Override


### PR DESCRIPTION
Fix the https://github.com/jetty/jetty.project/issues/13432 if the 127.0.0.2 address is not bindable, for example, on macOS