### PR TITLE
Fix Resolving XML external entity in user-controlled data XmlParser

### DIFF
--- a/jetty-core/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlParser.java
+++ b/jetty-core/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlParser.java
@@ -288,6 +288,18 @@ public class XmlParser
             _dtd = null;
             Handler handler = new Handler();
             XMLReader reader = _parser.getXMLReader();
+            // Secure the reader against XXE attacks
+            try
+            {
+                reader.setFeature("http://xml.org/sax/features/external-general-entities", false);
+                reader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+                reader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            }
+            catch (SAXException e)
+            {
+                if (LOG.isWarnEnabled())
+                    LOG.warn("Unable to secure XMLReader against XXE: " + e.getMessage(), e);
+            }
             reader.setContentHandler(handler);
             reader.setErrorHandler(handler);
             reader.setEntityResolver(handler);


### PR DESCRIPTION

The best way to fix this problem is to disable DTD and external entity processing when creating and configuring the parser and XMLReader used in `XmlParser`. This involves setting specific features both on the `SAXParserFactory` and on the created `XMLReader` to prevent resolution of external general entities, external parameter entities, and disallow DTD declarations entirely. Since the `_parser` instance is used to create the `XMLReader`, and may be shared, the secure configuration should take place immediately after retrieving the `XMLReader` but before parsing untrusted files. This can be done by setting the following features on the `XMLReader` object (and ideally also on the `SAXParserFactory`, if that is accessible):

- `http://xml.org/sax/features/external-general-entities` = false
- `http://xml.org/sax/features/external-parameter-entities` = false
- `http://apache.org/xml/features/disallow-doctype-decl` = true

This hardening should be enforced before any untrusted XML is parsed, ideally at the point where the parser is configured. In the code shown, this is best done in the `parse(InputSource)` and/or `parse(InputStream)` methods, immediately after obtaining the `XMLReader` and before any parsing occurs.

Required Actions:
- In `XmlParser.java`, in `parse(InputSource source)`, after `XMLReader reader = _parser.getXMLReader();`, add code to set the above features on the `reader`.
- Optionally, set these features in whichever code constructs and configures the `_parser` (`SAXParserFactory` or `SAXParser`), if such code is available in the snippet.

Parsing untrusted XML files with a weakly configured XML parser may lead to an XML External Entity (XXE) attack. This type of attack uses external entity references to access arbitrary files on a system, carry out denial of service, or server side request forgery. Even when the result of parsing is not returned to the user, out-of-band data retrieval techniques may allow attackers to steal sensitive data. Denial of services can also be carried out in this situation.

There are many XML parsers for Java, and most of them are vulnerable to XXE because their default settings enable parsing of external entities. This query currently identifies vulnerable XML parsing from the following parsers: javax.xml.parsers.DocumentBuilder, javax.xml.stream.XMLStreamReader, org.jdom.input.SAXBuilder/org.jdom2.input.SAXBuilder, javax.xml.parsers.SAXParser,org.dom4j.io.SAXReader, org.xml.sax.XMLReader, javax.xml.transform.sax.SAXSource, javax.xml.transform.TransformerFactory, javax.xml.transform.sax.SAXTransformerFactory, javax.xml.validation.SchemaFactory, javax.xml.bind.Unmarshaller and javax.xml.xpath.XPathExpression.


### References
[XML External Entity (XXE) Processing](https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Processing).
[XXE Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#java)
Paper by Timothy Morgen: [XML Schema, DTD, and Entity Attacks](https://research.nccgroup.com/2014/05/19/xml-schema-dtd-and-entity-attacks-a-compendium-of-known-techniques/)
Out-of-band data retrieval: Timur Yunusov & Alexey Osipov, Black hat EU 2013: [XML Out-Of-Band Data Retrieval](https://www.slideshare.net/qqlan/bh-ready-v4)
Denial of service attack (Billion laughs): [Billion Laughs.](https://en.wikipedia.org/wiki/Billion_laughs)
The Java Tutorials: [Processing Limit Definitions.](https://docs.oracle.com/javase/tutorial/jaxp/limits/limits.html)