### PR TITLE
Issue #13398 - Improve LoginAuthenticators to handle Proxy-Authenticate

### DIFF
--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientAuthenticationTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientAuthenticationTest.java
@@ -26,7 +26,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.IntFunction;
 
-import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.io.Content;
@@ -37,6 +36,7 @@ import org.eclipse.jetty.security.LoginService;
 import org.eclipse.jetty.security.SecurityHandler;
 import org.eclipse.jetty.security.authentication.BasicAuthenticator;
 import org.eclipse.jetty.security.authentication.DigestAuthenticator;
+import org.eclipse.jetty.security.authentication.LoginAuthenticator;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
@@ -58,6 +58,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
 {
+    private LoginAuthenticator authenticator;
+
     private String realm = "TestRealm";
 
     public void startBasic(Scenario scenario, Handler handler) throws Exception
@@ -67,18 +69,20 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
 
     public void startBasic(Scenario scenario, Handler handler, Charset charset) throws Exception
     {
-        BasicAuthenticator authenticator = new BasicAuthenticator();
+        BasicAuthenticator basicAuthenticator = new BasicAuthenticator();
         if (charset != null)
-            authenticator.setCharset(charset);
-        authenticator.setProxy(isProxyMode());
+            basicAuthenticator.setCharset(charset);
+        basicAuthenticator.setProxyMode(isProxyMode());
+        authenticator = basicAuthenticator;
 
         start(scenario, authenticator, handler);
     }
 
     public void startDigest(Scenario scenario, Handler handler) throws Exception
     {
-        DigestAuthenticator authenticator = new DigestAuthenticator();
-        authenticator.setProxy(isProxyMode());
+        DigestAuthenticator digestAuthenticator = new DigestAuthenticator();
+        digestAuthenticator.setProxyMode(isProxyMode());
+        authenticator = digestAuthenticator;
 
         start(scenario, authenticator, handler);
     }
@@ -176,11 +180,11 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         };
         client.getRequestListeners().addListener(requestListener);
 
-        // Request without Authentication causes 401 / 407
+        // Request without authentication causes 401 / 407
         Request request = client.newRequest("localhost", connector.getLocalPort()).scheme(scenario.getScheme()).path("/secure");
         ContentResponse response = request.timeout(5, TimeUnit.SECONDS).send();
         assertNotNull(response);
-        assertEquals(getUnauthorizedStatus(), response.getStatus());
+        assertEquals(authenticator.getUnauthorizedStatusCode(), response.getStatus());
         assertTrue(requests.get().await(5, TimeUnit.SECONDS));
         client.getRequestListeners().removeListener(requestListener);
 
@@ -368,7 +372,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         request = client.newRequest("localhost", connector.getLocalPort()).scheme(scenario.getScheme()).path("/secure");
         response = request.timeout(5, TimeUnit.SECONDS).send();
         assertNotNull(response);
-        assertEquals(getUnauthorizedStatus(), response.getStatus());
+        assertEquals(authenticator.getUnauthorizedStatusCode(), response.getStatus());
         assertTrue(requests.get().await(5, TimeUnit.SECONDS));
     }
 
@@ -386,7 +390,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         Request request = client.newRequest("localhost", connector.getLocalPort()).scheme(scenario.getScheme()).path("/secure");
         ContentResponse response = request.timeout(5, TimeUnit.SECONDS).send();
         assertNotNull(response);
-        assertEquals(getUnauthorizedStatus(), response.getStatus());
+        assertEquals(authenticator.getUnauthorizedStatusCode(), response.getStatus());
 
         Authentication.Result authenticationResult = authenticationStore.findAuthenticationResult(uri);
         assertNull(authenticationResult);
@@ -425,7 +429,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
             .send(result ->
             {
                 assertTrue(result.isFailed());
-                assertEquals(getUnauthorizedStatus(), result.getResponse().getStatus());
+                assertEquals(authenticator.getUnauthorizedStatusCode(), result.getResponse().getStatus());
                 assertEquals(cause, result.getFailure().getMessage());
                 latch.countDown();
             });
@@ -441,11 +445,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
 
         AuthenticationStore authenticationStore = client.getAuthenticationStore();
         URI uri = URI.create(scenario.getScheme() + "://localhost:" + connector.getLocalPort());
-        authenticationStore.addAuthenticationResult(
-            isProxyMode()
-                ? new BasicAuthentication.BasicResult(uri, HttpHeader.PROXY_AUTHORIZATION, "basic", "basic")
-                : new BasicAuthentication.BasicResult(uri, "basic", "basic")
-        );
+        authenticationStore.addAuthenticationResult(new BasicAuthentication.BasicResult(uri, authenticator.getAuthorizationHeader(), "basic", "basic"));
 
         AtomicInteger requests = new AtomicInteger();
         client.getRequestListeners().addListener(new Request.Listener()
@@ -486,7 +486,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
             .body(content);
         request.send(result ->
         {
-            if (result.isSucceeded() && result.getResponse().getStatus() == getUnauthorizedStatus())
+            if (result.isSucceeded() && result.getResponse().getStatus() == authenticator.getUnauthorizedStatusCode())
                 resultLatch.countDown();
         });
 
@@ -580,20 +580,15 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
     public void testInfiniteAuthentication(Scenario scenario) throws Exception
     {
         String authType = "Authenticate";
-        start(scenario, new Handler.Abstract()
+        startBasic(scenario, new Handler.Abstract()
         {
             @Override
             public boolean handle(org.eclipse.jetty.server.Request request, org.eclipse.jetty.server.Response response, Callback callback)
             {
-                // Always reply with a 401 to see if the client
+                // Always reply with a 401 / 407 to see if the client
                 // can handle an infinite authentication loop.
-                response.setStatus(getUnauthorizedStatus());
-                response.getHeaders().put(
-                    isProxyMode()
-                        ? HttpHeader.PROXY_AUTHENTICATE
-                        : HttpHeader.WWW_AUTHENTICATE,
-                    authType
-                );
+                response.setStatus(authenticator.getUnauthorizedStatusCode());
+                response.getHeaders().put(authenticator.getChallengeHeader(), authType);
                 callback.succeeded();
                 return true;
             }
@@ -632,7 +627,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
             .scheme(scenario.getScheme())
             .send();
 
-        assertEquals(getUnauthorizedStatus(), response.getStatus());
+        assertEquals(authenticator.getUnauthorizedStatusCode(), response.getStatus());
     }
 
     @Test
@@ -811,13 +806,6 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         assertEquals(",Digest realm=hello", headerInfo.getParameter("qop"));
         assertEquals("thermostat", headerInfo.getParameter("realm"));
         assertEquals(headerInfo.getParameter("nonce"), "1523430383=");
-    }
-
-    private int getUnauthorizedStatus()
-    {
-        return isProxyMode()
-            ? HttpStatus.PROXY_AUTHENTICATION_REQUIRED_407
-            : HttpStatus.UNAUTHORIZED_401;
     }
 
     private AuthenticationProtocolHandler newAuthenticationProtocolHandler(CountDownLatch authLatch)

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientAuthenticationTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientAuthenticationTest.java
@@ -70,12 +70,22 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         BasicAuthenticator authenticator = new BasicAuthenticator();
         if (charset != null)
             authenticator.setCharset(charset);
+        authenticator.setProxy(isProxyMode());
+
         start(scenario, authenticator, handler);
     }
 
     public void startDigest(Scenario scenario, Handler handler) throws Exception
     {
-        start(scenario, new DigestAuthenticator(), handler);
+        DigestAuthenticator authenticator = new DigestAuthenticator();
+        authenticator.setProxy(isProxyMode());
+
+        start(scenario, authenticator, handler);
+    }
+
+    protected boolean isProxyMode()
+    {
+        return false;
     }
 
     private void start(Scenario scenario, Authenticator authenticator, Handler handler) throws Exception
@@ -166,11 +176,11 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         };
         client.getRequestListeners().addListener(requestListener);
 
-        // Request without Authentication causes a 401
+        // Request without Authentication causes 401 / 407
         Request request = client.newRequest("localhost", connector.getLocalPort()).scheme(scenario.getScheme()).path("/secure");
         ContentResponse response = request.timeout(5, TimeUnit.SECONDS).send();
         assertNotNull(response);
-        assertEquals(401, response.getStatus());
+        assertEquals(getUnauthorizedStatus(), response.getStatus());
         assertTrue(requests.get().await(5, TimeUnit.SECONDS));
         client.getRequestListeners().removeListener(requestListener);
 
@@ -187,7 +197,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         };
         client.getRequestListeners().addListener(requestListener);
 
-        // Request with authentication causes a 401 (no previous successful authentication) + 200
+        // Request with authentication causes a 401 / 407 (no previous successful authentication) + 200
         request = client.newRequest("localhost", connector.getLocalPort()).scheme(scenario.getScheme()).path("/secure");
         response = request.timeout(5, TimeUnit.SECONDS).send();
         assertNotNull(response);
@@ -206,7 +216,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         };
         client.getRequestListeners().addListener(requestListener);
 
-        // Further requests do not trigger 401 because there is a previous successful authentication
+        // Further requests do not trigger 401 / 407 because there is a previous successful authentication
         // Remove existing header to be sure it's added by the implementation
         request = client.newRequest("localhost", connector.getLocalPort()).scheme(scenario.getScheme()).path("/secure");
         response = request.timeout(5, TimeUnit.SECONDS).send();
@@ -358,7 +368,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         request = client.newRequest("localhost", connector.getLocalPort()).scheme(scenario.getScheme()).path("/secure");
         response = request.timeout(5, TimeUnit.SECONDS).send();
         assertNotNull(response);
-        assertEquals(401, response.getStatus());
+        assertEquals(getUnauthorizedStatus(), response.getStatus());
         assertTrue(requests.get().await(5, TimeUnit.SECONDS));
     }
 
@@ -376,7 +386,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         Request request = client.newRequest("localhost", connector.getLocalPort()).scheme(scenario.getScheme()).path("/secure");
         ContentResponse response = request.timeout(5, TimeUnit.SECONDS).send();
         assertNotNull(response);
-        assertEquals(401, response.getStatus());
+        assertEquals(getUnauthorizedStatus(), response.getStatus());
 
         Authentication.Result authenticationResult = authenticationStore.findAuthenticationResult(uri);
         assertNull(authenticationResult);
@@ -415,6 +425,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
             .send(result ->
             {
                 assertTrue(result.isFailed());
+                assertEquals(getUnauthorizedStatus(), result.getResponse().getStatus());
                 assertEquals(cause, result.getFailure().getMessage());
                 latch.countDown();
             });
@@ -430,7 +441,11 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
 
         AuthenticationStore authenticationStore = client.getAuthenticationStore();
         URI uri = URI.create(scenario.getScheme() + "://localhost:" + connector.getLocalPort());
-        authenticationStore.addAuthenticationResult(new BasicAuthentication.BasicResult(uri, "basic", "basic"));
+        authenticationStore.addAuthenticationResult(
+            isProxyMode()
+                ? new BasicAuthentication.BasicResult(uri, HttpHeader.PROXY_AUTHORIZATION, "basic", "basic")
+                : new BasicAuthentication.BasicResult(uri, "basic", "basic")
+        );
 
         AtomicInteger requests = new AtomicInteger();
         client.getRequestListeners().addListener(new Request.Listener()
@@ -471,7 +486,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
             .body(content);
         request.send(result ->
         {
-            if (result.isSucceeded() && result.getResponse().getStatus() == HttpStatus.UNAUTHORIZED_401)
+            if (result.isSucceeded() && result.getResponse().getStatus() == getUnauthorizedStatus())
                 resultLatch.countDown();
         });
 
@@ -495,29 +510,12 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         });
 
         CountDownLatch authLatch = new CountDownLatch(1);
-        client.getProtocolHandlers().remove(WWWAuthenticationProtocolHandler.NAME);
-        client.getProtocolHandlers().put(new WWWAuthenticationProtocolHandler(client)
-        {
-            @Override
-            public Response.Listener getResponseListener()
-            {
-                Response.Listener listener = super.getResponseListener();
-                return new Response.Listener()
-                {
-                    @Override
-                    public void onSuccess(Response response)
-                    {
-                        authLatch.countDown();
-                    }
-
-                    @Override
-                    public void onComplete(Result result)
-                    {
-                        listener.onComplete(result);
-                    }
-                };
-            }
-        });
+        client.getProtocolHandlers().remove(
+            isProxyMode()
+                ? ProxyAuthenticationProtocolHandler.NAME
+                : WWWAuthenticationProtocolHandler.NAME
+        );
+        client.getProtocolHandlers().put(newAuthenticationProtocolHandler(authLatch));
 
         AuthenticationStore authenticationStore = client.getAuthenticationStore();
         URI uri = URI.create(scenario.getScheme() + "://localhost:" + connector.getLocalPort());
@@ -589,8 +587,13 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
             {
                 // Always reply with a 401 to see if the client
                 // can handle an infinite authentication loop.
-                response.setStatus(HttpStatus.UNAUTHORIZED_401);
-                response.getHeaders().put(HttpHeader.WWW_AUTHENTICATE, authType);
+                response.setStatus(getUnauthorizedStatus());
+                response.getHeaders().put(
+                    isProxyMode()
+                        ? HttpHeader.PROXY_AUTHENTICATE
+                        : HttpHeader.WWW_AUTHENTICATE,
+                    authType
+                );
                 callback.succeeded();
                 return true;
             }
@@ -629,7 +632,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
             .scheme(scenario.getScheme())
             .send();
 
-        assertEquals(HttpStatus.UNAUTHORIZED_401, response.getStatus());
+        assertEquals(getUnauthorizedStatus(), response.getStatus());
     }
 
     @Test
@@ -808,6 +811,57 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         assertEquals(",Digest realm=hello", headerInfo.getParameter("qop"));
         assertEquals("thermostat", headerInfo.getParameter("realm"));
         assertEquals(headerInfo.getParameter("nonce"), "1523430383=");
+    }
+
+    private int getUnauthorizedStatus()
+    {
+        return isProxyMode()
+            ? HttpStatus.PROXY_AUTHENTICATION_REQUIRED_407
+            : HttpStatus.UNAUTHORIZED_401;
+    }
+
+    private AuthenticationProtocolHandler newAuthenticationProtocolHandler(CountDownLatch authLatch)
+    {
+        if (isProxyMode())
+        {
+            return new ProxyAuthenticationProtocolHandler(client)
+            {
+                @Override
+                public Response.Listener getResponseListener()
+                {
+                    return wrapAuthenticationSuccess(super.getResponseListener(), authLatch);
+                }
+            };
+        }
+        else
+        {
+            return new WWWAuthenticationProtocolHandler(client)
+            {
+                @Override
+                public Response.Listener getResponseListener()
+                {
+                    return wrapAuthenticationSuccess(super.getResponseListener(), authLatch);
+                }
+            };
+        }
+    }
+
+    private Response.Listener wrapAuthenticationSuccess(Response.Listener base, CountDownLatch latch)
+    {
+        return new Response.Listener()
+        {
+            @Override
+            public void onSuccess(Response response)
+            {
+                latch.countDown();
+            }
+
+            @Override
+            public void onComplete(Result result)
+            {
+                base.onComplete(result);
+            }
+        };
     }
 
     private static class GeneratingRequestContent implements Request.Content

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientAuthenticationTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientAuthenticationTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.IntFunction;
 
+import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.io.Content;
@@ -580,15 +581,24 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
     public void testInfiniteAuthentication(Scenario scenario) throws Exception
     {
         String authType = "Authenticate";
-        startBasic(scenario, new Handler.Abstract()
+        start(scenario, new Handler.Abstract()
         {
             @Override
             public boolean handle(org.eclipse.jetty.server.Request request, org.eclipse.jetty.server.Response response, Callback callback)
             {
                 // Always reply with a 401 / 407 to see if the client
                 // can handle an infinite authentication loop.
-                response.setStatus(authenticator.getUnauthorizedStatusCode());
-                response.getHeaders().put(authenticator.getChallengeHeader(), authType);
+                response.setStatus(
+                    isProxyMode()
+                        ? HttpStatus.PROXY_AUTHENTICATION_REQUIRED_407
+                        : HttpStatus.UNAUTHORIZED_401
+                );
+                response.getHeaders().put(
+                    isProxyMode()
+                        ? HttpHeader.PROXY_AUTHENTICATE
+                        : HttpHeader.WWW_AUTHENTICATE,
+                    authType
+                );
                 callback.succeeded();
                 return true;
             }
@@ -627,7 +637,10 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
             .scheme(scenario.getScheme())
             .send();
 
-        assertEquals(authenticator.getUnauthorizedStatusCode(), response.getStatus());
+        assertEquals(
+            isProxyMode() ? HttpStatus.PROXY_AUTHENTICATION_REQUIRED_407 : HttpStatus.UNAUTHORIZED_401,
+            response.getStatus()
+        );
     }
 
     @Test

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientProxyAuthenticationTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientProxyAuthenticationTest.java
@@ -1,0 +1,26 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.client;
+
+/**
+ * Tests authentication in proxy mode by subclassing {@link HttpClientAuthenticationTest}.
+ */
+public class HttpClientProxyAuthenticationTest extends HttpClientAuthenticationTest
+{
+    @Override
+    protected boolean isProxyMode()
+    {
+        return true;
+    }
+}

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/BasicAuthenticator.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/BasicAuthenticator.java
@@ -87,7 +87,7 @@ public class BasicAuthenticator extends LoginAuthenticator
         res.getHeaders().put(getChallengeHeader().asString(), value);
 
         // Don't use AuthenticationState.writeError, to avoid possibility of doing a Servlet error dispatch.
-        Response.writeError(req, res, callback, getChallengeStatusCode());
+        Response.writeError(req, res, callback, getUnauthorizedStatusCode());
         return AuthenticationState.CHALLENGE;
     }
 

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/BasicAuthenticator.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/BasicAuthenticator.java
@@ -17,8 +17,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
-import org.eclipse.jetty.http.HttpHeader;
-import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.security.AuthenticationState;
 import org.eclipse.jetty.security.Authenticator;
 import org.eclipse.jetty.security.ServerAuthException;
@@ -50,7 +48,7 @@ public class BasicAuthenticator extends LoginAuthenticator
     @Override
     public AuthenticationState validateRequest(Request req, Response res, Callback callback) throws ServerAuthException
     {
-        String credentials = req.getHeaders().get(HttpHeader.AUTHORIZATION);
+        String credentials = req.getHeaders().get(getAuthorizationHeader());
 
         if (credentials != null)
         {
@@ -86,10 +84,10 @@ public class BasicAuthenticator extends LoginAuthenticator
         Charset charset = getCharset();
         if (charset != null)
             value += ", charset=\"" + charset.name() + "\"";
-        res.getHeaders().put(HttpHeader.WWW_AUTHENTICATE.asString(), value);
+        res.getHeaders().put(getChallengeHeader().asString(), value);
 
         // Don't use AuthenticationState.writeError, to avoid possibility of doing a Servlet error dispatch.
-        Response.writeError(req, res, callback, HttpStatus.UNAUTHORIZED_401);
+        Response.writeError(req, res, callback, getChallengeStatusCode());
         return AuthenticationState.CHALLENGE;
     }
 

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/DigestAuthenticator.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/DigestAuthenticator.java
@@ -26,8 +26,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 
-import org.eclipse.jetty.http.HttpHeader;
-import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.security.AuthenticationState;
 import org.eclipse.jetty.security.Authenticator;
 import org.eclipse.jetty.security.SecurityHandler;
@@ -112,7 +110,7 @@ public class DigestAuthenticator extends LoginAuthenticator
     @Override
     public AuthenticationState validateRequest(Request req, Response res, Callback callback) throws ServerAuthException
     {
-        String credentials = req.getHeaders().get(HttpHeader.AUTHORIZATION);
+        String credentials = req.getHeaders().get(getAuthorizationHeader());
 
         boolean stale = false;
         if (credentials != null)
@@ -185,7 +183,7 @@ public class DigestAuthenticator extends LoginAuthenticator
             String domain = req.getContext().getContextPath();
             if (domain == null)
                 domain = "/";
-            res.getHeaders().put(HttpHeader.WWW_AUTHENTICATE.asString(), "Digest realm=\"" + _loginService.getName() +
+            res.getHeaders().put(getChallengeHeader().asString(), "Digest realm=\"" + _loginService.getName() +
                     "\", domain=\"" + domain +
                     "\", nonce=\"" + newNonce(req) +
                     "\", algorithm=" + getAlgorithm() +
@@ -193,7 +191,7 @@ public class DigestAuthenticator extends LoginAuthenticator
                     ", stale=" + stale);
 
             // Don't use AuthenticationState.writeError, to avoid possibility of doing a Servlet error dispatch.
-            Response.writeError(req, res, callback, HttpStatus.UNAUTHORIZED_401);
+            Response.writeError(req, res, callback, getChallengeStatusCode());
             return AuthenticationState.CHALLENGE;
         }
 

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/DigestAuthenticator.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/DigestAuthenticator.java
@@ -191,7 +191,7 @@ public class DigestAuthenticator extends LoginAuthenticator
                     ", stale=" + stale);
 
             // Don't use AuthenticationState.writeError, to avoid possibility of doing a Servlet error dispatch.
-            Response.writeError(req, res, callback, getChallengeStatusCode());
+            Response.writeError(req, res, callback, getUnauthorizedStatusCode());
             return AuthenticationState.CHALLENGE;
         }
 

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/LoginAuthenticator.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/LoginAuthenticator.java
@@ -17,6 +17,8 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.util.function.Function;
 
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.security.AuthenticationState;
 import org.eclipse.jetty.security.Authenticator;
 import org.eclipse.jetty.security.IdentityService;
@@ -39,9 +41,41 @@ public abstract class LoginAuthenticator implements Authenticator
     protected IdentityService _identityService;
     private boolean _sessionRenewedOnAuthentication;
     private int _sessionMaxInactiveIntervalOnAuthentication;
+    private boolean _proxy;
 
     protected LoginAuthenticator()
     {
+    }
+
+    public boolean isProxy()
+    {
+        return _proxy;
+    }
+
+    public void setProxy(boolean proxy)
+    {
+        _proxy = proxy;
+    }
+
+    protected final HttpHeader getAuthorizationHeader()
+    {
+        return _proxy
+            ? HttpHeader.PROXY_AUTHORIZATION
+            : HttpHeader.AUTHORIZATION;
+    }
+
+    protected final HttpHeader getChallengeHeader()
+    {
+        return _proxy
+            ? HttpHeader.PROXY_AUTHENTICATE
+            : HttpHeader.WWW_AUTHENTICATE;
+    }
+
+    protected final int getChallengeStatusCode()
+    {
+        return _proxy
+            ? HttpStatus.PROXY_AUTHENTICATION_REQUIRED_407
+            : HttpStatus.UNAUTHORIZED_401;
     }
 
     /**

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/LoginAuthenticator.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/LoginAuthenticator.java
@@ -64,7 +64,7 @@ public abstract class LoginAuthenticator implements Authenticator
      * <ul>
      *  <li>{@link #getChallengeHeader()} will return {@code Proxy-Authenticate}.</li>
      *  <li>{@link #getUnauthorizedStatusCode()} will return {@code 407}.</li>
-     *  <li>{@link #getAuthorizationHeader()} will read the {@code Proxy-Authorization} header.</li>
+     *  <li>{@link #getAuthorizationHeader()} will return the {@code Proxy-Authorization} header.</li>
      * </ul>
      * The default is {@code false}, which uses the standard {@code WWW-Authenticate}
      * and {@code Authorization} headers with a {@code 401} status code.

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/LoginAuthenticator.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/LoginAuthenticator.java
@@ -47,31 +47,65 @@ public abstract class LoginAuthenticator implements Authenticator
     {
     }
 
-    public boolean isProxy()
+    /**
+     * @return true if this authenticator is in proxy mode.
+     * @see #setProxyMode(boolean)
+     */
+    public boolean isProxyMode()
     {
         return _proxy;
     }
 
-    public void setProxy(boolean proxy)
+    /**
+     * Sets the authenticator to operate in proxy authentication mode.
+     * <p>
+     * When set to {@code true}, this mode changes the behavior of the
+     * authentication helpers:
+     * <ul>
+     *  <li>{@link #getChallengeHeader()} will return {@code Proxy-Authenticate}.</li>
+     *  <li>{@link #getUnauthorizedStatusCode()} will return {@code 407}.</li>
+     *  <li>{@link #getAuthorizationHeader()} will read the {@code Proxy-Authorization} header.</li>
+     * </ul>
+     * The default is {@code false}, which uses the standard {@code WWW-Authenticate}
+     * and {@code Authorization} headers with a {@code 401} status code.
+     *
+     * @param proxy {@code true} to enable proxy authentication mode.
+     */
+    public void setProxyMode(boolean proxy)
     {
         _proxy = proxy;
     }
 
-    protected final HttpHeader getAuthorizationHeader()
+    /**
+     * @return The authorization header to read credentials from, either
+     * {@code Authorization} or {@code Proxy-Authorization}, depending on the proxy mode.
+     * @see #setProxyMode(boolean)
+     */
+    public HttpHeader getAuthorizationHeader()
     {
         return _proxy
             ? HttpHeader.PROXY_AUTHORIZATION
             : HttpHeader.AUTHORIZATION;
     }
 
-    protected final HttpHeader getChallengeHeader()
+    /**
+     * @return The challenge header to send to the client, either
+     * {@code WWW-Authenticate} or {@code Proxy-Authenticate}, depending on the proxy mode.
+     * @see #setProxyMode(boolean)
+     */
+    public HttpHeader getChallengeHeader()
     {
         return _proxy
             ? HttpHeader.PROXY_AUTHENTICATE
             : HttpHeader.WWW_AUTHENTICATE;
     }
 
-    protected final int getChallengeStatusCode()
+    /**
+     * @return The status code for an authentication challenge, either
+     * {@code 401} or {@code 407}, depending on the proxy mode.
+     * @see #setProxyMode(boolean)
+     */
+    public int getUnauthorizedStatusCode()
     {
         return _proxy
             ? HttpStatus.PROXY_AUTHENTICATION_REQUIRED_407

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/SPNEGOAuthenticator.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/SPNEGOAuthenticator.java
@@ -185,7 +185,7 @@ public class SPNEGOAuthenticator extends LoginAuthenticator
     {
         setSpnegoToken(res, token);
         // Don't use AuthenticationState.writeError, to avoid possibility of doing a Servlet error dispatch.
-        Response.writeError(req, res, callback, getChallengeStatusCode());
+        Response.writeError(req, res, callback, getUnauthorizedStatusCode());
     }
 
     private void setSpnegoToken(Response response, String token)

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/SPNEGOAuthenticator.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/SPNEGOAuthenticator.java
@@ -19,7 +19,6 @@ import java.time.Instant;
 
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
-import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.security.AuthenticationState;
 import org.eclipse.jetty.security.Authenticator;
 import org.eclipse.jetty.security.RoleDelegateUserIdentity;
@@ -110,7 +109,7 @@ public class SPNEGOAuthenticator extends LoginAuthenticator
     @Override
     public AuthenticationState validateRequest(Request req, Response res, Callback callback) throws ServerAuthException
     {
-        String header = req.getHeaders().get(HttpHeader.AUTHORIZATION);
+        String header = req.getHeaders().get(getAuthorizationHeader());
         String spnegoToken = getSpnegoToken(header);
         Session httpSession = req.getSession(false);
 
@@ -186,7 +185,7 @@ public class SPNEGOAuthenticator extends LoginAuthenticator
     {
         setSpnegoToken(res, token);
         // Don't use AuthenticationState.writeError, to avoid possibility of doing a Servlet error dispatch.
-        Response.writeError(req, res, callback, HttpStatus.UNAUTHORIZED_401);
+        Response.writeError(req, res, callback, getChallengeStatusCode());
     }
 
     private void setSpnegoToken(Response response, String token)
@@ -194,7 +193,7 @@ public class SPNEGOAuthenticator extends LoginAuthenticator
         String value = HttpHeader.NEGOTIATE.asString();
         if (token != null)
             value += " " + token;
-        response.getHeaders().put(HttpHeader.WWW_AUTHENTICATE.asString(), value);
+        response.getHeaders().put(getChallengeHeader().asString(), value);
     }
 
     private String getSpnegoToken(String header)

--- a/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/BasicAuthenticator.java
+++ b/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/BasicAuthenticator.java
@@ -26,7 +26,6 @@ import org.eclipse.jetty.ee9.nested.Authentication;
 import org.eclipse.jetty.ee9.nested.Authentication.User;
 import org.eclipse.jetty.ee9.security.ServerAuthException;
 import org.eclipse.jetty.ee9.security.UserAuthentication;
-import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.security.UserIdentity;
 
 public class BasicAuthenticator extends LoginAuthenticator
@@ -54,7 +53,7 @@ public class BasicAuthenticator extends LoginAuthenticator
     {
         HttpServletRequest request = (HttpServletRequest)req;
         HttpServletResponse response = (HttpServletResponse)res;
-        String credentials = request.getHeader(HttpHeader.AUTHORIZATION.asString());
+        String credentials = request.getHeader(getAuthorizationHeader().asString());
 
         try
         {
@@ -95,8 +94,8 @@ public class BasicAuthenticator extends LoginAuthenticator
             Charset charset = getCharset();
             if (charset != null)
                 value += ", charset=\"" + charset.name() + "\"";
-            response.setHeader(HttpHeader.WWW_AUTHENTICATE.asString(), value);
-            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setHeader(getChallengeHeader().asString(), value);
+            response.sendError(getChallengeStatusCode());
             return Authentication.SEND_CONTINUE;
         }
         catch (IOException e)

--- a/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/BasicAuthenticator.java
+++ b/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/BasicAuthenticator.java
@@ -95,7 +95,7 @@ public class BasicAuthenticator extends LoginAuthenticator
             if (charset != null)
                 value += ", charset=\"" + charset.name() + "\"";
             response.setHeader(getChallengeHeader().asString(), value);
-            response.sendError(getChallengeStatusCode());
+            response.sendError(getUnauthorizedStatusCode());
             return Authentication.SEND_CONTINUE;
         }
         catch (IOException e)

--- a/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/ConfigurableSpnegoAuthenticator.java
+++ b/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/ConfigurableSpnegoAuthenticator.java
@@ -200,7 +200,7 @@ public class ConfigurableSpnegoAuthenticator extends LoginAuthenticator
         try
         {
             setSpnegoToken(response, token);
-            response.sendError(getChallengeStatusCode());
+            response.sendError(getUnauthorizedStatusCode());
         }
         catch (IOException x)
         {

--- a/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/ConfigurableSpnegoAuthenticator.java
+++ b/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/ConfigurableSpnegoAuthenticator.java
@@ -123,7 +123,7 @@ public class ConfigurableSpnegoAuthenticator extends LoginAuthenticator
         HttpServletRequest request = (HttpServletRequest)req;
         HttpServletResponse response = (HttpServletResponse)res;
 
-        String header = request.getHeader(HttpHeader.AUTHORIZATION.asString());
+        String header = request.getHeader(getAuthorizationHeader().asString());
         String spnegoToken = getSpnegoToken(header);
         HttpSession httpSession = request.getSession(false);
 
@@ -200,7 +200,7 @@ public class ConfigurableSpnegoAuthenticator extends LoginAuthenticator
         try
         {
             setSpnegoToken(response, token);
-            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            response.sendError(getChallengeStatusCode());
         }
         catch (IOException x)
         {
@@ -213,7 +213,7 @@ public class ConfigurableSpnegoAuthenticator extends LoginAuthenticator
         String value = HttpHeader.NEGOTIATE.asString();
         if (token != null)
             value += " " + token;
-        response.setHeader(HttpHeader.WWW_AUTHENTICATE.asString(), value);
+        response.setHeader(getChallengeHeader().asString(), value);
     }
 
     private String getSpnegoToken(String header)

--- a/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/DigestAuthenticator.java
+++ b/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/DigestAuthenticator.java
@@ -37,7 +37,6 @@ import org.eclipse.jetty.ee9.nested.Request;
 import org.eclipse.jetty.ee9.security.SecurityHandler;
 import org.eclipse.jetty.ee9.security.ServerAuthException;
 import org.eclipse.jetty.ee9.security.UserAuthentication;
-import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.security.UserIdentity;
 import org.eclipse.jetty.util.QuotedStringTokenizer;
 import org.eclipse.jetty.util.TypeUtil;
@@ -126,7 +125,7 @@ public class DigestAuthenticator extends LoginAuthenticator
 
         HttpServletRequest request = (HttpServletRequest)req;
         HttpServletResponse response = (HttpServletResponse)res;
-        String credentials = request.getHeader(HttpHeader.AUTHORIZATION.asString());
+        String credentials = request.getHeader(getAuthorizationHeader().asString());
 
         try
         {
@@ -205,13 +204,13 @@ public class DigestAuthenticator extends LoginAuthenticator
                 String domain = request.getContextPath();
                 if (domain == null)
                     domain = "/";
-                response.setHeader(HttpHeader.WWW_AUTHENTICATE.asString(), "Digest realm=\"" + _loginService.getName() +
+                response.setHeader(getChallengeHeader().asString(), "Digest realm=\"" + _loginService.getName() +
                     "\", domain=\"" + domain +
                     "\", nonce=\"" + newNonce(baseRequest) +
                     "\", algorithm=" + getAlgorithm() +
                     ", qop=\"auth\"" +
                     ", stale=" + stale);
-                response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+                response.sendError(getChallengeStatusCode());
 
                 return Authentication.SEND_CONTINUE;
             }

--- a/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/DigestAuthenticator.java
+++ b/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/DigestAuthenticator.java
@@ -210,7 +210,7 @@ public class DigestAuthenticator extends LoginAuthenticator
                     "\", algorithm=" + getAlgorithm() +
                     ", qop=\"auth\"" +
                     ", stale=" + stale);
-                response.sendError(getChallengeStatusCode());
+                response.sendError(getUnauthorizedStatusCode());
 
                 return Authentication.SEND_CONTINUE;
             }

--- a/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/LoginAuthenticator.java
+++ b/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/LoginAuthenticator.java
@@ -65,7 +65,7 @@ public abstract class LoginAuthenticator implements Authenticator
      * <ul>
      *  <li>{@link #getChallengeHeader()} will return {@code Proxy-Authenticate}.</li>
      *  <li>{@link #getUnauthorizedStatusCode()} will return {@code 407}.</li>
-     *  <li>{@link #getAuthorizationHeader()} will read the {@code Proxy-Authorization} header.</li>
+     *  <li>{@link #getAuthorizationHeader()} will return the {@code Proxy-Authorization} header.</li>
      * </ul>
      * The default is {@code false}, which uses the standard {@code WWW-Authenticate}
      * and {@code Authorization} headers with a {@code 401} status code.

--- a/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/LoginAuthenticator.java
+++ b/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/LoginAuthenticator.java
@@ -48,31 +48,65 @@ public abstract class LoginAuthenticator implements Authenticator
     {
     }
 
-    public boolean isProxy()
+    /**
+     * @return true if this authenticator is in proxy mode.
+     * @see #setProxyMode(boolean)
+     */
+    public boolean isProxyMode()
     {
         return _proxy;
     }
 
-    public void setProxy(boolean proxy)
+    /**
+     * Sets the authenticator to operate in proxy authentication mode.
+     * <p>
+     * When set to {@code true}, this mode changes the behavior of the
+     * authentication helpers:
+     * <ul>
+     *  <li>{@link #getChallengeHeader()} will return {@code Proxy-Authenticate}.</li>
+     *  <li>{@link #getUnauthorizedStatusCode()} will return {@code 407}.</li>
+     *  <li>{@link #getAuthorizationHeader()} will read the {@code Proxy-Authorization} header.</li>
+     * </ul>
+     * The default is {@code false}, which uses the standard {@code WWW-Authenticate}
+     * and {@code Authorization} headers with a {@code 401} status code.
+     *
+     * @param proxy {@code true} to enable proxy authentication mode.
+     */
+    public void setProxyMode(boolean proxy)
     {
         _proxy = proxy;
     }
 
-    protected final HttpHeader getAuthorizationHeader()
+    /**
+     * @return The authorization header to read credentials from, either
+     * {@code Authorization} or {@code Proxy-Authorization}, depending on the proxy mode.
+     * @see #setProxyMode(boolean)
+     */
+    public HttpHeader getAuthorizationHeader()
     {
         return _proxy
             ? HttpHeader.PROXY_AUTHORIZATION
             : HttpHeader.AUTHORIZATION;
     }
 
-    protected final HttpHeader getChallengeHeader()
+    /**
+     * @return The challenge header to send to the client, either
+     * {@code WWW-Authenticate} or {@code Proxy-Authenticate}, depending on the proxy mode.
+     * @see #setProxyMode(boolean)
+     */
+    public HttpHeader getChallengeHeader()
     {
         return _proxy
             ? HttpHeader.PROXY_AUTHENTICATE
             : HttpHeader.WWW_AUTHENTICATE;
     }
 
-    protected final int getChallengeStatusCode()
+    /**
+     * @return The status code for an authentication challenge, either
+     * {@code 401} or {@code 407}, depending on the proxy mode.
+     * @see #setProxyMode(boolean)
+     */
+    public int getUnauthorizedStatusCode()
     {
         return _proxy
             ? HttpStatus.PROXY_AUTHENTICATION_REQUIRED_407

--- a/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/LoginAuthenticator.java
+++ b/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/LoginAuthenticator.java
@@ -22,6 +22,8 @@ import jakarta.servlet.http.HttpSession;
 import org.eclipse.jetty.ee9.nested.HttpChannel;
 import org.eclipse.jetty.ee9.nested.Request;
 import org.eclipse.jetty.ee9.security.Authenticator;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.security.IdentityService;
 import org.eclipse.jetty.security.LoginService;
 import org.eclipse.jetty.security.UserIdentity;
@@ -40,9 +42,41 @@ public abstract class LoginAuthenticator implements Authenticator
     protected IdentityService _identityService;
     private boolean _sessionRenewedOnAuthentication;
     private int _sessionMaxInactiveIntervalOnAuthentication;
+    private boolean _proxy;
 
     protected LoginAuthenticator()
     {
+    }
+
+    public boolean isProxy()
+    {
+        return _proxy;
+    }
+
+    public void setProxy(boolean proxy)
+    {
+        _proxy = proxy;
+    }
+
+    protected final HttpHeader getAuthorizationHeader()
+    {
+        return _proxy
+            ? HttpHeader.PROXY_AUTHORIZATION
+            : HttpHeader.AUTHORIZATION;
+    }
+
+    protected final HttpHeader getChallengeHeader()
+    {
+        return _proxy
+            ? HttpHeader.PROXY_AUTHENTICATE
+            : HttpHeader.WWW_AUTHENTICATE;
+    }
+
+    protected final int getChallengeStatusCode()
+    {
+        return _proxy
+            ? HttpStatus.PROXY_AUTHENTICATION_REQUIRED_407
+            : HttpStatus.UNAUTHORIZED_401;
     }
 
     @Override


### PR DESCRIPTION
This pull request resolves issue #13398 by enhancing server-side authenticators to support proxy authentication.

### Summary of Changes

1.  **Authenticator Enhancements:**
    *   Server-side authenticators like `BasicAuthenticator`, `DigestAuthenticator` and `SPNEGOAuthenticator ` no longer handle only hardcoded `WWW-Authenticate` headers.
    *   A new `setProxyMode(boolean)` method has been added to the base `LoginAuthenticator` in both `jetty-security` and `jetty-ee9-security`.
    *   When proxy mode is enabled, these authenticators now dynamically issue `407` challenges with `Proxy-Authenticate` headers and process credentials from the `Proxy-Authorization` header, using new internal helper methods.

2.  **Test Refactoring:**
    *   The parent `HttpClientAuthenticationTest` has been refactored to use a new `protected boolean isProxyMode()` method (which defaults to `false`), allowing it to test both authentication modes.
    *   A new `HttpClientProxyAuthenticationTest` subclass is introduced, which simply overrides `isProxyMode()` to return `true`, reusing the entire parent test suite for comprehensive validation of the new proxy mode.

Resolves #13398