### PR TITLE
H2 reset: fix missing callback completion

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -845,7 +845,7 @@ public abstract class HTTP2Session extends AbstractLifeCycle implements Session,
         }
         else
         {
-            onConnectionFailure(ErrorCode.ENHANCE_YOUR_CALM_ERROR.code, "invalid_rst_stream_frame_rate");
+            onSessionFailure(ErrorCode.ENHANCE_YOUR_CALM_ERROR.code, "invalid_rst_stream_frame_rate", callback);
         }
     }
 

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -2319,7 +2319,7 @@ public abstract class HTTP2Session extends AbstractLifeCycle implements Session,
             notifyFailure(HTTP2Session.this, cause, Callback.from(() ->
                 failStreams(stream -> true, error, reason, toFailure(error, reason), true, Callback.from(() ->
                     sendGoAway(goAwayFrame, Callback.from(() ->
-                        terminate(goAwayFrame)))))));
+                        terminate(goAwayFrame, callback)))))));
         }
 
         private void onWriteFailure(Throwable x)
@@ -2430,6 +2430,11 @@ public abstract class HTTP2Session extends AbstractLifeCycle implements Session,
 
         private void terminate(GoAwayFrame frame)
         {
+            terminate(frame, Callback.NOOP);
+        }
+
+        private void terminate(GoAwayFrame frame, Callback callback)
+        {
             if (LOG.isDebugEnabled())
                 LOG.debug("Terminating {}", HTTP2Session.this);
 
@@ -2442,7 +2447,7 @@ public abstract class HTTP2Session extends AbstractLifeCycle implements Session,
                 completable.complete(null);
 
             HTTP2Session.this.terminate(failure);
-            notifyClose(HTTP2Session.this, frame, Callback.NOOP);
+            notifyClose(HTTP2Session.this, frame, callback);
             notifyLifeCycleClose();
         }
 

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -2316,9 +2316,10 @@ public abstract class HTTP2Session extends AbstractLifeCycle implements Session,
             if (LOG.isDebugEnabled())
                 LOG.debug("Session failure {}", HTTP2Session.this, cause);
 
-            notifyFailure(HTTP2Session.this, cause, Callback.from(callback.getInvocationType(), () ->
-                failStreams(stream -> true, error, reason, toFailure(error, reason), true, Callback.from(callback.getInvocationType(), () ->
-                    sendGoAway(goAwayFrame, Callback.from(callback.getInvocationType(), () ->
+            Invocable.InvocationType invocationType = callback.getInvocationType();
+            notifyFailure(HTTP2Session.this, cause, Callback.from(invocationType, () ->
+                failStreams(stream -> true, error, reason, toFailure(error, reason), true, Callback.from(invocationType, () ->
+                    sendGoAway(goAwayFrame, Callback.from(invocationType, () ->
                         terminate(goAwayFrame, callback)))))));
         }
 

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -2316,9 +2316,9 @@ public abstract class HTTP2Session extends AbstractLifeCycle implements Session,
             if (LOG.isDebugEnabled())
                 LOG.debug("Session failure {}", HTTP2Session.this, cause);
 
-            notifyFailure(HTTP2Session.this, cause, Callback.from(() ->
-                failStreams(stream -> true, error, reason, toFailure(error, reason), true, Callback.from(() ->
-                    sendGoAway(goAwayFrame, Callback.from(() ->
+            notifyFailure(HTTP2Session.this, cause, Callback.from(callback.getInvocationType(), () ->
+                failStreams(stream -> true, error, reason, toFailure(error, reason), true, Callback.from(callback.getInvocationType(), () ->
+                    sendGoAway(goAwayFrame, Callback.from(callback.getInvocationType(), () ->
                         terminate(goAwayFrame, callback)))))));
         }
 

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/WriteFlusher.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/WriteFlusher.java
@@ -652,7 +652,7 @@ public abstract class WriteFlusher
             case COMPLETING -> "C";
             case CANCEL -> "l";
             case CANCELLING -> "L";
-            case FAILED -> "F";
+            case FAILED -> "f";
         };
     }
 

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/WriteFlusher.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/WriteFlusher.java
@@ -650,9 +650,9 @@ public abstract class WriteFlusher
             case FLUSHING -> "F";
             case PENDING -> "P";
             case COMPLETING -> "C";
-            case CANCEL -> "l";
-            case CANCELLING -> "L";
-            case FAILED -> "f";
+            case CANCEL -> "L";
+            case CANCELLING -> "N";
+            case FAILED -> "X";
         };
     }
 

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-http2-webapp/src/test/java/org/eclipse/jetty/test/webapp/StressHTTP2AbortTest.java
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-http2-webapp/src/test/java/org/eclipse/jetty/test/webapp/StressHTTP2AbortTest.java
@@ -1,0 +1,192 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.test.webapp;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.Request;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http2.RateControl;
+import org.eclipse.jetty.http2.WindowRateControl;
+import org.eclipse.jetty.http2.client.HTTP2Client;
+import org.eclipse.jetty.http2.client.transport.HttpClientTransportOverHTTP2;
+import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
+import org.eclipse.jetty.io.EndPoint;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.Blocker;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+
+@Tag("stress")
+@Timeout(value = 5, unit = TimeUnit.MINUTES)
+public class StressHTTP2AbortTest
+{
+    private static final Logger LOG = LoggerFactory.getLogger(StressHTTP2AbortTest.class);
+
+    private static final byte[] DATA = """
+        [start]
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
+        dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+        non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        [end]
+        """.repeat(50).getBytes(StandardCharsets.UTF_8);
+
+    private ExecutorService executorService;
+    private Server server;
+
+    @Test
+    public void testOutputWithAborts() throws Exception
+    {
+        int threads = 1;
+        int iterations = 30;
+        start(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(org.eclipse.jetty.server.Request request, Response response, Callback callback) throws Exception
+            {
+                response.setStatus(200);
+                try (Blocker.Callback blocker = Blocker.callback())
+                {
+                    response.write(true, ByteBuffer.wrap(DATA), blocker);
+                    blocker.block();
+                    callback.succeeded();
+                }
+                catch (Throwable x)
+                {
+                    callback.failed(x);
+                    throw x;
+                }
+                return true;
+            }
+        });
+
+        List<Throwable> errors = new CopyOnWriteArrayList<>();
+        AtomicInteger requestIdGenerator = new AtomicInteger();
+        try (HttpClient httpClient = new HttpClient(new HttpClientTransportOverHTTP2(new HTTP2Client())))
+        {
+            httpClient.start();
+
+            List<Future<?>> futures = new ArrayList<>();
+            for (int i = 0; i < threads; i++)
+            {
+                Future<?> future = executorService.submit(() ->
+                {
+                    for (int j = 0; j < iterations; j++)
+                    {
+                        CompletableFuture<Object> cf = new CompletableFuture<>();
+                        int id = requestIdGenerator.getAndIncrement();
+                        Request request = httpClient.newRequest(server.getURI());
+                        request.path("/" + id)
+                            .method(HttpMethod.GET)
+                            .send(result ->
+                            {
+                                if (result.isSucceeded())
+                                    cf.complete(null);
+                                else
+                                    cf.completeExceptionally(result.getFailure());
+                            });
+
+                        if (j % 2 == 0)
+                            request.abort(new Exception("client abort #" + id));
+
+                        try
+                        {
+                            cf.get(10, TimeUnit.SECONDS);
+                        }
+                        catch (Exception e)
+                        {
+                            Throwable cause = e.getCause();
+                            if (cause instanceof TimeoutException)
+                            {
+                                LOG.error("error in req #" + id, e);
+                                errors.add(e);
+                            }
+                        }
+                    }
+                });
+                futures.add(future);
+            }
+
+            for (Future<?> future : futures)
+            {
+                future.get();
+            }
+
+//            LOG.info("*** server dump ***");
+//            LOG.info(server.dump());
+//            LOG.info("*** client dump ***");
+//            LOG.info(httpClient.dump());
+        }
+        assertThat(errors, empty());
+    }
+
+    @AfterEach
+    public void tearDown()
+    {
+        if (executorService != null)
+            executorService.shutdownNow();
+        LifeCycle.stop(server);
+    }
+
+    private void start(Handler handler) throws Exception
+    {
+        executorService = Executors.newCachedThreadPool();
+        server = new Server();
+
+        HttpConfiguration httpConfiguration = new HttpConfiguration();
+        HTTP2CServerConnectionFactory connectionFactory = new HTTP2CServerConnectionFactory(httpConfiguration);
+        connectionFactory.setRateControlFactory(new RateControl.Factory()
+        {
+            @Override
+            public RateControl newRateControl(EndPoint endPoint)
+            {
+                return new WindowRateControl(8, Duration.ofSeconds(1));
+            }
+        });
+        ServerConnector serverConnector = new ServerConnector(server, connectionFactory);
+        serverConnector.setPort(0);
+        server.addConnector(serverConnector);
+
+        server.setHandler(handler);
+
+        server.start();
+    }
+}

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-http2-webapp/src/test/java/org/eclipse/jetty/test/webapp/StressHTTP2AbortTest.java
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-http2-webapp/src/test/java/org/eclipse/jetty/test/webapp/StressHTTP2AbortTest.java
@@ -16,16 +16,11 @@ package org.eclipse.jetty.test.webapp;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.Request;
@@ -69,13 +64,41 @@ public class StressHTTP2AbortTest
         [end]
         """.repeat(50).getBytes(StandardCharsets.UTF_8);
 
-    private ExecutorService executorService;
     private Server server;
+
+    @AfterEach
+    public void tearDown()
+    {
+        if (server != null)
+            LifeCycle.stop(server);
+    }
+
+    private void start(Handler handler) throws Exception
+    {
+        server = new Server();
+
+        HttpConfiguration httpConfiguration = new HttpConfiguration();
+        HTTP2CServerConnectionFactory connectionFactory = new HTTP2CServerConnectionFactory(httpConfiguration);
+        connectionFactory.setRateControlFactory(new RateControl.Factory()
+        {
+            @Override
+            public RateControl newRateControl(EndPoint endPoint)
+            {
+                return new WindowRateControl(8, Duration.ofSeconds(1));
+            }
+        });
+        ServerConnector serverConnector = new ServerConnector(server, connectionFactory);
+        serverConnector.setPort(0);
+        server.addConnector(serverConnector);
+
+        server.setHandler(handler);
+
+        server.start();
+    }
 
     @Test
     public void testOutputWithAborts() throws Exception
     {
-        int threads = 1;
         int iterations = 30;
         start(new Handler.Abstract()
         {
@@ -99,55 +122,40 @@ public class StressHTTP2AbortTest
         });
 
         List<Throwable> errors = new CopyOnWriteArrayList<>();
-        AtomicInteger requestIdGenerator = new AtomicInteger();
         try (HttpClient httpClient = new HttpClient(new HttpClientTransportOverHTTP2(new HTTP2Client())))
         {
             httpClient.start();
 
-            List<Future<?>> futures = new ArrayList<>();
-            for (int i = 0; i < threads; i++)
+            for (int i = 0; i < iterations; i++)
             {
-                Future<?> future = executorService.submit(() ->
-                {
-                    for (int j = 0; j < iterations; j++)
+                CompletableFuture<Object> cf = new CompletableFuture<>();
+                Request request = httpClient.newRequest(server.getURI());
+                request.path("/" + i)
+                    .method(HttpMethod.GET)
+                    .send(result ->
                     {
-                        CompletableFuture<Object> cf = new CompletableFuture<>();
-                        int id = requestIdGenerator.getAndIncrement();
-                        Request request = httpClient.newRequest(server.getURI());
-                        request.path("/" + id)
-                            .method(HttpMethod.GET)
-                            .send(result ->
-                            {
-                                if (result.isSucceeded())
-                                    cf.complete(null);
-                                else
-                                    cf.completeExceptionally(result.getFailure());
-                            });
+                        if (result.isSucceeded())
+                            cf.complete(null);
+                        else
+                            cf.completeExceptionally(result.getFailure());
+                    });
 
-                        if (j % 2 == 0)
-                            request.abort(new Exception("client abort #" + id));
+                if (i % 2 == 0)
+                    request.abort(new Exception("client abort #" + i));
 
-                        try
-                        {
-                            cf.get(10, TimeUnit.SECONDS);
-                        }
-                        catch (Exception e)
-                        {
-                            Throwable cause = e.getCause();
-                            if (cause instanceof TimeoutException)
-                            {
-                                LOG.error("error in req #" + id, e);
-                                errors.add(e);
-                            }
-                        }
+                try
+                {
+                    cf.get(10, TimeUnit.SECONDS);
+                }
+                catch (Exception e)
+                {
+                    Throwable cause = e.getCause();
+                    if (cause instanceof TimeoutException)
+                    {
+                        LOG.error("error in req #" + i, e);
+                        errors.add(e);
                     }
-                });
-                futures.add(future);
-            }
-
-            for (Future<?> future : futures)
-            {
-                future.get();
+                }
             }
 
 //            LOG.info("*** server dump ***");
@@ -156,37 +164,5 @@ public class StressHTTP2AbortTest
 //            LOG.info(httpClient.dump());
         }
         assertThat(errors, empty());
-    }
-
-    @AfterEach
-    public void tearDown()
-    {
-        if (executorService != null)
-            executorService.shutdownNow();
-        LifeCycle.stop(server);
-    }
-
-    private void start(Handler handler) throws Exception
-    {
-        executorService = Executors.newCachedThreadPool();
-        server = new Server();
-
-        HttpConfiguration httpConfiguration = new HttpConfiguration();
-        HTTP2CServerConnectionFactory connectionFactory = new HTTP2CServerConnectionFactory(httpConfiguration);
-        connectionFactory.setRateControlFactory(new RateControl.Factory()
-        {
-            @Override
-            public RateControl newRateControl(EndPoint endPoint)
-            {
-                return new WindowRateControl(8, Duration.ofSeconds(1));
-            }
-        });
-        ServerConnector serverConnector = new ServerConnector(server, connectionFactory);
-        serverConnector.setPort(0);
-        server.addConnector(serverConnector);
-
-        server.setHandler(handler);
-
-        server.start();
     }
 }


### PR DESCRIPTION
There is a missing callback completion in the H2 reset code that makes the server "abandon" some sessions instead of sending a GOAWAY to the client when the rate control triggers.