### PR TITLE
Ignore the removal of Persistent HttpFields

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/ResponseHttpFields.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/ResponseHttpFields.java
@@ -64,25 +64,18 @@ public class ResponseHttpFields extends HttpFields.Mutable.Wrapper
     @Override
     public boolean onRemoveField(HttpField field)
     {
-        if (isCommitted())
-            return false;
-        if (isPersistent(field))
-            throw new UnsupportedOperationException("Persistent field");
-        return true;
+        return !isCommitted() && !isPersistent(field);
     }
 
     @Override
     public HttpField onReplaceField(HttpField oldField, HttpField newField)
     {
-        if (isCommitted())
+        // If the fields are committed, we cannot replace them, nor can we delete or change the name.
+        if (isCommitted() || newField == null || !newField.isSameName(oldField))
             return oldField;
 
         if (oldField instanceof Persistent persistent)
         {
-            // cannot change the field name
-            if (newField == null || !newField.isSameName(oldField))
-                throw new UnsupportedOperationException("Persistent field");
-
             // new field must also be persistent and clear back to the previous value
             newField = (newField instanceof PreEncodedHttpField)
                 ? new PersistentPreEncodedHttpField(oldField.getHeader(), newField.getValue(), persistent.getOriginal())

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ResponseTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ResponseTest.java
@@ -58,7 +58,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ResponseTest
 {
@@ -246,38 +245,38 @@ public class ResponseTest
                 String date = response.getHeaders().get(HttpHeader.DATE);
                 String server = response.getHeaders().get(HttpHeader.SERVER);
 
-                response.getHeaders().add("Temp", "field");
-                response.getHeaders().add("Test", "before reset");
-                assertThrows(UnsupportedOperationException.class, () -> response.getHeaders().remove(HttpHeader.SERVER));
-                assertThrows(UnsupportedOperationException.class, () -> response.getHeaders().remove(HttpHeader.DATE));
-                response.getHeaders().remove("Temp");
-
-                response.getHeaders().add("Temp", "field");
+                response.getHeaders()
+                    .add("Temp", "field")
+                    .add("Test", "before reset")
+                    .remove(HttpHeader.SERVER)
+                    .remove(HttpHeader.DATE)
+                    .remove("Temp")
+                    .add("Temp", "field");
                 Iterator<HttpField> iterator = response.getHeaders().iterator();
                 assertThat(iterator.next().getHeader(), is(HttpHeader.SERVER));
-                assertThrows(UnsupportedOperationException.class, iterator::remove);
+                iterator.remove();
                 assertThat(iterator.next().getHeader(), is(HttpHeader.DATE));
-                assertThrows(UnsupportedOperationException.class, iterator::remove);
+                iterator.remove();
                 assertThat(iterator.next().getName(), is("Test"));
                 assertThat(iterator.next().getName(), is("Temp"));
                 iterator.remove();
                 assertFalse(response.getHeaders().contains("Temp"));
-                assertThrows(UnsupportedOperationException.class, () -> response.getHeaders().remove(HttpHeader.SERVER));
+                response.getHeaders().remove(HttpHeader.SERVER);
                 assertFalse(iterator.hasNext());
 
                 ListIterator<HttpField> listIterator = response.getHeaders().listIterator();
                 assertThat(listIterator.next().getHeader(), is(HttpHeader.SERVER));
-                assertThrows(UnsupportedOperationException.class, listIterator::remove);
+                listIterator.remove();
                 assertThat(listIterator.next().getHeader(), is(HttpHeader.DATE));
-                assertThrows(UnsupportedOperationException.class, () -> listIterator.set(new HttpField("Something", "else")));
+                listIterator.set(new HttpField("Something", "else"));
                 listIterator.set(new HttpField(HttpHeader.DATE, "1970-01-01"));
                 assertThat(listIterator.previous().getHeader(), is(HttpHeader.DATE));
-                assertThrows(UnsupportedOperationException.class, listIterator::remove);
+                listIterator.remove();
                 assertThat(listIterator.previous().getHeader(), is(HttpHeader.SERVER));
-                assertThrows(UnsupportedOperationException.class, listIterator::remove);
+                listIterator.remove();
                 assertThat(listIterator.next().getHeader(), is(HttpHeader.SERVER));
                 assertThat(listIterator.next().getHeader(), is(HttpHeader.DATE));
-                assertThrows(UnsupportedOperationException.class, listIterator::remove);
+                listIterator.remove();
                 listIterator.add(new HttpField("Temp", "value"));
                 assertThat(listIterator.previous().getName(), is("Temp"));
                 listIterator.remove();
@@ -294,9 +293,9 @@ public class ResponseTest
                 response.getHeaders().add("Test", "after reset");
 
                 response.getHeaders().putDate("Date", 1L);
-                assertThrows(UnsupportedOperationException.class, () -> response.getHeaders().put(HttpHeader.SERVER, (String)null));
+                response.getHeaders().put(HttpHeader.SERVER, (String)null);
                 response.getHeaders().put(HttpHeader.SERVER, "jettyrocks");
-                assertThrows(UnsupportedOperationException.class, () -> response.getHeaders().put(HttpHeader.SERVER, (String)null));
+                response.getHeaders().put(HttpHeader.SERVER, (String)null);
                 callback.succeeded();
                 return true;
             }

--- a/jetty-core/jetty-server/src/test/resources/jetty-logging.properties
+++ b/jetty-core/jetty-server/src/test/resources/jetty-logging.properties
@@ -3,7 +3,7 @@
 #org.eclipse.jetty.util.LEVEL=DEBUG
 #org.eclipse.jetty.io.LEVEL=DEBUG
 #org.eclipse.jetty.http.LEVEL=DEBUG
-org.eclipse.jetty.server.LEVEL=DEBUG
+#org.eclipse.jetty.server.LEVEL=DEBUG
 #org.eclipse.jetty.server.internal.HttpChannelState.LEVEL=DEBUG
 #org.eclipse.jetty.server.LargeHeaderTest.LEVEL=DEBUG
 #org.eclipse.jetty.server.ResponseCompleteTest.LEVEL=DEBUG

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/ContextHandlerTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/ContextHandlerTest.java
@@ -44,7 +44,6 @@ import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.util.Callback;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
@@ -211,8 +210,8 @@ public class ContextHandlerTest
             @Override
             public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
             {
-                Assertions.assertThrows(UnsupportedOperationException.class, () -> response.setHeader("Server", null));
-                Assertions.assertThrows(UnsupportedOperationException.class, () -> response.setHeader("Date", null));
+                response.setHeader("Server", null);
+                response.setHeader("Date", null);
                 String server = response.getHeader(HttpHeader.SERVER.asString());
                 String date = response.getHeader(HttpHeader.DATE.asString());
                 response.setHeader("Server", "testing123");


### PR DESCRIPTION
Fix #13385 by not throwing when persistent HttpFields are attempted to be removed.
This replaces #13388