### PR TITLE
Issue #13346 - initiate TCP close for websocket on server side first

### DIFF
--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConnection.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConnection.java
@@ -750,7 +750,7 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
     {
         private Flusher(Scheduler scheduler, int bufferSize, Generator generator, EndPoint endpoint)
         {
-            super(byteBufferPool, scheduler, generator, endpoint, bufferSize, 8);
+            super(byteBufferPool, scheduler, generator, endpoint, bufferSize, 8, coreSession.getBehavior());
             setUseDirectByteBuffers(isUseOutputDirectByteBuffers());
         }
 

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/FrameFlusher.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/FrameFlusher.java
@@ -35,6 +35,7 @@ import org.eclipse.jetty.util.NanoTime;
 import org.eclipse.jetty.util.TypeUtil;
 import org.eclipse.jetty.util.thread.AutoLock;
 import org.eclipse.jetty.util.thread.Scheduler;
+import org.eclipse.jetty.websocket.core.Behavior;
 import org.eclipse.jetty.websocket.core.CloseStatus;
 import org.eclipse.jetty.websocket.core.Frame;
 import org.eclipse.jetty.websocket.core.OpCode;
@@ -70,6 +71,7 @@ public class FrameFlusher extends IteratingCallback
     private final List<FlusherEntry> _currentEntries;
     private final List<FlusherEntry> _completedEntries = new ArrayList<>();
     private final List<RetainableByteBuffer> _releasableBuffers = new ArrayList<>();
+    private final Behavior _behavior;
     private long _currentMessageExpiry;
 
     private RetainableByteBuffer _batchBuffer;
@@ -77,8 +79,9 @@ public class FrameFlusher extends IteratingCallback
     private Throwable _closedCause;
     private boolean _useDirectByteBuffers;
 
-    public FrameFlusher(ByteBufferPool bufferPool, Scheduler scheduler, Generator generator, EndPoint endPoint, int bufferSize, int maxGather)
+    public FrameFlusher(ByteBufferPool bufferPool, Scheduler scheduler, Generator generator, EndPoint endPoint, int bufferSize, int maxGather, Behavior behavior)
     {
+        _behavior = behavior;
         _bufferPool = bufferPool;
         _endPoint = endPoint;
         _bufferSize = bufferSize;
@@ -387,7 +390,7 @@ public class FrameFlusher extends IteratingCallback
 
         for (FlusherEntry entry : _completedEntries)
         {
-            if (entry.getFrame().getOpCode() == OpCode.CLOSE)
+            if (entry.getFrame().getOpCode() == OpCode.CLOSE && _behavior == Behavior.SERVER)
                 _endPoint.shutdownOutput();
             notifyCallbackSuccess(entry.getCallback());
         }

--- a/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/internal/FrameFlusherTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/internal/FrameFlusherTest.java
@@ -32,6 +32,7 @@ import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.FutureCallback;
 import org.eclipse.jetty.util.thread.ScheduledExecutorScheduler;
 import org.eclipse.jetty.util.thread.Scheduler;
+import org.eclipse.jetty.websocket.core.Behavior;
 import org.eclipse.jetty.websocket.core.CloseStatus;
 import org.eclipse.jetty.websocket.core.Frame;
 import org.eclipse.jetty.websocket.core.OpCode;
@@ -79,7 +80,7 @@ public class FrameFlusherTest
         CapturingEndPoint endPoint = new CapturingEndPoint(bufferPool);
         int bufferSize = WebSocketConstants.DEFAULT_MAX_TEXT_MESSAGE_SIZE;
         int maxGather = 1;
-        FrameFlusher frameFlusher = new FrameFlusher(bufferPool, scheduler, generator, endPoint, bufferSize, maxGather);
+        FrameFlusher frameFlusher = new FrameFlusher(bufferPool, scheduler, generator, endPoint, bufferSize, maxGather, Behavior.SERVER);
 
         Frame closeFrame = new Frame(OpCode.CLOSE).setPayload(CloseStatus.asPayloadBuffer(CloseStatus.MESSAGE_TOO_LARGE, "Message be to big"));
         Frame textFrame = new Frame(OpCode.TEXT).setPayload("Hello").setFin(true);
@@ -110,7 +111,7 @@ public class FrameFlusherTest
         CapturingEndPoint endPoint = new CapturingEndPoint(bufferPool);
         int bufferSize = WebSocketConstants.DEFAULT_MAX_TEXT_MESSAGE_SIZE;
         int maxGather = 8;
-        FrameFlusher frameFlusher = new FrameFlusher(bufferPool, scheduler, generator, endPoint, bufferSize, maxGather);
+        FrameFlusher frameFlusher = new FrameFlusher(bufferPool, scheduler, generator, endPoint, bufferSize, maxGather, Behavior.SERVER);
 
         int largeMessageSize = 60000;
         byte[] buf = new byte[largeMessageSize];
@@ -164,7 +165,7 @@ public class FrameFlusherTest
 
         CountDownLatch flusherFailure = new CountDownLatch(1);
         AtomicReference<Throwable> error = new AtomicReference<>();
-        FrameFlusher frameFlusher = new FrameFlusher(bufferPool, scheduler, generator, endPoint, bufferSize, maxGather)
+        FrameFlusher frameFlusher = new FrameFlusher(bufferPool, scheduler, generator, endPoint, bufferSize, maxGather, Behavior.SERVER)
         {
             @Override
             public void onFailure(Throwable failure)
@@ -193,7 +194,7 @@ public class FrameFlusherTest
         endPoint.setBlockTime(100);
         int bufferSize = WebSocketConstants.DEFAULT_MAX_TEXT_MESSAGE_SIZE;
         int maxGather = 8;
-        FrameFlusher frameFlusher = new FrameFlusher(bufferPool, scheduler, generator, endPoint, bufferSize, maxGather);
+        FrameFlusher frameFlusher = new FrameFlusher(bufferPool, scheduler, generator, endPoint, bufferSize, maxGather, Behavior.SERVER);
 
         // Enqueue message before the error close.
         Frame frame1 = new Frame(OpCode.TEXT).setPayload("message before close").setFin(true);

--- a/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee11/websocket/tests/WebSocketOverHTTP2Test.java
+++ b/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee11/websocket/tests/WebSocketOverHTTP2Test.java
@@ -74,7 +74,6 @@ import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.eclipse.jetty.websocket.core.CloseStatus;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
@@ -404,7 +403,6 @@ public class WebSocketOverHTTP2Test
     }
 
     @Test
-    @Disabled("This test fails due to an issue with the WebSocket over HTTP/2 implementation, see https://github.com/jetty/jetty.project/issues/13349")
     public void testNetworkConnectionLimit() throws Exception
     {
         prepareServer();


### PR DESCRIPTION
In [rfc6455#section-7.1.1 ](https://datatracker.ietf.org/doc/html/rfc6455#section-7.1.1) it says

>    The underlying TCP connection, in most normal cases, SHOULD be closed
   first by the server, so that it holds the TIME_WAIT state and not the
   client (as this would prevent it from re-opening the connection for 2
   maximum segment lifetimes (2MSL), while there is no corresponding
   server impact as a TIME_WAIT connection is immediately reopened upon
   a new SYN with a higher seq number).  In abnormal cases (such as not
   having received a TCP Close from the server after a reasonable amount
   of time) a client MAY initiate the TCP Close.  As such, when a server
   is instructed to _Close the WebSocket Connection_ it SHOULD initiate
   a TCP Close immediately, and when a client is instructed to do the
   same, it SHOULD wait for a TCP Close from the server.


We currently always do a `endpoint.shutdownOutput()` directly after a close frame is sent.

And then we call `endpoint.close()` from `WebSocketCoreSession.closeConnection` once WebSocket is finished (either send/received a close frame, or an error occurs).

This PR makes it so that the client doesn't send the TCP FIN directly after initiating the close with a close frame.

closes #13346