### PR TITLE
Issue #13437 - Skip RolloverFileOutputStreamTest tests if the date abbreviations are not parsable

### DIFF
--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/RolloverFileOutputStreamTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/RolloverFileOutputStreamTest.java
@@ -32,6 +32,7 @@ import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -56,9 +57,18 @@ public class RolloverFileOutputStreamTest
 
     private static ZonedDateTime toDateTime(String timendate, ZoneId zone)
     {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd-hh:mm:ss.S a z")
-            .withZone(zone);
-        return ZonedDateTime.parse(timendate, formatter);
+        try
+        {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd-hh:mm:ss.S a z")
+                .withZone(zone);
+            return ZonedDateTime.parse(timendate, formatter);
+        }
+        catch (Exception e)
+        {
+            Assumptions.assumeTrue(false, 
+                "Timezone abbreviation parsing not supported on this system for: " + timendate);
+            return null;
+        }
     }
 
     private static String toString(TemporalAccessor date)

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/RolloverFileOutputStreamTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/RolloverFileOutputStreamTest.java
@@ -24,6 +24,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAccessor;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -60,13 +61,14 @@ public class RolloverFileOutputStreamTest
         try
         {
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd-hh:mm:ss.S a z")
+                .withLocale(Locale.ENGLISH)
                 .withZone(zone);
             return ZonedDateTime.parse(timendate, formatter);
         }
         catch (Exception e)
         {
-            // Skip the test when timezone abbreviation parsing fails (e.g., on macOS).
-            // DST information is crucial for the tests and cannot be lost by using timezone full names.
+            // Skip this test if timezone abbreviation parsing fails (for example, on macOS).
+            // DST information is critical for the tests, but it is lost when using full timezone names 
             Assumptions.assumeTrue(false, 
                 "Timezone abbreviation parsing not supported on this system for: " + timendate);
             return null;
@@ -75,7 +77,8 @@ public class RolloverFileOutputStreamTest
 
     private static String toString(TemporalAccessor date)
     {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd-hh:mm:ss.S a z");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd-hh:mm:ss.S a z")
+            .withLocale(Locale.ENGLISH);
         return formatter.format(date);
     }
 

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/RolloverFileOutputStreamTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/RolloverFileOutputStreamTest.java
@@ -65,6 +65,8 @@ public class RolloverFileOutputStreamTest
         }
         catch (Exception e)
         {
+            // Skip the test when timezone abbreviation parsing fails (e.g., on macOS).
+            // DST information is crucial for the tests and cannot be lost by using timezone full names.
             Assumptions.assumeTrue(false, 
                 "Timezone abbreviation parsing not supported on this system for: " + timendate);
             return null;


### PR DESCRIPTION
Fix the https://github.com/jetty/jetty.project/issues/13437 by catching date/time parsing exceptions and skipping the tests in the `toDateTime()` method