### PR TITLE
fix: close for abstract sockets

### DIFF
--- a/jetty-unixsocket/jetty-unixsocket-server/src/main/java/org/eclipse/jetty/unixsocket/server/UnixSocketConnector.java
+++ b/jetty-unixsocket/jetty-unixsocket-server/src/main/java/org/eclipse/jetty/unixsocket/server/UnixSocketConnector.java
@@ -246,9 +246,12 @@ public class UnixSocketConnector extends AbstractConnector
 
             try
             {
-                Files.deleteIfExists(Paths.get(_unixSocket));
+                if (_unixSocket.charAt(0) != '\0') // skip abstract sockets
+                {
+                    Files.deleteIfExists(Paths.get(_unixSocket));
+                }
             }
-            catch (IOException e)
+            catch (Exception e)
             {
                 LOG.warn("Unable to delete UnixSocket at {}", _unixSocket, e);
             }


### PR DESCRIPTION
The close method will throw an exception as Paths.get does not like the leading null byte in the abstract socket name.