### PR TITLE
Fixes #13475 - Jakarta Websocket served with h2 and timeouts disabled always times out after 30s

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpRequest.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpRequest.java
@@ -57,9 +57,9 @@ import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.io.CyclicTimeouts;
 import org.eclipse.jetty.io.Transport;
 import org.eclipse.jetty.util.Fields;
-import org.eclipse.jetty.util.NanoTime;
 import org.eclipse.jetty.util.Promise;
 import org.eclipse.jetty.util.URIUtil;
 
@@ -761,11 +761,7 @@ public class HttpRequest implements Request
     void sent()
     {
         if (timeoutNanoTime == Long.MAX_VALUE)
-        {
-            long timeout = getTimeout();
-            if (timeout > 0)
-                timeoutNanoTime = NanoTime.now() + TimeUnit.MILLISECONDS.toNanos(timeout);
-        }
+            timeoutNanoTime = CyclicTimeouts.Expirable.calcExpireNanoTime(getTimeout());
     }
 
     /**

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -296,9 +295,7 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
 
     public void notIdle()
     {
-        long idleTimeout = getIdleTimeout();
-        if (idleTimeout > 0)
-            expireNanoTime = NanoTime.now() + TimeUnit.MILLISECONDS.toNanos(idleTimeout);
+        expireNanoTime = CyclicTimeouts.Expirable.calcExpireNanoTime(getIdleTimeout());
     }
 
     @Override

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/HTTP3Stream.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/HTTP3Stream.java
@@ -15,7 +15,6 @@ package org.eclipse.jetty.http3;
 
 import java.util.EnumSet;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -116,9 +115,7 @@ public abstract class HTTP3Stream implements Stream, CyclicTimeouts.Expirable, A
 
     protected void notIdle()
     {
-        long idleTimeout = getIdleTimeout();
-        if (idleTimeout > 0)
-            expireNanoTime = NanoTime.now() + TimeUnit.MILLISECONDS.toNanos(idleTimeout);
+        expireNanoTime = CyclicTimeouts.Expirable.calcExpireNanoTime(getIdleTimeout());
     }
 
     void onIdleTimeout(TimeoutException timeout, Promise<Boolean> promise)

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/CyclicTimeouts.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/CyclicTimeouts.java
@@ -190,7 +190,31 @@ public abstract class CyclicTimeouts<T extends CyclicTimeouts.Expirable> impleme
          *
          * @return the expiration time in nanoseconds, or {@link Long#MAX_VALUE} if this entity does not expire
          */
-        public long getExpireNanoTime();
+        long getExpireNanoTime();
+
+        /**
+         * <p>Calculates the expiration time in nanoseconds.</p>
+         * <p>If the given {@code timeoutMs} is positive, the returned value is calculated from the
+         * current nanoTime: {@code NanoTime.now() + TimeUnit.MILLISECONDS.toNanos(timeoutMs)}.</p>
+         * <p>If the given {@code timeoutMs} is zero or negative, {@link Long#MAX_VALUE} is returned.</p>
+         *
+         * @param timeoutMs the timeout to add to the current nanoTime to calculate the expiration time
+         * @return the expiration time in nanoseconds, or {@link Long#MAX_VALUE} if the timeout is zero or negative
+         */
+        static long calcExpireNanoTime(long timeoutMs)
+        {
+            if (timeoutMs > 0)
+            {
+                long value = NanoTime.now() + TimeUnit.MILLISECONDS.toNanos(timeoutMs);
+                if (value == Long.MAX_VALUE)
+                    ++value;
+                return value;
+            }
+            else
+            {
+                return Long.MAX_VALUE;
+            }
+        }
     }
 
     private class Timeouts extends CyclicTimeout

--- a/jetty-core/jetty-quic/jetty-quic-server/src/main/java/org/eclipse/jetty/quic/server/ServerQuicSession.java
+++ b/jetty-core/jetty-quic/jetty-quic-server/src/main/java/org/eclipse/jetty/quic/server/ServerQuicSession.java
@@ -18,7 +18,6 @@ import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.concurrent.Executor;
-import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.Connection;
@@ -31,7 +30,6 @@ import org.eclipse.jetty.quic.common.QuicStreamEndPoint;
 import org.eclipse.jetty.quic.quiche.QuicheConnection;
 import org.eclipse.jetty.server.ConnectionFactory;
 import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.util.NanoTime;
 import org.eclipse.jetty.util.thread.Scheduler;
 
 /**
@@ -140,8 +138,6 @@ public class ServerQuicSession extends QuicSession implements CyclicTimeouts.Exp
 
     private void notIdle()
     {
-        long idleTimeout = getIdleTimeout();
-        if (idleTimeout > 0)
-            expireNanoTime = NanoTime.now() + TimeUnit.MILLISECONDS.toNanos(idleTimeout);
+        expireNanoTime = CyclicTimeouts.Expirable.calcExpireNanoTime(getIdleTimeout());
     }
 }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/QoSHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/QoSHandler.java
@@ -33,7 +33,6 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
-import org.eclipse.jetty.util.NanoTime;
 import org.eclipse.jetty.util.ProcessorUtils;
 import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.annotation.ManagedObject;
@@ -423,11 +422,7 @@ public class QoSHandler extends ConditionalHandler.Abstract
             this.response = response;
             this.callback = callback;
             this.priority = priority;
-            Duration maxSuspend = getMaxSuspend();
-            long suspendNanos = NanoTime.now() + maxSuspend.toNanos();
-            if (suspendNanos == Long.MAX_VALUE)
-                --suspendNanos;
-            this.expireNanoTime = maxSuspend.isZero() ? Long.MAX_VALUE : suspendNanos;
+            this.expireNanoTime = CyclicTimeouts.Expirable.calcExpireNanoTime(getMaxSuspend().toMillis());
         }
 
         @Override

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketCoreSession.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketCoreSession.java
@@ -69,7 +69,7 @@ public class WebSocketCoreSession implements CoreSession, Dumpable
     private int outputBufferSize = WebSocketConstants.DEFAULT_OUTPUT_BUFFER_SIZE;
     private long maxBinaryMessageSize = WebSocketConstants.DEFAULT_MAX_BINARY_MESSAGE_SIZE;
     private long maxTextMessageSize = WebSocketConstants.DEFAULT_MAX_TEXT_MESSAGE_SIZE;
-    private Duration idleTimeout = WebSocketConstants.DEFAULT_IDLE_TIMEOUT;
+    private Duration idleTimeout;
     private Duration frameWriteTimeout = WebSocketConstants.DEFAULT_WRITE_TIMEOUT;
     private ClassLoader classLoader;
 
@@ -131,13 +131,13 @@ public class WebSocketCoreSession implements CoreSession, Dumpable
     @Override
     public Duration getIdleTimeout()
     {
-        return idleTimeout;
+        return idleTimeout != null ? idleTimeout : WebSocketConstants.DEFAULT_IDLE_TIMEOUT;
     }
 
     @Override
     public void setIdleTimeout(Duration timeout)
     {
-        idleTimeout = timeout;
+        idleTimeout = Objects.requireNonNull(timeout);
         if (connection != null)
             connection.getEndPoint().setIdleTimeout(timeout.toMillis());
     }
@@ -190,7 +190,13 @@ public class WebSocketCoreSession implements CoreSession, Dumpable
      */
     public void setWebSocketConnection(WebSocketConnection connection)
     {
-        connection.getEndPoint().setIdleTimeout(idleTimeout.toMillis());
+        // If the idle timeout is not initialized by a WebSocket
+        // configurator, then inherit that of the EndPoint; otherwise
+        // force the EndPoint to use the WebSocket configured idle timeout.
+        if (idleTimeout == null)
+            idleTimeout = Duration.ofMillis(connection.getEndPoint().getIdleTimeout());
+        else
+            connection.getEndPoint().setIdleTimeout(idleTimeout.toMillis());
         connection.setWriteTimeout(frameWriteTimeout.toMillis());
         extensionStack.setLastDemand(connection::demand);
         this.connection = connection;

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/FrameFlusher.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/FrameFlusher.java
@@ -21,7 +21,6 @@ import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
 
 import org.eclipse.jetty.io.ByteBufferPool;
@@ -504,12 +503,7 @@ public class FrameFlusher extends IteratingCallback
         private Entry(Frame frame, Callback callback, boolean batch)
         {
             super(frame, callback, batch);
-
-            long currentTime = NanoTime.now();
-            long expiry = Long.MAX_VALUE;
-            if (_frameTimeout > 0)
-                expiry = currentTime + TimeUnit.MILLISECONDS.toNanos(_frameTimeout);
-            _expiry = expiry;
+            _expiry = CyclicTimeouts.Expirable.calcExpireNanoTime(_frameTimeout);
         }
 
         @Override

--- a/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/RFC6455Handshaker.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/RFC6455Handshaker.java
@@ -21,7 +21,7 @@ import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http.PreEncodedHttpField;
-import org.eclipse.jetty.io.ByteBufferPool;
+import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.server.ConnectionMetaData;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Request;
@@ -79,10 +79,8 @@ public final class RFC6455Handshaker extends AbstractHandshaker
     {
         ConnectionMetaData connectionMetaData = baseRequest.getConnectionMetaData();
         Connector connector = connectionMetaData.getConnector();
-        ByteBufferPool byteBufferPool = connector.getByteBufferPool();
-        WebSocketConnection connection = newWebSocketConnection(connectionMetaData.getConnection().getEndPoint(), connector.getExecutor(), connector.getScheduler(), byteBufferPool, coreSession);
-        coreSession.setWebSocketConnection(connection);
-        return connection;
+        EndPoint endPoint = connectionMetaData.getConnection().getEndPoint();
+        return newWebSocketConnection(endPoint, connector.getExecutor(), connector.getScheduler(), connector.getByteBufferPool(), coreSession);
     }
 
     @Override

--- a/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/RFC8441Handshaker.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/RFC8441Handshaker.java
@@ -16,12 +16,10 @@ package org.eclipse.jetty.websocket.core.server.internal;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpVersion;
-import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
-import org.eclipse.jetty.server.TunnelSupport;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.websocket.core.WebSocketComponents;
 import org.eclipse.jetty.websocket.core.WebSocketConnection;
@@ -59,10 +57,8 @@ public class RFC8441Handshaker extends AbstractHandshaker
     protected WebSocketConnection createWebSocketConnection(Request request, WebSocketCoreSession coreSession)
     {
         Connector connector = request.getConnectionMetaData().getConnector();
-        ByteBufferPool byteBufferPool = connector.getByteBufferPool();
-        TunnelSupport tunnelSupport = request.getTunnelSupport();
-        EndPoint endPoint = tunnelSupport.getEndPoint();
-        return newWebSocketConnection(endPoint, connector.getExecutor(), connector.getScheduler(), byteBufferPool, coreSession);
+        EndPoint endPoint = request.getTunnelSupport().getEndPoint();
+        return newWebSocketConnection(endPoint, connector.getExecutor(), connector.getScheduler(), connector.getByteBufferPool(), coreSession);
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/pom.xml
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/pom.xml
@@ -55,6 +55,16 @@
       <artifactId>jetty-util-ajax</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.http2</groupId>
+      <artifactId>jetty-http2-client-transport</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.http2</groupId>
+      <artifactId>jetty-http2-server</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/IdleTimeoutOverHTTP2Test.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/IdleTimeoutOverHTTP2Test.java
@@ -1,0 +1,175 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee10.websocket.jakarta.tests;
+
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.websocket.OnError;
+import jakarta.websocket.OnOpen;
+import jakarta.websocket.Session;
+import jakarta.websocket.server.ServerEndpoint;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.websocket.jakarta.client.JakartaWebSocketClientContainer;
+import org.eclipse.jetty.ee10.websocket.jakarta.server.config.JakartaWebSocketServletContainerInitializer;
+import org.eclipse.jetty.http2.client.HTTP2Client;
+import org.eclipse.jetty.http2.client.transport.HttpClientTransportOverHTTP2;
+import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
+import org.eclipse.jetty.io.ClientConnector;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class IdleTimeoutOverHTTP2Test
+{
+    private Server server;
+    private ServerConnector connector;
+    private HTTP2CServerConnectionFactory http2Server;
+    private HTTP2Client http2Client;
+    private JakartaWebSocketClientContainer wsClient;
+
+    private void startServer(JakartaWebSocketServletContainerInitializer.Configurator configurator) throws Exception
+    {
+        QueuedThreadPool serverThreads = new QueuedThreadPool();
+        serverThreads.setName("server");
+        server = new Server(serverThreads);
+        HttpConfiguration httpConfig = new HttpConfiguration();
+        http2Server = new HTTP2CServerConnectionFactory(httpConfig);
+        connector = new ServerConnector(server, 1, 1, http2Server);
+        server.addConnector(connector);
+
+        ServletContextHandler context = new ServletContextHandler("/");
+        server.setHandler(context);
+        JakartaWebSocketServletContainerInitializer.configure(context, configurator);
+
+        server.start();
+    }
+
+    private void startClient() throws Exception
+    {
+        ClientConnector clientConnector = new ClientConnector();
+        QueuedThreadPool clientThreads = new QueuedThreadPool();
+        clientThreads.setName("client");
+        clientConnector.setExecutor(clientThreads);
+        http2Client = new HTTP2Client(clientConnector);
+        HttpClient httpClient = new HttpClient(new HttpClientTransportOverHTTP2(http2Client));
+        wsClient = new JakartaWebSocketClientContainer(httpClient);
+        wsClient.start();
+    }
+
+    @AfterEach
+    public void dispose()
+    {
+        LifeCycle.stop(server);
+    }
+
+    @Test
+    public void testIdleTimeoutConfiguredByWebSocketEndPoint() throws Exception
+    {
+        startServer((context, container) -> container.addEndpoint(ConfigureIdleTimeoutAnnotatedEndPoint.class));
+        startClient();
+
+        EventSocket clientEndpoint = new EventSocket();
+        try (Session ignored = wsClient.connectToServer(clientEndpoint, URI.create("ws://localhost:" + connector.getLocalPort() + ConfigureIdleTimeoutAnnotatedEndPoint.PATH)))
+        {
+            assertTrue(clientEndpoint.closeLatch.await(2 * ConfigureIdleTimeoutAnnotatedEndPoint.IDLE_TIMEOUT, TimeUnit.MILLISECONDS));
+        }
+    }
+
+    @Test
+    public void testIdleTimeoutConfiguredByServerContainerDisabledByWebSocketEndPoint() throws Exception
+    {
+        long idleTimeout = 1000;
+        startServer((context, container) ->
+        {
+            container.setDefaultMaxSessionIdleTimeout(idleTimeout);
+            container.addEndpoint(DisableIdleTimeoutAnnotatedEndPoint.class);
+        });
+        startClient();
+
+        EventSocket clientEndpoint = new EventSocket();
+        try (Session ignored = wsClient.connectToServer(clientEndpoint, URI.create("ws://localhost:" + connector.getLocalPort() + DisableIdleTimeoutAnnotatedEndPoint.PATH)))
+        {
+            assertFalse(clientEndpoint.closeLatch.await(2 * idleTimeout, TimeUnit.MILLISECONDS));
+        }
+    }
+
+    @Test
+    public void testIdleTimeoutConfiguredExternally() throws Exception
+    {
+        long idleTimeout = 1000;
+        startServer((context, container) ->
+            container.addEndpoint(ExternalIdleTimeoutAnnotatedEndPoint.class));
+        // Configure the idle timeout here, WebSocket should inherit it.
+        http2Server.setStreamIdleTimeout(idleTimeout);
+        startClient();
+
+        EventSocket clientEndpoint = new EventSocket();
+        try (Session ignored = wsClient.connectToServer(clientEndpoint, URI.create("ws://localhost:" + connector.getLocalPort() + ExternalIdleTimeoutAnnotatedEndPoint.PATH)))
+        {
+            assertTrue(clientEndpoint.closeLatch.await(2 * idleTimeout, TimeUnit.MILLISECONDS));
+        }
+    }
+
+    @ServerEndpoint(ConfigureIdleTimeoutAnnotatedEndPoint.PATH)
+    public static class ConfigureIdleTimeoutAnnotatedEndPoint
+    {
+        public static final String PATH = "/configureIdleTimeout";
+        public static final long IDLE_TIMEOUT = 1000;
+
+        @OnOpen
+        public void onOpen(Session session)
+        {
+            session.setMaxIdleTimeout(IDLE_TIMEOUT);
+        }
+
+        @OnError
+        public void onError(Throwable failure)
+        {
+            // Just to reduce WARN logging in tests.
+        }
+    }
+
+    @ServerEndpoint(DisableIdleTimeoutAnnotatedEndPoint.PATH)
+    public static class DisableIdleTimeoutAnnotatedEndPoint
+    {
+        public static final String PATH = "/disableIdleTimeout";
+
+        @OnOpen
+        public void onOpen(Session session)
+        {
+            session.setMaxIdleTimeout(-1);
+        }
+    }
+
+    @ServerEndpoint(ExternalIdleTimeoutAnnotatedEndPoint.PATH)
+    public static class ExternalIdleTimeoutAnnotatedEndPoint
+    {
+        public static final String PATH = "/externalIdleTimeout";
+
+        @OnError
+        public void onError(Throwable failure)
+        {
+            // Just to reduce WARN logging in tests.
+        }
+    }
+}


### PR DESCRIPTION
The issue was that trying to disable the idle timeout was ignored in HTTP2Stream.notIdle(): the expireNanoTime was not reset to Long.MAX_VALUE like it should have been.

* Fixed logic to compute the expiration time in HTTP2Stream.notIdle().
* Fixed similar logic in HTTP3Stream, ServerQuicSession, QoSHandler, HttpRequest and WebSocket's FrameFlusher.
* Updated WebSocketCoreSession idle timeout handling to inherit that of the underlying EndPoint if none was explicitly configured via WebSocket.
* Code cleanups in RFC[6455|8441]Handshaker.