### PR TITLE
Issue #13509 - Fix multipart usage with Servlet dispatch.

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/Dispatcher.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/Dispatcher.java
@@ -19,6 +19,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
@@ -38,6 +39,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpServletResponseWrapper;
+import jakarta.servlet.http.Part;
 import org.eclipse.jetty.ee10.servlet.util.ServletOutputStreamWrapper;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.pathmap.MatchedResource;
@@ -67,7 +69,7 @@ public class Dispatcher implements RequestDispatcher
     public static final String JETTY_INCLUDE_HEADER_PREFIX = "org.eclipse.jetty.server.include.";
 
     /**
-     * This attribute is used to store the wrapped request for internal use during a dispatch.
+     * This attribute is used to store the wrapped request for internal use during a dispatch if needed.
      */
     public static final String WRAPPED_REQUEST_ATTRIBUTE = "org.eclipse.jetty.server.wrappedRequest";
 
@@ -128,18 +130,7 @@ public class Dispatcher implements RequestDispatcher
 
         ServletContextRequest servletContextRequest = ServletContextRequest.getServletContextRequest(request);
         servletContextRequest.getServletContextResponse().resetForForward();
-
-        Object oldWrappedRequest = httpRequest.getAttribute(WRAPPED_REQUEST_ATTRIBUTE);
-        try
-        {
-            ForwardRequest forwardRequest = new ForwardRequest(httpRequest);
-            httpRequest.setAttribute(WRAPPED_REQUEST_ATTRIBUTE, forwardRequest);
-            _mappedServlet.handle(_servletHandler, _decodedPathInContext, forwardRequest, httpResponse);
-        }
-        finally
-        {
-            httpRequest.setAttribute(WRAPPED_REQUEST_ATTRIBUTE, oldWrappedRequest);
-        }
+        _mappedServlet.handle(_servletHandler, _decodedPathInContext, new ForwardRequest(httpRequest), httpResponse);
 
         // If we are not async and not closed already, then close via the possibly wrapped response.
         if (!servletContextRequest.getState().isAsync() && !servletContextRequest.getServletContextResponse().hasLastWrite())
@@ -165,16 +156,12 @@ public class Dispatcher implements RequestDispatcher
         ServletContextResponse servletContextResponse = ServletContextResponse.getServletContextResponse(response);
 
         IncludeResponse includeResponse = new IncludeResponse(httpResponse);
-        Object oldWrappedRequest = httpRequest.getAttribute(WRAPPED_REQUEST_ATTRIBUTE);
         try
         {
-            IncludeRequest includeRequest = new IncludeRequest(httpRequest);
-            httpRequest.setAttribute(WRAPPED_REQUEST_ATTRIBUTE, includeRequest);
-            _mappedServlet.handle(_servletHandler, _decodedPathInContext, includeRequest, includeResponse);
+            _mappedServlet.handle(_servletHandler, _decodedPathInContext, new IncludeRequest(httpRequest), includeResponse);
         }
         finally
         {
-            httpRequest.setAttribute(WRAPPED_REQUEST_ATTRIBUTE, oldWrappedRequest);
             includeResponse.onIncluded();
             servletContextResponse.included();
         }
@@ -417,6 +404,34 @@ public class Dispatcher implements RequestDispatcher
             names.add(RequestDispatcher.FORWARD_QUERY_STRING);
             return Collections.enumeration(names);
         }
+
+        @Override
+        public Collection<Part> getParts() throws IOException, ServletException
+        {
+            try
+            {
+                setAttribute(WRAPPED_REQUEST_ATTRIBUTE, this);
+                return super.getParts();
+            }
+            finally
+            {
+                setAttribute(WRAPPED_REQUEST_ATTRIBUTE, null);
+            }
+        }
+
+        @Override
+        public Part getPart(String name) throws IOException, ServletException
+        {
+            try
+            {
+                setAttribute(WRAPPED_REQUEST_ATTRIBUTE, this);
+                return super.getPart(name);
+            }
+            finally
+            {
+                setAttribute(WRAPPED_REQUEST_ATTRIBUTE, null);
+            }
+        }
     }
 
     private class IncludeRequest extends ParameterRequestWrapper
@@ -491,6 +506,34 @@ public class Dispatcher implements RequestDispatcher
         public String getQueryString()
         {
             return _httpServletRequest.getQueryString();
+        }
+
+        @Override
+        public Collection<Part> getParts() throws IOException, ServletException
+        {
+            try
+            {
+                setAttribute(WRAPPED_REQUEST_ATTRIBUTE, this);
+                return super.getParts();
+            }
+            finally
+            {
+                setAttribute(WRAPPED_REQUEST_ATTRIBUTE, null);
+            }
+        }
+
+        @Override
+        public Part getPart(String name) throws IOException, ServletException
+        {
+            try
+            {
+                setAttribute(WRAPPED_REQUEST_ATTRIBUTE, this);
+                return super.getPart(name);
+            }
+            finally
+            {
+                setAttribute(WRAPPED_REQUEST_ATTRIBUTE, null);
+            }
         }
     }
 
@@ -770,6 +813,14 @@ public class Dispatcher implements RequestDispatcher
                 case AsyncContextState.ASYNC_PATH_INFO -> _httpServletRequest.getPathInfo();
                 case AsyncContextState.ASYNC_SERVLET_PATH -> _httpServletRequest.getServletPath();
                 case AsyncContextState.ASYNC_QUERY_STRING -> _httpServletRequest.getQueryString();
+                case ServletContextRequest.MULTIPART_CONFIG_ELEMENT ->
+                {
+                    // If we already have future parts, return the configuration of the wrapped request.
+                    if (super.getAttribute(ServletMultiPartFormData.class.getName()) != null)
+                        yield super.getAttribute(name);
+                    // otherwise, return the configuration of this mapping
+                    yield  _mappedServlet.getServletHolder().getMultipartConfigElement();
+                }
                 default -> super.getAttribute(name);
             };
         }
@@ -778,6 +829,11 @@ public class Dispatcher implements RequestDispatcher
         public Enumeration<String> getAttributeNames()
         {
             ArrayList<String> names = new ArrayList<>(Collections.list(super.getAttributeNames()));
+
+            //only return the multipart attribute name if this servlet mapping has multipart config
+            if (names.contains(ServletContextRequest.MULTIPART_CONFIG_ELEMENT) && _mappedServlet.getServletHolder().getMultipartConfigElement() == null)
+                names.remove(ServletContextRequest.MULTIPART_CONFIG_ELEMENT);
+
             names.add(AsyncContextState.ASYNC_REQUEST_URI);
             names.add(AsyncContextState.ASYNC_SERVLET_PATH);
             names.add(AsyncContextState.ASYNC_PATH_INFO);
@@ -816,6 +872,34 @@ public class Dispatcher implements RequestDispatcher
                     return super.getParameters();
             }
             return super.getParameters();
+        }
+
+        @Override
+        public Collection<Part> getParts() throws IOException, ServletException
+        {
+            try
+            {
+                setAttribute(WRAPPED_REQUEST_ATTRIBUTE, this);
+                return super.getParts();
+            }
+            finally
+            {
+                setAttribute(WRAPPED_REQUEST_ATTRIBUTE, null);
+            }
+        }
+
+        @Override
+        public Part getPart(String name) throws IOException, ServletException
+        {
+            try
+            {
+                setAttribute(WRAPPED_REQUEST_ATTRIBUTE, this);
+                return super.getPart(name);
+            }
+            finally
+            {
+                setAttribute(WRAPPED_REQUEST_ATTRIBUTE, null);
+            }
         }
     }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/Dispatcher.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/Dispatcher.java
@@ -45,7 +45,6 @@ import org.eclipse.jetty.io.WriterOutputStream;
 import org.eclipse.jetty.util.Fields;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.StringUtil;
-import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.UrlEncoded;
 
 public class Dispatcher implements RequestDispatcher
@@ -59,13 +58,18 @@ public class Dispatcher implements RequestDispatcher
      * Dispatch include attribute names
      */
     public static final String __FORWARD_PREFIX = "jakarta.servlet.forward.";
-    
+
     /**
      * Name of original request attribute
      */ 
     public static final String __ORIGINAL_REQUEST = "org.eclipse.jetty.originalRequest";
 
     public static final String JETTY_INCLUDE_HEADER_PREFIX = "org.eclipse.jetty.server.include.";
+
+    /**
+     * This attribute is used to store the wrapped request for internal use during a dispatch.
+     */
+    public static final String WRAPPED_REQUEST_ATTRIBUTE = "org.eclipse.jetty.server.wrappedRequest";
 
     private final ServletContextHandler _contextHandler;
     private final HttpURI _uri;
@@ -124,7 +128,18 @@ public class Dispatcher implements RequestDispatcher
 
         ServletContextRequest servletContextRequest = ServletContextRequest.getServletContextRequest(request);
         servletContextRequest.getServletContextResponse().resetForForward();
-        _mappedServlet.handle(_servletHandler, _decodedPathInContext, new ForwardRequest(httpRequest), httpResponse);
+
+        Object oldWrappedRequest = httpRequest.getAttribute(WRAPPED_REQUEST_ATTRIBUTE);
+        try
+        {
+            ForwardRequest forwardRequest = new ForwardRequest(httpRequest);
+            httpRequest.setAttribute(WRAPPED_REQUEST_ATTRIBUTE, forwardRequest);
+            _mappedServlet.handle(_servletHandler, _decodedPathInContext, forwardRequest, httpResponse);
+        }
+        finally
+        {
+            httpRequest.setAttribute(WRAPPED_REQUEST_ATTRIBUTE, oldWrappedRequest);
+        }
 
         // If we are not async and not closed already, then close via the possibly wrapped response.
         if (!servletContextRequest.getState().isAsync() && !servletContextRequest.getServletContextResponse().hasLastWrite())
@@ -150,12 +165,16 @@ public class Dispatcher implements RequestDispatcher
         ServletContextResponse servletContextResponse = ServletContextResponse.getServletContextResponse(response);
 
         IncludeResponse includeResponse = new IncludeResponse(httpResponse);
+        Object oldWrappedRequest = httpRequest.getAttribute(WRAPPED_REQUEST_ATTRIBUTE);
         try
         {
-            _mappedServlet.handle(_servletHandler, _decodedPathInContext, new IncludeRequest(httpRequest), includeResponse);
+            IncludeRequest includeRequest = new IncludeRequest(httpRequest);
+            httpRequest.setAttribute(WRAPPED_REQUEST_ATTRIBUTE, includeRequest);
+            _mappedServlet.handle(_servletHandler, _decodedPathInContext, includeRequest, includeResponse);
         }
         finally
         {
+            httpRequest.setAttribute(WRAPPED_REQUEST_ATTRIBUTE, oldWrappedRequest);
             includeResponse.onIncluded();
             servletContextResponse.included();
         }
@@ -434,6 +453,14 @@ public class Dispatcher implements RequestDispatcher
                 case RequestDispatcher.INCLUDE_REQUEST_URI -> (_uri == null) ? null : _uri.getPath();
                 case RequestDispatcher.INCLUDE_CONTEXT_PATH -> _httpServletRequest.getContextPath();
                 case RequestDispatcher.INCLUDE_QUERY_STRING -> (_uri == null) ? null : _uri.getQuery();
+                case ServletContextRequest.MULTIPART_CONFIG_ELEMENT ->
+                {
+                    // If we already have future parts, return the configuration of the wrapped request.
+                    if (super.getAttribute(ServletMultiPartFormData.class.getName()) != null)
+                        yield super.getAttribute(name);
+                    // otherwise, return the configuration of this mapping
+                    yield  _mappedServlet.getServletHolder().getMultipartConfigElement();
+                }
                 default -> super.getAttribute(name);
             };
         }
@@ -443,6 +470,11 @@ public class Dispatcher implements RequestDispatcher
         {
             //Servlet Spec 9.3.1 no include attributes if a named dispatcher
             ArrayList<String> names = new ArrayList<>(Collections.list(super.getAttributeNames()));
+
+            //only return the multipart attribute name if this servlet mapping has multipart config
+            if (names.contains(ServletContextRequest.MULTIPART_CONFIG_ELEMENT) && _mappedServlet.getServletHolder().getMultipartConfigElement() == null)
+                names.remove(ServletContextRequest.MULTIPART_CONFIG_ELEMENT);
+
             if (_named != null)
                 return Collections.enumeration(names);
             

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiRequest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiRequest.java
@@ -94,6 +94,8 @@ import org.eclipse.jetty.util.UrlEncoded;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.eclipse.jetty.ee10.servlet.Dispatcher.WRAPPED_REQUEST_ATTRIBUTE;
+
 /**
  * The Jetty implementation of the ee10 {@link HttpServletRequest} object.
  * This provides the bridge from Servlet {@link HttpServletRequest} to the Jetty Core {@link Request}
@@ -634,7 +636,8 @@ public class ServletApiRequest implements HttpServletRequest
         {
             try
             {
-                _parts = ServletMultiPartFormData.getParts(this);
+                ServletRequest dispatchedRequest = (ServletRequest)getAttribute(WRAPPED_REQUEST_ATTRIBUTE);
+                _parts = ServletMultiPartFormData.getParts(dispatchedRequest == null ? this : dispatchedRequest);
 
                 Collection<Part> parts = _parts.getParts();
 

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/MultiPartServletTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/MultiPartServletTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
 
 import jakarta.servlet.MultipartConfigElement;
@@ -64,6 +65,8 @@ import org.eclipse.jetty.util.component.LifeCycle;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -580,80 +583,21 @@ public class MultiPartServletTest
         assertThat(responseContent, not(containsString("Parameter: partFileName=" + contentString)));
     }
 
-    @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    public void testForwardDispatch(boolean eager) throws Exception
+    public static Stream<Arguments> dispatchTestArgs()
     {
-        start(servletContextHandler ->
-        {
-            servletContextHandler.addServlet(new HttpServlet()
-            {
-                @Override
-                protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
-                {
-                    request.getRequestDispatcher("/multipart").forward(request, response);
-                }
-            }, "/");
-
-            ServletHolder servletHolder = new ServletHolder(new HttpServlet()
-            {
-                @Override
-                protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
-                {
-                    Collection<Part> parts = request.getParts();
-                    assertNotNull(parts);
-                    assertEquals(1, parts.size());
-                    Part part = parts.iterator().next();
-                    assertEquals("part1", part.getName());
-                    Collection<String> headerNames = part.getHeaderNames();
-                    assertNotNull(headerNames);
-                    assertEquals(2, headerNames.size());
-                    String content1 = IO.toString(part.getInputStream(), UTF_8);
-                    assertEquals("content1", content1);
-                    response.getWriter().print("success!");
-                }
-            });
-            servletHolder.getRegistration().setMultipartConfig(new MultipartConfigElement(tmpDirString, MAX_FILE_SIZE, -1, 0));
-            servletContextHandler.addServlet(servletHolder, "/multipart");
-        }, eager);
-
-        if (server.getErrorHandler() instanceof ErrorHandler errorHandler)
-            errorHandler.setShowStacks(true);
-
-        try (Socket socket = new Socket("localhost", connector.getLocalPort()))
-        {
-            OutputStream output = socket.getOutputStream();
-
-            String content = """
-                --A1B2C3
-                Content-Disposition: form-data; name="part1"
-                Content-Type: text/plain; charset="UTF-8"
-                
-                content1
-                --A1B2C3--
-                """;
-            String header = """
-                POST / HTTP/1.1
-                Host: localhost
-                Content-Type: multipart/form-data; boundary="A1B2C3"
-                Content-Length: $L
-                
-                """.replace("$L", String.valueOf(content.length()));
-
-            output.write(header.getBytes(UTF_8));
-            output.write(content.getBytes(UTF_8));
-            output.flush();
-
-            HttpTester.Response response = HttpTester.parseResponse(socket.getInputStream());
-            assertNotNull(response);
-            assertEquals(HttpStatus.OK_200, response.getStatus());
-            assertThat(response.getContent(), equalTo("success!"));
-        }
+        return Stream.of(
+            Arguments.of(true, "forward"),
+            Arguments.of(false, "forward"),
+            Arguments.of(true, "include"),
+            Arguments.of(false, "include"),
+            Arguments.of(true, "async"),
+            Arguments.of(false, "async")
+        );
     }
 
     @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    public void testIncludeDispatch(boolean eager) throws Exception
+    @MethodSource("dispatchTestArgs")
+    public void testDispatch(boolean eager, String dispatchType) throws Exception
     {
         start(servletContextHandler ->
         {
@@ -662,7 +606,17 @@ public class MultiPartServletTest
                 @Override
                 protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
                 {
-                    request.getRequestDispatcher("/multipart").include(request, response);
+                    switch (dispatchType)
+                    {
+                        case "forward" -> request.getRequestDispatcher("/multipart").forward(request, response);
+                        case "include" -> request.getRequestDispatcher("/multipart").include(request, response);
+                        case "async" ->
+                        {
+                            request.startAsync();
+                            request.getAsyncContext().dispatch("/multipart");
+                        }
+                        default -> throw new ServletException("Unknown dispatch type: " + dispatchType);
+                    }
                 }
             }, "/");
 
@@ -717,8 +671,6 @@ public class MultiPartServletTest
 
             HttpTester.Response response = HttpTester.parseResponse(socket.getInputStream());
             assertNotNull(response);
-            System.err.println(response);
-            System.err.println(response.getContent());
             assertEquals(HttpStatus.OK_200, response.getStatus());
             assertThat(response.getContent(), equalTo("success!"));
         }

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/MultiPartServletTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/MultiPartServletTest.java
@@ -100,8 +100,8 @@ public class MultiPartServletTest
         start(servletContextHandler ->
         {
             ServletHolder servletHolder = new ServletHolder(servlet);
-            servletHolder.getRegistration().setMultipartConfig(config == null ?
-                new MultipartConfigElement(tmpDirString, MAX_FILE_SIZE, -1, 0) : config);
+            servletHolder.getRegistration().setMultipartConfig(config == null
+                ? new MultipartConfigElement(tmpDirString, MAX_FILE_SIZE, -1, 0) : config);
             servletContextHandler.addServlet(servletHolder, "/");
         }, eager);
     }

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/MultiPartServletTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/MultiPartServletTest.java
@@ -56,6 +56,7 @@ import org.eclipse.jetty.io.content.InputStreamContentSource;
 import org.eclipse.jetty.logging.StacklessLogging;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.util.Blocker;
 import org.eclipse.jetty.util.IO;
@@ -96,15 +97,23 @@ public class MultiPartServletTest
 
     private void start(HttpServlet servlet, MultipartConfigElement config, boolean eager) throws Exception
     {
-        config = config == null ? new MultipartConfigElement(tmpDirString, MAX_FILE_SIZE, -1, 0) : config;
+        start(servletContextHandler ->
+        {
+            ServletHolder servletHolder = new ServletHolder(servlet);
+            servletHolder.getRegistration().setMultipartConfig(config == null ?
+                new MultipartConfigElement(tmpDirString, MAX_FILE_SIZE, -1, 0) : config);
+            servletContextHandler.addServlet(servletHolder, "/");
+        }, eager);
+    }
+
+    private void start(Consumer<ServletContextHandler> consumer, boolean eager) throws Exception
+    {
         server = new Server(null, null, null);
         connector = new ServerConnector(server);
         server.addConnector(connector);
 
         ServletContextHandler servletContextHandler = new ServletContextHandler("/");
-        ServletHolder servletHolder = new ServletHolder(servlet);
-        servletHolder.getRegistration().setMultipartConfig(config);
-        servletContextHandler.addServlet(servletHolder, "/");
+        consumer.accept(servletContextHandler);
         server.setHandler(servletContextHandler);
 
         GzipHandler gzipHandler = new GzipHandler();
@@ -569,5 +578,149 @@ public class MultiPartServletTest
         assertThat(responseContent, containsString("Parameter: part2=" + contentString));
         assertThat(responseContent, containsString("Parameter: part3=" + contentString));
         assertThat(responseContent, not(containsString("Parameter: partFileName=" + contentString)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testForwardDispatch(boolean eager) throws Exception
+    {
+        start(servletContextHandler ->
+        {
+            servletContextHandler.addServlet(new HttpServlet()
+            {
+                @Override
+                protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+                {
+                    request.getRequestDispatcher("/multipart").forward(request, response);
+                }
+            }, "/");
+
+            ServletHolder servletHolder = new ServletHolder(new HttpServlet()
+            {
+                @Override
+                protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+                {
+                    Collection<Part> parts = request.getParts();
+                    assertNotNull(parts);
+                    assertEquals(1, parts.size());
+                    Part part = parts.iterator().next();
+                    assertEquals("part1", part.getName());
+                    Collection<String> headerNames = part.getHeaderNames();
+                    assertNotNull(headerNames);
+                    assertEquals(2, headerNames.size());
+                    String content1 = IO.toString(part.getInputStream(), UTF_8);
+                    assertEquals("content1", content1);
+                    response.getWriter().print("success!");
+                }
+            });
+            servletHolder.getRegistration().setMultipartConfig(new MultipartConfigElement(tmpDirString, MAX_FILE_SIZE, -1, 0));
+            servletContextHandler.addServlet(servletHolder, "/multipart");
+        }, eager);
+
+        if (server.getErrorHandler() instanceof ErrorHandler errorHandler)
+            errorHandler.setShowStacks(true);
+
+        try (Socket socket = new Socket("localhost", connector.getLocalPort()))
+        {
+            OutputStream output = socket.getOutputStream();
+
+            String content = """
+                --A1B2C3
+                Content-Disposition: form-data; name="part1"
+                Content-Type: text/plain; charset="UTF-8"
+                
+                content1
+                --A1B2C3--
+                """;
+            String header = """
+                POST / HTTP/1.1
+                Host: localhost
+                Content-Type: multipart/form-data; boundary="A1B2C3"
+                Content-Length: $L
+                
+                """.replace("$L", String.valueOf(content.length()));
+
+            output.write(header.getBytes(UTF_8));
+            output.write(content.getBytes(UTF_8));
+            output.flush();
+
+            HttpTester.Response response = HttpTester.parseResponse(socket.getInputStream());
+            assertNotNull(response);
+            assertEquals(HttpStatus.OK_200, response.getStatus());
+            assertThat(response.getContent(), equalTo("success!"));
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testIncludeDispatch(boolean eager) throws Exception
+    {
+        start(servletContextHandler ->
+        {
+            servletContextHandler.addServlet(new HttpServlet()
+            {
+                @Override
+                protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+                {
+                    request.getRequestDispatcher("/multipart").include(request, response);
+                }
+            }, "/");
+
+            ServletHolder servletHolder = new ServletHolder(new HttpServlet()
+            {
+                @Override
+                protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+                {
+                    Collection<Part> parts = request.getParts();
+                    assertNotNull(parts);
+                    assertEquals(1, parts.size());
+                    Part part = parts.iterator().next();
+                    assertEquals("part1", part.getName());
+                    Collection<String> headerNames = part.getHeaderNames();
+                    assertNotNull(headerNames);
+                    assertEquals(2, headerNames.size());
+                    String content1 = IO.toString(part.getInputStream(), UTF_8);
+                    assertEquals("content1", content1);
+                    response.getWriter().print("success!");
+                }
+            });
+            servletHolder.getRegistration().setMultipartConfig(new MultipartConfigElement(tmpDirString, MAX_FILE_SIZE, -1, 0));
+            servletContextHandler.addServlet(servletHolder, "/multipart");
+        }, eager);
+
+        if (server.getErrorHandler() instanceof ErrorHandler errorHandler)
+            errorHandler.setShowStacks(true);
+
+        try (Socket socket = new Socket("localhost", connector.getLocalPort()))
+        {
+            OutputStream output = socket.getOutputStream();
+
+            String content = """
+                --A1B2C3
+                Content-Disposition: form-data; name="part1"
+                Content-Type: text/plain; charset="UTF-8"
+                
+                content1
+                --A1B2C3--
+                """;
+            String header = """
+                POST / HTTP/1.1
+                Host: localhost
+                Content-Type: multipart/form-data; boundary="A1B2C3"
+                Content-Length: $L
+                
+                """.replace("$L", String.valueOf(content.length()));
+
+            output.write(header.getBytes(UTF_8));
+            output.write(content.getBytes(UTF_8));
+            output.flush();
+
+            HttpTester.Response response = HttpTester.parseResponse(socket.getInputStream());
+            assertNotNull(response);
+            System.err.println(response);
+            System.err.println(response.getContent());
+            assertEquals(HttpStatus.OK_200, response.getStatus());
+            assertThat(response.getContent(), equalTo("success!"));
+        }
     }
 }


### PR DESCRIPTION
closes #13509

Fix for multipart when used through a forward or include dispatch.

Currently `ServletApiRequest` does a call to `ServletMultiPartFormData.getParts(this)` in its `getParts()` implementation, and this bypasses the `MULTIPART_CONFIG_ELEMENT` attribute set available on the `ForwardRequest`/`IncludeRequest` wrappers.

So this PR sets the wrapped request into this request attribute `WRAPPED_REQUEST_ATTRIBUTE`, and then looks for this in the `ServletApiRequest.getParts` implementation.

I don't love this solution, so feel free to suggest a better one if you can think of one.