### PR TITLE
Ensure buffer is always released from HTTP/3 HeadersGenerator in case of failure. (12.1)

### DIFF
--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/generator/HeadersGenerator.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/generator/HeadersGenerator.java
@@ -53,7 +53,9 @@ public class HeadersGenerator extends FrameGenerator
         int maxHeaderLength = frameTypeLength + VarLenInt.MAX_LENGTH;
         // The capacity of the buffer is larger than maxLength, but we need to enforce at most maxLength.
         int maxLength = encoder.getMaxHeadersSize();
+        // Acquire buffer and immediately append to the accumulator so that it is released if a failure occurs.
         buffer = getByteBufferPool().acquire(maxHeaderLength + maxLength, useDirectByteBuffers);
+        accumulator.append(buffer);
         try
         {
             ByteBuffer byteBuffer = buffer.getByteBuffer();
@@ -71,12 +73,10 @@ public class HeadersGenerator extends FrameGenerator
             VarLenInt.encode(byteBuffer, FrameType.HEADERS.type());
             VarLenInt.encode(byteBuffer, dataLength);
             byteBuffer.position(position);
-            accumulator.append(buffer);
             return headerLength + dataLength;
         }
         catch (QpackException x)
         {
-            buffer.release();
             if (fail != null)
                 fail.accept(x);
             return -1;


### PR DESCRIPTION
Merge PR https://github.com/jetty/jetty.project/pull/13549 to `12.1.x` branch.