### PR TITLE
Jetty 10.0.x: backport #13261 to fix unreleased H2 connections bug

### DIFF
--- a/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
@@ -318,6 +318,16 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
             {
                 Connection connection = entry.getPooled();
 
+                if (connection.isClosed())
+                {
+                    // No point checking the return value,
+                    // the connection is already closed.
+                    remove(connection);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("Connection removed: closed {} {}", entry, pool);
+                    continue;
+                }
+
                 long maxDurationNanos = this.maxDurationNanos;
                 if (maxDurationNanos > 0L)
                 {

--- a/jetty-client/src/main/java/org/eclipse/jetty/client/HttpConnection.java
+++ b/jetty-client/src/main/java/org/eclipse/jetty/client/HttpConnection.java
@@ -112,9 +112,8 @@ public abstract class HttpConnection implements IConnection, Attachable
             }
             else
             {
-                // Association may fail, for example if the application
-                // aborted the request, so we must release the channel.
-                channel.release();
+                // Association may fail, for example if
+                // the application aborted the request.
                 result = new SendFailure(new HttpRequestException("Could not associate request to connection", request), false);
             }
 

--- a/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpChannelOverHTTP2.java
+++ b/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpChannelOverHTTP2.java
@@ -109,15 +109,19 @@ public class HttpChannelOverHTTP2 extends HttpChannel
         sender.send(exchange);
     }
 
+    void acquire()
+    {
+        if (LOG.isDebugEnabled())
+            LOG.debug("channel acquired {} {}", this, stream);
+    }
+
     @Override
     public void release()
     {
         setStream(null);
-        boolean released = connection.release(this);
+        connection.release(this);
         if (LOG.isDebugEnabled())
-            LOG.debug("released channel? {} {}", released, this);
-        if (released)
-            getHttpDestination().release(getHttpConnection());
+            LOG.debug("channel released {} {}", this, stream);
     }
 
     @Override

--- a/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpReceiverOverHTTP2.java
+++ b/jetty-http2/http2-http-client-transport/src/main/java/org/eclipse/jetty/http2/client/http/HttpReceiverOverHTTP2.java
@@ -168,7 +168,7 @@ public class HttpReceiverOverHTTP2 extends HttpReceiver implements HTTP2Channel.
             Response.CompleteListener listener = pushListener.apply(request, pushRequest);
             if (listener != null)
             {
-                HttpChannelOverHTTP2 pushChannel = getHttpChannel().getHttpConnection().acquireHttpChannel();
+                HttpChannelOverHTTP2 pushChannel = getHttpChannel().getHttpConnection().newHttpChannel();
                 HttpExchange pushExchange = new HttpExchange(getHttpDestination(), pushRequest, List.of(listener));
                 pushChannel.associate(pushExchange);
                 pushChannel.setStream(stream);

--- a/jetty-http2/http2-http-client-transport/src/test/java/org/eclipse/jetty/http2/client/http/GoAwayTest.java
+++ b/jetty-http2/http2-http-client-transport/src/test/java/org/eclipse/jetty/http2/client/http/GoAwayTest.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+
 import org.eclipse.jetty.client.AbstractConnectionPool;
 import org.eclipse.jetty.client.HttpDestination;
 import org.eclipse.jetty.client.RandomConnectionPool;

--- a/jetty-http3/http3-http-client-transport/src/main/java/org/eclipse/jetty/http3/client/http/internal/HttpConnectionOverHTTP3.java
+++ b/jetty-http3/http3-http-client-transport/src/main/java/org/eclipse/jetty/http3/client/http/internal/HttpConnectionOverHTTP3.java
@@ -94,7 +94,13 @@ public class HttpConnectionOverHTTP3 extends HttpConnection implements Connectio
         HttpChannelOverHTTP3 channel = newHttpChannel();
         activeChannels.add(channel);
 
-        return send(channel, exchange);
+        SendFailure result = send(channel, exchange);
+        if (result != null)
+        {
+            activeChannels.remove(channel);
+            channel.destroy();
+        }
+        return result;
     }
 
     protected HttpChannelOverHTTP3 newHttpChannel()
@@ -104,9 +110,10 @@ public class HttpConnectionOverHTTP3 extends HttpConnection implements Connectio
 
     public void release(HttpChannelOverHTTP3 channel)
     {
+        boolean removed = activeChannels.remove(channel);
         if (LOG.isDebugEnabled())
-            LOG.debug("released {}", channel);
-        if (activeChannels.remove(channel))
+            LOG.debug("released {} {}", removed, channel);
+        if (removed)
             getHttpDestination().release(this);
         else
             channel.destroy();
@@ -152,5 +159,14 @@ public class HttpConnectionOverHTTP3 extends HttpConnection implements Connectio
         if (super.onIdleTimeout(idleTimeout, failure))
             close(failure);
         return false;
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("%s(closed=%b)[%s]",
+            super.toString(),
+            isClosed(),
+            session);
     }
 }

--- a/jetty-util/src/main/java/org/eclipse/jetty/util/thread/AutoLock.java
+++ b/jetty-util/src/main/java/org/eclipse/jetty/util/thread/AutoLock.java
@@ -46,6 +46,22 @@ public class AutoLock implements AutoCloseable, Serializable
     }
 
     /**
+     * <p>Tries to acquire the lock.</p>
+     * <p>Whether the lock was acquired can be tested
+     * with {@link #isHeldByCurrentThread()}.</p>
+     * <p>Typical usage of this method is in {@code toString()},
+     * to avoid deadlocks when the implementation needs to lock
+     * to retrieve a consistent state to produce the string.</p>
+     *
+     * @return this AutoLock for unlocking
+     */
+    public AutoLock tryLock()
+    {
+        _lock.tryLock();
+        return this;
+    }
+
+    /**
      * @see ReentrantLock#isHeldByCurrentThread()
      * @return whether this lock is held by the current thread
      */


### PR DESCRIPTION
The unreleased H2 connections bug triggered when the server immediately responds with a GO_AWAY frame fixed for Jetty 12.0.x (#13261) also affects 10.0.x.

This PR attempts at backporting that fix.