### PR TITLE
Fixes #13499 - Jetty 12.1 brotli linking problem.

### DIFF
--- a/jetty-core/jetty-compression/jetty-compression-brotli/src/main/java/org/eclipse/jetty/compression/brotli/BrotliCompression.java
+++ b/jetty-core/jetty-compression/jetty-compression-brotli/src/main/java/org/eclipse/jetty/compression/brotli/BrotliCompression.java
@@ -49,17 +49,15 @@ public class BrotliCompression extends Compression
     private static final HttpField CONTENT_ENCODING = new PreEncodedHttpField(HttpHeader.CONTENT_ENCODING, ENCODING_NAME);
     private static final int DEFAULT_MIN_BROTLI_SIZE = 48;
 
-    static
-    {
-        Brotli4jLoader.ensureAvailability();
-    }
-
     private BrotliEncoderConfig defaultEncoderConfig = new BrotliEncoderConfig();
     private BrotliDecoderConfig defaultDecoderConfig = new BrotliDecoderConfig();
 
     public BrotliCompression()
     {
         super(ENCODING_NAME);
+        // Brotli4jLoader uses a static class block to link the
+        // native library, so it is thread-safe by definition.
+        Brotli4jLoader.ensureAvailability();
         setMinCompressSize(DEFAULT_MIN_BROTLI_SIZE);
     }
 

--- a/jetty-core/jetty-compression/jetty-compression-zstandard/src/main/java/org/eclipse/jetty/compression/zstandard/ZstandardCompression.java
+++ b/jetty-core/jetty-compression/jetty-compression-zstandard/src/main/java/org/eclipse/jetty/compression/zstandard/ZstandardCompression.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 
 import com.github.luben.zstd.ZstdInputStreamNoFinalizer;
 import com.github.luben.zstd.ZstdOutputStreamNoFinalizer;
+import com.github.luben.zstd.util.Native;
 import org.eclipse.jetty.compression.Compression;
 import org.eclipse.jetty.compression.DecoderConfig;
 import org.eclipse.jetty.compression.DecoderSource;
@@ -61,6 +62,9 @@ public class ZstandardCompression extends Compression
     public ZstandardCompression()
     {
         super(ENCODING_NAME);
+        // Zstandard's Native uses a static class block to link
+        // the native library, so it is thread-safe by definition.
+        Native.load();
         setMinCompressSize(DEFAULT_MIN_ZSTD_SIZE);
     }
 


### PR DESCRIPTION
Updated code to be more friendly when used in embedded Jetty.

* Moved Brotli initialization from static class block to constructor.
* Moved Zstandard initialization to constructor for eager failures.