### PR TITLE
Upgrade quiche to version 0.24.5

### DIFF
--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/main/java/org/eclipse/jetty/quic/quiche/foreign/quiche_h.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/main/java/org/eclipse/jetty/quic/quiche/foreign/quiche_h.java
@@ -30,7 +30,7 @@ import static org.eclipse.jetty.quic.quiche.foreign.NativeHelper.C_POINTER;
 
 public class quiche_h
 {
-    private static final String EXPECTED_QUICHE_VERSION = "0.24.4";
+    private static final String EXPECTED_QUICHE_VERSION = "0.24.5";
     private static final Logger LOG = LoggerFactory.getLogger(quiche_h.class);
 
     static void initialize()

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/LibQuiche.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/LibQuiche.java
@@ -30,7 +30,7 @@ public interface LibQuiche extends Library
 {
     // This interface is a translation of the quiche.h header of a specific version.
     // It needs to be reviewed each time the native lib version changes.
-    String EXPECTED_QUICHE_VERSION = "0.24.4";
+    String EXPECTED_QUICHE_VERSION = "0.24.5";
 
     // The charset used to convert java.lang.String to char * and vice versa.
     Charset CHARSET = StandardCharsets.UTF_8;

--- a/pom.xml
+++ b/pom.xml
@@ -209,7 +209,7 @@
     <jboss.logging.processor.version>2.2.2.Final</jboss.logging.processor.version>
     <jboss.logging.version>3.6.1.Final</jboss.logging.version>
     <jetty-assembly-descriptors.version>1.1</jetty-assembly-descriptors.version>
-    <jetty-quiche-native.version>0.24.4</jetty-quiche-native.version>
+    <jetty-quiche-native.version>0.24.5</jetty-quiche-native.version>
     <jetty-test-policy.version>1.2</jetty-test-policy.version>
     <jetty-version.maven.plugin.version>2.7</jetty-version.maven.plugin.version>
     <jetty.perf-helper.version>1.0.7</jetty.perf-helper.version>


### PR DESCRIPTION
This Quiche release fixes [CVE-2025-7054](https://www.cve.org/CVERecord?id=CVE-2025-7054) and a few other minor bugs, plus it introduces a handful of new minor features.

The C API has not been touched since the previous version, see https://github.com/cloudflare/quiche/compare/0.24.4...0.24.5 for the Quiche sources diff.

Closes https://github.com/jetty-project/jetty-quiche-native/issues/147