### PR TITLE
Issue #13592 ClosedFileSystemException for jar:file base resource

### DIFF
--- a/jetty-core/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/DeploymentScanner.java
+++ b/jetty-core/jetty-deploy/src/main/java/org/eclipse/jetty/deploy/DeploymentScanner.java
@@ -813,12 +813,14 @@ public class DeploymentScanner extends ContainerLifeCycle implements Scanner.Bul
                     {
                         // Track removal
                         removedApps.add(app);
-                        deployer.undeploy(app.getContextHandler());
+                        ContextHandler contextHandler = app.getContextHandler();
+                        deployer.undeploy(contextHandler);
+                        contextHandler.destroy();
                     }
                     case DEPLOY ->
                     {
                         // Undo tracking for prior removal in this list of actions.
-                        removedApps.remove(app);
+                        removedApps.remove(app); // TODO review this logic. Doesn't this untrack this app that we start tracking below?
 
                         // Load <basename>.properties into app.
                         app.loadProperties();
@@ -903,6 +905,7 @@ public class DeploymentScanner extends ContainerLifeCycle implements Scanner.Bul
                             LOG.debug("Redeploying {} to environment {}", app.getName(), envName);
 
                         deployer.redeploy(oldContextHandler, app.getContextHandler());
+                        oldContextHandler.destroy();
                     }
                 }
             }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -151,6 +151,12 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
     private boolean _tempDirectoryCreated = false;
     private boolean _createdTempDirectoryName = false;
     private boolean _crossContextDispatchSupported = false;
+    /**
+     * A ResourceFactory that will not be closed when the context stops, but
+     * only when the context is explicitly destroyed. Used by {@link #setBaseResourceAsString(String)}
+     * and {@link #setBaseResourceAsPath(Path)}.
+     */
+    private final ResourceFactory.Closeable _nonLifeCycleResourceFactory;
 
     public enum Availability
     {
@@ -204,6 +210,8 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
             classLoader = this.getClass().getClassLoader();
         if (classLoader != Server.class.getClassLoader())
             _classLoader = classLoader;
+
+        _nonLifeCycleResourceFactory = ResourceFactory.closeable();
     }
 
     @Override
@@ -1125,6 +1133,8 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
     @Override
     public void destroy()
     {
+        //get rid of any resources that were created before this context was started
+        _nonLifeCycleResourceFactory.close();
         _context.run(super::destroy);
     }
 
@@ -1281,29 +1291,33 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
     /**
      * <p>Set the base resource to serve content from.</p>
      *
-     * <p>Note: the {@link Resource} is created from {@link ResourceFactory#of(org.eclipse.jetty.util.component.Container)}
-     * which is tied to the lifecycle of this context.</p>
+     * <p>Note: the {@link Resource} is created from a {@link ResourceFactory#closeable()}
+     * that does not depend on the start/stop lifecycle of this context. This ensures that
+     * Resources that are created by this method _before_ the context has started can
+     * persist after the context has stopped.</p>
      *
      * @param path The path to create a base resource from.
      * @see #setBaseResource(Resource)
      */
     public void setBaseResourceAsPath(Path path)
     {
-        setBaseResource(path == null ? null : ResourceFactory.of(this).newResource(path));
+        setBaseResource(path == null ? null : _nonLifeCycleResourceFactory.newResource(path));
     }
 
     /**
      * <p>Set the base resource to serve content from.</p>
      *
-     * <p>Note: the {@link Resource} is created from {@link ResourceFactory#of(org.eclipse.jetty.util.component.Container)}
-     * which is tied to the lifecycle of this context.</p>
+     * <p>Note: the {@link Resource} is created from a {@link ResourceFactory#closeable()}
+     * that does not depend on the start/stop lifecycle of this context. This ensures that
+     * Resources that are created by this method _before_ the context has started can
+     * persist after the context has stopped.</p>
      *
      * @param base The path to create a base resource from.
      * @see #setBaseResource(Resource)
      */
     public void setBaseResourceAsString(String base)
     {
-        setBaseResource((base == null ? null : ResourceFactory.of(this).newResource(base)));
+        setBaseResource((base == null ? null : _nonLifeCycleResourceFactory.newResource(base)));
     }
 
     /**

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppContextTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppContextTest.java
@@ -19,6 +19,7 @@ import java.io.PrintWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -671,6 +672,36 @@ public class WebAppContextTest
                 writer.printf("getParameterMap()[%s]=%s%n", entry.getKey(), valueOf(value));
             }
         }
+    }
+
+    @Test
+    public void testJarFileBaseResource(WorkDir workDir) throws Exception
+    {
+        //create a war that we can use as the resource base
+        Path warPath = createWar(workDir.getEmptyPathDir(), "test.war");
+        warPath = warPath.toAbsolutePath();
+        URI warURI =  URIUtil.toJarFileUri(warPath.toUri());
+
+        Server server = null;
+        WebAppContext context = null;
+
+        server = newServer();
+
+        context = new WebAppContext();
+        context.setContextPath("/");
+        context.setBaseResourceAsString(warURI.toString());
+        assertNotNull(context.getBaseResource());
+        server.setHandler(context);
+        server.start();
+
+        server.stop();
+        assertNotNull(context.getBaseResource());
+
+        //Cause the non-lifecycle ResourceFactory in the context
+        //to be closed, thus closing the jar:file Resource that
+        //was created by the setBaseResourceAsString() method
+        server.destroy();
+        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
     }
 
     @Test

--- a/jetty-ee11/jetty-ee11-webapp/src/test/java/org/eclipse/jetty/ee11/webapp/WebAppContextTest.java
+++ b/jetty-ee11/jetty-ee11-webapp/src/test/java/org/eclipse/jetty/ee11/webapp/WebAppContextTest.java
@@ -676,6 +676,36 @@ public class WebAppContextTest
     }
 
     @Test
+    public void testJarFileBaseResource(WorkDir workDir) throws Exception
+    {
+        //create a war that we can use as the resource base
+        Path warPath = createWar(workDir.getEmptyPathDir(), "test.war");
+        warPath = warPath.toAbsolutePath();
+        URI warURI =  URIUtil.toJarFileUri(warPath.toUri());
+
+        Server server = null;
+        WebAppContext context = null;
+
+        server = newServer();
+
+        context = new WebAppContext();
+        context.setContextPath("/");
+        context.setBaseResourceAsString(warURI.toString());
+        assertNotNull(context.getBaseResource());
+        server.setHandler(context);
+        server.start();
+
+        server.stop();
+        assertNotNull(context.getBaseResource());
+
+        //Cause the non-lifecycle ResourceFactory in the context
+        //to be closed, thus closing the jar:file Resource that
+        //was created by the setBaseResourceAsString() method
+        server.destroy();
+        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
+    }
+
+    @Test
     public void testBaseResourceAbsolutePath(WorkDir workDir) throws Exception
     {
         Server server = newServer();

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppContextTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppContextTest.java
@@ -701,6 +701,36 @@ public class WebAppContextTest
     }
 
     @Test
+    public void testJarFileBaseResource(WorkDir workDir) throws Exception
+    {
+        //create a war that we can use as the resource base
+        Path warPath = createWar(workDir.getEmptyPathDir(), "test.war");
+        warPath = warPath.toAbsolutePath();
+        URI warURI =  URIUtil.toJarFileUri(warPath.toUri());
+
+        Server server = null;
+        WebAppContext context = null;
+
+        server = newServer();
+
+        context = new WebAppContext();
+        context.setContextPath("/");
+        context.setBaseResourceAsString(warURI.toString());
+        assertNotNull(context.getBaseResource());
+        server.setHandler(context);
+        server.start();
+
+        server.stop();
+        assertNotNull(context.getBaseResource());
+
+        //Cause the non-lifecycle ResourceFactory in the context
+        //to be closed, thus closing the jar:file Resource that
+        //was created by the setBaseResourceAsString() method
+        server.destroy();
+        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
+    }
+
+    @Test
     public void testBaseResourceAbsolutePath(WorkDir workDir) throws Exception
     {
         Server server = newServer();


### PR DESCRIPTION
Closes #13592

When `setBaseResourceAsString(String)` or `setBaseResourceAsPath(Path)` are called, the context needs to convert the reference into a `Resource`.  Currently the context uses a `ResourceFactory` linked to its lifecycle to do this conversion. Consequently, when the context is stopped, the `Resource` is closed, which in the case of a `jar:file` `Resource` results in the closing of the associated `ZipFileSystem`.  This causes a problem during `stop` because we reset the base resource to its original value (see `WebInfConfiguration.deconfigure()`)  which now refers to a closed `ZipFileSystem`.

For more details on the exact exception, see the OP.

This PR introduces a `ResourceFactory` that is not bound to the lifecycle of a context, and is used by methods that produce `Resources` before the context starts (ie `setBaseResourceAsString(String)` and `setBaseResourceAsPath(Path)`).  The `ResourceFactory` is closed (and thus its resources also closed) only when `context.destroy()` is called. Therefore, over a stop/start the `Resource` reference remains valid.