### PR TITLE
Deprecate org.eclipse.jetty.ee9.servlets.CrossOriginFilter in favor of CrossOriginHandler

### DIFF
--- a/jetty-ee9/jetty-ee9-servlets/src/main/java/org/eclipse/jetty/ee9/servlets/CrossOriginFilter.java
+++ b/jetty-ee9/jetty-ee9-servlets/src/main/java/org/eclipse/jetty/ee9/servlets/CrossOriginFilter.java
@@ -116,7 +116,9 @@ import org.slf4j.LoggerFactory;
  *     ...
  * &lt;/web-app&gt;
  * </pre>
+ * @deprecated Use {@link org.eclipse.jetty.server.handler.CrossOriginHandler} instead
  */
+@Deprecated
 public class CrossOriginFilter implements Filter
 {
     private static final Logger LOG = LoggerFactory.getLogger(CrossOriginFilter.class);


### PR DESCRIPTION
Deprecate `org.eclipse.jetty.ee9.servlets.CrossOriginFilter` in favor of `org.eclipse.jetty.server.handler.CrossOriginHandler`.

This is related to https://github.com/jetty/jetty.project/issues/13467