### PR TITLE
Allow disabling ShutdownIdleTimeout during graceful shutdown

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractConnector.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractConnector.java
@@ -253,7 +253,7 @@ public abstract class AbstractConnector extends ContainerLifeCycle implements Co
     /**
      * Sets an idle timeout to be used when {@link AbstractConnector#shutdown()} is called.
      * This will replace the existing idle timeouts on all the connected endpoints.
-     * This mechanism can be disabled by setting the shutdown idle timeout to non-positive value.
+     * This mechanism can be disabled by setting the shutdown idle timeout to a negative value.
      */
     public void setShutdownIdleTimeout(long idle)
     {
@@ -356,7 +356,7 @@ public abstract class AbstractConnector extends ContainerLifeCycle implements Co
         interruptAcceptors();
 
         // Reduce the idle timeout of existing connections
-        if (getShutdownIdleTimeout() > 0)
+        if (getShutdownIdleTimeout() >= 0)
         {
             for (EndPoint ep : _endpoints)
                 ep.setIdleTimeout(getShutdownIdleTimeout());

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractConnector.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractConnector.java
@@ -250,6 +250,11 @@ public abstract class AbstractConnector extends ContainerLifeCycle implements Co
             _shutdownIdleTimeout = Math.min(1000L, _idleTimeout);
     }
 
+    /**
+     * Sets an idle timeout to be used when {@link AbstractConnector#shutdown()} is called.
+     * This will replace the existing idle timeouts on all the connected endpoints.
+     * This mechanism can be disabled by setting the shutdown idle timeout to non-positive value.
+     */
     public void setShutdownIdleTimeout(long idle)
     {
         _shutdownIdleTimeout = idle;
@@ -351,8 +356,11 @@ public abstract class AbstractConnector extends ContainerLifeCycle implements Co
         interruptAcceptors();
 
         // Reduce the idle timeout of existing connections
-        for (EndPoint ep : _endpoints)
-            ep.setIdleTimeout(getShutdownIdleTimeout());
+        if (getShutdownIdleTimeout() > 0)
+        {
+            for (EndPoint ep : _endpoints)
+                ep.setIdleTimeout(getShutdownIdleTimeout());
+        }
 
         // Return Future that waits for no acceptors and no connections.
         return done;


### PR DESCRIPTION
Closes https://github.com/jetty/jetty.project/issues/13523 cc: @gregw 

## Background

During a graceful shutdown I would like existing requests and WebSockets to be able to proceed normally. Whilst it is currently possible to set the shutdownIdleTimeout value to be equal to the regular idleTimeout, this does not account for having unique idle timeouts on the (HTTP/1.1) WebSocket sessions, they would all be overwritten to the same value.

This is not ideal because it can lead to erroneous timeout errors, for example a WebSocket session may have been calibrated to a particular timeout value, I don't want to see timeout errors in the logs because this could be misleading.

## Solution

This change allows disabling the shutdownIdleTimeout override mechanism by setting it to a non positive value. 

## Additional Thoughts

To make the graceful shutdown complete quicker it would be nice if there was a way to reduce the idle timeout, or even immediately close connections that are not currently serving a request or WebSocket. (I think this was mentioned at https://github.com/jetty/jetty.project/issues/2749#issuecomment-410159107).