### PR TITLE
Fixes for multipart ByteBufferPool usage

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPart.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPart.java
@@ -263,6 +263,17 @@ public class MultiPart
         }
 
         /**
+         * <p>Returns the {@link ByteBufferPool.Sized} used to create {@link Content.Source}s for this part.</p>
+         * <p>This may be null if the part was created without a buffer pool, which might be because the specific part
+         * implementation does not require one.</p>
+         * @return the buffer pool, or null if none was provided.
+         */
+        public ByteBufferPool.Sized getBufferPool()
+        {
+            return bufferPool;
+        }
+
+        /**
          * <p>Returns the content of this part as a {@link Content.Source}.</p>
          * <p>Calling this method multiple times will return the same instance, which can only be consumed once.</p>
          * <p>The content type and content encoding are specified in this part's
@@ -279,7 +290,7 @@ public class MultiPart
             try (AutoLock ignored = lock.lock())
             {
                 if (contentSource == null)
-                    contentSource = newContentSource(bufferPool, first, length);
+                    contentSource = createContentSource();
                 return contentSource;
             }
         }
@@ -302,6 +313,28 @@ public class MultiPart
         public Content.Source newContentSource()
         {
             return null;
+        }
+
+        /**
+         * <p>Returns the content of this part as a new {@link Content.Source}</p>
+         * <p>If the content is reproducible, invoking this method multiple times will return
+         * a different independent instance for every invocation.</p>
+         * <p>If the content is not reproducible, subsequent calls to this method will return null.</p>
+         * <p>The content type and content encoding are specified in this part's {@link #getHeaders() headers}.</p>
+         * <p>The content encoding may be specified by the part named {@code _charset_},
+         * as specified in
+         * <a href="https://datatracker.ietf.org/doc/html/rfc7578#section-4.6">RFC 7578, section 4.6</a>.</p>
+         *
+         * <p>This calls {@link #newContentSource(ByteBufferPool.Sized, long, long)} with the
+         * {@link ByteBufferPool.Sized} and {@code first}, and {@code length} arguments provided in the constructor.</p>
+         *
+         * @return the content of this part as a new {@link Content.Source} or null if the content cannot be consumed multiple times.
+         * @see #getContentSource()
+         * @see #newContentSource(ByteBufferPool.Sized, long, long)
+         */
+        public final Content.Source createContentSource()
+        {
+            return newContentSource(bufferPool, first, length);
         }
 
         /**
@@ -354,7 +387,7 @@ public class MultiPart
                 Charset charset = defaultCharset != null ? defaultCharset : UTF_8;
                 if (charsetName != null)
                     charset = Charset.forName(charsetName);
-                return Content.Source.asString(newContentSource(bufferPool, first, length), charset);
+                return Content.Source.asString(createContentSource(), charset);
             }
             catch (IOException x)
             {
@@ -384,7 +417,7 @@ public class MultiPart
             {
                 try (OutputStream out = Files.newOutputStream(path))
                 {
-                    IO.copy(Content.Source.asInputStream(newContentSource(bufferPool, first, length)), out);
+                    IO.copy(Content.Source.asInputStream(createContentSource()), out);
                 }
                 newPath = path;
             }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartConfig.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartConfig.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.http;
 
 import java.nio.file.Path;
 
+import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.util.Attributes;
 import org.eclipse.jetty.util.Promise;
@@ -47,6 +48,7 @@ public class MultiPartConfig
         private Boolean _useFilesForPartsWithoutFileName;
         private MultiPartCompliance _complianceMode;
         private ComplianceViolation.Listener _violationListener;
+        private ByteBufferPool.Sized _bufferPool;
 
         public Builder()
         {
@@ -146,6 +148,15 @@ public class MultiPartConfig
             return this;
         }
 
+        /**
+         * @param bufferPool the buffer pool to use.
+         */
+        public Builder bufferPool(ByteBufferPool.Sized bufferPool)
+        {
+            _bufferPool = bufferPool;
+            return this;
+        }
+
         public MultiPartConfig build()
         {
             return new MultiPartConfig(_location,
@@ -156,7 +167,8 @@ public class MultiPartConfig
                 _maxHeadersSize == null ? DEFAULT_MAX_HEADERS_SIZE : _maxHeadersSize,
                 _useFilesForPartsWithoutFileName == null ? DEFAULT_USE_FILES_FOR_PARTS_WITHOUT_FILE_NAME : _useFilesForPartsWithoutFileName,
                 _complianceMode == null ? MultiPartCompliance.RFC7578 : _complianceMode,
-                _violationListener == null ? NOOP : _violationListener);
+                _violationListener == null ? NOOP : _violationListener,
+                _bufferPool);
         }
     }
 
@@ -169,10 +181,11 @@ public class MultiPartConfig
     private final boolean _useFilesForPartsWithoutFileName;
     private final MultiPartCompliance _compliance;
     private final ComplianceViolation.Listener _listener;
+    private final ByteBufferPool.Sized _bufferPool;
 
     private MultiPartConfig(Path location, int maxParts, long maxSize, long maxPartSize, long maxMemoryPartSize,
                             int maxHeadersSize, boolean useFilesForPartsWithoutFileName,
-                            MultiPartCompliance compliance, ComplianceViolation.Listener listener)
+                            MultiPartCompliance compliance, ComplianceViolation.Listener listener, ByteBufferPool.Sized bufferPool)
     {
         this._location = location;
         this._maxParts = maxParts;
@@ -183,6 +196,7 @@ public class MultiPartConfig
         this._useFilesForPartsWithoutFileName = useFilesForPartsWithoutFileName;
         this._compliance = compliance;
         this._listener = listener;
+        this._bufferPool = bufferPool;
     }
 
     public Path getLocation()
@@ -228,5 +242,10 @@ public class MultiPartConfig
     public ComplianceViolation.Listener getViolationListener()
     {
         return _listener;
+    }
+
+    public ByteBufferPool.Sized getBufferPool()
+    {
+        return _bufferPool;
     }
 }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartFormData.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPartFormData.java
@@ -29,6 +29,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 
+import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.content.ContentSourceCompletableFuture;
 import org.eclipse.jetty.util.Attributes;
@@ -389,6 +390,7 @@ public class MultiPartFormData
     {
         private final PartsListener listener = new PartsListener();
         private final MultiPart.Parser parser;
+        private ByteBufferPool.Sized bufferPool;
         private MultiPartCompliance compliance;
         private ComplianceViolation.Listener complianceListener;
         private boolean useFilesForPartsWithoutFileName = true;
@@ -692,6 +694,7 @@ public class MultiPartFormData
             filesDirectory = config.getLocation();
             complianceListener = config.getViolationListener();
             compliance = config.getMultiPartCompliance();
+            bufferPool = config.getBufferPool();
         }
 
         // Only used for testing.
@@ -856,7 +859,7 @@ public class MultiPartFormData
 
                     MultiPart.Part part;
                     if (fileChannel != null)
-                        part = new MultiPart.PathPart(null, name, fileName, headers, filePath); // TODO use a pool
+                        part = new MultiPart.PathPart(bufferPool, name, fileName, headers, filePath);
                     else
                         part = new MultiPart.ChunksPart(name, fileName, headers, List.copyOf(partChunks));
                     // Reset part-related state.

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletMultiPartFormData.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletMultiPartFormData.java
@@ -178,21 +178,17 @@ public class ServletMultiPartFormData
                 {
                     // No existing core parts, so we need to configure the parser.
                     ServletContextHandler contextHandler = servletContextRequest.getServletContext().getServletContextHandler();
+                    ByteBufferPool byteBufferPool = servletContextRequest.getComponents().getByteBufferPool();
+                    ConnectionMetaData connectionMetaData = servletContextRequest.getConnectionMetaData();
+                    Connection connection = connectionMetaData.getConnection();
+                    int bufferSize = connection instanceof AbstractConnection c ? c.getInputBufferSize() : ByteBufferPool.SIZED_NON_POOLING.getSize();
+                    ByteBufferPool.Sized sized = new ByteBufferPool.Sized(byteBufferPool, false, bufferSize);
 
                     Content.Source source;
                     if (servletRequest instanceof ServletApiRequest servletApiRequest)
-                    {
                         source = servletApiRequest.getRequest();
-                    }
                     else
-                    {
-                        // TODO use the size specified in ByteBufferPool.SIZED_NON_POOLING instead of specifying a 2K buffer size?
-                        ByteBufferPool byteBufferPool = servletContextRequest.getComponents().getByteBufferPool();
-                        ConnectionMetaData connectionMetaData = servletContextRequest.getConnectionMetaData();
-                        Connection connection = connectionMetaData.getConnection();
-                        int bufferSize = connection instanceof AbstractConnection c ? c.getInputBufferSize() : 2048;
-                        source = new InputStreamContentSource(servletRequest.getInputStream(), new ByteBufferPool.Sized(byteBufferPool, false, bufferSize));
-                    }
+                        source = new InputStreamContentSource(servletRequest.getInputStream(), sized);
 
                     MultiPartConfig multiPartConfig = Request.getMultiPartConfig(servletContextRequest, filesDirectory)
                         .location(filesDirectory)
@@ -200,6 +196,7 @@ public class ServletMultiPartFormData
                         .maxMemoryPartSize(config.getFileSizeThreshold())
                         .maxPartSize(config.getMaxFileSize())
                         .maxSize(config.getMaxRequestSize())
+                        .bufferPool(sized)
                         .build();
 
                     futureServletParts = new CompletableFuture<>();
@@ -280,7 +277,7 @@ public class ServletMultiPartFormData
         @Override
         public InputStream getInputStream()
         {
-            return Content.Source.asInputStream(_part.newContentSource(null, 0L, -1L)); // TODO use a pool
+            return Content.Source.asInputStream(_part.createContentSource());
         }
 
         @Override

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/MultiPartServletTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/MultiPartServletTest.java
@@ -51,6 +51,7 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.http.MultiPart;
 import org.eclipse.jetty.http.MultiPartFormData;
+import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.EofException;
 import org.eclipse.jetty.io.content.InputStreamContentSource;
@@ -685,6 +686,54 @@ public class MultiPartServletTest
         // Even after the request is processed, the temp file should remain in the tmpDir.
         Thread.sleep(1000);
         assertThat(getTempDirFiles(), hasSize(1));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testByteBufferPool(boolean eager) throws Exception
+    {
+        String contentString = "the quick brown fox jumps over the lazy dog, " +
+            "the quick brown fox jumps over the lazy dog";
+
+        start(new HttpServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest request, HttpServletResponse response1) throws ServletException, IOException
+            {
+                Collection<Part> parts = request.getParts();
+                assertNotNull(parts);
+                assertEquals(1, parts.size());
+                Part part = parts.iterator().next();
+
+                String partContent = IO.toString(part.getInputStream(), UTF_8);
+                assertThat(partContent, equalTo(contentString));
+
+                // Get the core parts so we can check the type and buffer pool.
+                MultiPartFormData.Parts coreParts = MultiPartFormData.getParts(((ServletApiRequest)request).getRequest());
+                assertNotNull(coreParts);
+                assertEquals(1, coreParts.size());
+                MultiPart.Part corePart = coreParts.get(0);
+                assertThat(corePart, instanceOf(MultiPart.PathPart.class));
+                MultiPart.PathPart pathPart = (MultiPart.PathPart)corePart;
+                assertThat(pathPart.getBufferPool(), is(instanceOf(ByteBufferPool.Sized.class)));
+
+                response1.getWriter().print("success");
+            }
+        }, null, eager);
+
+        StringRequestContent content = new StringRequestContent(contentString);
+        MultiPartRequestContent multiPart = new MultiPartRequestContent();
+        multiPart.addPart(new MultiPart.ContentSourcePart("myPart", null, HttpFields.EMPTY, content));
+        multiPart.close();
+
+        ContentResponse response = client.newRequest("localhost", connector.getLocalPort())
+            .scheme(HttpScheme.HTTP.asString())
+            .method(HttpMethod.POST)
+            .body(multiPart)
+            .send();
+
+        assertEquals(200, response.getStatus());
+        assertThat(response.getContentAsString(), containsString("success"));
     }
 
     @SuppressWarnings("resource")

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletMultiPartFormData.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletMultiPartFormData.java
@@ -178,21 +178,17 @@ public class ServletMultiPartFormData
                 {
                     // No existing core parts, so we need to configure the parser.
                     ServletContextHandler contextHandler = servletContextRequest.getServletContext().getServletContextHandler();
+                    ByteBufferPool byteBufferPool = servletContextRequest.getComponents().getByteBufferPool();
+                    ConnectionMetaData connectionMetaData = servletContextRequest.getConnectionMetaData();
+                    Connection connection = connectionMetaData.getConnection();
+                    int bufferSize = connection instanceof AbstractConnection c ? c.getInputBufferSize() : ByteBufferPool.SIZED_NON_POOLING.getSize();
+                    ByteBufferPool.Sized sized = new ByteBufferPool.Sized(byteBufferPool, false, bufferSize);
 
                     Content.Source source;
                     if (servletRequest instanceof ServletApiRequest servletApiRequest)
-                    {
                         source = servletApiRequest.getRequest();
-                    }
                     else
-                    {
-                        // TODO use the size specified in ByteBufferPool.SIZED_NON_POOLING instead of specifying a 2K buffer size?
-                        ByteBufferPool byteBufferPool = servletContextRequest.getComponents().getByteBufferPool();
-                        ConnectionMetaData connectionMetaData = servletContextRequest.getConnectionMetaData();
-                        Connection connection = connectionMetaData.getConnection();
-                        int bufferSize = connection instanceof AbstractConnection c ? c.getInputBufferSize() : 2048;
-                        source = new InputStreamContentSource(servletRequest.getInputStream(), new ByteBufferPool.Sized(byteBufferPool, false, bufferSize));
-                    }
+                        source = new InputStreamContentSource(servletRequest.getInputStream(), sized);
 
                     MultiPartConfig multiPartConfig = Request.getMultiPartConfig(servletContextRequest, filesDirectory)
                         .location(filesDirectory)
@@ -200,6 +196,7 @@ public class ServletMultiPartFormData
                         .maxMemoryPartSize(config.getFileSizeThreshold())
                         .maxPartSize(config.getMaxFileSize())
                         .maxSize(config.getMaxRequestSize())
+                        .bufferPool(sized)
                         .build();
 
                     futureServletParts = new CompletableFuture<>();
@@ -280,7 +277,7 @@ public class ServletMultiPartFormData
         @Override
         public InputStream getInputStream()
         {
-            return Content.Source.asInputStream(_part.newContentSource(null, 0L, -1L)); // TODO use a pool
+            return Content.Source.asInputStream(_part.createContentSource());
         }
 
         @Override

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/MultiPartServletTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/MultiPartServletTest.java
@@ -51,6 +51,7 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.http.MultiPart;
 import org.eclipse.jetty.http.MultiPartFormData;
+import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.EofException;
 import org.eclipse.jetty.io.content.InputStreamContentSource;
@@ -680,6 +681,55 @@ public class MultiPartServletTest
         Thread.sleep(1000);
         assertThat(getTempDirFiles(), hasSize(1));
     }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testByteBufferPool(boolean eager) throws Exception
+    {
+        String contentString = "the quick brown fox jumps over the lazy dog, " +
+            "the quick brown fox jumps over the lazy dog";
+
+        start(new HttpServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest request, HttpServletResponse response1) throws ServletException, IOException
+            {
+                Collection<Part> parts = request.getParts();
+                assertNotNull(parts);
+                assertEquals(1, parts.size());
+                Part part = parts.iterator().next();
+
+                String partContent = IO.toString(part.getInputStream(), UTF_8);
+                assertThat(partContent, equalTo(contentString));
+
+                // Get the core parts so we can check the type and buffer pool.
+                MultiPartFormData.Parts coreParts = MultiPartFormData.getParts(((ServletApiRequest)request).getRequest());
+                assertNotNull(coreParts);
+                assertEquals(1, coreParts.size());
+                MultiPart.Part corePart = coreParts.get(0);
+                assertThat(corePart, instanceOf(MultiPart.PathPart.class));
+                MultiPart.PathPart pathPart = (MultiPart.PathPart)corePart;
+                assertThat(pathPart.getBufferPool(), is(instanceOf(ByteBufferPool.Sized.class)));
+
+                response1.getWriter().print("success");
+            }
+        }, null, eager);
+
+        StringRequestContent content = new StringRequestContent(contentString);
+        MultiPartRequestContent multiPart = new MultiPartRequestContent();
+        multiPart.addPart(new MultiPart.ContentSourcePart("myPart", null, HttpFields.EMPTY, content));
+        multiPart.close();
+
+        ContentResponse response = client.newRequest("localhost", connector.getLocalPort())
+            .scheme(HttpScheme.HTTP.asString())
+            .method(HttpMethod.POST)
+            .body(multiPart)
+            .send();
+
+        assertEquals(200, response.getStatus());
+        assertThat(response.getContentAsString(), containsString("success"));
+    }
+
 
     @SuppressWarnings("resource")
     private Collection<Path> getTempDirFiles() throws IOException

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/MultiPartServletTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/MultiPartServletTest.java
@@ -730,7 +730,6 @@ public class MultiPartServletTest
         assertThat(response.getContentAsString(), containsString("success"));
     }
 
-
     @SuppressWarnings("resource")
     private Collection<Path> getTempDirFiles() throws IOException
     {

--- a/tests/test-integration/src/test/java/org/eclipse/jetty/test/CoreMultiPartTest.java
+++ b/tests/test-integration/src/test/java/org/eclipse/jetty/test/CoreMultiPartTest.java
@@ -47,6 +47,8 @@ import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.http.MultiPart;
 import org.eclipse.jetty.http.MultiPartConfig;
 import org.eclipse.jetty.http.MultiPartFormData;
+import org.eclipse.jetty.io.ArrayByteBufferPool;
+import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.EofException;
 import org.eclipse.jetty.io.content.InputStreamContentSource;
@@ -537,11 +539,11 @@ public class CoreMultiPartTest
                 PrintWriter writer = new PrintWriter(Content.Sink.asOutputStream(response));
                 for (MultiPart.Part part : getParts(request, config))
                 {
-                    String partContent = IO.toString(Content.Source.asInputStream(part.getContentSource()));
+                    String partContent = IO.toString(Content.Source.asInputStream(part.createContentSource()));
                     writer.println("Part: name=" + part.getName() + ", size=" + part.getLength() + ", content=" + partContent);
 
                     // We can only consume the getContentSource() once so we must use newContentSource().
-                    partContent = IO.toString(Content.Source.asInputStream(part.newContentSource(null, 0, -1)));
+                    partContent = IO.toString(Content.Source.asInputStream(part.createContentSource()));
                     writer.println("Part: name=" + part.getName() + ", size=" + part.getLength() + ", content=" + partContent);
                 }
 
@@ -695,6 +697,62 @@ public class CoreMultiPartTest
         // Even after the request is processed, the temp file should remain in the tmpDir.
         Thread.sleep(1000);
         assertThat(getTempDirFiles(), hasSize(1));
+    }
+
+    @Test
+    public void testByteBufferPool() throws Exception
+    {
+        String contentString = "the quick brown fox jumps over the lazy dog, " +
+            "the quick brown fox jumps over the lazy dog";
+
+        ByteBufferPool.Sized sized = new ByteBufferPool.Sized(new ArrayByteBufferPool(), false, 1024);
+        start(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            {
+                response.getHeaders().put(HttpHeader.CONTENT_TYPE, "text/plain");
+                PrintWriter writer = new PrintWriter(Content.Sink.asOutputStream(response));
+                try
+                {
+                    MultiPartFormData.Parts parts = getParts(request, config);
+                    assertThat(parts.size(), is(1));
+                    MultiPart.Part part = parts.get(0);
+
+                    String partContent = IO.toString(Content.Source.asInputStream(part.createContentSource()));
+                    assertThat(partContent, equalTo(contentString));
+
+                    assertThat(part, instanceOf(MultiPart.PathPart.class));
+                    MultiPart.PathPart pathPart = (MultiPart.PathPart)part;
+                    assertThat(pathPart.getBufferPool(), is(instanceOf(ByteBufferPool.Sized.class)));
+
+                    writer.print("success");
+                    writer.close();
+                    callback.succeeded();
+                }
+                catch (Throwable t)
+                {
+                    t.printStackTrace(writer);
+                    writer.close();
+                }
+
+                return true;
+            }
+        }, new MultiPartConfig.Builder().location(tmpDir).maxMemoryPartSize(0).bufferPool(sized).build());
+
+        StringRequestContent content = new StringRequestContent(contentString);
+        MultiPartRequestContent multiPart = new MultiPartRequestContent();
+        multiPart.addPart(new MultiPart.ContentSourcePart("myPart", null, HttpFields.EMPTY, content));
+        multiPart.close();
+
+        ContentResponse response = client.newRequest("localhost", connector.getLocalPort())
+            .scheme(HttpScheme.HTTP.asString())
+            .method(HttpMethod.POST)
+            .body(multiPart)
+            .send();
+
+        assertEquals(200, response.getStatus());
+        assertThat(response.getContentAsString(), containsString("success"));
     }
 
     @SuppressWarnings("resource")


### PR DESCRIPTION
- ensure a `ByteBufferPool.Sized` is passed into the constructor for `PathPart`, which is provided as a new field on `MultiPartConfig`.
- add final method `createContentSource()` to `Part` so you don't need to manually use `newContentSource(ByteBufferPool.Sized bufferPool, long offset, long length)`, as those arguments are already provided to the `Part` constructor.
- Add new tests to ensure the `ByteBufferPool` is actually set on the parts.