### PR TITLE
Issue #13360 - Introduce a "virtual" Connection limit class

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/VirtualConnectionLimit.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/VirtualConnectionLimit.java
@@ -1,0 +1,330 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.server;
+
+import java.io.IOException;
+import java.nio.channels.SelectableChannel;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.jetty.io.Connection;
+import org.eclipse.jetty.io.Connection.Listener;
+import org.eclipse.jetty.io.EndPoint;
+import org.eclipse.jetty.io.SelectorManager;
+import org.eclipse.jetty.util.IO;
+import org.eclipse.jetty.util.annotation.ManagedAttribute;
+import org.eclipse.jetty.util.annotation.ManagedObject;
+import org.eclipse.jetty.util.annotation.Name;
+import org.eclipse.jetty.util.component.AbstractLifeCycle;
+import org.eclipse.jetty.util.component.Container;
+import org.eclipse.jetty.util.thread.AutoLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * <p>A Listener that limits the number of virtual {@link Connection}s.</p>
+ * <p>This listener applies a limit to the number of connections, which when
+ * exceeded results in a call to {@link AbstractConnector#setAccepting(boolean)}
+ * to prevent further connections being received, and any further virtual connections
+ * that are opened will be immediately closed.
+ * This listener can be applied to an entire {@link Server} or to a specific
+ * {@link Connector} by adding it via {@link Container#addBean(Object)}.
+ * </p>
+ * <p>When the number of connections is exceeded, the idle timeout of existing
+ * connections is changed with the value configured in this listener (typically
+ * a shorter value).</p>
+ * <p>This differs from {@link NetworkConnectionLimit} in that it limits the number of
+ * virtual connections not network connections. One network connection may have multiple
+ * virtual connections associated with it. For example over an HTTP/2 connection multiple
+ * streams can be upgraded to WebSocket, each counting as their own virtual connection.</p>
+ * <p>
+ * <b>Typical usage:</b>
+ * </p>
+ * <pre>{@code
+ *   Server server = new Server();
+ *   server.addBean(new VirtualConnectionLimit(5000,server));
+ *   ...
+ *   server.start();
+ * }</pre>
+ *
+ *
+ * @see LowResourceMonitor
+ * @see Connection.Listener
+ * @see SelectorManager.AcceptListener
+ */
+@ManagedObject
+public class VirtualConnectionLimit extends AbstractLifeCycle implements Listener, SelectorManager.AcceptListener
+{
+    private static final Logger LOG = LoggerFactory.getLogger(VirtualConnectionLimit.class);
+
+    private final AutoLock _lock = new AutoLock();
+    private final Server _server;
+    private final List<AbstractConnector> _connectors = new ArrayList<>();
+    private final Set<SelectableChannel> _acceptedChannels = new HashSet<>();
+    private int _pendingConnections;
+    private int _connections;
+    private int _maxVirtualConnections;
+    private long _endPointIdleTimeout;
+    private boolean _limiting = false;
+
+    public VirtualConnectionLimit(@Name("maxConnections") int maxVirtualConnections, @Name("server") Server server)
+    {
+        _maxVirtualConnections = maxVirtualConnections;
+        _server = server;
+    }
+
+    public VirtualConnectionLimit(@Name("maxConnections") int maxVirtualConnections, @Name("connectors") Connector... connectors)
+    {
+        this(maxVirtualConnections, (Server)null);
+        registerConnectors(connectors);
+    }
+
+    private void registerConnectors(Connector[] connectors)
+    {
+        for (Connector c : connectors)
+        {
+            if (c instanceof AbstractConnector)
+                _connectors.add((AbstractConnector)c);
+            else
+                LOG.warn("Connector {} is not an instance of {}: network connections will not be limited", c, AbstractConnector.class.getSimpleName());
+        }
+    }
+
+    /**
+     * @return the idle timeout in ms to apply to all EndPoints when the network connection limit is reached
+     */
+    @ManagedAttribute("The EndPoint idle timeout in ms to apply when the network connection limit is reached")
+    public long getEndPointIdleTimeout()
+    {
+        return _endPointIdleTimeout;
+    }
+
+    /**
+     * <p>Sets the idle timeout in ms to apply to all EndPoints when the network connection limit is reached.</p>
+     * <p>A value less than or equal to zero will not change the existing EndPoint idle timeout.</p>
+     *
+     * @param idleTimeout the idle timeout in ms to apply to all EndPoints when the network connection limit is reached
+     */
+    public void setEndPointIdleTimeout(long idleTimeout)
+    {
+        _endPointIdleTimeout = idleTimeout;
+    }
+
+    @ManagedAttribute("The maximum number of virtual connections")
+    public int getMaxVirtualConnectionCount()
+    {
+        try (AutoLock ignored = _lock.lock())
+        {
+            return _maxVirtualConnections;
+        }
+    }
+
+    public void setMaxVirtualConnectionCount(int max)
+    {
+        try (AutoLock ignored = _lock.lock())
+        {
+            _maxVirtualConnections = max;
+        }
+    }
+
+    @ManagedAttribute(value = "The number of connected virtual connections")
+    public int getVirtualConnectionCount()
+    {
+        try (AutoLock ignored = _lock.lock())
+        {
+            return _connections;
+        }
+    }
+
+    @ManagedAttribute(value = "The number of pending virtual connections")
+    public int getPendingVirtualConnectionCount()
+    {
+        try (AutoLock ignored = _lock.lock())
+        {
+            return _pendingConnections;
+        }
+    }
+
+    @Override
+    protected void doStart() throws Exception
+    {
+        try (AutoLock ignored = _lock.lock())
+        {
+            if (_server != null)
+                registerConnectors(_server.getConnectors());
+
+            if (LOG.isDebugEnabled())
+                LOG.debug("Connection limit {} for {}", _maxVirtualConnections, _connectors);
+
+            _connections = 0;
+            _limiting = false;
+            for (AbstractConnector c : _connectors)
+            {
+                c.addBean(this);
+            }
+        }
+    }
+
+    @Override
+    protected void doStop() throws Exception
+    {
+        try (AutoLock ignored = _lock.lock())
+        {
+            for (AbstractConnector c : _connectors)
+            {
+                c.removeBean(this);
+            }
+            _connections = 0;
+            if (_server != null)
+                _connectors.clear();
+        }
+    }
+
+    private boolean lockedCheck()
+    {
+        assert _lock.isHeldByCurrentThread();
+        int total = _pendingConnections + _connections;
+        if (total >= _maxVirtualConnections)
+        {
+            if (!_limiting)
+            {
+                _limiting = true;
+                LOG.info("Virtual connection limit {} reached for {}", _maxVirtualConnections, _connectors);
+                limit();
+            }
+            return total > _maxVirtualConnections;
+        }
+        else
+        {
+            if (_limiting)
+            {
+                _limiting = false;
+                LOG.info("Virtual connection limit {} cleared for {}", _maxVirtualConnections, _connectors);
+                unlimit();
+            }
+            return false;
+        }
+    }
+
+    protected void limit()
+    {
+        for (AbstractConnector c : _connectors)
+        {
+            c.setAccepting(false);
+
+            if (_endPointIdleTimeout > 0)
+            {
+                for (EndPoint endPoint : c.getConnectedEndPoints())
+                {
+                    endPoint.setIdleTimeout(_endPointIdleTimeout);
+                }
+            }
+        }
+    }
+
+    protected void unlimit()
+    {
+        for (AbstractConnector c : _connectors)
+        {
+            c.setAccepting(true);
+
+            if (_endPointIdleTimeout > 0)
+            {
+                for (EndPoint endPoint : c.getConnectedEndPoints())
+                {
+                    endPoint.setIdleTimeout(c.getIdleTimeout());
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onAccepting(SelectableChannel channel)
+    {
+        try (AutoLock ignored = _lock.lock())
+        {
+            _pendingConnections++;
+            if (LOG.isDebugEnabled())
+                LOG.debug("Accepting ({}+{}) <= {} {}", _pendingConnections, _connections, _maxVirtualConnections, channel);
+
+            for (AbstractConnector c : _connectors)
+            {
+                System.err.println("    " + c + ": " + c.isAccepting());
+            }
+
+            if (lockedCheck())
+            {
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Closing (limit reached) {}", channel);
+                IO.close(channel);
+            }
+        }
+    }
+
+    @Override
+    public void onAcceptFailed(SelectableChannel channel, Throwable cause)
+    {
+        try (AutoLock ignored = _lock.lock())
+        {
+            _pendingConnections--;
+            if (LOG.isDebugEnabled())
+                LOG.debug("Accept failed ({}+{}) <= {} {}", _pendingConnections, _connections, _maxVirtualConnections, channel, cause);
+            lockedCheck();
+        }
+    }
+
+    @Override
+    public void onAccepted(SelectableChannel channel)
+    {
+        try (AutoLock ignored = _lock.lock())
+        {
+            _acceptedChannels.add(channel);
+        }
+    }
+
+    @Override
+    public void onOpened(Connection connection)
+    {
+        try (AutoLock ignored = _lock.lock())
+        {
+            // We should only decrement _accepting once per SelectableChannel.
+            Object transport = connection.getEndPoint().getTransport();
+            if (transport instanceof SelectableChannel selectableChannel && _acceptedChannels.remove(selectableChannel))
+                _pendingConnections--;
+
+            _connections++;
+            if (LOG.isDebugEnabled())
+                LOG.debug("Opened ({}+{}) <= {} {}", _pendingConnections, _connections, _maxVirtualConnections, connection);
+
+            // HTTP/2 will need to rely on this close to prevent streams on an existing HTTP2Connection from exceeding
+            // the limit by upgrading streams to WebSocket, as the call to connector.setAccepting(false) will not prevent this.
+            if (lockedCheck())
+                connection.getEndPoint().close(new IOException("Exceeded Connection Limit"));
+        }
+    }
+
+    @Override
+    public void onClosed(Connection connection)
+    {
+        try (AutoLock ignored = _lock.lock())
+        {
+            _connections--;
+            if (LOG.isDebugEnabled())
+                LOG.debug("Closed ({}+{}) <= {} {}", _pendingConnections, _connections, _maxVirtualConnections, connection);
+            lockedCheck();
+        }
+    }
+}

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/VirtualConnectionLimitTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/VirtualConnectionLimitTest.java
@@ -1,0 +1,188 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.server;
+
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.SocketChannel;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.IO;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class VirtualConnectionLimitTest
+{
+    private Server server;
+    private ServerConnector connector;
+
+    private void prepare(int acceptors, Handler handler)
+    {
+        if (server == null)
+            server = new Server();
+        connector = new ServerConnector(server, acceptors, 1);
+        server.addConnector(connector);
+        server.setHandler(handler);
+    }
+
+    @AfterEach
+    public void dispose()
+    {
+        LifeCycle.stop(server);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    public void testVirtualConnectionLimitWithConnector(int acceptors) throws Exception
+    {
+        prepare(acceptors, new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                callback.succeeded();
+                return true;
+            }
+        });
+        int maxConnections = 2;
+        VirtualConnectionLimit limiter = new VirtualConnectionLimit(maxConnections, connector);
+        connector.addBean(limiter);
+        server.start();
+
+        List<SocketChannel> channels = new ArrayList<>();
+        for (int i = 0; i < maxConnections; ++i)
+        {
+            SocketChannel channel = SocketChannel.open(new InetSocketAddress("localhost", connector.getLocalPort()));
+            channels.add(channel);
+        }
+        // On the client connections may be accepted, but on server not yet.
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertEquals(maxConnections, limiter.getVirtualConnectionCount()));
+        // The limit was reached.
+        assertFalse(connector.isAccepting());
+
+        // An extra connection is accepted at the TCP level, but not notified to the JVM yet:
+        // it remains in the connector accept queue, which cannot be configured to be zero.
+        List<SocketChannel> extraChannels = new ArrayList<>();
+        for (int i = 0; i < 2; ++i)
+        {
+            SocketChannel channel = SocketChannel.open(new InetSocketAddress("localhost", connector.getLocalPort()));
+            extraChannels.add(channel);
+        }
+        await().during(1, TimeUnit.SECONDS).untilAsserted(() -> assertEquals(maxConnections, limiter.getVirtualConnectionCount()));
+
+        // Closing one existing connection may accept
+        // all the extra connections when acceptors=0.
+        channels.remove(0).close();
+        // Verify that we are still correctly limited
+        // and that we have accepted a pending connection.
+        await().atMost(5, TimeUnit.SECONDS).during(1, TimeUnit.SECONDS).untilAsserted(() -> assertEquals(maxConnections, limiter.getVirtualConnectionCount()));
+
+        extraChannels.forEach(IO::close);
+        channels.forEach(IO::close);
+    }
+
+    @Test
+    public void testVirtualConnectionLimitWithServer() throws Exception
+    {
+        prepare(1, new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                callback.succeeded();
+                return true;
+            }
+        });
+        ServerConnector connector2 = new ServerConnector(server, 0, 1);
+        server.addConnector(connector2);
+        int maxConnections = 2;
+        VirtualConnectionLimit limiter = new VirtualConnectionLimit(maxConnections, server);
+        server.addBean(limiter);
+        server.start();
+
+        // Max out the connections.
+        SocketChannel.open(new InetSocketAddress("localhost", connector.getLocalPort()));
+        SocketChannel.open(new InetSocketAddress("localhost", connector2.getLocalPort()));
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertEquals(maxConnections, limiter.getVirtualConnectionCount()));
+
+        // Try to create more, should not be possible.
+        SocketChannel extraChannel1 = SocketChannel.open(new InetSocketAddress("localhost", connector.getLocalPort()));
+        await().during(1, TimeUnit.SECONDS).untilAsserted(() -> assertEquals(maxConnections, limiter.getVirtualConnectionCount()));
+        SocketChannel extraChannel2 = SocketChannel.open(new InetSocketAddress("localhost", connector2.getLocalPort()));
+        await().during(1, TimeUnit.SECONDS).untilAsserted(() -> assertEquals(maxConnections, limiter.getVirtualConnectionCount()));
+
+        extraChannel2.close();
+        extraChannel1.close();
+    }
+
+    @Test
+    public void testAcceptRejectedByExecutor() throws Exception
+    {
+        // One acceptor, one selector, one application.
+        int maxThreads = 3;
+        int maxQueue = 1;
+        QueuedThreadPool serverThreads = new QueuedThreadPool(maxThreads, 0, new ArrayBlockingQueue<>(maxQueue));
+        serverThreads.setReservedThreads(0);
+        serverThreads.setDetailedDump(true);
+        server = new Server(serverThreads);
+        prepare(1, new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                callback.succeeded();
+                return true;
+            }
+        });
+        int maxConnections = 2;
+        VirtualConnectionLimit limiter = new VirtualConnectionLimit(maxConnections, connector);
+        connector.addBean(limiter);
+        server.start();
+
+        // Block the last thread.
+        CompletableFuture<Void> blocker = new CompletableFuture<>();
+        serverThreads.execute(blocker::join);
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertEquals(maxThreads, serverThreads.getThreads()));
+
+        // Fill the thread pool queue.
+        IntStream.range(0, maxQueue).forEach(i -> serverThreads.execute(() ->
+        {
+        }));
+
+        // Try to connect, the accept task should be rejected.
+        try (SocketChannel channel = SocketChannel.open(new InetSocketAddress("localhost", connector.getLocalPort())))
+        {
+            ByteBuffer byteBuffer = ByteBuffer.allocate(16);
+            assertEquals(-1, channel.read(byteBuffer));
+            await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertEquals(0, limiter.getPendingVirtualConnectionCount()));
+        }
+
+        // Release the blocked task.
+        blocker.complete(null);
+    }
+}

--- a/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/WebSocketNetworkConnectionLimitTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/WebSocketNetworkConnectionLimitTest.java
@@ -13,7 +13,9 @@
 
 package org.eclipse.jetty.websocket.core;
 
+import java.io.EOFException;
 import java.net.URI;
+import java.nio.channels.AsynchronousCloseException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -24,6 +26,7 @@ import java.util.concurrent.TimeoutException;
 import org.eclipse.jetty.server.NetworkConnectionLimit;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.VirtualConnectionLimit;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.websocket.core.client.WebSocketCoreClient;
 import org.eclipse.jetty.websocket.core.server.WebSocketUpgradeHandler;
@@ -33,6 +36,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -40,13 +44,17 @@ import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 public class WebSocketNetworkConnectionLimitTest
 {
-    private static final int CONNECTION_LIMIT = 5;
-
     private Server _server;
     private WebSocketUpgradeHandler _upgradeHandler;
     private WebSocketCoreClient _client;
     private ServerConnector _serverConnector;
-    private NetworkConnectionLimit _networkConnectionLimit;
+
+    public void startServer() throws Exception
+    {
+        _server.start();
+        _client = new WebSocketCoreClient();
+        _client.start();
+    }
 
     @BeforeEach
     public void before() throws Exception
@@ -56,14 +64,6 @@ public class WebSocketNetworkConnectionLimitTest
         _server.addConnector(_serverConnector);
         _upgradeHandler = new WebSocketUpgradeHandler();
         _server.setHandler(_upgradeHandler);
-
-        _networkConnectionLimit = new NetworkConnectionLimit(CONNECTION_LIMIT, _serverConnector);
-        _serverConnector.addBean(_networkConnectionLimit);
-
-        _server.start();
-
-        _client = new WebSocketCoreClient();
-        _client.start();
     }
 
     @AfterEach
@@ -74,28 +74,34 @@ public class WebSocketNetworkConnectionLimitTest
     }
 
     @Test
-    public void test() throws Exception
+    public void testNetworkConnectionLimit() throws Exception
     {
+        int connectionLimit = 5;
+        NetworkConnectionLimit limiter = new NetworkConnectionLimit(connectionLimit, _serverConnector);
+        _serverConnector.addBean(limiter);
+        startServer();
+
         _upgradeHandler.addMapping("/", (req, resp, cb) -> new EchoFrameHandler());
         URI uri = URI.create("ws://localhost:" + _serverConnector.getLocalPort());
 
         List<TestMessageHandler> clientHandlers = new ArrayList<>();
-        for (int i = 0; i < CONNECTION_LIMIT; i++)
+        for (int i = 0; i < connectionLimit; i++)
         {
             TestMessageHandler clientHandler = new TestMessageHandler();
             clientHandlers.add(clientHandler);
             _client.connect(clientHandler, uri).get(5, TimeUnit.SECONDS);
             assertTrue(clientHandler.openLatch.await(5, TimeUnit.SECONDS));
-            awaitConnections(i + 1);
+            awaitConnections(i + 1, limiter);
         }
 
         // Trying to open an additional connection results in a failure.
+        assertFalse(_serverConnector.isAccepting());
         TestMessageHandler clientHandler = new TestMessageHandler();
         _client.getHttpClient().setConnectTimeout(1000);
         _client.getHttpClient().setIdleTimeout(1000);
         ExecutionException error = assertThrows(ExecutionException.class, () -> _client.connect(clientHandler, uri).get(5, TimeUnit.SECONDS));
-        assertCausedByTimeout(error);
-        assertThat(_networkConnectionLimit.getNetworkConnectionCount(), equalTo(CONNECTION_LIMIT));
+        assertValidCause(error);
+        assertThat(limiter.getNetworkConnectionCount(), equalTo(connectionLimit));
 
         // Close all the sessions.
         for (TestMessageHandler handler : clientHandlers)
@@ -106,22 +112,79 @@ public class WebSocketNetworkConnectionLimitTest
         }
 
         // All connections should be closed.
-        awaitConnections(0);
+        awaitConnections(0, limiter);
 
         // Now additional connections can be opened without error.
         TestMessageHandler clientHandler2 = new TestMessageHandler();
         _client.connect(clientHandler2, uri).get(5, TimeUnit.SECONDS);
         assertTrue(clientHandler2.openLatch.await(5, TimeUnit.SECONDS));
-        awaitConnections(1);
+        awaitConnections(1, limiter);
         clientHandler2.getCoreSession().close(Callback.NOOP);
         assertTrue(clientHandler2.closeLatch.await(5, TimeUnit.SECONDS));
         assertThat(clientHandler2.closeStatus.getCode(), equalTo(CloseStatus.NO_CODE));
-        awaitConnections(0);
+        awaitConnections(0, limiter);
     }
 
-    public void assertCausedByTimeout(Throwable error)
+    @Test
+    public void testVirtualConnectionLimit() throws Exception
+    {
+        int connectionLimit = 1;
+        VirtualConnectionLimit limiter = new VirtualConnectionLimit(connectionLimit, _serverConnector);
+        _serverConnector.addBean(limiter);
+        startServer();
+
+        _upgradeHandler.addMapping("/", (req, resp, cb) -> new EchoFrameHandler());
+        URI uri = URI.create("ws://localhost:" + _serverConnector.getLocalPort());
+
+        List<TestMessageHandler> clientHandlers = new ArrayList<>();
+        for (int i = 0; i < connectionLimit; i++)
+        {
+            TestMessageHandler clientHandler = new TestMessageHandler();
+            clientHandlers.add(clientHandler);
+            _client.connect(clientHandler, uri).get(5, TimeUnit.SECONDS);
+            assertTrue(clientHandler.openLatch.await(5, TimeUnit.SECONDS));
+            awaitConnections(i + 1, limiter);
+        }
+
+        // Trying to open an additional connection results in a failure.
+        assertFalse(_serverConnector.isAccepting());
+        TestMessageHandler clientHandler = new TestMessageHandler();
+        _client.getHttpClient().setConnectTimeout(1000);
+        _client.getHttpClient().setIdleTimeout(1000);
+        ExecutionException error = assertThrows(ExecutionException.class, () -> _client.connect(clientHandler, uri).get(5, TimeUnit.SECONDS));
+        assertValidCause(error);
+        assertThat(limiter.getVirtualConnectionCount(), equalTo(connectionLimit));
+
+        // Close all the sessions.
+        for (TestMessageHandler handler : clientHandlers)
+        {
+            handler.getCoreSession().close(Callback.NOOP);
+            assertTrue(handler.closeLatch.await(5, TimeUnit.SECONDS));
+            assertThat(handler.closeStatus.getCode(), equalTo(CloseStatus.NO_CODE));
+        }
+
+        // All connections should be closed.
+        awaitConnections(0, limiter);
+
+        // Now additional connections can be opened without error.
+        TestMessageHandler clientHandler2 = new TestMessageHandler();
+        _client.connect(clientHandler2, uri).get(5, TimeUnit.SECONDS);
+        assertTrue(clientHandler2.openLatch.await(5, TimeUnit.SECONDS));
+        awaitConnections(1, limiter);
+        clientHandler2.getCoreSession().close(Callback.NOOP);
+        assertTrue(clientHandler2.closeLatch.await(5, TimeUnit.SECONDS));
+        assertThat(clientHandler2.closeStatus.getCode(), equalTo(CloseStatus.NO_CODE));
+        awaitConnections(0, limiter);
+    }
+
+    public void assertValidCause(Throwable error)
     {
         Throwable cause = error.getCause();
+        if (cause instanceof AsynchronousCloseException)
+            return;
+        if (cause instanceof EOFException)
+            return;
+
         while (cause != null)
         {
             if (cause instanceof TimeoutException)
@@ -132,15 +195,27 @@ public class WebSocketNetworkConnectionLimitTest
         fail("No timeout exception cause", error);
     }
 
-    public void awaitConnections(int connections)
+    public void awaitConnections(int connections, NetworkConnectionLimit limiter)
     {
         await()
             .atMost(1, TimeUnit.SECONDS)
             .pollInterval(Duration.ofMillis(100))
             .untilAsserted(() ->
             {
-                assertThat(_networkConnectionLimit.getNetworkConnectionCount(), equalTo(connections));
-                assertThat(_networkConnectionLimit.getPendingNetworkConnectionCount(), equalTo(0));
+                assertThat(limiter.getNetworkConnectionCount(), equalTo(connections));
+                assertThat(limiter.getPendingNetworkConnectionCount(), equalTo(0));
+            });
+    }
+
+    public void awaitConnections(int connections, VirtualConnectionLimit limiter)
+    {
+        await()
+            .atMost(1, TimeUnit.SECONDS)
+            .pollInterval(Duration.ofMillis(100))
+            .untilAsserted(() ->
+            {
+                assertThat(limiter.getVirtualConnectionCount(), equalTo(connections));
+                assertThat(limiter.getPendingVirtualConnectionCount(), equalTo(0));
             });
     }
 }

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/WebSocketOverHTTP2Test.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/WebSocketOverHTTP2Test.java
@@ -54,6 +54,7 @@ import org.eclipse.jetty.server.SecureRequestCustomizer;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.SslConnectionFactory;
+import org.eclipse.jetty.server.VirtualConnectionLimit;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.EventsHandler;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
@@ -509,14 +510,71 @@ public class WebSocketOverHTTP2Test
         assertThat(networkConnectionLimit.getNetworkConnectionCount(), equalTo(1));
     }
 
-    private static void awaitConnections(int connections, NetworkConnectionLimit networkConnectionLimit)
+    @Test
+    public void testVirtualConnectionLimit() throws Exception
+    {
+        prepareServer(container -> container.addMapping("/echo", (rq, rs, cb) -> new EchoSocket()));
+
+        int maxNetworkConnectionCount = 5;
+        VirtualConnectionLimit limiter = new VirtualConnectionLimit(maxNetworkConnectionCount, connector, tlsConnector);
+        connector.addBean(limiter);
+        tlsConnector.addBean(limiter);
+
+        server.start();
+
+        startClient(clientConnector -> List.of(new ClientConnectionFactoryOverHTTP2.HTTP2(new HTTP2Client(clientConnector))));
+
+        URI uri = URI.create("ws://localhost:" + connector.getLocalPort() + "/echo");
+        List<EventSocket> clientHandlers = new ArrayList<>();
+        for (int i = 0; i < maxNetworkConnectionCount - 1; i++)
+        {
+            EventSocket clientEndpoint = new EventSocket();
+            clientHandlers.add(clientEndpoint);
+            wsClient.connect(clientEndpoint, uri).get(5, TimeUnit.SECONDS);
+            assertTrue(clientEndpoint.openLatch.await(5, TimeUnit.SECONDS));
+            assertThat(clientEndpoint.session.getUpgradeRequest().getHttpVersion(), equalTo(HttpVersion.HTTP_2.asString()));
+
+            // One connection per HTTP/2 Connection, then one per WebSocket connection.
+            awaitConnections(i + 2, limiter);
+        }
+
+        // Opening an additional connection results in a failure.
+        EventSocket clientEndpoint = new EventSocket();
+        wsClient.connect(clientEndpoint, uri).get(5, TimeUnit.SECONDS);
+        assertTrue(clientEndpoint.closeLatch.await(5, TimeUnit.SECONDS));
+        assertThat(clientEndpoint.error, instanceOf(ClosedChannelException.class));
+
+        // Close all the sessions.
+        for (EventSocket handler : clientHandlers)
+        {
+            handler.session.close();
+            assertTrue(handler.closeLatch.await(5, TimeUnit.SECONDS));
+            assertThat(handler.closeCode, equalTo(CloseStatus.NORMAL));
+        }
+
+        assertThat(limiter.getPendingVirtualConnectionCount(), equalTo(0));
+        assertThat(limiter.getVirtualConnectionCount(), equalTo(1));
+    }
+
+    private static void awaitConnections(int connections, NetworkConnectionLimit limiter)
     {
         await().atMost(1, TimeUnit.SECONDS)
             .pollInterval(Duration.ofMillis(100))
             .untilAsserted(() ->
             {
-                assertThat(networkConnectionLimit.getNetworkConnectionCount(), equalTo(connections));
-                assertThat(networkConnectionLimit.getPendingNetworkConnectionCount(), equalTo(0));
+                assertThat(limiter.getNetworkConnectionCount(), equalTo(connections));
+                assertThat(limiter.getPendingNetworkConnectionCount(), equalTo(0));
+            });
+    }
+
+    private static void awaitConnections(int connections, VirtualConnectionLimit limiter)
+    {
+        await().atMost(1, TimeUnit.SECONDS)
+            .pollInterval(Duration.ofMillis(100))
+            .untilAsserted(() ->
+            {
+                assertThat(limiter.getVirtualConnectionCount(), equalTo(connections));
+                assertThat(limiter.getPendingVirtualConnectionCount(), equalTo(0));
             });
     }
 }


### PR DESCRIPTION
closes #13360

Introduces a `VirtualConnectionLimit` class which limits the number of "virtual" connection instances opened by monitoring them with a `Connection.Listener`.