### PR TITLE
Fixes #13583 - NPE in WriteFlusher after org.eclipse.jetty.http.BadMessageException: 417.

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
@@ -20,10 +20,14 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
+import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.ComplianceViolation;
 import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.http.HttpException;
+import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpHeaderValue;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpVersion;
@@ -117,6 +121,10 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
                     _requestMetaData.getMethod(), _requestMetaData.getHttpURI(), _requestMetaData.getHttpVersion(),
                     System.lineSeparator(), fields);
             }
+
+            HttpField expectField = fields.getField(HttpHeader.EXPECT);
+            if (expectField != null && !HttpHeaderValue.CONTINUE.is(expectField.getValue()))
+                throw new BadMessageException(HttpStatus.EXPECTATION_FAILED_417);
 
             InvocationType invocationType = Invocable.getInvocationType(handler);
             return new ReadyTask(invocationType, handler)

--- a/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HttpStreamOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HttpStreamOverHTTP3.java
@@ -20,10 +20,14 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
+import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.ComplianceViolation;
 import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.http.HttpException;
+import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpHeaderValue;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpVersion;
@@ -103,6 +107,10 @@ public class HttpStreamOverHTTP3 implements HttpStream
                     requestMetaData.getMethod(), requestMetaData.getHttpURI(), requestMetaData.getHttpVersion(),
                     System.lineSeparator(), fields);
             }
+
+            HttpField expectField = fields.getField(HttpHeader.EXPECT);
+            if (expectField != null && !HttpHeaderValue.CONTINUE.is(expectField.getValue()))
+                throw new BadMessageException(HttpStatus.EXPECTATION_FAILED_417);
 
             InvocationType invocationType = Invocable.getInvocationType(handler);
             return new ReadyTask(invocationType, handler)

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -1222,9 +1222,7 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
                     {
                         HttpCompliance httpCompliance = getHttpConfiguration().getHttpCompliance();
                         if (httpCompliance.allows(MISMATCHED_AUTHORITY))
-                        {
                             getHttpChannel().getComplianceViolationListener().onComplianceViolation(new ComplianceViolation.Event(httpCompliance, MISMATCHED_AUTHORITY, _uri.asString()));
-                        }
                         else
                             throw new BadMessageException("Authority!=Host");
                     }
@@ -1252,9 +1250,7 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
 
             // Set path (if not already set)
             if (_uri.getPath() == null)
-            {
                 _uri.path("/");
-            }
 
             _request = new MetaData.Request(_parser.getBeginNanoTime(), _method, _uri.asImmutable(), _version, _headerBuilder, _contentLength)
             {
@@ -1278,7 +1274,6 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
             }
 
             boolean persistent;
-
             switch (_request.getHttpVersion())
             {
                 case HTTP_0_9:
@@ -1299,14 +1294,10 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
 
                     break;
                 }
-
                 case HTTP_1_1:
                 {
                     if (_unknownExpectation)
-                    {
-                        _requestHandler.badMessage(new BadMessageException(HttpStatus.EXPECTATION_FAILED_417));
-                        return null;
-                    }
+                        throw new BadMessageException(HttpStatus.EXPECTATION_FAILED_417);
 
                     persistent = getHttpConfiguration().isPersistentConnectionsEnabled() &&
                         !_connectionClose ||
@@ -1325,7 +1316,6 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
 
                     break;
                 }
-
                 case HTTP_2:
                 {
                     // Allow prior knowledge "upgrade" to HTTP/2 only if the connector supports h2c.
@@ -1341,7 +1331,6 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
                     _parser.close();
                     throw new BadMessageException(HttpStatus.UPGRADE_REQUIRED_426, "Upgrade Required");
                 }
-
                 default:
                 {
                     throw new IllegalStateException("unsupported version " + _version);

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
@@ -42,6 +42,7 @@ import org.eclipse.jetty.client.InputStreamResponseListener;
 import org.eclipse.jetty.client.Origin;
 import org.eclipse.jetty.client.Response;
 import org.eclipse.jetty.client.Result;
+import org.eclipse.jetty.client.StringRequestContent;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
@@ -71,6 +72,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -1135,6 +1137,29 @@ public class HttpClientTest extends AbstractTest
             .send();
 
         assertEquals(200, response.getStatus());
+    }
+
+    @ParameterizedTest
+    @MethodSource("transportsNoFCGI")
+    public void testInvalidExpectation(Transport transport) throws Exception
+    {
+        start(transport, new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
+            {
+                Content.Source.consumeAll(request, callback);
+                return true;
+            }
+        });
+
+        ContentResponse response = client.newRequest(newURI(transport))
+            .headers(h -> h.put(HttpHeader.EXPECT, "Invalid"))
+            .body(new StringRequestContent("hello"))
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertThat(response.getStatus(), equalTo(HttpStatus.EXPECTATION_FAILED_417));
     }
 
     public static java.util.stream.Stream<Arguments> validFieldValues()


### PR DESCRIPTION
Fixes handling of an `Expect` header with an invalid value (one that is not 100-Continue).

For HTTP/1 replaced direct call to `badMessage()` with throwing, so that the request is not handled in `HttpConnection.onFillable()`.

HTTP/2 and HTTP/3 did not handle the case, so the handling was added.