### PR TITLE
Issue #13500 - Add missing jetty-compression artifacts to jetty-bom

### DIFF
--- a/jetty-core/jetty-bom/pom.xml
+++ b/jetty-core/jetty-bom/pom.xml
@@ -176,6 +176,31 @@
         <version>12.1.1-SNAPSHOT</version>
       </dependency>
       <dependency>
+        <groupId>org.eclipse.jetty.compression</groupId>
+        <artifactId>jetty-compression-brotli</artifactId>
+        <version>12.1.1-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.compression</groupId>
+        <artifactId>jetty-compression-common</artifactId>
+        <version>12.1.1-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.compression</groupId>
+        <artifactId>jetty-compression-gzip</artifactId>
+        <version>12.1.1-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.compression</groupId>
+        <artifactId>jetty-compression-server</artifactId>
+        <version>12.1.1-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.compression</groupId>
+        <artifactId>jetty-compression-zstandard</artifactId>
+        <version>12.1.1-SNAPSHOT</version>
+      </dependency>
+      <dependency>
         <groupId>org.eclipse.jetty.demos</groupId>
         <artifactId>jetty-core-demo-handler</artifactId>
         <version>12.1.1-SNAPSHOT</version>


### PR DESCRIPTION
The new compression artifacts were missing from jetty-core/jetty-bom

Resolves: #13500