### PR TITLE
Prevent `RBB.DynamicCapacity` from aggregating into a buffer passed to `add(ByteBuffer)`

### DIFF
--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/RetainableByteBuffer.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/RetainableByteBuffer.java
@@ -2086,34 +2086,19 @@ public interface RetainableByteBuffer extends Retainable
             if (space <= 0)
                 return false;
 
-            // We will aggregate, either into the last buffer or a newly allocated one.
-            if (!existing &&
-                !_buffers.isEmpty() &&
-                _buffers.get(_buffers.size() - 1) instanceof Mutable mutable &&
-                mutable.isMutable() &&
-                mutable.space() >= length &&
-                !mutable.isRetained())
-            {
-                // We can use the last buffer as the aggregate
-                _aggregate = mutable;
-                checkAggregateLimit(space);
-            }
-            else
-            {
-                // acquire a new aggregate buffer
-                int aggregateSize = _pool.getSize();
+            // acquire a new aggregate buffer
+            int aggregateSize = _pool.getSize();
 
-                // If we cannot grow, allow a single allocation only if we have not already retained.
-                if (aggregateSize == 0 && _buffers.isEmpty() && _maxSize < Integer.MAX_VALUE)
-                    aggregateSize = (int)_maxSize;
+            // If we cannot grow, allow a single allocation only if we have not already retained.
+            if (aggregateSize == 0 && _buffers.isEmpty() && _maxSize < Integer.MAX_VALUE)
+                aggregateSize = (int)_maxSize;
 
-                aggregateSize = Math.max(length, aggregateSize);
-                if (aggregateSize > space)
-                    aggregateSize = (int)space;
-                _aggregate = _pool.acquire(aggregateSize, _pool.isDirect());
-                checkAggregateLimit(space);
-                _buffers.add(_aggregate);
-            }
+            aggregateSize = Math.max(length, aggregateSize);
+            if (aggregateSize > space)
+                aggregateSize = (int)space;
+            _aggregate = _pool.acquire(aggregateSize, _pool.isDirect());
+            checkAggregateLimit(space);
+            _buffers.add(_aggregate);
 
             return _aggregate.append(bytes);
         }
@@ -2331,15 +2316,6 @@ public interface RetainableByteBuffer extends Retainable
             {
                 if (_aggregate.space() >= needed)
                     return _aggregate;
-            }
-            else if (!_buffers.isEmpty() &&
-                _buffers.get(_buffers.size() - 1) instanceof Mutable mutable &&
-                mutable.isMutable() &&
-                mutable.space() >= needed &&
-                !mutable.isRetained())
-            {
-                _aggregate = mutable;
-                return _aggregate;
             }
 
             // We need a new aggregate, acquire a new aggregate buffer

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
@@ -17,11 +17,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.net.URI;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -84,6 +87,53 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class HttpClientTest extends AbstractTest
 {
+    @ParameterizedTest
+    @MethodSource("transports")
+    public void testWriteSingleByteBufferInstanceInTwoParts(TransportType transportType) throws Exception
+    {
+        start(transportType, new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback) throws Exception
+            {
+                // Use a 64 KB buffer.
+                ByteBuffer byteBuffer = ByteBuffer.allocate(65536);
+                // Let the first 13 bytes untouched.
+                byteBuffer.position(13);
+
+                try (Blocker.Callback cb = Blocker.callback())
+                {
+                    // Write the first part: 40 KB.
+                    byteBuffer.limit(13 + 40 * 1024);
+                    response.write(false, byteBuffer, cb);
+                    cb.block();
+                }
+
+                // Write the second part: 24 KB - 13 bytes.
+                byteBuffer.limit(byteBuffer.capacity());
+                response.write(true, byteBuffer, callback);
+                return true;
+            }
+        });
+
+        final int count = 10;
+        CountDownLatch latch = new CountDownLatch(count);
+        Map<Integer, List<ByteBuffer>> contents = new HashMap<>();
+        for (int i = 0; i < count; i++)
+        {
+            List<ByteBuffer> contentList = contents.computeIfAbsent(i, (k) -> new CopyOnWriteArrayList<>());
+            client.newRequest(newURI(transportType))
+                .onResponseContent((response, content) -> contentList.add(BufferUtil.copy(content)))
+                .send(result -> latch.countDown());
+        }
+        assertTrue(latch.await(15, TimeUnit.SECONDS));
+
+        for (Map.Entry<Integer, List<ByteBuffer>> entry : contents.entrySet())
+        {
+            assertThat("Request #" + entry.getKey() + " failed", entry.getValue().stream().mapToInt(Buffer::remaining).sum(), is(65536 - 13));
+        }
+    }
+
     @ParameterizedTest
     @MethodSource("transports")
     public void testClientUseContentSourceInSpawnedThreadEmptyResponseContent(TransportType transportType) throws Exception

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
@@ -29,6 +29,7 @@ import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -91,6 +92,8 @@ public class HttpClientTest extends AbstractTest
     @MethodSource("transports")
     public void testWriteSingleByteBufferInstanceInTwoParts(TransportType transportType) throws Exception
     {
+        final int count = 10;
+        CyclicBarrier barrier = new CyclicBarrier(count);
         start(transportType, new Handler.Abstract()
         {
             @Override
@@ -105,18 +108,19 @@ public class HttpClientTest extends AbstractTest
                 {
                     // Write the first part: 40 KB.
                     byteBuffer.limit(13 + 40 * 1024);
+                    barrier.await(); // Maximize concurrency on the server.
                     response.write(false, byteBuffer, cb);
                     cb.block();
                 }
 
                 // Write the second part: 24 KB - 13 bytes.
                 byteBuffer.limit(byteBuffer.capacity());
+                barrier.await(); // Maximize concurrency on the server.
                 response.write(true, byteBuffer, callback);
                 return true;
             }
         });
 
-        final int count = 10;
         CountDownLatch latch = new CountDownLatch(count);
         Map<Integer, List<ByteBuffer>> contents = new HashMap<>();
         for (int i = 0; i < count; i++)

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
@@ -21,6 +21,7 @@ import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -93,6 +94,7 @@ public class HttpClientTest extends AbstractTest
     public void testWriteSingleByteBufferInstanceInTwoParts(TransportType transportType) throws Exception
     {
         final int count = 10;
+        List<byte[]> byteArrays = new CopyOnWriteArrayList<>();
         CyclicBarrier barrier = new CyclicBarrier(count);
         start(transportType, new Handler.Abstract()
         {
@@ -100,7 +102,11 @@ public class HttpClientTest extends AbstractTest
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback) throws Exception
             {
                 // Use a 64 KB buffer.
-                ByteBuffer byteBuffer = ByteBuffer.allocate(65536);
+                byte[] array = new byte[65536];
+                byteArrays.add(array);
+                Arrays.fill(array, (byte)'A');
+                ByteBuffer byteBuffer = ByteBuffer.wrap(array);
+
                 // Let the first 13 bytes untouched.
                 byteBuffer.position(13);
 
@@ -132,9 +138,28 @@ public class HttpClientTest extends AbstractTest
         }
         assertTrue(latch.await(15, TimeUnit.SECONDS));
 
+        // Check that the responses were not corrupted.
         for (Map.Entry<Integer, List<ByteBuffer>> entry : contents.entrySet())
         {
-            assertThat("Request #" + entry.getKey() + " failed", entry.getValue().stream().mapToInt(Buffer::remaining).sum(), is(65536 - 13));
+            assertThat("Request #" + entry.getKey() + " failed on size", entry.getValue().stream().mapToInt(Buffer::remaining).sum(), is(65536 - 13));
+            assertThat("Request #" + entry.getKey() + " failed on data", entry.getValue().stream().anyMatch(bb ->
+            {
+                while (bb.hasRemaining())
+                {
+                    byte b = bb.get();
+                    if (b != 'A')
+                        return true;
+                }
+                return false;
+            }), is(false));
+        }
+        // Check that the original buffers were not corrupted.
+        for (byte[] byteArray : byteArrays)
+        {
+            for (byte b : byteArray)
+            {
+                assertThat(b, is((byte)'A'));
+            }
         }
     }
 


### PR DESCRIPTION
Modify `DynamicCapacity` to stop using the last enlisted buffer as an aggregator, as this buffer's ownership may not totally be under `DynamicCapacity`'s control.

Fixes #13567


