### PR TITLE
Fixes #13598 - Server hangs when client closes too many connections

### DIFF
--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/BufferedContentSink.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/BufferedContentSink.java
@@ -24,6 +24,7 @@ import org.eclipse.jetty.io.RetainableByteBuffer;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.IteratingCallback;
+import org.eclipse.jetty.util.thread.Invocable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -300,6 +301,12 @@ public class BufferedContentSink implements Content.Sink
         {
             _buffer = null;
             _callback.failed(cause);
+        }
+
+        @Override
+        public InvocationType getInvocationType()
+        {
+            return Invocable.getInvocationType(_callback);
         }
     }
 }

--- a/jetty-core/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/ProxyHandler.java
+++ b/jetty-core/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/ProxyHandler.java
@@ -611,6 +611,7 @@ public abstract class ProxyHandler extends Handler.Abstract
 
         public ProxyResponseListener(Request clientToProxyRequest, org.eclipse.jetty.client.Request proxyToServerRequest, Response proxyToClientResponse, Callback proxyToClientCallback)
         {
+            super(InvocationType.NON_BLOCKING);
             this.clientToProxyRequest = clientToProxyRequest;
             this.proxyToServerRequest = proxyToServerRequest;
             this.proxyToClientResponse = proxyToClientResponse;

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
@@ -219,8 +219,15 @@ public class BufferedResponseHandler extends ConditionalHandler.Abstract
         public void failed(Throwable x)
         {
             if (_bufferedContentSink != null && !_lastWritten)
-                _bufferedContentSink.write(true, null, Callback.NOOP);
-            _callback.failed(x);
+                _bufferedContentSink.write(true, null, Callback.from(_callback, x));
+            else
+                _callback.failed(x);
+        }
+
+        @Override
+        public InvocationType getInvocationType()
+        {
+            return _callback.getInvocationType();
         }
     }
 }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ErrorHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ErrorHandler.java
@@ -52,6 +52,7 @@ import org.eclipse.jetty.util.ExceptionUtil;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.annotation.ManagedObject;
+import org.eclipse.jetty.util.thread.Invocable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -611,7 +612,7 @@ public class ErrorHandler implements Request.Handler
      */
     private static class WriteErrorCallback implements Callback
     {
-        private final AtomicReference<Callback>  _callback;
+        private final AtomicReference<Callback> _callback;
         private final ByteBufferPool _pool;
         private final RetainableByteBuffer _buffer;
 
@@ -636,6 +637,12 @@ public class ErrorHandler implements Request.Handler
             Callback callback = _callback.getAndSet(null);
             if (callback != null)
                 ExceptionUtil.callAndThen(x, t -> _pool.removeAndRelease(_buffer), callback::failed);
+        }
+
+        @Override
+        public InvocationType getInvocationType()
+        {
+            return Invocable.getInvocationType(_callback.get());
         }
     }
 }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/EventsHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/EventsHandler.java
@@ -350,7 +350,15 @@ public abstract class EventsHandler extends Handler.Wrapper
         {
             notifyOnResponseBegin(getRequest(), this);
             notifyOnResponseWrite(getRequest(), last, byteBuffer);
-            super.write(last, byteBuffer, Callback.from(callback, (x) -> notifyOnResponseWriteComplete(getRequest(), x)));
+            super.write(last, byteBuffer, Callback.from(callback.getInvocationType(), () ->
+            {
+                notifyOnResponseWriteComplete(getRequest(), null);
+                callback.succeeded();
+            }, x ->
+            {
+                notifyOnResponseWriteComplete(getRequest(), x);
+                callback.failed(x);
+            }));
         }
 
         @Override

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ThreadLimitHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ThreadLimitHandler.java
@@ -301,7 +301,7 @@ public class ThreadLimitHandler extends ConditionalHandler.Abstract
             return _callback;
         }
 
-        protected void handle() throws Exception
+        protected void handle()
         {
             Permit permit = _remote.acquire();
 
@@ -309,13 +309,13 @@ public class ThreadLimitHandler extends ConditionalHandler.Abstract
             if (permit.isAllocated())
             {
                 if (LOG.isDebugEnabled())
-                    LOG.debug("Thread permitted {} {} {}", _remote, getWrapped(), _handler);
+                    LOG.debug("Thread permitted {} {} {}", _remote, getWrapped(), getHandler());
                 handle(permit);
             }
             else
             {
                 if (LOG.isDebugEnabled())
-                    LOG.debug("Thread limited {} {} {}", _remote, getWrapped(), _handler);
+                    LOG.debug("Thread limited {} {} {}", _remote, getWrapped(), getHandler());
                 permit.whenAllocated(this::handle);
             }
         }
@@ -324,12 +324,12 @@ public class ThreadLimitHandler extends ConditionalHandler.Abstract
         {
             try
             {
-                if (!_handler.handle(this, _response, _callback))
-                    Response.writeError(this, _response, _callback, HttpStatus.NOT_FOUND_404);
+                if (!getHandler().handle(this, getResponse(), getCallback()))
+                    Response.writeError(this, getResponse(), getCallback(), HttpStatus.NOT_FOUND_404);
             }
             catch (Throwable x)
             {
-                _callback.failed(x);
+                getCallback().failed(x);
             }
             finally
             {
@@ -444,6 +444,12 @@ public class ThreadLimitHandler extends ConditionalHandler.Abstract
             {
                 permit.release();
             }
+        }
+
+        @Override
+        public InvocationType getInvocationType()
+        {
+            return Invocable.getInvocationType(_writeCallback.get());
         }
     }
 

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/EventsHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/EventsHandlerTest.java
@@ -253,7 +253,8 @@ public class EventsHandlerTest
     @Test
     public void testCongestedInvocationType() throws Exception
     {
-        startServer(new EventsHandler(new Handler.Abstract() {
+        startServer(new EventsHandler(new Handler.Abstract()
+        {
             @Override
             public boolean handle(Request request, Response response, Callback callback)
             {

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/EventsHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/EventsHandlerTest.java
@@ -13,45 +13,54 @@
 
 package org.eclipse.jetty.server.handler;
 
+import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
+import java.nio.channels.SocketChannel;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.io.AbstractEndPoint;
 import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.io.WriteFlusher;
 import org.eclipse.jetty.server.Handler;
-import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.NanoTime;
+import org.eclipse.jetty.util.thread.Invocable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EventsHandlerTest
 {
     private Server server;
-    private LocalConnector connector;
+    private ServerConnector connector;
 
     @BeforeEach
-    public void setUp() throws Exception
+    public void setUp()
     {
         server = new Server();
-        connector = new LocalConnector(server);
+        connector = new ServerConnector(server, 1, 1);
         server.addConnector(connector);
     }
 
@@ -102,16 +111,19 @@ public class EventsHandlerTest
 
         startServer(eventsHandler);
 
-        String rawRequest = """
-            GET / HTTP/1.1\r
-            Host: localhost\r
-            Connection: close\r
-            \r
-            """;
+        try (SocketChannel client = SocketChannel.open(new InetSocketAddress("localhost", connector.getLocalPort())))
+        {
+            client.write(UTF_8.encode("""
+                GET / HTTP/1.1\r
+                Host: localhost\r
+                Connection: close\r
+                \r
+                """));
 
-        String response = connector.getResponse(rawRequest);
-        assertThat(response, containsString("HTTP/1.1 200 OK"));
-        await().atMost(5, TimeUnit.SECONDS).until(attribute::get, is("testModifyRequestAttributes-123"));
+            HttpTester.Response response = HttpTester.parseResponse(client);
+            assertEquals(HttpStatus.OK_200, response.getStatus());
+            await().atMost(5, TimeUnit.SECONDS).until(attribute::get, is("testModifyRequestAttributes-123"));
+        }
     }
 
     @Test
@@ -132,26 +144,23 @@ public class EventsHandlerTest
         };
         startServer(eventsHandler);
 
-        String reqLine = "POST / HTTP/1.1\r\n";
-        String headers = """
-            Host: localhost\r
-            Content-length: 6\r
-            Content-type: application/octet-stream\r
-            Connection: close\r
-            \r
-            """;
-        String body = "ABCDEF";
-
-        try (LocalConnector.LocalEndPoint endPoint = connector.connect())
+        try (SocketChannel client = SocketChannel.open(new InetSocketAddress("localhost", connector.getLocalPort())))
         {
-            endPoint.addInput(reqLine);
+            client.write(UTF_8.encode("POST / HTTP/1.1\r\n"));
             Thread.sleep(500);
-            endPoint.addInput(headers);
+            client.write(UTF_8.encode("""
+                Host: localhost\r
+                Content-length: 6\r
+                Content-type: application/octet-stream\r
+                Connection: close\r
+                \r
+                """));
             Thread.sleep(500);
-            endPoint.addInput(body);
-            String response = endPoint.getResponse();
+            client.write(UTF_8.encode("ABCDEF"));
 
-            assertThat(response, containsString("HTTP/1.1 200 OK"));
+            HttpTester.Response response = HttpTester.parseResponse(client);
+
+            assertEquals(HttpStatus.OK_200, response.getStatus());
             assertTrue(latch.await(5, TimeUnit.SECONDS));
             assertThat(NanoTime.millisSince(beginNanoTime.get()), greaterThan(900L));
             assertThat(NanoTime.millisSince(readyNanoTime.get()), greaterThan(450L));
@@ -224,17 +233,55 @@ public class EventsHandlerTest
 
         startServer(eventsHandler);
 
-        String rawRequest = """
-            GET / HTTP/1.1\r
-            Host: localhost\r
-            Connection: close\r
-            \r
-            """;
+        try (SocketChannel client = SocketChannel.open(new InetSocketAddress("localhost", connector.getLocalPort())))
+        {
+            client.write(UTF_8.encode("""
+                GET / HTTP/1.1\r
+                Host: localhost\r
+                Connection: close\r
+                \r
+                """));
 
-        String response = connector.getResponse(rawRequest);
-        assertThat(response, containsString("HTTP/1.1 200 OK"));
-        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() ->
-            assertThat(events, equalTo(Arrays.asList("onBeforeHandling", "onAfterHandling", "onResponseBegin", "onComplete"))
-        ));
+            HttpTester.Response response = HttpTester.parseResponse(client);
+            assertEquals(HttpStatus.OK_200, response.getStatus());
+            await().atMost(5, TimeUnit.SECONDS).untilAsserted(() ->
+                assertThat(events, equalTo(Arrays.asList("onBeforeHandling", "onAfterHandling", "onResponseBegin", "onComplete"))
+            ));
+        }
+    }
+
+    @Test
+    public void testCongestedInvocationType() throws Exception
+    {
+        startServer(new EventsHandler(new Handler.Abstract() {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                assertEquals(Invocable.InvocationType.NON_BLOCKING, callback.getInvocationType());
+                // Perform a large write to become TCP congested.
+                response.write(true, ByteBuffer.allocate(128 * 1024 * 1024), callback);
+                return true;
+            }
+        }) {});
+
+        try (SocketChannel client = SocketChannel.open(new InetSocketAddress("localhost", connector.getLocalPort())))
+        {
+            client.write(UTF_8.encode("""
+                GET / HTTP/1.1
+                Host: localhost
+                Connection: close
+                
+                """));
+
+            // Do not read yet to cause TCP congestion.
+            WriteFlusher writeFlusher = await().atMost(5, TimeUnit.SECONDS).until(() ->
+                connector.getConnectedEndPoints().stream().findFirst()
+                    .map(AbstractEndPoint.class::cast)
+                    .map(AbstractEndPoint::getWriteFlusher)
+                    .orElse(null), Objects::nonNull);
+            await().atMost(5, TimeUnit.SECONDS).until(writeFlusher::isPending);
+
+            assertEquals(Invocable.InvocationType.NON_BLOCKING, writeFlusher.getCallbackInvocationType());
+        }
     }
 }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Callback.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Callback.java
@@ -242,12 +242,16 @@ public interface Callback extends Invocable
     }
 
     /**
-     * Creates a nested callback that runs completed after
-     * completing the nested callback.
+     * <p>Creates a callback that runs the {@link Runnable} argument after
+     * completing the callback argument.</p>
+     * <p>The {@link Runnable} is assumed to be {@code NON_BLOCKING}, so the
+     * {@link InvocationType} of the returned callback is the same as the
+     * callback argument.</p>
      *
      * @param callback The nested callback
-     * @param completed The completion to run after the nested callback is completed
-     * @return a new callback.
+     * @param completed The {@link Runnable} to run after the nested callback
+     * is completed
+     * @return a new callback
      */
     static Callback from(Callback callback, Runnable completed)
     {
@@ -261,12 +265,18 @@ public interface Callback extends Invocable
     }
 
     /**
-     * Creates a nested callback that runs completed after
-     * completing the nested callback.
+     * <p>Creates a callback that runs the {@link Consumer} argument after
+     * completing the callback argument.</p>
+     * <p>The {@link Consumer} receives {@code null} if the callback succeeded,
+     * or the {@link Throwable} failure if the callback failed.</p>
+     * <p>The {@link Consumer} is assumed to be {@code NON_BLOCKING}, so the
+     * {@link InvocationType} of the returned callback is the same as the
+     * callback parameter.</p>
      *
      * @param callback The nested callback
-     * @param completed The completion to run after the nested callback is completed
-     * @return a new callback.
+     * @param completed The {@link Consumer} to run after the nested callback
+     * is completed
+     * @return a new callback
      */
     static Callback from(Callback callback, Consumer<Throwable> completed)
     {
@@ -290,17 +300,27 @@ public interface Callback extends Invocable
             {
                 Callback.failed(callback::failed, completed, x);
             }
+
+            @Override
+            public InvocationType getInvocationType()
+            {
+                return callback.getInvocationType();
+            }
         };
     }
 
     /**
-     * Creates a nested callback that runs completed before
-     * completing the nested callback.
+     * Creates a callback that runs the {@link Runnable} argument before
+     * completing the callback argument.
+     * <p>The {@link Runnable} is assumed to be {@code NON_BLOCKING}, so the
+     * {@link InvocationType} of the returned callback is the same as the
+     * callback argument.</p>
      *
      * @param callback The nested callback
-     * @param completed The completion to run before the nested callback is completed. Any exceptions thrown
-     * from completed will result in a callback failure.
-     * @return a new callback.
+     * @param completed The {@link Runnable} to run before the nested callback
+     * is completed. Any exceptions thrown from the {@link Runnable} will
+     * result in the callback failure.
+     * @return a new callback
      */
     static Callback from(Runnable completed, Callback callback)
     {
@@ -330,32 +350,44 @@ public interface Callback extends Invocable
             {
                 Callback.failed(this::completed, callback::failed, x);
             }
+
+            @Override
+            public InvocationType getInvocationType()
+            {
+                return callback.getInvocationType();
+            }
         };
     }
 
     /**
-     * Creates a nested callback which always fails the nested callback on completion.
+     * <p>Creates a callback which always fails the callback argument on completion.</p>
      *
      * @param callback The nested callback
-     * @param cause The cause to fail the nested callback, if the new callback is failed the reason
-     * will be added to this cause as a suppressed exception.
+     * @param failure The cause to fail the nested callback; if the new callback is failed,
+     * the cause will be added to the failure argument as a suppressed exception.
      * @return a new callback.
      */
-    static Callback from(Callback callback, Throwable cause)
+    static Callback from(Callback callback, Throwable failure)
     {
         return new Callback()
         {
             @Override
             public void succeeded()
             {
-                callback.failed(cause);
+                callback.failed(failure);
             }
 
             @Override
             public void failed(Throwable x)
             {
-                ExceptionUtil.addSuppressedIfNotAssociated(cause, x);
-                Callback.failed(callback, cause);
+                ExceptionUtil.addSuppressedIfNotAssociated(failure, x);
+                Callback.failed(callback, failure);
+            }
+
+            @Override
+            public InvocationType getInvocationType()
+            {
+                return callback.getInvocationType();
             }
         };
     }
@@ -490,7 +522,7 @@ public interface Callback extends Invocable
             @Override
             public InvocationType getInvocationType()
             {
-                return Invocable.combine(Invocable.getInvocationType(cb1), Invocable.getInvocationType(cb2));
+                return Invocable.combine(cb1.getInvocationType(), cb2.getInvocationType());
             }
         };
     }
@@ -539,16 +571,16 @@ public interface Callback extends Invocable
             };
         }
 
-        private final InvocationType invocation;
+        private final InvocationType invocationType;
 
         public Completable()
         {
             this(Invocable.InvocationType.NON_BLOCKING);
         }
 
-        public Completable(InvocationType invocation)
+        public Completable(InvocationType invocationType)
         {
-            this.invocation = invocation;
+            this.invocationType = invocationType;
         }
 
         @Override
@@ -566,7 +598,7 @@ public interface Callback extends Invocable
         @Override
         public InvocationType getInvocationType()
         {
-            return invocation;
+            return invocationType;
         }
 
         /**

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/IteratingNestedCallback.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/IteratingNestedCallback.java
@@ -17,19 +17,19 @@ package org.eclipse.jetty.util;
  * Iterating Nested Callback.
  * <p>This specialized callback is used when breaking up an
  * asynchronous task into smaller asynchronous tasks.  A typical pattern
- * is that a successful callback is used to schedule the next sub task, but
- * if that task completes quickly and uses the calling thread to callback
+ * is that a successful callback is used to schedule the next subtask, but
+ * if that task completes quickly and uses the calling thread to call back
  * the success notification, this can result in a growing stack depth.
  * </p>
  * <p>To avoid this issue, this callback uses an AtomicBoolean to note
  * if the success callback has been called during the processing of a
- * sub task, and if so then the processing iterates rather than recurses.
+ * subtask, and if so then the processing iterates rather than recurses.
  * </p>
- * <p>This callback is passed to the asynchronous handling of each sub
- * task and a call the {@link #succeeded()} on this call back represents
+ * <p>This callback is passed to the asynchronous handling of each subtask
+ * and a call the {@link #succeeded()} on this call back represents
  * completion of the subtask.  Only once all the subtasks are completed is
  * the {@link Callback#succeeded()} method called on the {@link Callback} instance
- * passed the the {@link #IteratingNestedCallback(Callback)} constructor.</p>
+ * passed the {@link #IteratingNestedCallback(Callback)} constructor.</p>
  */
 public abstract class IteratingNestedCallback extends IteratingCallback
 {

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
@@ -16,7 +16,6 @@ package org.eclipse.jetty.ee10.servlet;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.util.Objects;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -703,7 +702,9 @@ public class ServletChannel
         try
         {
             _state.completing();
-            getServletContextResponse().write(true, getServletContextResponse().getHttpOutput().getByteBuffer(), Callback.from(() -> _state.completed(null), _state::completed));
+            // _state::completed may invoke async listeners, but assume non-blocking.
+            Callback callback = Callback.from(NON_BLOCKING, () -> _state.completed(null), _state::completed);
+            getServletContextResponse().write(true, getServletContextResponse().getHttpOutput().getByteBuffer(), callback);
         }
         catch (Throwable x)
         {


### PR DESCRIPTION
* Overridden getInvocationType() where necessary.
* In particular, BufferedResponseHandler, EventsHandler and ThreadLimitHandler wrap the Response, which is used as a Callback and must report the correct InvocationType from the original Callback.
* Fixed EventsHandler to invoke the "responseWriteComplete" event _before_ completing the callback, as per javadoc specification.