### PR TITLE
Fixes #13621 - Restore BufferingResponseListener.onContent(Response, ByteBuffer) behavior.

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractResponseListener.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractResponseListener.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.client;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
@@ -32,6 +33,7 @@ public abstract class AbstractResponseListener implements Response.Listener
     private String encoding;
     private String mediaType;
     private byte[] content;
+    private boolean append;
 
     protected AbstractResponseListener(RetainableByteBuffer.Mutable accumulator)
     {
@@ -100,10 +102,27 @@ public abstract class AbstractResponseListener implements Response.Listener
     @Override
     public void onContent(Response response, Content.Chunk chunk, Runnable demander) throws Exception
     {
-        if (accumulator.append(chunk))
-            demander.run();
+        onContent(response, chunk.getByteBuffer());
+        if (append)
+        {
+            append = false;
+            if (accumulator.append(chunk))
+                demander.run();
+            else
+                response.abort(new IllegalArgumentException("Buffering capacity " + getMaxLength() + " exceeded"));
+        }
         else
-            response.abort(new IllegalArgumentException("Buffering capacity " + getMaxLength() + " exceeded"));
+        {
+            demander.run();
+        }
+    }
+
+    @Override
+    public void onContent(Response response, ByteBuffer content)
+    {
+        // For backward compatibility, mark whether applications called
+        // this method, which means they wanted to perform accumulation.
+        append = true;
     }
 
     @Override

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientDemandTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientDemandTest.java
@@ -16,7 +16,9 @@ package org.eclipse.jetty.test.client.transport;
 import java.io.InterruptedIOException;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.Random;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -25,6 +27,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
 import java.util.zip.GZIPOutputStream;
 
 import org.eclipse.jetty.client.BufferingResponseListener;
@@ -44,10 +47,12 @@ import org.eclipse.jetty.util.IteratingNestedCallback;
 import org.eclipse.jetty.util.NanoTime;
 import org.eclipse.jetty.util.thread.Invocable;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
@@ -60,6 +65,59 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 public class HttpClientDemandTest extends AbstractTest
 {
+    public static Stream<Arguments> bufferingParams()
+    {
+        String content = "ABCDEF";
+        return Arrays.stream(TransportType.values()).flatMap(transportType ->
+            Stream.of(
+                Arguments.of(transportType, content, /*consumeBuffer*/false, /*invokeSuper*/false, /*expectedContent*/""),
+                Arguments.of(transportType, content, true, false, ""),
+                Arguments.of(transportType, content, false, true, content),
+                Arguments.of(transportType, content, true, true, "")
+            )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("bufferingParams")
+    public void testBufferingResponseListenerOverridingOnContent(TransportType transportType, String content, boolean consumeBuffer, boolean invokeSuper, String expectedContent) throws Exception
+    {
+        start(transportType, new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
+            {
+                Content.Sink.write(response, true, content, callback);
+                return true;
+            }
+        });
+
+        AtomicReference<String> contentRef = new AtomicReference<>();
+        client.newRequest(newURI(transportType))
+            .send(new BufferingResponseListener()
+            {
+                @Override
+                public void onContent(Response response, ByteBuffer content)
+                {
+                    // Consuming the buffer here results in no accumulation.
+                    if (consumeBuffer)
+                        content.position(content.limit());
+                    // Not invoking super results in no accumulation.
+                    if (invokeSuper)
+                        super.onContent(response, content);
+                }
+
+                @Override
+                public void onComplete(Result result)
+                {
+                    contentRef.set(getContentAsString());
+                }
+            });
+
+        String string = await().atMost(5, TimeUnit.SECONDS).until(contentRef::get, Objects::nonNull);
+        assertThat(string, equalTo(expectedContent));
+    }
+
     @ParameterizedTest
     @MethodSource("transports")
     public void testDemandInTwoChunks(TransportType transportType) throws Exception


### PR DESCRIPTION
Restore Jetty 12.0.x behavior where `onContent(Response, Chunk, Runnable)` was calling `onContent(Response, ByteBuffer)`, but Jetty 12.1.x was not.