### PR TITLE
Issue #13624 use context classloader for resumed qos threads

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java
@@ -47,6 +47,7 @@ import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.Jetty;
 import org.eclipse.jetty.util.NanoTime;
 import org.eclipse.jetty.util.Uptime;
+import org.eclipse.jetty.util.VirtualThreads;
 import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.annotation.ManagedObject;
 import org.eclipse.jetty.util.annotation.Name;
@@ -957,7 +958,7 @@ public class Server extends Handler.Wrapper implements Attributes
         @Override
         public void execute(Runnable runnable)
         {
-            getThreadPool().execute(runnable);
+            VirtualThreads.execute(getThreadPool(), runnable);
         }
 
         @Override

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -1674,7 +1674,7 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
 
         public void execute(Runnable runnable, Request request)
         {
-            VirtualThreads.asPossiblyVirtual(getServer().getThreadPool()).execute(() -> run(runnable, request));
+            VirtualThreads.execute(getServer().getThreadPool(), () -> run(runnable, request));
         }
 
         protected DecoratedObjectFactory getDecoratedObjectFactory()

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -56,6 +56,7 @@ import org.eclipse.jetty.util.Index;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.TypeUtil;
 import org.eclipse.jetty.util.URIUtil;
+import org.eclipse.jetty.util.VirtualThreads;
 import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.annotation.ManagedObject;
 import org.eclipse.jetty.util.component.ClassLoaderDump;
@@ -1671,7 +1672,7 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
 
         public void execute(Runnable runnable, Request request)
         {
-            getServer().getContext().execute(() -> run(runnable, request));
+            VirtualThreads.asPossiblyVirtual(getServer().getThreadPool()).execute(() -> run(runnable, request));
         }
 
         protected DecoratedObjectFactory getDecoratedObjectFactory()

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/QoSHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/QoSHandler.java
@@ -405,7 +405,7 @@ public class QoSHandler extends ConditionalHandler.Abstract
 
     private void execute(Request request, Runnable task)
     {
-        request.getContext().execute(task);
+        request.getComponents().getExecutor().execute(() -> request.getContext().run(task));
     }
 
     private class Entry implements CyclicTimeouts.Expirable, Runnable

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/QoSHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/QoSHandler.java
@@ -405,7 +405,7 @@ public class QoSHandler extends ConditionalHandler.Abstract
 
     private void execute(Request request, Runnable task)
     {
-        request.getComponents().getExecutor().execute(task);
+        request.getContext().execute(task);
     }
 
     private class Entry implements CyclicTimeouts.Expirable, Runnable

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/QoSHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/QoSHandler.java
@@ -405,7 +405,7 @@ public class QoSHandler extends ConditionalHandler.Abstract
 
     private void execute(Request request, Runnable task)
     {
-        request.getComponents().getExecutor().execute(() -> request.getContext().run(task));
+        request.getContext().execute(task);
     }
 
     private class Entry implements CyclicTimeouts.Expirable, Runnable

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -243,7 +243,7 @@ public class HttpChannelState implements HttpChannel, Components
     @Override
     public Executor getExecutor()
     {
-        return VirtualThreads.asPossiblyVirtual(getServer().getThreadPool());
+        return VirtualThreads.getExecutor(getServer().getThreadPool());
     }
 
     @Override

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -243,9 +243,7 @@ public class HttpChannelState implements HttpChannel, Components
     @Override
     public Executor getExecutor()
     {
-        Executor executor = getServer().getThreadPool();
-        Executor virtualExecutor = VirtualThreads.getVirtualThreadsExecutor(executor);
-        return virtualExecutor != null ? virtualExecutor : executor;
+        return VirtualThreads.asPossiblyVirtual(getServer().getThreadPool());
     }
 
     @Override

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/QoSHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/QoSHandlerTest.java
@@ -14,6 +14,8 @@
 package org.eclipse.jetty.server.handler;
 
 import java.net.InetSocketAddress;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.channels.SocketChannel;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -81,6 +83,89 @@ public class QoSHandlerTest
         start(qosHandler);
 
         assertThat(qosHandler.getMaxRequestCount(), greaterThan(0));
+    }
+
+    @Test
+    public void testInContext() throws Exception
+    {
+        int maxRequests = 2;
+        ContextHandler context = new ContextHandler();
+        URLClassLoader contextClassLoader = new URLClassLoader(new URL[0], Thread.currentThread().getContextClassLoader());
+        context.setClassLoader(contextClassLoader);
+        context.setContextPath("/");
+        ContextHandlerCollection contexts = new ContextHandlerCollection(context);
+        Server server = new Server();
+        server.setHandler(contexts);
+        QoSHandler qosHandler = new QoSHandler();
+        qosHandler.setMaxRequestCount(maxRequests);
+        context.setHandler(qosHandler);
+        List<Callback> callbacks = new ArrayList<>();
+        qosHandler.setHandler(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                callbacks.add(callback);
+                assertEquals(contextClassLoader, Thread.currentThread().getContextClassLoader());
+                return true;
+            }
+        });
+
+        connector = new LocalConnector(server);
+        server.addConnector(connector);
+
+        try
+        {
+            server.start();
+            List<LocalConnector.LocalEndPoint> endPoints = new ArrayList<>();
+            for (int i = 0; i < maxRequests; ++i)
+            {
+                LocalConnector.LocalEndPoint endPoint = connector.executeRequest("""
+                GET /%d HTTP/1.1
+                Host: localhost
+
+                """.formatted(i));
+                endPoints.add(endPoint);
+                // Wait that the request arrives at the server.
+                await().atMost(5, TimeUnit.SECONDS).until(callbacks::size, is(i + 1));
+            }
+
+            // Send one more request, it should be suspended by QoSHandler.
+            LocalConnector.LocalEndPoint endPoint = connector.executeRequest("""
+            GET /%d HTTP/1.1
+            Host: localhost
+
+            """.formatted(maxRequests));
+            endPoints.add(endPoint);
+
+            assertEquals(maxRequests, callbacks.size());
+            await().atMost(5, TimeUnit.SECONDS).until(qosHandler::getSuspendedRequestCount, is(1));
+            List<Callback> copy = List.copyOf(callbacks);
+            callbacks.clear();
+            for (int i = 0; i < copy.size(); ++i)
+            {
+                Callback callback = copy.get(i);
+                callback.succeeded();
+                String text = endPoints.get(i).getResponse(false, 5, TimeUnit.SECONDS);
+                HttpTester.Response response = HttpTester.parseResponse(text);
+                assertEquals(HttpStatus.OK_200, response.getStatus());
+            }
+
+            // The suspended request should have been resumed.
+            await().atMost(5, TimeUnit.SECONDS).until(qosHandler::getSuspendedRequestCount, is(0));
+            await().atMost(5, TimeUnit.SECONDS).until(callbacks::size, is(1));
+
+            // Finish the resumed request that is now waiting.
+            callbacks.get(0).succeeded();
+
+            String text = endPoints.get(endPoints.size() - 1).getResponse(false, 5, TimeUnit.SECONDS);
+            HttpTester.Response response = HttpTester.parseResponse(text);
+            assertEquals(HttpStatus.OK_200, response.getStatus());
+        }
+       finally
+        {
+            LifeCycle.stop(server);
+        }
     }
 
     @Test
@@ -365,7 +450,6 @@ public class QoSHandlerTest
         });
         start(qosHandler);
 
-
         // Wait until a normal request arrives at the handler.
         LocalConnector.LocalEndPoint normalEndPoint = connector.executeRequest("""
             GET /normal/request HTTP/1.1
@@ -452,7 +536,7 @@ public class QoSHandlerTest
             LocalConnector.LocalEndPoint endPoint = connector.executeRequest("""
                 GET /pass/%d HTTP/1.1
                 Host: localhost
-                
+                                
                 """.formatted(i));
             endPoints.add(endPoint);
         }
@@ -463,7 +547,7 @@ public class QoSHandlerTest
             LocalConnector.LocalEndPoint endPoint = connector.executeRequest("""
                 GET /suspend/%d HTTP/1.1
                 Host: localhost
-                
+                                
                 """.formatted(i));
             endPoints.add(endPoint);
         }
@@ -474,7 +558,7 @@ public class QoSHandlerTest
             HttpTester.Response response = HttpTester.parseResponse(connector.getResponse("""
                 GET /rejected/%d HTTP/1.1
                 Host: localhost
-                
+                                
                 """.formatted(i)));
             assertEquals(HttpStatus.SERVICE_UNAVAILABLE_503, response.getStatus());
         }
@@ -525,7 +609,7 @@ public class QoSHandlerTest
             client1.write(StandardCharsets.UTF_8.encode("""
                 GET /first HTTP/1.1
                 Host: localhost
-                
+                                
                 """));
             // Wait that the request arrives at the server.
             await().atMost(5, TimeUnit.SECONDS).until(callbacks::size, is(1));
@@ -536,7 +620,7 @@ public class QoSHandlerTest
                 client2.write(StandardCharsets.UTF_8.encode("""
                     GET /second HTTP/1.1
                     Host: localhost
-                    
+                                        
                     """));
                 // Wait for the second request to be suspended.
                 await().atMost(5, TimeUnit.SECONDS).until(qosHandler::getSuspendedRequestCount, is(1));

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/QoSHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/QoSHandlerTest.java
@@ -162,7 +162,7 @@ public class QoSHandlerTest
             HttpTester.Response response = HttpTester.parseResponse(text);
             assertEquals(HttpStatus.OK_200, response.getStatus());
         }
-       finally
+        finally
         {
             LifeCycle.stop(server);
         }
@@ -536,7 +536,7 @@ public class QoSHandlerTest
             LocalConnector.LocalEndPoint endPoint = connector.executeRequest("""
                 GET /pass/%d HTTP/1.1
                 Host: localhost
-                                
+                
                 """.formatted(i));
             endPoints.add(endPoint);
         }
@@ -547,7 +547,7 @@ public class QoSHandlerTest
             LocalConnector.LocalEndPoint endPoint = connector.executeRequest("""
                 GET /suspend/%d HTTP/1.1
                 Host: localhost
-                                
+                
                 """.formatted(i));
             endPoints.add(endPoint);
         }
@@ -558,7 +558,7 @@ public class QoSHandlerTest
             HttpTester.Response response = HttpTester.parseResponse(connector.getResponse("""
                 GET /rejected/%d HTTP/1.1
                 Host: localhost
-                                
+                
                 """.formatted(i)));
             assertEquals(HttpStatus.SERVICE_UNAVAILABLE_503, response.getStatus());
         }
@@ -609,7 +609,7 @@ public class QoSHandlerTest
             client1.write(StandardCharsets.UTF_8.encode("""
                 GET /first HTTP/1.1
                 Host: localhost
-                                
+                
                 """));
             // Wait that the request arrives at the server.
             await().atMost(5, TimeUnit.SECONDS).until(callbacks::size, is(1));
@@ -620,7 +620,7 @@ public class QoSHandlerTest
                 client2.write(StandardCharsets.UTF_8.encode("""
                     GET /second HTTP/1.1
                     Host: localhost
-                                        
+                    
                     """));
                 // Wait for the second request to be suspended.
                 await().atMost(5, TimeUnit.SECONDS).until(qosHandler::getSuspendedRequestCount, is(1));

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/QoSHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/QoSHandlerTest.java
@@ -86,7 +86,7 @@ public class QoSHandlerTest
     }
 
     @Test
-    public void testInContext() throws Exception
+    public void testRequestIsResumedInSameContextClassLoader() throws Exception
     {
         int maxRequests = 2;
         ContextHandler context = new ContextHandler();

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/VirtualThreads.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/VirtualThreads.java
@@ -45,7 +45,7 @@ public class VirtualThreads
      * @return An executor that will use virtual threads if configured, otherwise the passed executor
      * @see #getVirtualThreadsExecutor(Executor)
      */
-    public static Executor asPossiblyVirtual(Executor executor)
+    public static Executor getExecutor(Executor executor)
     {
         Executor virtualExecutor = VirtualThreads.getVirtualThreadsExecutor(executor);
         return virtualExecutor == null ? executor : virtualExecutor;
@@ -60,7 +60,7 @@ public class VirtualThreads
      */
     public static void execute(Executor executor, Runnable task)
     {
-        asPossiblyVirtual(executor).execute(task);
+        getExecutor(executor).execute(task);
     }
 
     private static Method probeIsVirtualThread()

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/VirtualThreads.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/VirtualThreads.java
@@ -35,6 +35,34 @@ public class VirtualThreads
     private static final Executor executor = getNamedVirtualThreadsExecutor(null);
     private static final Method isVirtualThread = probeIsVirtualThread();
 
+    /**
+     * Get an executor that will use virtual threads if the given executor
+     * has been configured to use them.
+     * If the given executor does not implement {@link Configurable},
+     * or it has not been configured to use virtual threads, then the
+     * given executor is returned.
+     * @param executor The executor to use
+     * @return An executor that will use virtual threads if configured, otherwise the passed executor
+     * @see #getVirtualThreadsExecutor(Executor)
+     */
+    public static Executor asPossiblyVirtual(Executor executor)
+    {
+        Executor virtualExecutor = VirtualThreads.getVirtualThreadsExecutor(executor);
+        return virtualExecutor == null ? executor : virtualExecutor;
+    }
+
+    /**
+     * Execute a task on the given executor, using virtual threads if the executor
+     * has been configured to use them.
+     * @param executor The executor to use
+     * @param task The task to execute
+     * @see #getVirtualThreadsExecutor(Executor)
+     */
+    public static void execute(Executor executor, Runnable task)
+    {
+        asPossiblyVirtual(executor).execute(task);
+    }
+
     private static Method probeIsVirtualThread()
     {
         try

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/strategy/AdaptiveExecutionStrategy.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/strategy/AdaptiveExecutionStrategy.java
@@ -133,9 +133,9 @@ public class AdaptiveExecutionStrategy extends ContainerLifeCycle implements Exe
     private final LongAdder _epcMode = new LongAdder();
     private final LongAdder _epcProduce = new LongAdder();
     private final Producer _producer;
-    private final Executor _executor;
+    private final Executor _baseExecutor;
     private final TryExecutor _tryExecutor;
-    private final Executor _virtualExecutor;
+    private final Executor _executor;
     private final AtomicReference<State> _state = new AtomicReference<>(State.IDLE);
 
     /**
@@ -145,12 +145,13 @@ public class AdaptiveExecutionStrategy extends ContainerLifeCycle implements Exe
     public AdaptiveExecutionStrategy(Producer producer, Executor executor)
     {
         _producer = producer;
-        _executor = executor;
         _tryExecutor = TryExecutor.asTryExecutor(executor);
-        _virtualExecutor = VirtualThreads.getVirtualThreadsExecutor(_executor);
+        _baseExecutor = VirtualThreads.getExecutor(executor);
+        _executor = VirtualThreads.getExecutor(_baseExecutor);
+        installBean(_baseExecutor);
         installBean(_producer);
         installBean(_tryExecutor);
-        installBean(_virtualExecutor);
+        installBean(_executor);
         if (LOG.isDebugEnabled())
             LOG.debug("created {}", this);
     }
@@ -184,7 +185,7 @@ public class AdaptiveExecutionStrategy extends ContainerLifeCycle implements Exe
         {
             // Try to avoid queuing a producer if we can run it directly.
             if (!_tryExecutor.tryExecute(this))
-                _executor.execute(this);
+                _baseExecutor.execute(this);
         }
     }
 
@@ -525,10 +526,7 @@ public class AdaptiveExecutionStrategy extends ContainerLifeCycle implements Exe
     {
         try
         {
-            Executor executor = _virtualExecutor;
-            if (executor == null)
-                executor = _executor;
-            executor.execute(task);
+            _executor.execute(task);
         }
         catch (RejectedExecutionException e)
         {
@@ -545,7 +543,7 @@ public class AdaptiveExecutionStrategy extends ContainerLifeCycle implements Exe
     @ManagedAttribute(value = "whether this execution strategy uses virtual threads", readonly = true)
     public boolean isUseVirtualThreads()
     {
-        return _virtualExecutor != null;
+        return VirtualThreads.isUseVirtualThreads(_baseExecutor);
     }
 
     @ManagedAttribute(value = "number of tasks consumed with PC mode", readonly = true)

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/strategy/AdaptiveExecutionStrategy.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/strategy/AdaptiveExecutionStrategy.java
@@ -133,9 +133,9 @@ public class AdaptiveExecutionStrategy extends ContainerLifeCycle implements Exe
     private final LongAdder _epcMode = new LongAdder();
     private final LongAdder _epcProduce = new LongAdder();
     private final Producer _producer;
-    private final Executor _baseExecutor;
     private final TryExecutor _tryExecutor;
     private final Executor _executor;
+    private final boolean _isUseVirtualThreads;
     private final AtomicReference<State> _state = new AtomicReference<>(State.IDLE);
 
     /**
@@ -145,13 +145,12 @@ public class AdaptiveExecutionStrategy extends ContainerLifeCycle implements Exe
     public AdaptiveExecutionStrategy(Producer producer, Executor executor)
     {
         _producer = producer;
+        _executor = VirtualThreads.getExecutor(executor);
         _tryExecutor = TryExecutor.asTryExecutor(executor);
-        _baseExecutor = VirtualThreads.getExecutor(executor);
-        _executor = VirtualThreads.getExecutor(_baseExecutor);
-        installBean(_baseExecutor);
+        _isUseVirtualThreads = VirtualThreads.isUseVirtualThreads(executor);
         installBean(_producer);
-        installBean(_tryExecutor);
         installBean(_executor);
+        installBean(_tryExecutor);
         if (LOG.isDebugEnabled())
             LOG.debug("created {}", this);
     }
@@ -185,7 +184,7 @@ public class AdaptiveExecutionStrategy extends ContainerLifeCycle implements Exe
         {
             // Try to avoid queuing a producer if we can run it directly.
             if (!_tryExecutor.tryExecute(this))
-                _baseExecutor.execute(this);
+                _executor.execute(this);
         }
     }
 
@@ -543,7 +542,7 @@ public class AdaptiveExecutionStrategy extends ContainerLifeCycle implements Exe
     @ManagedAttribute(value = "whether this execution strategy uses virtual threads", readonly = true)
     public boolean isUseVirtualThreads()
     {
-        return VirtualThreads.isUseVirtualThreads(_baseExecutor);
+        return _isUseVirtualThreads;
     }
 
     @ManagedAttribute(value = "number of tasks consumed with PC mode", readonly = true)


### PR DESCRIPTION
Closes #13624

Ensure that  resumed requests in the `QoSHandler` uses the context's `execute` method so that the threads will use the context's classloader (if there is one).