### PR TITLE
Style: Align MailSessionReference with project code conventions

### DIFF
--- a/jetty-ee9/jetty-ee9-jndi/src/main/java/org/eclipse/jetty/ee9/jndi/factories/MailSessionReference.java
+++ b/jetty-ee9/jetty-ee9-jndi/src/main/java/org/eclipse/jetty/ee9/jndi/factories/MailSessionReference.java
@@ -137,9 +137,7 @@ public class MailSessionReference extends Reference implements ObjectFactory
     {
         StringRefAddr addr = (StringRefAddr)get("user");
         if (addr != null)
-        {
             throw new RuntimeException("user already set on SessionReference, can't be changed");
-        }
         add(new StringRefAddr("user", user));
     }
 


### PR DESCRIPTION
### Summary
- Removed unnecessary braces `{}` from single-line if statements in the SessionReference class
- Aligned code with the project's existing style conventions

### Why
- Maintain consistent code style across the project

I wanted to contribute to open source, so I gave this a try. This is my first contribution, so I would appreciate any feedback.
