### PR TITLE
Simplify checkSni conditions and improve error messages

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/SecureRequestCustomizer.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/SecureRequestCustomizer.java
@@ -216,23 +216,21 @@ public class SecureRequestCustomizer implements HttpConfiguration.Customizer
 
     protected void checkSni(Request request, SSLSession session)
     {
-        if (isSniRequired() || isSniHostCheck())
-        {
-            String sniHost = retrieveSni(request, session);
+        X509 x509 = getX509(session);
+        if (x509 == null)
+            throw new BadMessageException(400, "Invalid TLS Message");
 
-            X509 x509 = getX509(session);
-            if (x509 == null)
-                throw new BadMessageException(400, "Invalid SNI");
-            String serverName = Request.getServerName(request);
-            if (LOG.isDebugEnabled())
-                LOG.debug("Host={}, SNI={}, SNI Certificate={}", serverName, sniHost, x509);
+        String serverName = Request.getServerName(request);
+        String sniHost = retrieveSni(request, session);
 
-            if (isSniRequired() && (sniHost == null || !x509.matches(sniHost)))
-                throw new BadMessageException(400, "Invalid SNI");
+        if (LOG.isDebugEnabled())
+            LOG.debug("Host={}, SNI={}, Certificate={}", serverName, sniHost, x509);
 
-            if (isSniHostCheck() && !x509.matches(serverName))
-                throw new BadMessageException(400, "Invalid SNI");
-        }
+        if (isSniRequired() && (sniHost == null || !x509.matches(sniHost)))
+            throw new BadMessageException(400, "Invalid SNI");
+
+        if (isSniHostCheck() && !x509.matches(serverName))
+            throw new BadMessageException(400, "Host header value is not a subject in the certificate");
     }
 
     protected String retrieveSni(Request request, SSLSession session)

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/SecureRequestCustomizer.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/SecureRequestCustomizer.java
@@ -221,7 +221,7 @@ public class SecureRequestCustomizer implements HttpConfiguration.Customizer
             throw new BadMessageException(400, "Invalid TLS Message");
 
         String serverName = Request.getServerName(request);
-        String sniHost = retrieveSni(request, session);
+        String sniHost = retrieveSni(session);
 
         if (LOG.isDebugEnabled())
             LOG.debug("Host={}, SNI={}, Certificate={}", serverName, sniHost, x509);
@@ -233,7 +233,7 @@ public class SecureRequestCustomizer implements HttpConfiguration.Customizer
             throw new BadMessageException(400, "Host header value is not a subject in the certificate");
     }
 
-    protected String retrieveSni(Request request, SSLSession session)
+    protected String retrieveSni(SSLSession session)
     {
         // Quick retrieval of the SNI from a SSLSession attribute put by SniX509ExtendedKeyManager.
         String sniHost = (String)session.getValue(SslContextFactory.Server.SNI_HOST);

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ssl/SniSslConnectionFactoryTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ssl/SniSslConnectionFactoryTest.java
@@ -242,7 +242,7 @@ public class SniSslConnectionFactoryTest
 
         String response = getResponse("www.example.com", "some.other.com", "www.example.com");
         assertThat(response, Matchers.containsString("HTTP/1.1 400 "));
-        assertThat(response, Matchers.containsString("Invalid SNI"));
+        assertThat(response, Matchers.containsString("Invalid TLS Message"));
     }
 
     @DisabledOnOs(value = OS.WINDOWS, disabledReason = "See Issue #6609 - TLSv1.3 behavior differences between Linux and Windows")
@@ -387,7 +387,7 @@ public class SniSslConnectionFactoryTest
             response = HttpTester.parseResponse(input);
             assertNotNull(response);
             assertThat(response.getStatus(), is(400));
-            assertThat(response.getContent(), containsString("Invalid SNI"));
+            assertThat(response.getContent(), containsString("Host header value is not a subject in the certificate"));
         }
         finally
         {
@@ -447,7 +447,7 @@ public class SniSslConnectionFactoryTest
             response = HttpTester.parseResponse(input);
             assertNotNull(response);
             assertThat(response.getStatus(), is(400));
-            assertThat(response.getContent(), containsString("Invalid SNI"));
+            assertThat(response.getContent(), containsString("Host header value is not a subject in the certificate"));
         }
         finally
         {


### PR DESCRIPTION
In reading through code, I noticed that the `checkSni` method body was a little convoluted. I have simplified it and corrected the error messages.

I have also removed unused parameter from `retrieveSni`

> [!NOTE]
> There is no associated issue (the [contributing docs] made it sounds optional), and I made a guess to which branch to raise the PR on. Please let me know if I need to correct anything.

[contributing docs]: https://jetty.org/docs/contribution-guide/patches/index.html