### PR TITLE
Add @deprecated notes to GzipHandler to match existing deprecation in gzip.mod

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
 /**
  * @deprecated use the new {@code CompressionHandler} available in {@code org.eclipse.jetty.compression:jetty-compression-server}
  *             with your choice of compression implementation (gzip is {@code org.eclipse.jetty.compression:jetty-compression-gzip},
- *             brolti is {@code org.eclipse.jetty.compression:jetty-compression-gzip}, and zstandard is
+ *             brotli is {@code org.eclipse.jetty.compression:jetty-compression-brotli}, and zstandard is
  *             {@code org.eclipse.jetty.compression:jetty-compression-zstandard})
  */
 @Deprecated(since = "12.1.1", forRemoval = true)

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
@@ -39,6 +39,13 @@ import org.eclipse.jetty.util.compression.InflaterPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * @deprecated use the new {@code CompressionHandler} available in {@code org.eclipse.jetty.compression:jetty-compression-server}
+ *             with your choice of compression implementation (gzip is {@code org.eclipse.jetty.compression:jetty-compression-gzip},
+ *             brolti is {@code org.eclipse.jetty.compression:jetty-compression-gzip}, and zstandard is
+ *             {@code org.eclipse.jetty.compression:jetty-compression-zstandard})
+ */
+@Deprecated(since = "12.1.1", forRemoval = true)
 public class GzipHandler extends Handler.Wrapper implements GzipFactory
 {
     public static final String GZIP_HANDLER_ETAGS = "o.e.j.s.h.gzip.GzipHandler.etag";


### PR DESCRIPTION
The GzipHandler in 12.1.x is deprecated (see `gzip.mod`), but we missed the `@deprecated` annotations / javadoc for the class.

Link to existing [`gzip.mod`](https://github.com/jetty/jetty.project/blob/jetty-12.1.x/jetty-core/jetty-server/src/main/config/modules/gzip.mod)