### PR TITLE
Improve HTTP/2 and HTTP/3 invalid header value exception message

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackEncoder.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackEncoder.java
@@ -194,7 +194,7 @@ public class HpackEncoder
 
                     String value = field.getValue();
                     if (!HttpTokens.isLegalFieldValue(value))
-                        throw new HpackException.StreamException(metadata.isRequest(), metadata.isResponse(), "Invalid header value: '%s'", value);
+                        throw new HpackException.StreamException(metadata.isRequest(), metadata.isResponse(), "Invalid '%s' header value: '%s'", name, value);
                 }
             }
 

--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HpackTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/test/java/org/eclipse/jetty/http2/hpack/HpackTest.java
@@ -154,7 +154,7 @@ public class HpackTest
             BufferUtil.flipToFlush(buffer, 0);
         });
 
-        assertThat(throwable.getMessage(), containsString("Invalid header value"));
+        assertThat(throwable.getMessage(), containsString("Invalid 'cookie' header value"));
     }
 
     @Test

--- a/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/QpackEncoder.java
+++ b/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/QpackEncoder.java
@@ -210,7 +210,7 @@ public class QpackEncoder implements Dumpable
                 String value = field.getValue();
                 if (!HttpTokens.isLegalFieldValue(value))
                     throw new QpackException.StreamException(metadata.isRequest(), metadata.isResponse(),
-                        H3_MESSAGE_ERROR, String.format("Invalid header value: '%s'", value));
+                        H3_MESSAGE_ERROR, String.format("Invalid '%s' header value: '%s'", name, value));
 
                 if (_maxHeadersSize > 0)
                 {

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTest.java
@@ -1313,7 +1313,7 @@ public class HttpClientTest extends AbstractTest
                 .send();
         });
 
-        assertThat(exception.getMessage(), containsString("Invalid header value"));
+        assertThat(exception.getMessage(), containsString("Invalid 'name' header value"));
     }
 
     private static void sleep(long time) throws IOException


### PR DESCRIPTION
Small improvement to include header name in exception message about invalid header value.