### PR TITLE
Jetty 12.1.x simplified epc no pending (#13372)

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpChannelOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpChannelOverHTTP2.java
@@ -200,10 +200,11 @@ public class HttpChannelOverHTTP2 extends HttpChannel
         }
 
         @Override
-        public void onDataAvailable(Stream stream)
+        public void onDataAvailable(Stream stream, boolean dispatch)
         {
             HTTP2Channel.Client channel = (HTTP2Channel.Client)((HTTP2Stream)stream).getAttachment();
-            connection.offerTask(channel.onDataAvailable(), false);
+            Runnable task = channel.onDataAvailable();
+            connection.offerTask(task, dispatch);
         }
 
         @Override

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Connection.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Connection.java
@@ -186,6 +186,12 @@ public class HTTP2Connection extends AbstractConnection implements Parser.Listen
         return false;
     }
 
+    /**
+     * @param task  The task to offer to the connection.
+     * @param dispatch {@code true} to dispatch the task, {@code false} to produce in the calling thread.
+     *                 Callers from application threads should use {@code true}, otherwise they may be arbitrarily
+     *                 delayed. Callers from I/O threads should use {@code false} to avoid thread hops.
+     */
     public void offerTask(Runnable task, boolean dispatch)
     {
         offerTask(task);

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
@@ -389,7 +389,6 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
 
     private void onHeaders(HeadersFrame frame, Callback callback)
     {
-        boolean offered = false;
         MetaData metaData = frame.getMetaData();
         boolean isTrailer = !metaData.isRequest() && !metaData.isResponse();
         if (isTrailer)
@@ -398,10 +397,11 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
             // avoid race conditions due to concurrent calls to readData().
             boolean closed = updateClose(true, CloseState.Event.RECEIVED);
             notifyHeaders(this, frame);
+            // Offer EOF in case the application calls readData() or demand().
+            if (offer(Data.eof(getId())))
+                processData(true);
             if (closed)
                 getSession().removeStream(this);
-            // Offer EOF in case the application calls readData() or demand().
-            offered = offer(Data.eof(getId()));
         }
         else
         {
@@ -411,25 +411,21 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
                 length = fields.getLongField(HttpHeader.CONTENT_LENGTH);
             dataLength = length;
 
-            if (frame.isEndStream())
-            {
-                // Offer EOF for either the request or the response in
-                // case the application calls readData() or demand().
-                offered = offer(Data.eof(getId()));
-            }
+            // Offer EOF for either the request or the response in
+            // case the application calls readData() or demand().
+            boolean eof = frame.isEndStream() && offer(Data.eof(getId()));
 
             // Requests are notified to a Session.Listener, here only notify responses.
             if (metaData.isResponse())
             {
                 boolean closed = updateClose(frame.isEndStream(), CloseState.Event.RECEIVED);
                 notifyHeaders(this, frame);
+                if (eof)
+                    processData(true);
                 if (closed)
                     getSession().removeStream(this);
             }
         }
-
-        if (offered)
-            processData();
 
         callback.succeeded();
     }
@@ -462,7 +458,11 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
         }
 
         if (offer(data))
-            processData();
+        {
+            // Data was not immediately available, it has just
+            // now been notified to this method from the network.
+            processData(false);
+        }
     }
 
     private boolean offer(Data data)
@@ -533,10 +533,13 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
         if (LOG.isDebugEnabled())
             LOG.debug("Demand, {} data processing for {}", process ? "proceeding" : "stalling", this);
         if (process)
-            processData();
+        {
+            // Data is immediately available.
+            processData(true);
+        }
     }
 
-    public void processData()
+    public void processData(boolean immediate)
     {
         while (true)
         {
@@ -552,7 +555,7 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
                 dataDemand = false;
                 dataStalled = false;
             }
-            notifyDataAvailable(this);
+            notifyDataAvailable(this, immediate);
         }
     }
 
@@ -869,12 +872,12 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
         }
     }
 
-    private void notifyDataAvailable(Stream stream)
+    private void notifyDataAvailable(Stream stream, boolean immediate)
     {
         Listener listener = Objects.requireNonNullElse(this.listener, Listener.AUTO_DISCARD);
         try
         {
-            listener.onDataAvailable(stream);
+            listener.onDataAvailable(stream, immediate);
         }
         catch (Throwable x)
         {

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/api/Session.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/api/Session.java
@@ -228,12 +228,13 @@ public interface Session
          * <p>Applications can detect whether request DATA frames will be arriving
          * by testing {@link HeadersFrame#isEndStream()}. If the application is
          * interested in processing the DATA frames, it must demand for DATA
-         * frames using {@link Stream#demand()} and then return either a
-         * {@link Stream.Listener} implementation that overrides
-         * {@link Stream.Listener#onDataAvailable(Stream)} where applications can
-         * read from the {@link Stream} via {@link Stream#readData()}, or
-         * {@link Stream.Listener#AUTO_DISCARD} that automatically reads and
-         * discards DATA frames.
+         * frames using {@link Stream#demand()} and then return a
+         * {@link Stream.Listener} implementation that overrides either
+         * {@link Stream.Listener#onDataAvailable(Stream)} or
+         * {@link Stream.Listener#onDataAvailable(Stream, boolean)},
+         * where applications can read from the {@link Stream} via
+         * {@link Stream#readData()}, or return {@link Stream.Listener#AUTO_DISCARD}
+         * that automatically reads and discards DATA frames.
          * Returning {@code null} is possible but discouraged, and has the
          * same effect of demanding and discarding the DATA frames.</p>
          *

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/api/Stream.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/api/Stream.java
@@ -128,7 +128,7 @@ public interface Stream
      * @return a {@link Stream.Data} object containing the DATA frame,
      * or null if no DATA frame is available
      * @see #demand()
-     * @see Listener#onDataAvailable(Stream)
+     * @see Listener#onDataAvailable(Stream, boolean)
      */
     public Data readData();
 
@@ -229,22 +229,22 @@ public interface Stream
 
     /**
      * <p>Demands more {@code DATA} frames for this stream.</p>
-     * <p>Calling this method causes {@link Listener#onDataAvailable(Stream)}
+     * <p>Calling this method causes {@link Listener#onDataAvailable(Stream, boolean)}
      * to be invoked, possibly at a later time, when the stream has data
      * to be read, but also when the stream has reached EOF.</p>
      * <p>This method is idempotent: calling it when there already is an
-     * outstanding demand to invoke {@link Listener#onDataAvailable(Stream)}
+     * outstanding demand to invoke {@link Listener#onDataAvailable(Stream, boolean)}
      * is a no-operation.</p>
      * <p>The thread invoking this method may invoke directly
-     * {@link Listener#onDataAvailable(Stream)}, unless another thread
-     * that must invoke {@link Listener#onDataAvailable(Stream)}
+     * {@link Listener#onDataAvailable(Stream, boolean)}, unless another thread
+     * that must invoke {@link Listener#onDataAvailable(Stream, boolean)}
      * notices the outstanding demand first.</p>
      * <p>It is always guaranteed that invoking this method from within
-     * {@code onDataAvailable(Stream)} will not cause a
+     * {@code onDataAvailable(Stream, boolean)} will not cause a
      * {@link StackOverflowError}.</p>
      *
      * @see #readData()
-     * @see Listener#onDataAvailable(Stream)
+     * @see Listener#onDataAvailable(Stream, boolean)
      */
     public void demand();
 
@@ -298,12 +298,12 @@ public interface Stream
          * <p>Callback method invoked when a PUSH_PROMISE frame has been received.</p>
          * <p>Applications that override this method are typically interested in
          * processing the pushed stream DATA frames, and must demand for pushed
-         * DATA frames via {@link Stream#demand()} and then return either a
-         * {@link Listener} implementation that overrides
-         * {@link #onDataAvailable(Stream)} where applications can
-         * read from the {@link Stream} via {@link Stream#readData()}, or
-         * {@link #AUTO_DISCARD} that automatically reads and
-         * discards DATA frames.
+         * DATA frames via {@link Stream#demand()} and then return a
+         * {@link Listener} implementation that overrides either
+         * {@link #onDataAvailable(Stream)} or {@link #onDataAvailable(Stream, boolean)},
+         * where applications can read from the {@link Stream} via
+         * {@link Stream#readData()}, or return {@link #AUTO_DISCARD} that automatically
+         * reads and discards DATA frames.
          * Returning {@code null} is possible but discouraged, and has the
          * same effect of demanding and discarding the pushed DATA frames.</p>
          *
@@ -318,9 +318,32 @@ public interface Stream
         }
 
         /**
+         * <p>A simplified version of {@link #onDataAvailable(Stream, boolean)}.</p>
+         * <p>The default implementation of this method reads and discards data.</p>
+         *
+         * @param stream the stream
+         * @see Stream#demand()
+         */
+        default void onDataAvailable(Stream stream)
+        {
+            while (true)
+            {
+                Data data = stream.readData();
+                if (data == null)
+                {
+                    stream.demand();
+                    return;
+                }
+                data.release();
+                if (data.frame().isEndStream())
+                    return;
+            }
+        }
+
+        /**
          * <p>Callback method invoked if the application has expressed
          * {@link Stream#demand() demand} for DATA frames, and if there
-         * may be content available.</p>
+         * is content available.</p>
          * <p>Applications that wish to handle DATA frames should call
          * {@link Stream#demand()} for this method to be invoked when
          * the data is available.</p>
@@ -342,7 +365,7 @@ public interface Stream
          * class MyStreamListener implements Stream.Listener
          * {
          *     @Override
-         *     public void onDataAvailable(Stream stream)
+         *     public void onDataAvailable(Stream stream, boolean immediate)
          *     {
          *         // Read a chunk of the content.
          *         Stream.Data data = stream.readData();
@@ -366,24 +389,20 @@ public interface Stream
          *     }
          * }
          * }</pre>
+         * <p>The default implementation of this method calls
+         * {@link #onDataAvailable(Stream)}.</p>
          *
          * @param stream the stream
+         * @param immediate {@code true} when data is immediately available at the time
+         * {@link #demand()} is invoked (this method is directly invoked from {@link #demand()};
+         * {@code false} when data was not immediately available at the time {@link #demand()}
+         * was called, but is now available (this method is invoked from the network layer,
+         * not directly from {@link #demand()}
          * @see Stream#demand()
          */
-        public default void onDataAvailable(Stream stream)
+        default void onDataAvailable(Stream stream, boolean immediate)
         {
-            while (true)
-            {
-                Data data = stream.readData();
-                if (data == null)
-                {
-                    stream.demand();
-                    return;
-                }
-                data.release();
-                if (data.frame().isEndStream())
-                    return;
-            }
+            onDataAvailable(stream);
         }
 
         /**
@@ -465,7 +484,7 @@ public interface Stream
 
         private static class EOF extends Data
         {
-            public EOF(int streamId)
+            private EOF(int streamId)
             {
                 super(new DataFrame(streamId, BufferUtil.EMPTY_BUFFER, true));
             }

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/HTTP2ServerConnectionFactory.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/HTTP2ServerConnectionFactory.java
@@ -155,9 +155,9 @@ public class HTTP2ServerConnectionFactory extends AbstractHTTP2ServerConnectionF
         }
 
         @Override
-        public void onDataAvailable(Stream stream)
+        public void onDataAvailable(Stream stream, boolean immediate)
         {
-            getConnection().onDataAvailable(stream);
+            getConnection().onDataAvailable(stream, immediate);
         }
 
         @Override

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HTTP2ServerConnection.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HTTP2ServerConnection.java
@@ -149,7 +149,7 @@ public class HTTP2ServerConnection extends HTTP2Connection implements Connection
             offerTask(task, false);
     }
 
-    public void onDataAvailable(Stream stream)
+    public void onDataAvailable(Stream stream, boolean dispatch)
     {
         if (LOG.isDebugEnabled())
             LOG.debug("Processing data available on {}", stream);
@@ -159,7 +159,7 @@ public class HTTP2ServerConnection extends HTTP2Connection implements Connection
         {
             Runnable task = channel.onDataAvailable();
             if (task != null)
-                offerTask(task, false);
+                offerTask(task, dispatch);
         }
     }
 

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
@@ -227,7 +227,11 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
         {
             Runnable task = _httpChannel.onContentAvailable();
             if (task != null)
-                _connection.offerTask(task, false);
+            {
+                // We must dispatch, so an application thread does not 
+                // become a producer and then consume another request.
+                _connection.offerTask(task, true);
+            }
         }
         else if (demand)
         {

--- a/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpReceiverOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpReceiverOverHTTP3.java
@@ -120,7 +120,7 @@ public class HttpReceiverOverHTTP3 extends HttpReceiver implements Stream.Client
     }
 
     @Override
-    public void onDataAvailable(Stream.Client stream)
+    public void onDataAvailable(Stream.Client stream, boolean immediate)
     {
         if (LOG.isDebugEnabled())
             LOG.debug("Data available notification in {}", this);

--- a/jetty-core/jetty-http3/jetty-http3-client/src/main/java/org/eclipse/jetty/http3/client/HTTP3StreamClient.java
+++ b/jetty-core/jetty-http3/jetty-http3-client/src/main/java/org/eclipse/jetty/http3/client/HTTP3StreamClient.java
@@ -100,13 +100,13 @@ public class HTTP3StreamClient extends HTTP3Stream implements Stream.Client
         }
     }
 
-    protected void notifyDataAvailable()
+    protected void notifyDataAvailable(boolean immediate)
     {
         Listener listener = getListener();
         try
         {
             if (listener != null)
-                listener.onDataAvailable(this);
+                listener.onDataAvailable(this, immediate);
         }
         catch (Throwable x)
         {

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/HTTP3Stream.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/HTTP3Stream.java
@@ -227,7 +227,7 @@ public abstract class HTTP3Stream implements Stream, CyclicTimeouts.Expirable, A
             LOG.debug("demand, wasStalled={} dataAvailable={} on {}", process, hasData, this);
         if (process)
         {
-            processData();
+            processData(true);
         }
         else if (!hasData)
         {
@@ -236,7 +236,7 @@ public abstract class HTTP3Stream implements Stream, CyclicTimeouts.Expirable, A
         }
     }
 
-    private void processData()
+    private void processData(boolean immediate)
     {
         while (true)
         {
@@ -263,7 +263,7 @@ public abstract class HTTP3Stream implements Stream, CyclicTimeouts.Expirable, A
             if (!notify)
                 break;
 
-            onDataAvailable();
+            onDataAvailable(immediate);
         }
     }
 
@@ -324,11 +324,11 @@ public abstract class HTTP3Stream implements Stream, CyclicTimeouts.Expirable, A
             notIdle();
     }
 
-    private void onDataAvailable()
+    private void onDataAvailable(boolean immediate)
     {
         if (LOG.isDebugEnabled())
-            LOG.debug("notifying data available on {}", this);
-        notifyDataAvailable();
+            LOG.debug("notifying data available (immediate={}) on {}", immediate, this);
+        notifyDataAvailable(immediate);
     }
 
     public void onData(Data data)
@@ -348,10 +348,10 @@ public abstract class HTTP3Stream implements Stream, CyclicTimeouts.Expirable, A
         }
 
         if (process)
-            processData();
+            processData(false);
     }
 
-    protected abstract void notifyDataAvailable();
+    protected abstract void notifyDataAvailable(boolean immediate);
 
     public void onTrailer(HeadersFrame frame)
     {

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/api/Session.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/api/Session.java
@@ -155,14 +155,14 @@ public interface Session
              *     <li>return {@code null} to indicate that they are not interested in
              *     reading the content</li>
              *     <li><em>must</em> call {@link Stream#demand()} and return a {@link Stream.Server.Listener}
-             *     that overrides {@link Stream.Server.Listener#onDataAvailable(Stream.Server)} that reads
+             *     that overrides {@link Stream.Server.Listener#onDataAvailable(Stream.Server, boolean)} that reads
              *     and consumes the content.</li>
              * </ul>
              *
              * @param stream the stream associated with the request
              * @param frame the HEADERS frame containing the request headers
              * @return a {@link Stream.Server.Listener} that will be notified of stream events
-             * @see Stream.Server.Listener#onDataAvailable(Stream.Server)
+             * @see Stream.Server.Listener#onDataAvailable(Stream.Server, boolean)
              */
             public default Stream.Server.Listener onRequest(Stream.Server stream, HeadersFrame frame)
             {

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/api/Stream.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/api/Stream.java
@@ -86,15 +86,15 @@ public interface Stream
      *
      * @return a {@link Stream.Data} object containing the request bytes or
      * the response bytes, or null if no bytes are available
-     * @see Stream.Client.Listener#onDataAvailable(Stream.Client)
-     * @see Stream.Server.Listener#onDataAvailable(Stream.Server)
+     * @see Stream.Client.Listener#onDataAvailable(Stream.Client, boolean)
+     * @see Stream.Server.Listener#onDataAvailable(Stream.Server, boolean)
      */
     public Stream.Data readData();
 
     /**
      * <p>Demands more {@code DATA} frames for this stream.</p>
-     * <p>Calling this method causes {@link Stream.Client.Listener#onDataAvailable(Stream.Client)}
-     * on the client, or {@link Stream.Server.Listener#onDataAvailable(Stream.Server)}
+     * <p>Calling this method causes {@link Stream.Client.Listener#onDataAvailable(Stream.Client, boolean)}
+     * on the client, or {@link Stream.Server.Listener#onDataAvailable(Stream.Server, boolean)}
      * on the server, to be invoked, possibly at a later time, when the stream
      * has data to be read, but also when the stream has reached EOF.</p>
      * <p>This method is idempotent: calling it when there already is an
@@ -109,8 +109,8 @@ public interface Stream
      * {@link StackOverflowError}.</p>
      *
      * @see #readData()
-     * @see Stream.Client.Listener#onDataAvailable(Stream.Client)
-     * @see Stream.Server.Listener#onDataAvailable(Stream.Server)
+     * @see Stream.Client.Listener#onDataAvailable(Stream.Client, boolean)
+     * @see Stream.Server.Listener#onDataAvailable(Stream.Server, boolean)
      */
     public void demand();
 
@@ -156,16 +156,28 @@ public interface Stream
             /**
              * <p>Callback method invoked when a response is received.</p>
              * <p>To read response content, applications should call
-             * {@link Stream#demand()} and override
-             * {@link Stream.Client.Listener#onDataAvailable(Client)}.</p>
+             * {@link Stream#demand()} and override either
+             * {@link Stream.Client.Listener#onDataAvailable(Client)} or
+             * {@link Stream.Client.Listener#onDataAvailable(Client, boolean)}.</p>
              *
              * @param stream the stream
              * @param frame the HEADERS frame containing the response headers
-             * @see Stream.Client.Listener#onDataAvailable(Client)
+             * @see Stream.Client.Listener#onDataAvailable(Client, boolean)
              */
             public default void onResponse(Stream.Client stream, HeadersFrame frame)
             {
                 stream.demand();
+            }
+
+            /**
+             * <p>A simplified version of {@link #onDataAvailable(Stream.Client, boolean)}.</p>
+             * <p>The default implementation of this method reads and discards data.</p>
+             *
+             * @param stream the stream
+             * @see Stream#demand()
+             */
+            default void onDataAvailable(Stream.Client stream)
+            {
             }
 
             /**
@@ -215,12 +227,21 @@ public interface Stream
              *         }
              *     }
              * }
-             * </pre>
+             * }</pre>
+             * <p>The default implementation of this method calls
+             * {@link #onDataAvailable(Stream.Client)}.</p>
              *
              * @param stream the stream
+             * @param immediate {@code true} when data is immediately available at the time
+             * {@link #demand()} is invoked (this method is directly invoked from {@link #demand()};
+             * {@code false} when data was not immediately available at the time {@link #demand()}
+             * was called, but is now available (this method is invoked from the network layer,
+             * not directly from {@link #demand()}
+             * @see Stream#demand()
              */
-            public default void onDataAvailable(Stream.Client stream)
+            default void onDataAvailable(Stream.Client stream, boolean immediate)
             {
+                onDataAvailable(stream);
             }
 
             /**
@@ -285,6 +306,17 @@ public interface Stream
         public interface Listener
         {
             /**
+             * <p>A simplified version of {@link #onDataAvailable(Stream.Server, boolean)}.</p>
+             * <p>The default implementation of this method reads and discards data.</p>
+             *
+             * @param stream the stream
+             * @see Stream#demand()
+             */
+            default void onDataAvailable(Stream.Server stream)
+            {
+            }
+
+            /**
              * <p>Callback method invoked if the application has expressed
              * {@link Stream#demand() demand} for content, and if there may
              * be content available.</p>
@@ -304,11 +336,11 @@ public interface Stream
              * <p>It is always guaranteed that invoking {@link Stream#demand()}
              * from within this method will not cause a {@link StackOverflowError}.</p>
              * <p>Typical usage:</p>
-             * <pre>
+             * <pre>{@code
              * class MyStreamListener implements Stream.Server.Listener
              * {
-             *     &#64;Override
-             *     public void onDataAvailable(Stream.Server stream)
+             *     @Override
+             *     public void onDataAvailable(Stream.Server stream, boolean immediate)
              *     {
              *         // Read a chunk of the content.
              *         Stream.Data data = stream.readData();
@@ -331,12 +363,21 @@ public interface Stream
              *         }
              *     }
              * }
-             * </pre>
+             * }</pre>
+             * <p>The default implementation of this method calls
+             * {@link #onDataAvailable(Stream.Server)}.</p>
              *
              * @param stream the stream
+             * @param immediate {@code true} when data is immediately available at the time
+             * {@link #demand()} is invoked (this method is directly invoked from {@link #demand()};
+             * {@code false} when data was not immediately available at the time {@link #demand()}
+             * was called, but is now available (this method is invoked from the network layer,
+             * not directly from {@link #demand()}
+             * @see Stream#demand()
              */
-            public default void onDataAvailable(Stream.Server stream)
+            default void onDataAvailable(Stream.Server stream, boolean immediate)
             {
+                onDataAvailable(stream);
             }
 
             /**

--- a/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/HTTP3ServerConnectionFactory.java
+++ b/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/HTTP3ServerConnectionFactory.java
@@ -139,14 +139,14 @@ public class HTTP3ServerConnectionFactory extends AbstractHTTP3ServerConnectionF
         }
 
         @Override
-        public void onDataAvailable(Stream.Server stream)
+        public void onDataAvailable(Stream.Server stream, boolean immediate)
         {
             HTTP3Stream http3Stream = (HTTP3Stream)stream;
             Runnable task = getConnection().onDataAvailable(http3Stream);
             if (task != null)
             {
                 ServerHTTP3Session protocolSession = (ServerHTTP3Session)http3Stream.getSession().getProtocolSession();
-                protocolSession.offer(task, false);
+                protocolSession.offer(task, immediate);
             }
         }
 

--- a/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HTTP3StreamServer.java
+++ b/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HTTP3StreamServer.java
@@ -72,13 +72,13 @@ public class HTTP3StreamServer extends HTTP3Stream implements Stream.Server
         return write(frame);
     }
 
-    protected void notifyDataAvailable()
+    protected void notifyDataAvailable(boolean immediate)
     {
         Stream.Server.Listener listener = this.listener;
         try
         {
             if (listener != null)
-                listener.onDataAvailable(this);
+                listener.onDataAvailable(this, immediate);
         }
         catch (Throwable x)
         {

--- a/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HttpStreamOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HttpStreamOverHTTP3.java
@@ -193,7 +193,11 @@ public class HttpStreamOverHTTP3 implements HttpStream
         {
             Runnable task = httpChannel.onContentAvailable();
             if (task != null)
-                connection.offer(task);
+            {
+                // We must dispatch, so an application thread does not
+                // become a producer and then consume another request.
+                connection.offer(task, true);
+            }
         }
         else
         {

--- a/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/ServerHTTP3StreamConnection.java
+++ b/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/ServerHTTP3StreamConnection.java
@@ -92,9 +92,9 @@ public class ServerHTTP3StreamConnection extends HTTP3StreamConnection
         return httpStream.onFailure(failure);
     }
 
-    void offer(Runnable task)
+    void offer(Runnable task, boolean dispatch)
     {
-        session.offer(task, false);
+        session.offer(task, dispatch);
     }
 
     private class MetaData implements ConnectionMetaData

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/strategy/AdaptiveExecutionStrategy.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/strategy/AdaptiveExecutionStrategy.java
@@ -14,14 +14,13 @@
 package org.eclipse.jetty.util.thread.strategy;
 
 import java.io.Closeable;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 
-import org.eclipse.jetty.util.AtomicBiInteger;
 import org.eclipse.jetty.util.IO;
+import org.eclipse.jetty.util.TypeUtil;
 import org.eclipse.jetty.util.VirtualThreads;
 import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.annotation.ManagedObject;
@@ -98,9 +97,12 @@ public class AdaptiveExecutionStrategy extends ContainerLifeCycle implements Exe
     /**
      * The production state of the strategy.
      */
-    private static final int IDLE = 0;        // No tasks or producers.
-    private static final int PRODUCING = 1;   // There is an active producing thread.
-    private static final int REPRODUCING = 2; // There is an active producing thread and demand for more production.
+    private enum State
+    {
+        IDLE,       // No tasks or producers.
+        PRODUCING,  // There is an active producing thread.
+        REPRODUCING // There is an active producing thread and demand for more production.
+    }
 
     /**
      * The sub-strategies used by the strategy to consume tasks that are produced.
@@ -129,11 +131,12 @@ public class AdaptiveExecutionStrategy extends ContainerLifeCycle implements Exe
     private final LongAdder _picMode = new LongAdder();
     private final LongAdder _pecMode = new LongAdder();
     private final LongAdder _epcMode = new LongAdder();
+    private final LongAdder _epcProduce = new LongAdder();
     private final Producer _producer;
     private final Executor _executor;
     private final TryExecutor _tryExecutor;
     private final Executor _virtualExecutor;
-    private final AtomicBiInteger _state = new AtomicBiInteger();
+    private final AtomicReference<State> _state = new AtomicReference<>(State.IDLE);
 
     /**
      * @param producer The producer of tasks to be consumed.
@@ -158,23 +161,15 @@ public class AdaptiveExecutionStrategy extends ContainerLifeCycle implements Exe
         boolean execute = false;
         loop: while (true)
         {
-            long biState = _state.get();
-            int state = AtomicBiInteger.getLo(biState);
-            int pending = AtomicBiInteger.getHi(biState);
-
+            State state = _state.get();
             switch (state)
             {
                 case IDLE:
-                    if (pending <= 0)
-                    {
-                        if (!_state.compareAndSet(biState, pending + 1, state))
-                            continue;
-                        execute = true;
-                    }
+                    execute = true;
                     break loop;
 
                 case PRODUCING:
-                    if (!_state.compareAndSet(biState, pending, REPRODUCING))
+                    if (!_state.compareAndSet(State.PRODUCING, State.REPRODUCING))
                         continue;
                     break loop;
 
@@ -186,47 +181,44 @@ public class AdaptiveExecutionStrategy extends ContainerLifeCycle implements Exe
         if (LOG.isDebugEnabled())
             LOG.debug("{} dispatch {}", this, execute);
         if (execute)
-            _executor.execute(this);
+        {
+            // Try to avoid queuing a producer if we can run it directly.
+            if (!_tryExecutor.tryExecute(this))
+                _executor.execute(this);
+        }
     }
 
     @Override
     public void produce()
     {
-        tryProduce(false);
+        if (LOG.isDebugEnabled())
+            LOG.debug("produce() producing {}", this);
+        tryProduce();
     }
 
     @Override
     public void run()
     {
-        tryProduce(true);
+        if (LOG.isDebugEnabled())
+            LOG.debug("dispatch() producing {}", this);
+        tryProduce();
     }
 
     /**
      * Tries to become the producing thread and then produces and consumes tasks.
-     *
-     * @param wasPending True if the calling thread was started as a pending producer.
      */
-    private void tryProduce(boolean wasPending)
+    private void tryProduce()
     {
-        if (LOG.isDebugEnabled())
-            LOG.debug("{} tryProduce {}", this, wasPending);
-
         // check if the thread can produce.
         loop: while (true)
         {
-            long biState = _state.get();
-            int state = AtomicBiInteger.getLo(biState);
-            int pending = AtomicBiInteger.getHi(biState);
-
-            // If the calling thread was the pending producer, there is no longer one pending.
-            if (wasPending)
-                pending--;
+            State state = _state.get();
 
             switch (state)
             {
                 case IDLE:
                     // The strategy was IDLE, so this thread can become the producer.
-                    if (!_state.compareAndSet(biState, pending, PRODUCING))
+                    if (!_state.compareAndSet(state, State.PRODUCING))
                         continue;
                     break loop;
 
@@ -234,65 +226,62 @@ public class AdaptiveExecutionStrategy extends ContainerLifeCycle implements Exe
                     // The strategy is already producing, so another thread must be the producer.
                     // However, it may be just about to stop being the producer so we set the
                     // REPRODUCING state to force it to produce at least once more.
-                    if (!_state.compareAndSet(biState, pending, REPRODUCING))
+                    if (!_state.compareAndSet(state, State.REPRODUCING))
                         continue;
                     return;
 
                 case REPRODUCING:
                     // Another thread is already producing and will already try again to produce.
-                    if (!_state.compareAndSet(biState, pending, state))
-                        continue;
                     return;
 
                 default:
-                    throw new IllegalStateException(toString(biState));
+                    throw new IllegalStateException(toString(state));
             }
         }
 
-        // Determine the thread's invocation type once, outside of the production loop.
+        if (LOG.isDebugEnabled())
+            LOG.debug("producing {}", this);
+
+        // Determine the thread's invocation type once, outside the production loop.
         boolean nonBlocking = Invocable.isNonBlockingInvocation();
         running: while (isRunning())
         {
             try
             {
                 Runnable task = produceTask();
-
-                // If we did not produce a task
-                if (task == null)
+                if (task != null)
                 {
-                    // determine if we should keep producing.
-                    while (true)
-                    {
-                        long biState = _state.get();
-                        int state = AtomicBiInteger.getLo(biState);
-                        int pending = AtomicBiInteger.getHi(biState);
-
-                        switch (state)
-                        {
-                            case PRODUCING:
-                                // The calling thread was the only producer, so it is now IDLE and we stop producing.
-                                if (!_state.compareAndSet(biState, pending, IDLE))
-                                    continue;
-                                return;
-
-                            case REPRODUCING:
-                                // Another thread may have queued a task and tried to produce
-                                // so the calling thread should continue to produce.
-                                if (!_state.compareAndSet(biState, pending, PRODUCING))
-                                    continue;
-                                continue running;
-
-                            default:
-                                throw new IllegalStateException(toString(biState));
-                        }
-                    }
+                    // Consume the task according to a selected substrategy.
+                    if (consumeTask(task, selectSubStrategy(task, nonBlocking)))
+                        // continue producing
+                        continue;
+                    // do not continue producing
+                    return;
                 }
 
-                // Consume the task according the selected sub-strategy, then
-                // continue producing only if the sub-strategy returns true.
-                if (consumeTask(task, selectSubStrategy(task, nonBlocking)))
-                    continue;
-                return;
+                // No task produce, so determine if we should keep producing.
+                while (true)
+                {
+                    State state = _state.get();
+                    switch (state)
+                    {
+                        case PRODUCING:
+                            // This thread is still the producer, so it is now IDLE and we stop producing.
+                            if (!_state.compareAndSet(state, State.IDLE))
+                                continue;
+                            return;
+
+                        case REPRODUCING:
+                            // Another thread may have queued a task and tried to produce
+                            // so the calling thread should continue to produce.
+                            if (!_state.compareAndSet(state, State.PRODUCING))
+                                continue;
+                            continue running;
+
+                        default:
+                            throw new IllegalStateException(toString(state));
+                    }
+                }
             }
             catch (Throwable th)
             {
@@ -327,34 +316,8 @@ public class AdaptiveExecutionStrategy extends ContainerLifeCycle implements Exe
                 if (nonBlocking)
                     return SubStrategy.PRODUCE_CONSUME;
 
-                // check if a pending producer is available.
-                boolean tryExecuted = false;
-                while (true)
-                {
-                    long biState = _state.get();
-                    int state = AtomicBiInteger.getLo(biState);
-                    int pending = AtomicBiInteger.getHi(biState);
-
-                    // If a pending producer is available or one can be started
-                    if (tryExecuted || pending <= 0 && _tryExecutor.tryExecute(this))
-                    {
-                        tryExecuted = true;
-                        pending++;
-                    }
-
-                    if (pending > 0)
-                    {
-                        // Use EPC: this producer thread directly consumes the task, which may block
-                        // and then races with the pending producer to resume production.
-                        if (!_state.compareAndSet(biState, pending, IDLE))
-                            continue;
-                        return SubStrategy.EXECUTE_PRODUCE_CONSUME;
-                    }
-
-                    if (!_state.compareAndSet(biState, pending, state))
-                        continue;
-                    break;
-                }
+                if (tryExecuteProduceConsume())
+                    return SubStrategy.EXECUTE_PRODUCE_CONSUME;
 
                 // Otherwise use PIC: this producer thread consumes the task
                 // in non-blocking mode and then resumes production.
@@ -371,41 +334,50 @@ public class AdaptiveExecutionStrategy extends ContainerLifeCycle implements Exe
                 if (nonBlocking)
                     return SubStrategy.PRODUCE_EXECUTE_CONSUME;
 
-                // check if a pending producer is available.
-                boolean tryExecuted = false;
-                while (true)
-                {
-                    long biState = _state.get();
-                    int state = AtomicBiInteger.getLo(biState);
-                    int pending = AtomicBiInteger.getHi(biState);
+                if (tryExecuteProduceConsume())
+                    return SubStrategy.EXECUTE_PRODUCE_CONSUME;
 
-                    // If a pending producer is available or one can be started
-                    if (tryExecuted || pending <= 0 && _tryExecutor.tryExecute(this))
-                    {
-                        tryExecuted = true;
-                        pending++;
-                    }
-
-                    // If a pending producer is available or one can be started
-                    if (pending > 0)
-                    {
-                        // use EPC: This producer thread directly consumes the task, which may block
-                        // and then races with the pending producer to resume production.
-                        if (!_state.compareAndSet(biState, pending, IDLE))
-                            continue;
-                        return SubStrategy.EXECUTE_PRODUCE_CONSUME;
-                    }
-
-                    if (!_state.compareAndSet(biState, pending, state))
-                        continue;
-
-                    // Otherwise use PEC: the task is consumed by the executor and this producer thread continues to produce.
-                    return SubStrategy.PRODUCE_EXECUTE_CONSUME;
-                }
+                // Otherwise use PEC: the task is consumed by the executor and this producer thread continues to produce.
+                return SubStrategy.PRODUCE_EXECUTE_CONSUME;
             }
 
             default:
                 throw new IllegalStateException(String.format("taskType=%s %s", taskType, this));
+        }
+    }
+
+    private boolean tryExecuteProduceConsume()
+    {
+        // Try to go in EPC mode from PRODUCING/REPRODUCING, but only
+        // if we can guarantee that there is another producer thread.
+
+        State state = _state.get();
+        if (!_state.compareAndSet(state, State.IDLE))
+            return false;
+
+        // If we can execute another producer, then we are EPC.
+        if (_tryExecutor.tryExecute(this))
+            return true;
+
+        // No reserved thread available, so we need to try to return to production.
+        while (true)
+        {
+            state = _state.get();
+            switch (state)
+            {
+                case IDLE:
+                    if (!_state.compareAndSet(state, State.PRODUCING))
+                        continue;
+                    // We are the producer again, so we are not EPC.
+                    return false;
+                case PRODUCING:
+                    if (!_state.compareAndSet(state, State.REPRODUCING))
+                        continue;
+                    // Somebody else is producing so we can be EPC.
+                    return true;
+                case REPRODUCING:
+                    return true;
+            }
         }
     }
 
@@ -421,50 +393,90 @@ public class AdaptiveExecutionStrategy extends ContainerLifeCycle implements Exe
         // Consume and/or execute task according to the selected mode.
         if (LOG.isDebugEnabled())
             LOG.debug("consumeTask ss={}/{}/{} t={} {}", subStrategy, Invocable.isNonBlockingInvocation(), Invocable.getInvocationType(task), task, this);
-        switch (subStrategy)
+        return switch (subStrategy)
         {
-            case PRODUCE_CONSUME:
-                _pcMode.increment();
-                runTask(task);
-                return true;
+            case PRODUCE_CONSUME -> pcRunTask(task);
+            case PRODUCE_INVOKE_CONSUME -> picRunTask(task);
+            case PRODUCE_EXECUTE_CONSUME -> pecRunTask(task);
+            case EXECUTE_PRODUCE_CONSUME -> epcRunTask(task);
+        };
+    }
 
-            case PRODUCE_INVOKE_CONSUME:
-                _picMode.increment();
-                invokeAsNonBlocking(task);
-                return true;
+    /**
+     * Runs a task in produce-consume mode.
+     *
+     * @param task the task to run
+     * @return always true, as this thread remains the producer
+     */
+    private boolean pcRunTask(Runnable task)
+    {
+        _pcMode.increment();
+        runTask(task);
+        return true;
+    }
 
-            case PRODUCE_EXECUTE_CONSUME:
-                _pecMode.increment();
-                execute(task);
-                return true;
+    /**
+     * Runs a task in execute-produce-consume mode.
+     *
+     * @param task the task to run
+     * @return whether this thread remains the producer
+     */
+    private boolean epcRunTask(Runnable task)
+    {
+        _epcMode.increment();
 
-            case EXECUTE_PRODUCE_CONSUME:
-                _epcMode.increment();
-                runTask(task);
+        runTask(task);
 
-                // Race the pending producer to produce again.
-                while (true)
-                {
-                    long biState = _state.get();
-                    int state = AtomicBiInteger.getLo(biState);
-                    int pending = AtomicBiInteger.getHi(biState);
+        // Race the pending producer to produce again.
+        while (true)
+        {
+            State state = _state.get();
+            if (state != State.IDLE)
+                // The pending producer is now producing, so this thread no longer produces.
+                return false;
 
-                    if (state == IDLE)
-                    {
-                        // We beat the pending producer, so we will become the producer instead.
-                        // The pending produce will become a noop if it arrives whilst we are producing,
-                        // or it may take over if we subsequently do another EPC consumption.
-                        if (!_state.compareAndSet(biState, pending, PRODUCING))
-                            continue;
-                        return true;
-                    }
+            if (!_state.compareAndSet(state, State.PRODUCING))
+                continue;
 
-                    // The pending producer is now producing, so this thread no longer produces.
-                    return false;
-                }
+            // We beat the pending producer, so we will become the producer instead.
+            // The pending producer will become a noop if it arrives whilst we are producing,
+            // or it may take over if we subsequently do another EPC consumption.
+            _epcProduce.increment();
+            return true;
+        }
+    }
 
-            default:
-                throw new IllegalStateException(String.format("ss=%s %s", subStrategy, this));
+    /**
+     * Runs a task in produce-execute-consume mode.
+     *
+     * @param task the task to run
+     * @return always true, as this thread remains the producer
+     */
+    private boolean pecRunTask(Runnable task)
+    {
+        _pecMode.increment();
+        execute(task);
+        return true;
+    }
+
+    /**
+     * Runs a task in produce-invoke-consume mode.
+     *
+     * @param task the task to run
+     * @return always true, as this thread remains the producer
+     */
+    private boolean picRunTask(Runnable task)
+    {
+        try
+        {
+            _picMode.increment();
+            Invocable.invokeNonBlocking(task);
+            return true;
+        }
+        catch (Throwable x)
+        {
+            LOG.warn("Task invoke failed", x);
+            return true;
         }
     }
 
@@ -577,10 +589,16 @@ public class AdaptiveExecutionStrategy extends ContainerLifeCycle implements Exe
         return _epcMode.longValue();
     }
 
+    @ManagedAttribute(value = "number of times a EPC thread produces again", readonly = true)
+    public long getEPCProduceCount()
+    {
+        return _epcProduce.longValue();
+    }
+
     @ManagedAttribute(value = "whether this execution strategy is idle", readonly = true)
     public boolean isIdle()
     {
-        return _state.getLo() == IDLE;
+        return _state.get() == State.IDLE;
     }
 
     @ManagedOperation(value = "resets the task counts", impact = "ACTION")
@@ -598,50 +616,39 @@ public class AdaptiveExecutionStrategy extends ContainerLifeCycle implements Exe
         return toString(_state.get());
     }
 
-    public String toString(long biState)
+    private String toString(State state)
     {
         StringBuilder builder = new StringBuilder();
         getString(builder);
-        getState(builder, biState);
+        getState(builder, state);
         return builder.toString();
     }
 
     private void getString(StringBuilder builder)
     {
-        builder.append(getClass().getSimpleName());
-        builder.append('@');
-        builder.append(Integer.toHexString(hashCode()));
-        builder.append('/');
-        builder.append(_producer);
-        builder.append('/');
+        builder.append(TypeUtil.toShortName(getClass()))
+            .append('@')
+            .append(Integer.toHexString(hashCode()))
+            .append('/')
+            .append(_producer)
+            .append('/');
     }
 
-    private void getState(StringBuilder builder, long biState)
+    private void getState(StringBuilder builder, State state)
     {
-        int state = AtomicBiInteger.getLo(biState);
-        int pending = AtomicBiInteger.getHi(biState);
-        builder.append(
-            switch (state)
-            {
-                case IDLE -> "IDLE";
-                case PRODUCING -> "PRODUCING";
-                case REPRODUCING -> "REPRODUCING";
-                default -> "UNKNOWN(%d)".formatted(state);
-            });
-        builder.append("/p=");
-        builder.append(pending);
-        builder.append('/');
-        builder.append(_tryExecutor);
-        builder.append("[pc=");
-        builder.append(getPCTasksConsumed());
-        builder.append(",pic=");
-        builder.append(getPICTasksExecuted());
-        builder.append(",pec=");
-        builder.append(getPECTasksExecuted());
-        builder.append(",epc=");
-        builder.append(getEPCTasksConsumed());
-        builder.append("]");
-        builder.append("@");
-        builder.append(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now()));
+        builder.append(state)
+            .append('/')
+            .append(_tryExecutor)
+            .append("[pc=")
+            .append(getPCTasksConsumed())
+            .append(",pic=")
+            .append(getPICTasksExecuted())
+            .append(",pec=")
+            .append(getPECTasksExecuted())
+            .append(",epc=")
+            .append(getEPCProduceCount())
+            .append("/")
+            .append(getEPCTasksConsumed())
+            .append("]");
     }
 }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/thread/strategy/ExecutionStrategyTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/thread/strategy/ExecutionStrategyTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import org.eclipse.jetty.util.VirtualThreads;
@@ -41,6 +42,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ExecutionStrategyTest
@@ -167,7 +169,7 @@ public class ExecutionStrategyTest
 
         Producer producer = new TestProducer()
         {
-            AtomicInteger tasks = new AtomicInteger(TASKS);
+            final AtomicInteger tasks = new AtomicInteger(TASKS);
 
             @Override
             public Runnable produce()
@@ -205,7 +207,7 @@ public class ExecutionStrategyTest
                 for (int t = TASKS; t-- > 0; )
                 {
                     Thread.sleep(5);
-                    q.offer(latch);
+                    assertTrue(q.offer(latch));
                 }
             }
             catch (Exception e)
@@ -219,5 +221,74 @@ public class ExecutionStrategyTest
                 strategy, TASKS, latch.getCount(), q.size(), threadPool instanceof Dumpable dumpable ? dumpable.dump() : ""));
 
         LifeCycle.stop(threadPool);
+    }
+
+    @ParameterizedTest
+    @MethodSource("pooledStrategies")
+    public void testRecursion(Class<? extends ThreadPool> threadPoolClass, Class<? extends ExecutionStrategy> strategyClass) throws Exception
+    {
+        ThreadPool threadPool = threadPoolClass.getDeclaredConstructor().newInstance();
+        LifeCycle.start(threadPool);
+        try
+        {
+            final int TASKS = 100;
+            CountDownLatch latch = new CountDownLatch(TASKS);
+            AtomicReference<ExecutionStrategy> strategyRef = new AtomicReference<>();
+            AtomicReference<Throwable> failureRef = new AtomicReference<>();
+            Producer producer = new TestProducer()
+            {
+                private static final ThreadLocal<Thread> THREAD = new ThreadLocal<>();
+                int tasks = TASKS;
+
+                @Override
+                public Runnable produce()
+                {
+                    if (tasks-- > 0)
+                    {
+                        // Return a BLOCKING task.
+                        return () ->
+                        {
+                            Thread thread = THREAD.get();
+                            if (thread != null)
+                                failureRef.compareAndSet(null, new AssertionError("recursion detected"));
+                            THREAD.set(Thread.currentThread());
+                            try
+                            {
+                                if (tasks > 0)
+                                {
+                                    // Calling produce() here will cause
+                                    // recursion and the test will fail.
+                                    strategyRef.get().dispatch();
+                                }
+                                latch.countDown();
+                            }
+                            finally
+                            {
+                                THREAD.set(null);
+                            }
+                        };
+                    }
+                    return null;
+                }
+            };
+
+            ExecutionStrategy strategy = newExecutionStrategy(strategyClass, producer, threadPool);
+            strategyRef.set(strategy);
+            strategy.produce();
+
+            assertTrue(latch.await(10, TimeUnit.SECONDS), () ->
+            {
+                // Dump state on failure.
+                return String.format("Timed out waiting for latch: %s%ntasks=%d latch=%d%n%s",
+                    strategy, TASKS, latch.getCount(), threadPool instanceof Dumpable dumpable ? dumpable.dump() : "");
+            });
+
+            Throwable failure = failureRef.get();
+            assertThat(String.valueOf(failure), failure, nullValue());
+        }
+        finally
+        {
+            LifeCycle.stop(threadPool);
+        }
     }
 }


### PR DESCRIPTION
Simplified EPC ExecutionStrategy

Only have a single attempt at EPC, never loop.
Set IDLE before the attempt so a reserved thread can always become the producer

added dispatch=true to h2/h3 demand mechanisms to avoid recursion in offerTask

(cherry picked from commit 7e4a9beb4adff3a27fc427752226ce7d07677e85)