### PR TITLE
Fixes #13599 - Merge ConstantThrowable and StaticException

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPart.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPart.java
@@ -42,10 +42,10 @@ import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.content.ByteBufferContentSource;
 import org.eclipse.jetty.io.content.ChunksContentSource;
 import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.util.ConstantThrowable;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.QuotedStringTokenizer;
 import org.eclipse.jetty.util.SearchPattern;
-import org.eclipse.jetty.util.StaticException;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.TypeUtil;
 import org.eclipse.jetty.util.UrlEncoded;
@@ -183,7 +183,7 @@ public class MultiPart
      */
     public abstract static class Part implements Content.Source.Factory, Closeable
     {
-        static final Throwable CLOSE_EXCEPTION = new StaticException("Closed");
+        static final Throwable CLOSE_EXCEPTION = new ConstantThrowable("Closed");
 
         private final AutoLock lock = new AutoLock();
         private final ByteBufferPool.Sized bufferPool;

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/ContentSourcePublisher.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/ContentSourcePublisher.java
@@ -19,9 +19,9 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.util.ConstantThrowable;
 import org.eclipse.jetty.util.IteratingCallback;
 import org.eclipse.jetty.util.MathUtils;
-import org.eclipse.jetty.util.StaticException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -130,7 +130,7 @@ public class ContentSourcePublisher implements Flow.Publisher<Content.Chunk>
     private static final class ActiveSubscription extends IteratingCallback implements Flow.Subscription, Runnable
     {
         private static final long NO_MORE_DEMAND = -1;
-        private static final Throwable COMPLETED = new StaticException("Source.Content read fully");
+        private static final Throwable COMPLETED = new ConstantThrowable("Completed");
         private final AtomicReference<Throwable> cancelled;
         private final AtomicLong demand;
         private Content.Source content;

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpStream.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpStream.java
@@ -21,7 +21,7 @@ import org.eclipse.jetty.io.Connection;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.Content.Chunk;
 import org.eclipse.jetty.util.Callback;
-import org.eclipse.jetty.util.StaticException;
+import org.eclipse.jetty.util.ConstantThrowable;
 
 /**
  * A HttpStream is an abstraction that together with {@link MetaData.Request}, represents the
@@ -31,7 +31,7 @@ import org.eclipse.jetty.util.StaticException;
  */
 public interface HttpStream extends Callback
 {
-    Exception CONTENT_NOT_CONSUMED = new StaticException("Unconsumed request content");
+    Throwable CONTENT_NOT_CONSUMED = new ConstantThrowable("Unconsumed");
 
     /**
      * <p>Attribute name to be used as a {@link Request} attribute to store/retrieve

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
@@ -797,7 +797,7 @@ public class HttpChannelTest
 
         assertThat(stream.isComplete(), is(true));
         assertThat(stream.getFailure(), notNullValue());
-        assertThat(stream.getFailure().getMessage(), containsString("Unconsumed request content"));
+        assertThat(stream.getFailure().getMessage(), containsString("Unconsumed"));
         assertThat(stream.getResponse(), notNullValue());
         assertThat(stream.getResponse().getStatus(), equalTo(200));
         assertThat(stream.getResponseHeaders().get(HttpHeader.CONTENT_TYPE), equalTo(MimeTypes.Type.TEXT_PLAIN_UTF_8.asString()));

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Blocker.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Blocker.java
@@ -75,8 +75,8 @@ import org.slf4j.LoggerFactory;
 public class Blocker
 {
     private static final Logger LOG = LoggerFactory.getLogger(Blocker.class);
-    private static final Throwable ACQUIRED = new StaticException("ACQUIRED");
-    private static final Throwable SUCCEEDED = new StaticException("SUCCEEDED");
+    private static final Throwable ACQUIRED = new ConstantThrowable("ACQUIRED");
+    private static final Throwable SUCCEEDED = new ConstantThrowable("SUCCEEDED");
 
     public interface Runnable extends java.lang.Runnable, AutoCloseable, Invocable
     {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ConstantThrowable.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ConstantThrowable.java
@@ -14,8 +14,15 @@
 package org.eclipse.jetty.util;
 
 /**
- * A {@link Throwable} that may be used in static contexts. It uses Java 7
- * constructor that prevents setting stackTrace inside exception object.
+ * <p>A {@link Throwable} that may be used in static contexts,
+ * for example when stored as a {@code static} field.</p>
+ * <p>Suppressed exceptions are disabled; adding a suppressed
+ * exception has no effect, so that instances of this class
+ * stored as {@code static} fields do not accumulate suppressed
+ * exceptions.</p>
+ * <p>The stack trace is also disabled, since it would only be
+ * captured at the time this exception is created, not when the
+ * failure actually occurs.</p>
  */
 public class ConstantThrowable extends Throwable
 {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/StaticException.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/StaticException.java
@@ -18,7 +18,10 @@ package org.eclipse.jetty.util;
  * meaning calling {@link #addSuppressed(Throwable)} has no effect.
  * This prevents potential memory leaks where a statically-stored exception would accumulate
  * suppressed exceptions added to them.
+ *
+ * @deprecated use {@link ConstantThrowable} instead
  */
+@Deprecated(since = "12.1.2", forRemoval = true)
 public class StaticException extends Exception
 {
     /**

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/util/WebSocketDemander.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/util/WebSocketDemander.java
@@ -16,10 +16,10 @@ package org.eclipse.jetty.websocket.core.util;
 import java.nio.channels.ReadPendingException;
 
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.ConstantThrowable;
 import org.eclipse.jetty.util.CountingCallback;
 import org.eclipse.jetty.util.ExceptionUtil;
 import org.eclipse.jetty.util.IteratingCallback;
-import org.eclipse.jetty.util.StaticException;
 import org.eclipse.jetty.util.thread.AutoLock;
 import org.eclipse.jetty.websocket.core.Extension;
 import org.eclipse.jetty.websocket.core.Frame;
@@ -39,7 +39,7 @@ import org.eclipse.jetty.websocket.core.IncomingFrames;
  */
 public abstract class WebSocketDemander extends IteratingCallback implements DemandChain
 {
-    private static final Throwable SENTINEL_CLOSE_EXCEPTION = new StaticException("Closed");
+    private static final Throwable SENTINEL_CLOSE_EXCEPTION = new ConstantThrowable("Closed");
 
     private final AutoLock _lock = new AutoLock();
     private final IncomingFrames _emitFrame;

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/util/WebSocketFlusher.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/util/WebSocketFlusher.java
@@ -19,8 +19,8 @@ import java.util.List;
 import java.util.Queue;
 
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.ConstantThrowable;
 import org.eclipse.jetty.util.IteratingCallback;
-import org.eclipse.jetty.util.StaticException;
 import org.eclipse.jetty.util.thread.AutoLock;
 import org.eclipse.jetty.websocket.core.OutgoingEntry;
 import org.eclipse.jetty.websocket.core.OutgoingFrames;
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class WebSocketFlusher implements OutgoingFrames
 {
-    private static final Throwable SENTINEL_CLOSE_EXCEPTION = new StaticException("Closed");
+    private static final Throwable SENTINEL_CLOSE_EXCEPTION = new ConstantThrowable("Closed");
     private final Logger log = LoggerFactory.getLogger(this.getClass());
 
     private final AutoLock _lock = new AutoLock();

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/AsyncContentProducer.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/AsyncContentProducer.java
@@ -20,8 +20,8 @@ import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.Trailers;
 import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.util.ConstantThrowable;
 import org.eclipse.jetty.util.NanoTime;
-import org.eclipse.jetty.util.StaticException;
 import org.eclipse.jetty.util.TypeUtil;
 import org.eclipse.jetty.util.thread.AutoLock;
 import org.eclipse.jetty.util.thread.Invocable;
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 class AsyncContentProducer implements ContentProducer
 {
     private static final Logger LOG = LoggerFactory.getLogger(AsyncContentProducer.class);
-    private static final Content.Chunk RECYCLED_ERROR_CHUNK = Content.Chunk.from(new StaticException("ContentProducer has been recycled"), true);
+    private static final Content.Chunk RECYCLED_ERROR_CHUNK = Content.Chunk.from(new ConstantThrowable("Recycled"), true);
 
     final AutoLock _lock;
     private final ServletChannel _servletChannel;

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/AsyncContentProducer.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/AsyncContentProducer.java
@@ -20,8 +20,8 @@ import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.Trailers;
 import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.util.ConstantThrowable;
 import org.eclipse.jetty.util.NanoTime;
-import org.eclipse.jetty.util.StaticException;
 import org.eclipse.jetty.util.TypeUtil;
 import org.eclipse.jetty.util.thread.AutoLock;
 import org.eclipse.jetty.util.thread.Invocable;
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 class AsyncContentProducer implements ContentProducer
 {
     private static final Logger LOG = LoggerFactory.getLogger(AsyncContentProducer.class);
-    private static final Content.Chunk RECYCLED_ERROR_CHUNK = Content.Chunk.from(new StaticException("ContentProducer has been recycled"), true);
+    private static final Content.Chunk RECYCLED_ERROR_CHUNK = Content.Chunk.from(new ConstantThrowable("Recycled"), true);
 
     final AutoLock _lock;
     private final ServletChannel _servletChannel;

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/AsyncContentProducer.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/AsyncContentProducer.java
@@ -20,8 +20,8 @@ import java.util.concurrent.locks.Condition;
 import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.HttpStream;
+import org.eclipse.jetty.util.ConstantThrowable;
 import org.eclipse.jetty.util.NanoTime;
-import org.eclipse.jetty.util.StaticException;
 import org.eclipse.jetty.util.TypeUtil;
 import org.eclipse.jetty.util.component.Destroyable;
 import org.eclipse.jetty.util.thread.AutoLock;
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 class AsyncContentProducer implements ContentProducer
 {
     private static final Logger LOG = LoggerFactory.getLogger(AsyncContentProducer.class);
-    private static final HttpInput.ErrorContent RECYCLED_ERROR_CONTENT = new HttpInput.ErrorContent(new StaticException("ContentProducer has been recycled"));
+    private static final HttpInput.ErrorContent RECYCLED_ERROR_CONTENT = new HttpInput.ErrorContent(new ConstantThrowable("Recycled"));
 
     private final AutoLock _lock = new AutoLock();
     private final HttpChannel _httpChannel;
@@ -186,7 +186,7 @@ class AsyncContentProducer implements ContentProducer
         Throwable x = HttpStream.CONTENT_NOT_CONSUMED;
         if (LOG.isTraceEnabled())
         {
-            x = new StaticException("Unconsumed content", true);
+            x = new IOException("Unconsumed content");
             LOG.trace("consumeAll {}", this, x);
         }
         failCurrentContent(x);


### PR DESCRIPTION
Deprecated `StaticException` in favor of `ConstantThrowable`, because `StaticException` had a constructor that made it capture the stack trace, which was unnecessary and would have been deprecated.