### PR TITLE
Fixes #13466 - Lost WebSocket upgrade failure.

### DIFF
--- a/jetty-core/jetty-websocket/jetty-websocket-core-client/src/main/java/org/eclipse/jetty/websocket/core/client/CoreClientUpgradeRequest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-client/src/main/java/org/eclipse/jetty/websocket/core/client/CoreClientUpgradeRequest.java
@@ -256,9 +256,6 @@ public abstract class CoreClientUpgradeRequest implements Response.CompleteListe
         String responseLine = status + " " + response.getReason();
         boolean receivedResponse = status > 0;
         Throwable cause = result.getFailure();
-        Throwable failure = null;
-        if (cause != null)
-            failure = cause instanceof IOException || cause instanceof UpgradeException ? cause : new UpgradeException(requestURI, cause);
 
         if (receivedResponse)
         {
@@ -277,7 +274,10 @@ public abstract class CoreClientUpgradeRequest implements Response.CompleteListe
                 }
             }
 
-            if (failure == null)
+            Throwable failure;
+            if (cause != null)
+                failure = cause instanceof IOException || cause instanceof UpgradeException ? cause : new UpgradeException(requestURI, status, cause.getMessage(), cause);
+            else
                 failure = new UpgradeException(requestURI, status, "Failed to upgrade to websocket: Unexpected HTTP Response Status Code: " + responseLine);
             handleException(failure);
         }
@@ -286,10 +286,11 @@ public abstract class CoreClientUpgradeRequest implements Response.CompleteListe
             if (LOG.isDebugEnabled())
             {
                 if (result.getRequestFailure() != null)
-                    LOG.debug("Failed to upgrade to WebSocket: request failure", result.getRequestFailure());
+                    LOG.debug("Failed to upgrade to websocket: request failure", result.getRequestFailure());
                 if (result.getResponseFailure() != null)
-                    LOG.debug("Failed to upgrade to WebSocket: response failure", result.getResponseFailure());
+                    LOG.debug("Failed to upgrade to websocket: response failure", result.getResponseFailure());
             }
+            Throwable failure = cause instanceof IOException || cause instanceof UpgradeException ? cause : new UpgradeException(requestURI, cause);
             handleException(failure);
         }
     }

--- a/jetty-core/jetty-websocket/jetty-websocket-core-client/src/main/java/org/eclipse/jetty/websocket/core/client/CoreClientUpgradeRequest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-client/src/main/java/org/eclipse/jetty/websocket/core/client/CoreClientUpgradeRequest.java
@@ -255,6 +255,10 @@ public abstract class CoreClientUpgradeRequest implements Response.CompleteListe
         int status = response.getStatus();
         String responseLine = status + " " + response.getReason();
         boolean receivedResponse = status > 0;
+        Throwable cause = result.getFailure();
+        Throwable failure = null;
+        if (cause != null)
+            failure = cause instanceof IOException || cause instanceof UpgradeException ? cause : new UpgradeException(requestURI, cause);
 
         if (receivedResponse)
         {
@@ -273,24 +277,19 @@ public abstract class CoreClientUpgradeRequest implements Response.CompleteListe
                 }
             }
 
-            if (result.getFailure() != null)
-                handleException(new UpgradeException(requestURI, status, result.getFailure().getMessage()));
-            else
-                handleException(new UpgradeException(requestURI, status, "Failed to upgrade to websocket: Unexpected HTTP Response Status Code: " + responseLine));
+            if (failure == null)
+                failure = new UpgradeException(requestURI, status, "Failed to upgrade to websocket: Unexpected HTTP Response Status Code: " + responseLine);
+            handleException(failure);
         }
         else
         {
             if (LOG.isDebugEnabled())
             {
                 if (result.getRequestFailure() != null)
-                    LOG.debug("Failed to upgrade to websocket: request failure", result.getRequestFailure());
+                    LOG.debug("Failed to upgrade to WebSocket: request failure", result.getRequestFailure());
                 if (result.getResponseFailure() != null)
-                    LOG.debug("Failed to upgrade to websocket: response failure", result.getResponseFailure());
+                    LOG.debug("Failed to upgrade to WebSocket: response failure", result.getResponseFailure());
             }
-            Throwable failure = result.getFailure();
-            boolean wrapFailure = !(failure instanceof IOException) && !(failure instanceof UpgradeException);
-            if (wrapFailure)
-                failure = new UpgradeException(requestURI, failure);
             handleException(failure);
         }
     }

--- a/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/WebSocketNegotiationTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/WebSocketNegotiationTest.java
@@ -47,7 +47,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -516,7 +515,7 @@ public class WebSocketNegotiationTest extends WebSocketTester
         {
             ExecutionException exception = assertThrows(ExecutionException.class, () -> client.connect(upgradeRequest).get(5, TimeUnit.SECONDS));
             assertThat(exception.getCause(), instanceOf(UpgradeException.class));
-            assertThat(exception.getCause().getMessage(), equalTo("onHandshakeResponse error"));
+            assertThat(exception.getCause().getMessage(), containsString("onHandshakeResponse error"));
             assertThat(onHandshakeResponseCounter.get(), is(1));
         }
     }


### PR DESCRIPTION
This PR is an addendum to #13486, that improves the handling of WebSocket upgrade failures.

If there was a failure in the HTTP upgrade, it is now retained and handled as-is, not converted to an UpgradeException. This should ensure better backward compatibility with 12.0.x, and avoids exception wrapping (the original failure is reported to the application).