### PR TITLE
cherry-pick from 12.1.x to 12.0.x disable detectOfflineLinks of m-javadoc-plugin and add test to ensure javadoc:jar still works fine with eclipse-release profile (#13512)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,18 +39,19 @@ pipeline {
           }
         }
 
-        stage("Build / Test - JDK17 Javadoc") {
+        stage("Build / Test - JDK22 Javadoc") {
           agent { node { label 'linux-light' } }
           steps {
             timeout( time: 180, unit: 'MINUTES' ) {
               checkout scm
-              withEnv(["JAVA_HOME=${ tool 'jdk17' }",
-                       "PATH+MAVEN=${ tool 'jdk17' }/bin:${tool 'maven3'}/bin",
+              withEnv(["JAVA_HOME=${ tool 'jdk22' }",
+                       "PATH+MAVEN=${ tool 'jdk22' }/bin:${tool 'maven3'}/bin",
                        "MAVEN_OPTS=-Xms3G -Xmx5G -Djava.awt.headless=true"]) {
                 configFileProvider(
                         [configFile(fileId: 'oss-settings.xml', variable: 'GLOBAL_MVN_SETTINGS'),
                          configFile(fileId: 'maven-build-cache-config.xml', variable: 'MVN_BUILD_CACHE_CONFIG')]) {
-                  sh "mvn -s $GLOBAL_MVN_SETTINGS clean install -DskipTests javadoc:aggregate -B -Pjavadoc-aggregate"
+                  sh "mvn -e -DsettingsPath=$GLOBAL_MVN_SETTINGS clean verify -DskipTests javadoc:jar -Peclipse-release -Dgpg.skip=true"
+                  sh "mvn -e -DsettingsPath=$GLOBAL_MVN_SETTINGS clean install -DskipTests javadoc:aggregate -B -Pjavadoc-aggregate"
                 }
               }
             }

--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,7 @@
     <conscrypt.version>2.5.2</conscrypt.version>
     <cyclonedx.maven.plugin.version>2.8.0</cyclonedx.maven.plugin.version>
     <depends.maven.plugin.version>1.5.0</depends.maven.plugin.version>
+    <detectOfflineLinks>false</detectOfflineLinks>
     <duplicate-finder-maven-plugin.version>2.0.1</duplicate-finder-maven-plugin.version>
     <eclipse.jdt.ecj.version>3.38.0</eclipse.jdt.ecj.version>
     <felix.version>7.0.5</felix.version>


### PR DESCRIPTION
* disable detectOfflineLinks of m-javadoc-plugin and add test to ensure javadoc:jar still works fine with eclipse-release profile

Signed-off-by: Olivier Lamy <olamy@apache.org>

* test eclipse release only with jdk22

Signed-off-by: Olivier Lamy <olamy@apache.org>

---------

Signed-off-by: Olivier Lamy <olamy@apache.org>
