### PR TITLE
Fixes StackOverflowError in redirect tests.

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -491,7 +491,7 @@ public class HttpClient extends ContainerLifeCycle implements AutoCloseable
         String scheme = request.getScheme();
         if (!HttpScheme.HTTP.is(scheme) && !HttpScheme.HTTPS.is(scheme) &&
             !HttpScheme.WS.is(scheme) && !HttpScheme.WSS.is(scheme))
-            throw new IllegalArgumentException("Invalid protocol " + scheme);
+            throw new IllegalArgumentException("Invalid URI scheme " + scheme);
         scheme = scheme.toLowerCase(Locale.ENGLISH);
         String host = request.getHost();
         host = host.toLowerCase(Locale.ENGLISH);

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRedirector.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRedirector.java
@@ -155,16 +155,26 @@ public class HttpRedirector
                 if (LOG.isDebugEnabled())
                     LOG.debug("Redirecting to {} (Location: {})", newURI, location);
 
-                if (listener == null)
+                Response.CompleteListener wrapper = result ->
                 {
-                    listener = result ->
+                    if (listener != null)
+                        listener.onComplete(result);
+                    if (result.isFailed())
                     {
-                        if (result.isFailed())
+                        // If the redirect request has already been added to the conversation,
+                        // failures will be notified to the original request by HttpClient, and
+                        // we must not do it, otherwise recursion happens and then StackOverflowError.
+                        // If the redirect request has not been added to the conversation yet,
+                        // we must notify the failure by calling fail(), like we do when we
+                        // cannot redirect (see the else branch below where we cannot redirect
+                        // because the Location header is missing).
+                        Request redirectRequest = result.getRequest();
+                        if (!((HttpRequest)request).getConversation().contains(redirectRequest))
                             fail(result);
-                    };
-                }
+                    }
+                };
 
-                return redirect(request, response, listener, newURI);
+                return redirect(request, response, wrapper, newURI);
             }
             else
             {
@@ -293,10 +303,10 @@ public class HttpRedirector
                 String authority = matcher.group(3);
                 String path = matcher.group(4);
                 String query = matcher.group(5);
-                if (query.length() == 0)
+                if (query.isEmpty())
                     query = null;
                 String fragment = matcher.group(6);
-                if (fragment.length() == 0)
+                if (fragment.isEmpty())
                     fragment = null;
                 try
                 {
@@ -390,6 +400,9 @@ public class HttpRedirector
 
     private void fail(Request request, Throwable requestFailure, Response response, Throwable responseFailure)
     {
+        // This method should only be called to fail the conversation
+        // when the redirect request has not been sent.
+        // See comment in #redirect(Request, Response, CompleteListener).
         HttpConversation conversation = ((HttpRequest)request).getConversation();
         conversation.updateResponseListeners(null);
         conversation.getResponseListeners().emitFailureComplete(new Result(request, requestFailure, response, responseFailure));

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpConversation.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpConversation.java
@@ -22,6 +22,7 @@ import org.eclipse.jetty.client.Request;
 import org.eclipse.jetty.client.Response;
 import org.eclipse.jetty.util.Attributes;
 import org.eclipse.jetty.util.Promise;
+import org.eclipse.jetty.util.TypeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -142,6 +143,17 @@ public class HttpConversation extends Attributes.Lazy
     }
 
     /**
+     * <p>Whether the given request is in this conversation.</p>
+     *
+     * @param request the request to test
+     * @return whether the given request is in this conversation
+     */
+    public boolean contains(Request request)
+    {
+        return getExchanges().stream().anyMatch(exchange -> exchange.getRequest() == request);
+    }
+
+    /**
      * <p>Returns the total timeout for the conversation.</p>
      * <p>The conversation total timeout is the total timeout
      * of the first request in the conversation.</p>
@@ -167,6 +179,6 @@ public class HttpConversation extends Attributes.Lazy
     @Override
     public String toString()
     {
-        return String.format("%s[%x]", HttpConversation.class.getSimpleName(), hashCode());
+        return String.format("%s@%x[exchanges=%d]", TypeUtil.toShortName(getClass()), hashCode(), exchanges.size());
     }
 }

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpRequest.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpRequest.java
@@ -764,15 +764,31 @@ public class HttpRequest implements Request
     @Override
     public void send(Response.CompleteListener listener)
     {
+        Destination destination = resolveDestination(listener);
+        if (destination == null)
+            return;
         try
         {
-            Destination destination = client.resolveDestination(this);
             destination.send(this, listener);
         }
         catch (Throwable x)
         {
+            abort(x);
+        }
+    }
+
+    private Destination resolveDestination(Response.CompleteListener listener)
+    {
+        try
+        {
+            return client.resolveDestination(this);
+        }
+        catch (Throwable x)
+        {
+            // Must notify the listener, since it is not yet associated with this request.
             Result result = new Result(this, x, new HttpResponse(this), null);
             abort(x).thenRun(() -> ResponseListeners.notifyComplete(listener, result));
+            return null;
         }
     }
 

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientRedirectTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientRedirectTest.java
@@ -47,6 +47,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -314,7 +315,7 @@ public class HttpClientRedirectTest extends AbstractHttpClientServerTest
             protected void service(Request request, org.eclipse.jetty.server.Response response) throws Exception
             {
                 response.setStatus(303);
-                response.getHeaders().put("Location", "ssh://localhost:" + connector.getLocalPort() + "/path");
+                response.getHeaders().put("Location", "ssh://localhost:" + connector.getLocalPort() + "/wrong/scheme");
             }
         });
 
@@ -657,6 +658,40 @@ public class HttpClientRedirectTest extends AbstractHttpClientServerTest
                 .timeout(3 * timeout, TimeUnit.MILLISECONDS)
                 .send();
         });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testAbortRedirectRequest(Scenario scenario) throws Exception
+    {
+        start(scenario, new EmptyServerHandler()
+        {
+            @Override
+            protected void service(Request request, org.eclipse.jetty.server.Response response) throws Throwable
+            {
+                String serverURI = scenario.getScheme() + "://localhost:" + connector.getLocalPort();
+                String target = Request.getPathInContext(request);
+                if ("/initial".equals(target))
+                {
+                    response.setStatus(HttpStatus.SEE_OTHER_303);
+                    response.getHeaders().put(HttpHeader.LOCATION, serverURI + "/redirect");
+                }
+            }
+        });
+
+        client.getRequestListeners().addBeginListener(r ->
+        {
+            if ("/redirect".equals(r.getPath()))
+                r.abort(new HttpRequestException("aborted by test", r));
+        });
+
+        ExecutionException failure = assertThrows(ExecutionException.class, () -> client.newRequest("localhost", connector.getLocalPort())
+            .scheme(scenario.getScheme())
+            .path("/initial")
+            .timeout(5, TimeUnit.SECONDS)
+            .send());
+
+        assertInstanceOf(HttpRequestException.class, failure.getCause());
     }
 
     private void testSameMethodRedirect(final Scenario scenario, final HttpMethod method, int redirectCode) throws Exception

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
@@ -94,6 +94,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -2094,6 +2095,20 @@ public class HttpClientTest extends AbstractHttpClientServerTest
             .headers(h -> h.put("X-Capacity", capacity))
             .timeout(5, TimeUnit.SECONDS)
             .send());
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testRequestWithWrongScheme(Scenario scenario) throws Exception
+    {
+        start(scenario, new EmptyServerHandler());
+
+        ExecutionException failure = assertThrows(ExecutionException.class, () -> client.newRequest("localhost", connector.getLocalPort())
+            .scheme("ssh")
+            .timeout(5, TimeUnit.SECONDS)
+            .send());
+
+        assertInstanceOf(IllegalArgumentException.class, failure.getCause());
     }
 
     private void assertCopyRequest(Request original)


### PR DESCRIPTION
A stack overflow was happening when a redirect was failed (for example, bad scheme of the redirect location).

This was caused as a side effect of the changes done in #13381.

HttpRedirector was registering a `Response.CompleteListener` that was notifying the original request/response listeners. This is necessary to notify failures before the redirect request is sent. But calling this listener after the redirect request is sent causes a stack overflow.

The solution is to check whether the redirect request is already part of the conversation. If so, the notification of the listeners is performed by the `HttpClient` implementation. Otherwise, it must be explicitly done by HttpRedirector.