### PR TITLE
Issue #13603 - Bad Accept-Language parsing fix for Locale. [12.0.x]

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -514,25 +514,27 @@ public interface Request extends Attributes, Content.Source
         if (fields == null)
             return DEFAULT_LOCALES;
 
-        List<String> acceptable = fields.getQualityCSV(HttpHeader.ACCEPT_LANGUAGE);
+        List<String> acceptable =
+            fields.getQualityCSV(HttpHeader.ACCEPT_LANGUAGE)
+                .stream()
+                .filter(StringUtil::isNotBlank)
+                .toList();
 
-        // return sorted list of locals, with known locales in quality order before unknown locales in quality order
-        return switch (acceptable.size())
-        {
-            case 0 -> DEFAULT_LOCALES;
-            case 1 -> List.of(Locale.forLanguageTag(acceptable.get(0)));
-            default ->
-            {
-                List<Locale> locales = acceptable.stream().map(Locale::forLanguageTag).toList();
-                List<Locale> known = locales.stream().filter(MimeTypes::isKnownLocale).toList();
-                if (known.size() == locales.size())
-                    yield locales; // All locales are known
-                List<Locale> unknown = locales.stream().filter(l -> !MimeTypes.isKnownLocale(l)).toList();
-                locales = new ArrayList<>(known);
-                locales.addAll(unknown);
-                yield locales; // List of known locales before unknown locales
-            }
-        };
+        if (acceptable.isEmpty())
+            return DEFAULT_LOCALES;
+
+        // return sorted list of locales, with known locales in quality order before unknown locales in quality order
+        List<Locale> locales = acceptable.stream().map(Locale::forLanguageTag).toList();
+        // Filter again, only allowing known locales
+        List<Locale> known = locales.stream().filter(MimeTypes::isKnownLocale).toList();
+        if (known.isEmpty())
+            return DEFAULT_LOCALES;
+        if (known.size() == locales.size())
+            return locales; // All locales are known
+        List<Locale> unknown = locales.stream().filter(l -> !MimeTypes.isKnownLocale(l)).toList();
+        locales = new ArrayList<>(known);
+        locales.addAll(unknown);
+        return locales; // List of known locales before unknown locales
     }
 
     static InputStream asInputStream(Request request)

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java
@@ -547,7 +547,11 @@ public class RequestTest
     {
         return Stream.of(
             Arguments.of(null, List.of(Locale.getDefault().toLanguageTag()).toString()),
-            Arguments.of("zz", "[zz]"),
+            Arguments.of(";", List.of(Locale.getDefault().toLanguageTag()).toString()),
+            Arguments.of(",", List.of(Locale.getDefault().toLanguageTag()).toString()),
+            Arguments.of("bogus", List.of(Locale.getDefault().toLanguageTag()).toString()),
+            Arguments.of("en-en", List.of(Locale.getDefault().toLanguageTag()).toString()),
+            Arguments.of("zz", List.of(Locale.getDefault().toLanguageTag()).toString()),
             Arguments.of("en", "[en]"),
             Arguments.of("en-gb", List.of(Locale.UK.toLanguageTag()).toString()),
             Arguments.of("en-us", List.of(Locale.US.toLanguageTag()).toString()),

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/RequestHeadersTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/RequestHeadersTest.java
@@ -19,82 +19,73 @@ import java.io.PrintWriter;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.function.Consumer;
 
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.IO;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class RequestHeadersTest
 {
-    @SuppressWarnings("serial")
-    private static class RequestHeaderServlet extends HttpServlet
-    {
-        @Override
-        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException
-        {
-            resp.setContentType("text/plain");
-            PrintWriter out = resp.getWriter();
-            out.printf("X-Camel-Type = %s", req.getHeader("X-Camel-Type"));
-        }
-    }
+    private Server server;
+    private URI serverUri;
 
-    private static Server server;
-    private static ServerConnector connector;
-    private static URI serverUri;
-
-    @BeforeAll
-    public static void startServer() throws Exception
+    public void startServer(Consumer<ServletContextHandler> servletContextConsumer) throws Exception
     {
         // Configure Server
         server = new Server();
-        connector = new ServerConnector(server);
+        ServerConnector connector = new ServerConnector(server);
         server.addConnector(connector);
 
         ServletContextHandler context = new ServletContextHandler();
         context.setContextPath("/");
         server.setHandler(context);
 
-        // Serve capture servlet
-        context.addServlet(new ServletHolder(new RequestHeaderServlet()), "/*");
+        servletContextConsumer.accept(context);
 
         // Start Server
         server.start();
-
-        String host = connector.getHost();
-        if (host == null)
-        {
-            host = "localhost";
-        }
-        int port = connector.getLocalPort();
-        serverUri = new URI(String.format("http://%s:%d/", host, port));
+        serverUri = server.getURI().resolve("/");
     }
 
-    @AfterAll
-    public static void stopServer()
+    @AfterEach
+    public void stopServer()
     {
-        try
-        {
-            server.stop();
-        }
-        catch (Exception e)
-        {
-            e.printStackTrace(System.err);
-        }
+        LifeCycle.stop(server);
     }
 
     @Test
-    public void testGetLowercaseHeader() throws IOException
+    public void testGetLowercaseHeader() throws Exception
     {
+        startServer((context) ->
+        {
+            HttpServlet requestHeaderServlet = new HttpServlet()
+            {
+                @Override
+                protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+                {
+                    resp.setContentType("text/plain");
+                    PrintWriter out = resp.getWriter();
+                    out.printf("X-Camel-Type = %s", req.getHeader("X-Camel-Type"));
+                }
+            };
+
+            // Serve capture servlet
+            context.addServlet(new ServletHolder(requestHeaderServlet), "/*");
+        });
+
         HttpURLConnection http = null;
         try
         {
@@ -106,6 +97,68 @@ public class RequestHeadersTest
             {
                 String resp = IO.toString(in, StandardCharsets.UTF_8);
                 assertThat("Response", resp, is("X-Camel-Type = bactrian"));
+            }
+        }
+        finally
+        {
+            if (http != null)
+            {
+                http.disconnect();
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        delimiter = '|',
+        textBlock = """
+            # Request Value | Expected Locale
+            ;q=0.5          | en-US
+            q=0.6           | en-US
+            de              | de
+            en-GB           | en-GB
+            en;q=0.5,it     | it
+            bogus           | en-US
+            en_en           | <undefined>
+            """)
+    public void testLocale(String requestHeaderValue, String expectedLocale) throws Exception
+    {
+        startServer((context) ->
+        {
+            HttpServlet requestHeaderServlet = new HttpServlet()
+            {
+                @Override
+                protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+                {
+                    Locale locale = req.getLocale();
+                    resp.setContentType("text/plain");
+                    PrintWriter out = resp.getWriter();
+                    out.print("Locale = ");
+                    String langTag = locale.toLanguageTag();
+                    // Show undefined language tags differently
+                    // See javadoc for Locale.toLanguageTag() for details
+                    if (langTag.equalsIgnoreCase("und"))
+                        out.println("<undefined>");
+                    else
+                        out.println(langTag);
+                }
+            };
+
+            // Serve capture servlet
+            context.addServlet(new ServletHolder(requestHeaderServlet), "/*");
+        });
+
+        HttpURLConnection http = null;
+        try
+        {
+            http = (HttpURLConnection)serverUri.toURL().openConnection();
+            // Set header in all lowercase
+            http.setRequestProperty("Accept-Language", requestHeaderValue);
+
+            try (InputStream in = http.getInputStream())
+            {
+                String resp = IO.toString(in, StandardCharsets.UTF_8);
+                assertThat("Response", resp, is("Locale = " + expectedLocale + "\n"));
             }
         }
         finally

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
@@ -937,22 +937,22 @@ public class Request implements HttpServletRequest
         if (fields == null)
             return Locale.getDefault();
 
-        List<String> acceptable = fields.getQualityCSV(HttpHeader.ACCEPT_LANGUAGE);
+        List<String> acceptable = fields.getQualityCSV(HttpHeader.ACCEPT_LANGUAGE)
+            .stream()
+            .filter(StringUtil::isNotBlank)
+            .toList();
 
         // handle no locale
         if (acceptable.isEmpty())
             return Locale.getDefault();
 
-        String language = acceptable.get(0);
-        language = HttpField.stripParameters(language);
-        String country = "";
-        int dash = language.indexOf('-');
-        if (dash > -1)
-        {
-            country = language.substring(dash + 1).trim();
-            language = language.substring(0, dash).trim();
-        }
-        return new Locale(language, country);
+        // return sorted list of locales, with known locales in quality order before unknown locales in quality order
+        List<Locale> locales = acceptable.stream().map(Locale::forLanguageTag).toList();
+        // Filter again, only allowing known locales
+        List<Locale> known = locales.stream().filter(MimeTypes::isKnownLocale).toList();
+        if (known.isEmpty())
+            return Locale.getDefault();
+        return known.get(0);
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/RequestHeadersTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/RequestHeadersTest.java
@@ -19,82 +19,73 @@ import java.io.PrintWriter;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.function.Consumer;
 
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.IO;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class RequestHeadersTest
 {
-    @SuppressWarnings("serial")
-    private static class RequestHeaderServlet extends HttpServlet
-    {
-        @Override
-        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException
-        {
-            resp.setContentType("text/plain");
-            PrintWriter out = resp.getWriter();
-            out.printf("X-Camel-Type = %s", req.getHeader("X-Camel-Type"));
-        }
-    }
+    private Server server;
+    private URI serverUri;
 
-    private static Server server;
-    private static ServerConnector connector;
-    private static URI serverUri;
-
-    @BeforeAll
-    public static void startServer() throws Exception
+    public void startServer(Consumer<ServletContextHandler> servletContextConsumer) throws Exception
     {
         // Configure Server
         server = new Server();
-        connector = new ServerConnector(server);
+        ServerConnector connector = new ServerConnector(server);
         server.addConnector(connector);
 
         ServletContextHandler context = new ServletContextHandler();
         context.setContextPath("/");
         server.setHandler(context);
 
-        // Serve capture servlet
-        context.addServlet(new ServletHolder(new RequestHeaderServlet()), "/*");
+        servletContextConsumer.accept(context);
 
         // Start Server
         server.start();
-
-        String host = connector.getHost();
-        if (host == null)
-        {
-            host = "localhost";
-        }
-        int port = connector.getLocalPort();
-        serverUri = new URI(String.format("http://%s:%d/", host, port));
+        serverUri = server.getURI().resolve("/");
     }
 
-    @AfterAll
-    public static void stopServer()
+    @AfterEach
+    public void stopServer()
     {
-        try
-        {
-            server.stop();
-        }
-        catch (Exception e)
-        {
-            e.printStackTrace(System.err);
-        }
+        LifeCycle.stop(server);
     }
 
     @Test
-    public void testGetLowercaseHeader() throws IOException
+    public void testGetLowercaseHeader() throws Exception
     {
+        startServer((context) ->
+        {
+            HttpServlet requestHeaderServlet = new HttpServlet()
+            {
+                @Override
+                protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+                {
+                    resp.setContentType("text/plain");
+                    PrintWriter out = resp.getWriter();
+                    out.printf("X-Camel-Type = %s", req.getHeader("X-Camel-Type"));
+                }
+            };
+
+            // Serve capture servlet
+            context.addServlet(new ServletHolder(requestHeaderServlet), "/*");
+        });
+
         HttpURLConnection http = null;
         try
         {
@@ -106,6 +97,68 @@ public class RequestHeadersTest
             {
                 String resp = IO.toString(in, StandardCharsets.UTF_8);
                 assertThat("Response", resp, is("X-Camel-Type = bactrian"));
+            }
+        }
+        finally
+        {
+            if (http != null)
+            {
+                http.disconnect();
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        delimiter = '|',
+        textBlock = """
+            # Request Value | Expected Locale
+            ;q=0.5          | en-US
+            q=0.6           | en-US
+            de              | de
+            en-GB           | en-GB
+            en;q=0.5,it     | it
+            bogus           | en-US
+            en_en           | <undefined>
+            """)
+    public void testLocale(String requestHeaderValue, String expectedLocale) throws Exception
+    {
+        startServer((context) ->
+        {
+            HttpServlet requestHeaderServlet = new HttpServlet()
+            {
+                @Override
+                protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+                {
+                    Locale locale = req.getLocale();
+                    resp.setContentType("text/plain");
+                    PrintWriter out = resp.getWriter();
+                    out.print("Locale = ");
+                    String langTag = locale.toLanguageTag();
+                    // Show undefined language tags differently
+                    // See javadoc for Locale.toLanguageTag() for details
+                    if (langTag.equalsIgnoreCase("und"))
+                        out.println("<undefined>");
+                    else
+                        out.println(langTag);
+                }
+            };
+
+            // Serve capture servlet
+            context.addServlet(new ServletHolder(requestHeaderServlet), "/*");
+        });
+
+        HttpURLConnection http = null;
+        try
+        {
+            http = (HttpURLConnection)serverUri.toURL().openConnection();
+            // Set header in all lowercase
+            http.setRequestProperty("Accept-Language", requestHeaderValue);
+
+            try (InputStream in = http.getInputStream())
+            {
+                String resp = IO.toString(in, StandardCharsets.UTF_8);
+                assertThat("Response", resp, is("Locale = " + expectedLocale + "\n"));
             }
         }
         finally


### PR DESCRIPTION
If a value-less entry in an `Accept-Language` request header is received, this can result in a failure when looking up the Locale of the request.

Example bad Request Headers.

```
Accept-Language: ;q=0.5
Accept-Language: q=0.6
```

This actually results in the QuotedQualityCSV in having an entry that is blank.
The fix in this PR fixes the parsing of Quoted CSV headers to ignore those headers where the quality exists without a value, not adding them to the sorted list of values.

Fixes: #13603