### PR TITLE
Fixes #12029 - OutputStreamContentSource.AsyncOutputStream rethrows already thrown exception.

### DIFF
--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/ContentSinkOutputStream.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/ContentSinkOutputStream.java
@@ -95,9 +95,10 @@ public class ContentSinkOutputStream extends OutputStream
 
     private void handleException(Throwable x) throws IOException
     {
+        IOException failure = IO.rethrow(x);
         if (failed)
-            throw new IOException(x.toString());
+            throw new IOException(failure.toString());
         failed = true;
-        throw IO.rethrow(x);
+        throw failure;
     }
 }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/OutputStreamContentSource.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/OutputStreamContentSource.java
@@ -72,6 +72,8 @@ public class OutputStreamContentSource implements Content.Source, Closeable
 
     private class AsyncOutputStream extends OutputStream
     {
+        private boolean failed;
+
         @Override
         public void write(int b) throws IOException
         {
@@ -89,7 +91,7 @@ public class OutputStreamContentSource implements Content.Source, Closeable
             }
             catch (Throwable x)
             {
-                throw IO.rethrow(x);
+                handleException(x);
             }
         }
 
@@ -103,6 +105,15 @@ public class OutputStreamContentSource implements Content.Source, Closeable
         public void close()
         {
             async.close();
+        }
+
+        private void handleException(Throwable x) throws IOException
+        {
+            IOException failure = IO.rethrow(x);
+            if (failed)
+                throw new IOException(failure.toString());
+            failed = true;
+            throw failure;
         }
     }
 }

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/content/OutputStreamContentSourceTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/content/OutputStreamContentSourceTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class OutputStreamContentSourceTest
 {
     @Test
-    public void testNoDuplicateExceptionThrown() throws Exception
+    public void testNoDuplicateExceptionThrown()
     {
         EofException cause = new EofException();
         IOException failure = assertThrows(IOException.class, () ->
@@ -43,7 +43,7 @@ public class OutputStreamContentSourceTest
                 try (BufferedOutputStream buffered = new BufferedOutputStream(source.getOutputStream()))
                 {
                     buffered.write(new byte[16]);
-                    // Flushing the first write causes the failure to be thrown.
+                    // Flushing the first write causes the failure cause to be thrown.
                     buffered.flush();
                     fail("expecting IOException to be thrown");
                 }
@@ -54,7 +54,7 @@ public class OutputStreamContentSourceTest
             }
         });
 
-        assertThat(failure, not(sameInstance(cause)));
+        assertThat(failure, sameInstance(cause));
 
         StringWriter stringWriter = new StringWriter();
         failure.printStackTrace(new PrintWriter(stringWriter));

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/content/OutputStreamContentSourceTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/content/OutputStreamContentSourceTest.java
@@ -1,0 +1,63 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.io.content;
+
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import org.eclipse.jetty.io.EofException;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class OutputStreamContentSourceTest
+{
+    @Test
+    public void testNoDuplicateExceptionThrown() throws Exception
+    {
+        EofException cause = new EofException();
+        IOException failure = assertThrows(IOException.class, () ->
+        {
+            try (OutputStreamContentSource source = new OutputStreamContentSource())
+            {
+                source.fail(cause);
+
+                try (BufferedOutputStream buffered = new BufferedOutputStream(source.getOutputStream()))
+                {
+                    buffered.write(new byte[16]);
+                    // Flushing the first write causes the failure to be thrown.
+                    buffered.flush();
+                    fail("expecting IOException to be thrown");
+                }
+                // Here BufferedOutputStream.close() is called, which calls flush() again.
+                // This second flush also throws, and we must guarantee that it is not
+                // the same exception instance, or otherwise the try-with-resources
+                // fails with IllegalArgumentException: Self-suppression not permitted.
+            }
+        });
+
+        assertThat(failure, not(sameInstance(cause)));
+
+        StringWriter stringWriter = new StringWriter();
+        failure.printStackTrace(new PrintWriter(stringWriter));
+        assertThat(stringWriter.toString(), not(containsString("CIRCULAR REFERENCE")));
+    }
+}


### PR DESCRIPTION
Avoid throwing the same exception, if it was already thrown. 
Similar solution as #11759.