### PR TITLE
Ensure buffer is always released from HTTP/3 HeadersGenerator in case of failure.

### DIFF
--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/generator/HeadersGenerator.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/generator/HeadersGenerator.java
@@ -54,7 +54,11 @@ public class HeadersGenerator extends FrameGenerator
             int maxHeaderLength = frameTypeLength + VarLenInt.MAX_LENGTH;
             // The capacity of the buffer is larger than maxLength, but we need to enforce at most maxLength.
             int maxLength = encoder.getMaxHeadersSize();
+
+            // Acquire buffer and immediately append to the accumulator so that it is released if a failure occurs.
             RetainableByteBuffer buffer = getByteBufferPool().acquire(maxHeaderLength + maxLength, useDirectByteBuffers);
+            accumulator.append(buffer);
+
             ByteBuffer byteBuffer = buffer.getByteBuffer();
             BufferUtil.clearToFill(byteBuffer);
             byteBuffer.position(maxHeaderLength);
@@ -70,7 +74,6 @@ public class HeadersGenerator extends FrameGenerator
             VarLenInt.encode(byteBuffer, FrameType.HEADERS.type());
             VarLenInt.encode(byteBuffer, dataLength);
             byteBuffer.position(position);
-            accumulator.append(buffer);
             return headerLength + dataLength;
         }
         catch (QpackException x)


### PR DESCRIPTION
I was getting a failed test from `org.eclipse.jetty.test.client.transport.HttpClientTest#testInvalidFieldValues` about a buffer being acquired but never released.

This was because there was an error when encoding the headers, and in `HeadersGenerator` the buffer was being allocated but not being added to the `accumulator` and only buffers in the `accumulator` were being released on failure.

This change fixes the test failure (not sure why the failure is not showing up in CI).