### PR TITLE
Fixes #13436 - AssertionError in MemoryEndPointPipe.MemoryEndPoint.fill().

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/HeaderBlockFragments.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/HeaderBlockFragments.java
@@ -47,7 +47,7 @@ public class HeaderBlockFragments
     {
         if (storage == null)
         {
-            if (length > maxCapacity)
+            if (maxCapacity > 0 && length > maxCapacity)
                 return false;
             int capacity = last ? length : length * 2;
             storage = bufferPool.acquire(capacity, fragment.isDirect());
@@ -58,7 +58,7 @@ public class HeaderBlockFragments
         if (storage.remaining() < length)
         {
             ByteBuffer byteBuffer = storage.getByteBuffer();
-            if (byteBuffer.position() + length > maxCapacity)
+            if (maxCapacity > 0 && (byteBuffer.position() + length) > maxCapacity)
                 return false;
             int space = last ? length : length * 2;
             int capacity = byteBuffer.position() + space;

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/FillInterest.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/FillInterest.java
@@ -91,16 +91,20 @@ public abstract class FillInterest
      */
     public boolean fillable()
     {
-        if (LOG.isDebugEnabled())
-            LOG.debug("fillable {}", this);
         Callback callback = _interested.get();
-        if (callback != null && _interested.compareAndSet(callback, null))
+        if (callback == null)
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("fillable, no callback {}", this);
+            return false;
+        }
+        if (_interested.compareAndSet(callback, null))
         {
             callback.succeeded();
             return true;
         }
         if (LOG.isDebugEnabled())
-            LOG.debug("{} lost race {}", this, callback);
+            LOG.debug("fillable, callback lost race {} {}", callback, this);
         return false;
     }
 

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/FillInterest.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/FillInterest.java
@@ -100,6 +100,8 @@ public abstract class FillInterest
         }
         if (_interested.compareAndSet(callback, null))
         {
+            if (LOG.isDebugEnabled())
+                LOG.debug("fillable, notifying callback {} {}", callback, this);
             callback.succeeded();
             return true;
         }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/MemoryEndPointPipe.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/MemoryEndPointPipe.java
@@ -193,6 +193,8 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
         {
             try (AutoLock ignored = lock.lock())
             {
+                // Checking for data and setting the callback must be atomic,
+                // otherwise the notification issued by a write() may be lost.
                 if (peerEndPoint.byteBuffers.isEmpty())
                 {
                     super.fillInterested(callback);
@@ -209,6 +211,8 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
         {
             try (AutoLock ignored = lock.lock())
             {
+                // Checking for data and setting the callback must be atomic,
+                // otherwise the notification issued by a write() may be lost.
                 if (peerEndPoint.byteBuffers.isEmpty())
                     return super.tryFillInterested(callback);
             }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/MemoryEndPointPipe.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/MemoryEndPointPipe.java
@@ -36,8 +36,6 @@ import org.slf4j.LoggerFactory;
  */
 public class MemoryEndPointPipe implements EndPoint.Pipe
 {
-    private static final Logger LOG = LoggerFactory.getLogger(MemoryEndPointPipe.class);
-
     private final LocalEndPoint localEndPoint;
     private final RemoteEndPoint remoteEndPoint;
     private final Consumer<Invocable.Task> taskConsumer;
@@ -75,6 +73,7 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
 
     private class MemoryEndPoint extends AbstractEndPoint
     {
+        private static final Logger LOG = LoggerFactory.getLogger(MemoryEndPoint.class);
         private static final ByteBuffer EOF = ByteBuffer.allocate(0);
 
         private final AutoLock lock = new AutoLock();
@@ -174,7 +173,7 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
                     if (data == null)
                         return filled;
                     if (data == EOF)
-                        return -1;
+                        return filled > 0 ? filled : -1;
                     int length = data.remaining();
                     int copied = BufferUtil.append(buffer, data);
                     capacity -= copied;

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/MemoryEndPointPipe.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/MemoryEndPointPipe.java
@@ -247,7 +247,7 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
                     // The buffer must be copied, otherwise a write() would complete
                     // and return it to the buffer pool where its backing store would
                     // be overwritten before it is read by the peer EndPoint.
-                    ByteBuffer copy = copy(buffer);
+                    ByteBuffer copy = lockedCopy(buffer);
                     if (copy == null)
                     {
                         result = false;
@@ -277,7 +277,7 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
             return result;
         }
 
-        private ByteBuffer copy(ByteBuffer buffer)
+        private ByteBuffer lockedCopy(ByteBuffer buffer)
         {
             int length = buffer.remaining();
             long maxCapacity = getMaxCapacity();

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/MemoryEndPointPipe.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/MemoryEndPointPipe.java
@@ -165,19 +165,24 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
 
         private int fillInto(ByteBuffer buffer)
         {
+            int filled = 0;
             try (AutoLock ignored = lock.lock())
             {
-                ByteBuffer data = byteBuffers.peek();
-                if (data == null)
-                    return 0;
-                if (data == EOF)
-                    return -1;
-                int length = data.remaining();
-                int copied = BufferUtil.append(buffer, data);
-                capacity -= copied;
-                if (copied == length)
+                while (true)
+                {
+                    ByteBuffer data = byteBuffers.peek();
+                    if (data == null)
+                        return filled;
+                    if (data == EOF)
+                        return -1;
+                    int length = data.remaining();
+                    int copied = BufferUtil.append(buffer, data);
+                    capacity -= copied;
+                    filled += copied;
+                    if (copied < length)
+                        return filled;
                     byteBuffers.poll();
-                return copied;
+                }
             }
         }
 
@@ -240,28 +245,17 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
                     if (remaining == 0)
                         continue;
 
-                    ByteBuffer slice;
-                    long maxCapacity = getMaxCapacity();
-                    if (maxCapacity > 0)
+                    // The buffer must be copied, otherwise a write() would complete
+                    // and return it to the buffer pool where its backing store would
+                    // be overwritten before it is read by the peer EndPoint.
+                    ByteBuffer copy = copy(buffer);
+                    if (copy == null)
                     {
-                        long space = maxCapacity - capacity;
-                        if (space == 0)
-                        {
-                            result = false;
-                            break;
-                        }
-                        if (remaining <= space)
-                            slice = buffer.slice();
-                        else
-                            slice = buffer.slice(buffer.position(), (int)space);
+                        result = false;
+                        break;
                     }
-                    else
-                    {
-                        slice = buffer.slice();
-                    }
-                    byteBuffers.offer(slice);
-                    int length = slice.remaining();
-                    buffer.position(buffer.position() + length);
+                    byteBuffers.offer(copy);
+                    int length = copy.remaining();
                     capacity += length;
                     flushed += length;
                     if (length < remaining)
@@ -282,6 +276,24 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
             }
 
             return result;
+        }
+
+        private ByteBuffer copy(ByteBuffer buffer)
+        {
+            int length = buffer.remaining();
+            long maxCapacity = getMaxCapacity();
+            if (maxCapacity > 0)
+            {
+                long space = maxCapacity - capacity;
+                if (space == 0)
+                    return null;
+                length = (int)Math.min(length, space);
+            }
+            // TODO: Use RetainableByteBuffer.DynamicCapacity in Jetty 12.1.x.
+            ByteBuffer copy = buffer.isDirect() ? ByteBuffer.allocateDirect(length) : ByteBuffer.allocate(length);
+            copy.put(0, buffer, buffer.position(), length);
+            buffer.position(buffer.position() + length);
+            return copy;
         }
 
         @Override

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/MemoryEndPointPipe.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/MemoryEndPointPipe.java
@@ -20,11 +20,11 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.HexFormat;
 import java.util.Objects;
-import java.util.Queue;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
 import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.thread.AutoLock;
 import org.eclipse.jetty.util.thread.Invocable;
 import org.eclipse.jetty.util.thread.Scheduler;
@@ -62,7 +62,17 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
     {
         return remoteEndPoint;
     }
+
+    public void setLocalEndPointMaxCapacity(int maxCapacity)
+    {
+        localEndPoint.setMaxCapacity(maxCapacity);
+    }
     
+    public void setRemoteEndPointMaxCapacity(int maxCapacity)
+    {
+        remoteEndPoint.setMaxCapacity(maxCapacity);
+    }
+
     private class MemoryEndPoint extends AbstractEndPoint
     {
         private static final ByteBuffer EOF = ByteBuffer.allocate(0);
@@ -135,60 +145,77 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
             if (isInputShutdown())
                 return -1;
 
-            int filled;
-            ByteBuffer data;
-            try (AutoLock ignored = peerEndPoint.lock.lock())
-            {
-                Queue<ByteBuffer> byteBuffers = peerEndPoint.byteBuffers;
-                data = byteBuffers.peek();
-
-                if (data == null)
-                {
-                    filled = 0;
-                }
-                else if (data == EOF)
-                {
-                    filled = -1;
-                }
-                else
-                {
-                    int length = data.remaining();
-                    int space = BufferUtil.space(buffer);
-                    if (length <= space)
-                        byteBuffers.poll();
-
-                    filled = Math.min(length, space);
-                    peerEndPoint.capacity -= filled;
-                }
-            }
+            int filled = peerEndPoint.fillInto(buffer);
 
             if (LOG.isDebugEnabled())
                 LOG.debug("filled {} from {}", filled, this);
-
-            if (data == null)
-                return 0;
-
-            if (data == EOF)
-            {
-                shutdownInput();
-                return -1;
-            }
-
-            int copied = BufferUtil.append(buffer, data);
-            assert copied == filled;
 
             if (filled > 0)
             {
                 notIdle();
                 onFilled();
             }
+            else if (filled < 0)
+            {
+                shutdownInput();
+            }
 
             return filled;
         }
 
+        private int fillInto(ByteBuffer buffer)
+        {
+            try (AutoLock ignored = lock.lock())
+            {
+                ByteBuffer data = byteBuffers.peek();
+                if (data == null)
+                    return 0;
+                if (data == EOF)
+                    return -1;
+                int length = data.remaining();
+                int copied = BufferUtil.append(buffer, data);
+                capacity -= copied;
+                if (copied == length)
+                    byteBuffers.poll();
+                return copied;
+            }
+        }
+
         private void onFilled()
         {
+            if (LOG.isDebugEnabled())
+                LOG.debug("filled, notifying completeWrite {}", this);
             taskConsumer.accept(completeWriteTask);
+        }
+
+        @Override
+        public void fillInterested(Callback callback)
+        {
+            try (AutoLock ignored = lock.lock())
+            {
+                if (peerEndPoint.byteBuffers.isEmpty())
+                {
+                    super.fillInterested(callback);
+                    return;
+                }
+            }
+            if (LOG.isDebugEnabled())
+                LOG.debug("fill interested, data available {}", this);
+            callback.succeeded();
+        }
+
+        @Override
+        public boolean tryFillInterested(Callback callback)
+        {
+            try (AutoLock ignored = lock.lock())
+            {
+                if (peerEndPoint.byteBuffers.isEmpty())
+                    return super.tryFillInterested(callback);
+            }
+            if (LOG.isDebugEnabled())
+                LOG.debug("try fill interested, data available {}", this);
+            callback.succeeded();
+            return false;
         }
 
         @Override
@@ -209,18 +236,35 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
                     if (remaining == 0)
                         continue;
 
-                    long newCapacity = capacity + remaining;
+                    ByteBuffer slice;
                     long maxCapacity = getMaxCapacity();
-                    if (maxCapacity > 0 && newCapacity > maxCapacity)
+                    if (maxCapacity > 0)
+                    {
+                        long space = maxCapacity - capacity;
+                        if (space == 0)
+                        {
+                            result = false;
+                            break;
+                        }
+                        if (remaining <= space)
+                            slice = buffer.slice();
+                        else
+                            slice = buffer.slice(buffer.position(), (int)space);
+                    }
+                    else
+                    {
+                        slice = buffer.slice();
+                    }
+                    byteBuffers.offer(slice);
+                    int length = slice.remaining();
+                    buffer.position(buffer.position() + length);
+                    capacity += length;
+                    flushed += length;
+                    if (length < remaining)
                     {
                         result = false;
                         break;
                     }
-
-                    byteBuffers.offer(BufferUtil.copy(buffer));
-                    buffer.position(buffer.limit());
-                    capacity = newCapacity;
-                    flushed += remaining;
                 }
             }
 
@@ -262,6 +306,8 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
 
         private void onFlushed()
         {
+            if (LOG.isDebugEnabled())
+                LOG.debug("flushed, notifying fillable {}", this);
             taskConsumer.accept(fillableTask);
         }
     }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/WriteFlusher.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/WriteFlusher.java
@@ -42,7 +42,6 @@ import org.slf4j.LoggerFactory;
 public abstract class WriteFlusher
 {
     private static final Logger LOG = LoggerFactory.getLogger(WriteFlusher.class);
-    private static final boolean DEBUG = LOG.isDebugEnabled(); // Easy for the compiler to remove the code if DEBUG==false
     private static final ByteBuffer[] EMPTY_BUFFERS = new ByteBuffer[]{BufferUtil.EMPTY_BUFFER};
     private static final EnumMap<StateType, Set<StateType>> __stateTransitions = new EnumMap<>(StateType.class);
     private static final State __IDLE = new IdleState();
@@ -104,7 +103,7 @@ public abstract class WriteFlusher
             throw new IllegalStateException();
 
         boolean updated = _state.compareAndSet(previous, next);
-        if (DEBUG)
+        if (LOG.isDebugEnabled())
             LOG.debug("update {}:{}{}{}", this, previous, updated ? "-->" : "!->", next);
         return updated;
     }
@@ -227,7 +226,7 @@ public abstract class WriteFlusher
         State s = _state.get();
         return (s instanceof PendingState)
             ? ((PendingState)s).getCallbackInvocationType()
-            : Invocable.InvocationType.BLOCKING;
+            : Invocable.InvocationType.NON_BLOCKING;
     }
 
     /**
@@ -264,7 +263,7 @@ public abstract class WriteFlusher
             return;
         }
 
-        if (DEBUG)
+        if (LOG.isDebugEnabled())
             LOG.debug("write: {} {}", this, BufferUtil.toDetailString(buffers));
 
         if (!updateState(__IDLE, __WRITING))
@@ -276,7 +275,7 @@ public abstract class WriteFlusher
 
             if (buffers != null)
             {
-                if (DEBUG)
+                if (LOG.isDebugEnabled())
                     LOG.debug("flush incomplete {}", this);
                 PendingState pending = new PendingState(callback, address, buffers);
                 if (updateState(__WRITING, pending))
@@ -294,7 +293,7 @@ public abstract class WriteFlusher
         }
         catch (Throwable e)
         {
-            if (DEBUG)
+            if (LOG.isDebugEnabled())
                 LOG.debug("write exception", e);
             if (updateState(__WRITING, new FailedState(e)))
                 callback.failed(e);
@@ -356,7 +355,7 @@ public abstract class WriteFlusher
      */
     public void completeWrite()
     {
-        if (DEBUG)
+        if (LOG.isDebugEnabled())
             LOG.debug("completeWrite: {}", this);
 
         State previous = _state.get();
@@ -378,7 +377,7 @@ public abstract class WriteFlusher
 
             if (buffers != null)
             {
-                if (DEBUG)
+                if (LOG.isDebugEnabled())
                     LOG.debug("flushed incomplete {}", BufferUtil.toDetailString(buffers));
                 if (buffers != pending._buffers)
                     pending = new PendingState(callback, address, buffers);
@@ -396,7 +395,7 @@ public abstract class WriteFlusher
         }
         catch (Throwable e)
         {
-            if (DEBUG)
+            if (LOG.isDebugEnabled())
                 LOG.debug("completeWrite exception", e);
             if (updateState(__COMPLETING, new FailedState(e)))
                 callback.failed(e);
@@ -419,7 +418,7 @@ public abstract class WriteFlusher
         while (progress && buffers != null)
         {
             long before = BufferUtil.remaining(buffers);
-            boolean flushed = address == null ? _endPoint.flush(buffers) : ((DatagramChannelEndPoint)_endPoint).send(address, buffers);
+            boolean flushed = address == null ? _endPoint.flush(buffers) : _endPoint.send(address, buffers);
             long after = BufferUtil.remaining(buffers);
             long written = before - after;
 
@@ -486,7 +485,7 @@ public abstract class WriteFlusher
             {
                 case IDLE:
                 case FAILED:
-                    if (DEBUG)
+                    if (LOG.isDebugEnabled())
                     {
                         LOG.debug("ignored: {} {}", cause, this);
                         LOG.trace("IGNORED", cause);
@@ -494,7 +493,7 @@ public abstract class WriteFlusher
                     return false;
 
                 case PENDING:
-                    if (DEBUG)
+                    if (LOG.isDebugEnabled())
                         LOG.debug("failed: {}", this, cause);
 
                     PendingState pending = (PendingState)current;
@@ -507,7 +506,7 @@ public abstract class WriteFlusher
 
                 case WRITING:
                 case COMPLETING:
-                    if (DEBUG)
+                    if (LOG.isDebugEnabled())
                         LOG.debug("failed: {}", this, cause);
                     if (updateState(current, new FailedState(cause)))
                         return true;
@@ -554,21 +553,14 @@ public abstract class WriteFlusher
 
     public String toStateString()
     {
-        switch (_state.get().getType())
+        return switch (_state.get().getType())
         {
-            case WRITING:
-                return "W";
-            case PENDING:
-                return "P";
-            case COMPLETING:
-                return "C";
-            case IDLE:
-                return "-";
-            case FAILED:
-                return "F";
-            default:
-                return "?";
-        }
+            case WRITING -> "W";
+            case PENDING -> "P";
+            case COMPLETING -> "C";
+            case IDLE -> "-";
+            case FAILED -> "F";
+        };
     }
 
     @Override

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/WriteFlusher.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/WriteFlusher.java
@@ -224,9 +224,7 @@ public abstract class WriteFlusher
     public InvocationType getCallbackInvocationType()
     {
         State s = _state.get();
-        return (s instanceof PendingState)
-            ? ((PendingState)s).getCallbackInvocationType()
-            : Invocable.InvocationType.NON_BLOCKING;
+        return (s instanceof PendingState p) ? p.getCallbackInvocationType() : Invocable.InvocationType.BLOCKING;
     }
 
     /**

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/MemoryEndPointPipeTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/MemoryEndPointPipeTest.java
@@ -1,0 +1,150 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.io;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.util.Blocker;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.eclipse.jetty.util.thread.ScheduledExecutorScheduler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MemoryEndPointPipeTest
+{
+    private final ByteBufferPool buffers = new ArrayByteBufferPool();
+    private final ScheduledExecutorScheduler scheduler = new ScheduledExecutorScheduler();
+    private final QueuedThreadPool executor = new QueuedThreadPool();
+
+    @BeforeEach
+    public void prepare() throws Exception
+    {
+        scheduler.start();
+        executor.start();
+    }
+
+    @AfterEach
+    public void dispose() throws Exception
+    {
+        executor.stop();
+        scheduler.stop();
+    }
+
+    @Test
+    public void testEndPointPiping() throws Exception
+    {
+        MemoryEndPointPipe pipe = new MemoryEndPointPipe(scheduler, executor::execute, null);
+
+        EndPoint localEndPoint = pipe.getLocalEndPoint();
+        EndPoint remoteEndPoint = pipe.getRemoteEndPoint();
+
+        Callback.Completable remoteFillCallback = new Callback.Completable();
+        remoteEndPoint.fillInterested(remoteFillCallback);
+
+        RetainableByteBuffer buffer = buffers.acquire(512, false);
+        ByteBuffer byteBuffer = buffer.getByteBuffer();
+
+        byte[] smallZeros = new byte[byteBuffer.capacity() / 2];
+        byte[] largeOnes = new byte[byteBuffer.capacity() * 2];
+        Arrays.fill(largeOnes, (byte)1);
+        Blocker.Shared blocker = new Blocker.Shared();
+        try (Blocker.Callback callback = blocker.callback())
+        {
+            localEndPoint.write(callback, ByteBuffer.wrap(smallZeros));
+            callback.block();
+        }
+        try (Blocker.Callback callback = blocker.callback())
+        {
+            localEndPoint.write(callback, ByteBuffer.wrap(largeOnes));
+            callback.block();
+        }
+        int totalWritten = smallZeros.length + largeOnes.length;
+
+        remoteFillCallback.get(5, TimeUnit.SECONDS);
+
+        int totalFilled = 0;
+        while (true)
+        {
+            int filled = remoteEndPoint.fill(byteBuffer);
+            if (filled > 0)
+            {
+                byteBuffer.position(byteBuffer.position() + filled);
+                totalFilled += filled;
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        assertThat(totalFilled, equalTo(totalWritten));
+    }
+
+    @Test
+    public void testWriteCongestedResumesWhenReading() throws Exception
+    {
+        MemoryEndPointPipe pipe = new MemoryEndPointPipe(scheduler, executor::execute, null);
+        pipe.setLocalEndPointMaxCapacity(1024);
+
+        EndPoint localEndPoint = pipe.getLocalEndPoint();
+        EndPoint remoteEndPoint = pipe.getRemoteEndPoint();
+
+        Callback.Completable remoteFillCallback = new Callback.Completable();
+        remoteEndPoint.fillInterested(remoteFillCallback);
+
+        Callback.Completable localWriteCallback = new Callback.Completable();
+        int totalWritten = 2048;
+        localEndPoint.write(localWriteCallback, ByteBuffer.allocate(totalWritten));
+        localWriteCallback.thenRun(localEndPoint::close);
+
+        assertTrue(((AbstractEndPoint)localEndPoint).getWriteFlusher().isPending());
+
+        remoteFillCallback.get(5, TimeUnit.SECONDS);
+
+        RetainableByteBuffer buffer = buffers.acquire(512, false);
+        ByteBuffer byteBuffer = buffer.getByteBuffer();
+        int totalFilled = 0;
+        while (true)
+        {
+            int filled = remoteEndPoint.fill(byteBuffer);
+            if (filled > 0)
+            {
+                byteBuffer.position(byteBuffer.position() + filled);
+                totalFilled += filled;
+            }
+            else if (filled == 0)
+            {
+                try (Blocker.Callback callback = Blocker.callback())
+                {
+                    remoteEndPoint.fillInterested(callback);
+                    callback.block();
+                }
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        assertThat(totalFilled, equalTo(totalWritten));
+    }
+}

--- a/jetty-core/jetty-io/src/test/resources/jetty-logging.properties
+++ b/jetty-core/jetty-io/src/test/resources/jetty-logging.properties
@@ -1,4 +1,5 @@
 #org.eclipse.jetty.LEVEL=DEBUG
+#org.eclipse.jetty.io.LEVEL=DEBUG
 #org.eclipse.jetty.io.AbstractConnection.LEVEL=DEBUG
 #org.eclipse.jetty.io.ManagedSelector.LEVEL=DEBUG
 #org.eclipse.jetty.io.ssl.SslConnection.LEVEL=DEBUG

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Blocker.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Blocker.java
@@ -72,23 +72,8 @@ import org.slf4j.LoggerFactory;
 public class Blocker
 {
     private static final Logger LOG = LoggerFactory.getLogger(Blocker.class);
-
-    private static final Throwable ACQUIRED = new Throwable()
-    {
-        @Override
-        public Throwable fillInStackTrace()
-        {
-            return this;
-        }
-    };
-    private static final Throwable SUCCEEDED = new Throwable()
-    {
-        @Override
-        public Throwable fillInStackTrace()
-        {
-            return this;
-        }
-    };
+    private static final Throwable ACQUIRED = new StaticException("ACQUIRED");
+    private static final Throwable SUCCEEDED = new StaticException("SUCCEEDED");
 
     public interface Runnable extends java.lang.Runnable, AutoCloseable, Invocable
     {


### PR DESCRIPTION
* Improved MemoryEndPoint.fill() to avoid assuming the space in the buffer parameter.
* Fixed race condition in [try]fillInterested(): now checks if the peer has data available.
* Improved MemoryEndPoint.flush() to flush as many bytes as possible, up to max capacity.