### PR TITLE
Issue #13441 - Use eclipse.org/jetty for the testExternalSiteRedirect

### DIFF
--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/ExternalSiteTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/ExternalSiteTest.java
@@ -132,7 +132,7 @@ public class ExternalSiteTest
     @Test
     public void testExternalSiteRedirect() throws Exception
     {
-        String host = "twitter.com";
+        String host = "eclipse.org";
         int port = 443;
 
         // Verify that we have connectivity
@@ -140,7 +140,7 @@ public class ExternalSiteTest
 
         ContentResponse response = client.newRequest(host, port)
             .scheme(HttpScheme.HTTPS.asString())
-            .path("/twitter")
+            .path("/jetty")
             .timeout(15, TimeUnit.SECONDS)
             .send();
         assertEquals(200, response.getStatus());


### PR DESCRIPTION
Fix the https://github.com/jetty/jetty.project/issues/13441 by changing the URL used in testExternalSiteRedirect to  https://eclipse.org/jetty which results in successful double redirect to the URL https://jetty.org