### PR TITLE
Issue #13588 - Improve ResourceFactory.split() and URIUtil.toURI to work properly on Windows.

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -16,7 +16,6 @@ package org.eclipse.jetty.util;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
@@ -1901,72 +1900,78 @@ public final class URIUtil
     }
 
     /**
-     * <p>Convert a String into a URI suitable for use as a Resource.</p>
+     * <p>Convert a String reference into an absolute URI.</p>
      *
-     * @param resource If the string starts with one of the ALLOWED_SCHEMES, then it is assumed to be a
-     * representation of a {@link URI}, otherwise it is treated as a {@link Path}.
-     * @return The {@link URI} form of the resource.
-     * @deprecated This method is currently resolving relative paths against the current directory, which is a mechanism
-     * that should be implemented by a {@link ResourceFactory}.   All calls to this method need to be reviewed.
+     * <p>If given a relative reference string to a path, it will convert it to an absolute path
+     * using the same techniques present in the JVM itself (eg: {@code Path.of(reference).toAbsolutePath()})</p>
+     *
+     * <p>Relative URI reference strings (eg: {@code "file:path/dir/"}
+     * and {@code "file:path/foo.jar!/"}) are not supported.</p>
+     *
+     * @param reference the raw String input.
+     * @return The absolute {@link URI} form of the reference.
+     * @throws IllegalArgumentException if unable to convert the input string.
      */
-    @Deprecated(since = "12.0.8")
-    public static URI toURI(String resource)
+    public static URI toURI(String reference)
     {
-        Objects.requireNonNull(resource);
+        Objects.requireNonNull(reference);
 
-        if (URIUtil.hasScheme(resource))
-        {
-            try
-            {
-                URI uri = new URI(resource);
-
-                if (ResourceFactory.isSupported(uri))
-                    return correctURI(uri);
-
-                // We don't have a supported URI scheme
-                if (uri.getScheme().length() == 1)
-                {
-                    // Input is a possible Windows path disguised as a URI "D:/path/to/resource.txt".
-                    try
-                    {
-                        return toURI(Paths.get(resource).toUri().toASCIIString());
-                    }
-                    catch (InvalidPathException x)
-                    {
-                        LOG.trace("ignored", x);
-                    }
-                }
-
-                // If we reached this point, that means the input String has a scheme,
-                // and is not recognized as supported by the registered schemes in ResourceFactory.
-                if (LOG.isDebugEnabled())
-                    LOG.debug("URI scheme is not registered: {}", uri.toASCIIString());
-                throw new IllegalArgumentException("URI scheme not registered: " + uri.getScheme());
-            }
-            catch (URISyntaxException x)
-            {
-                // We have an input string that has what looks like a scheme, but isn't a URI.
-                // Eg: "C:\path\to\resource.txt"
-                LOG.trace("ignored", x);
-            }
-        }
-
-        // If we reached this point, we have a String with no valid scheme.
-        // Treat it as a Path, as that's all we have left to investigate.
         try
         {
-            return toURI(Paths.get(resource).toUri().toASCIIString());
+            /* Perform URI test first.
+             * We don't want to perform Path.of(String) first.
+             *
+             * Example: reference parameter is the String "file:///path/to/dir"
+             *
+             * On Unix, the Path.of(reference) will result in a relative directory reference
+             * that includes the "file:" portion in the path after the current working directory.
+             * You'll wind up with something like "file:///home/user/code/jetty/12.1.x/jetty-core/jetty-util/file:///path/to/dir" in this case
+             *
+             * On Windows, the Path.of(reference) will not allow a Path.of("file:///path/to/dir") to work.
+             * This is because there cannot be multi-character drive letters (yes, Windows is limited to only 26 drive letters max)
+             */
+            URI uri = URI.create(reference);
+            if (uri.isAbsolute())
+            {
+                // At this point we have a string detected as a URI.
+                // But that could also include Windows paths like "C:\path\to\foo.jar" or "C:/path/to/foo.jar"
+                String scheme = uri.getScheme();
+                if (scheme.length() == 1 && Character.isLetter(scheme.charAt(0)))
+                {
+                    // Single character schemes are assumed to be windows.
+                    // Make it a file: URI and process it separately.
+                    return toURI("file:///" + uri.toASCIIString());
+                }
+                {
+                    // Anything else, scheme wise, is acceptable.
+                    return correctURI(uri);
+                }
+            }
+            if (LOG.isDebugEnabled())
+                LOG.debug("Input string is detected as a non-absolute URI \"{}\"", reference);
+            throw new IllegalArgumentException("Non-absolute URI reference strings not supported");
         }
-        catch (InvalidPathException x)
+        catch (IllegalArgumentException e)
         {
-            LOG.trace("ignored", x);
+            LOG.trace("IGNORED: Invalid as URI Reference: {}", reference, e);
+        }
+
+        try
+        {
+            Path path = Path.of(reference).toAbsolutePath();
+            return path.toUri();
+        }
+        catch (InvalidPathException e)
+        {
+            // Not a path reference.
+            LOG.trace("IGNORED: Invalid as Path Reference: {}", reference, e);
         }
 
         // If we reached this here, that means the input string cannot be used as
         // a URI or a File Path.  The cause is usually due to bad input (eg:
         // characters that are not supported by file system)
         if (LOG.isDebugEnabled())
-            LOG.debug("Input string cannot be converted to URI \"{}\"", resource);
+            LOG.debug("Input string cannot be converted to URI \"{}\"", reference);
         throw new IllegalArgumentException("Cannot be converted to URI");
     }
 

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -1947,9 +1947,6 @@ public final class URIUtil
                     return correctURI(uri);
                 }
             }
-            if (LOG.isDebugEnabled())
-                LOG.debug("Input string is detected as a non-absolute URI \"{}\"", reference);
-            throw new IllegalArgumentException("Non-absolute URI reference strings not supported");
         }
         catch (IllegalArgumentException e)
         {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.util;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
@@ -1930,7 +1931,7 @@ public final class URIUtil
              * On Windows, the Path.of(reference) will not allow a Path.of("file:///path/to/dir") to work.
              * This is because there cannot be multi-character drive letters (yes, Windows is limited to only 26 drive letters max)
              */
-            URI uri = URI.create(reference);
+            URI uri = new URI(reference);
             if (uri.isAbsolute())
             {
                 // At this point we have a string detected as a URI.
@@ -1948,7 +1949,7 @@ public final class URIUtil
                 }
             }
         }
-        catch (IllegalArgumentException e)
+        catch (URISyntaxException e)
         {
             LOG.trace("IGNORED: Invalid as URI Reference: {}", reference, e);
         }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
@@ -558,7 +558,7 @@ public interface ResourceFactory
                     }
                     else
                     {
-                        list.add(newResource(reference));
+                        list.add(newResource(uri));
                     }
                 }
             }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
@@ -358,7 +358,7 @@ public interface ResourceFactory
         // Treat it as a Path, as that's all we have left to investigate.
         try
         {
-            Path path = Paths.get(resource);
+            Path path = Paths.get(resource).toAbsolutePath();
             URI uri = new URI(path.toUri().toASCIIString());
             return new PathResource(path, uri, true);
         }
@@ -500,11 +500,13 @@ public interface ResourceFactory
     /**
      * Split a string of references by provided delims into a List of {@link Resource}.
      * <p>
-     *     Each part of the input string could be path references (unix or windows style), string URI references, or even glob references (eg: {@code /path/to/libs/*}).
+     *     Each part of the input string could be path references (unix or windows style),
+     *     string URI references, or even glob references (eg: {@code /path/to/libs/*}).
      *     Note: that if you use the {@code :} character in your delims, then URI references will be impossible.
      * </p>
      * <p>
-     *     If the result of processing the input segment is a java archive it will not be automatically mounted, the caller must mount if necessary
+     *     If the result of processing the input segment is a java archive it will not be automatically mounted,
+     *     the caller must mount if necessary
      * </p>
      *
      * @param str the input string of references
@@ -523,11 +525,24 @@ public interface ResourceFactory
             try
             {
                 // Is this a glob reference?
+                // Note: a glob reference can be a java.net.URI
                 if (reference.endsWith("/*") || reference.endsWith("\\*"))
                 {
-                    Resource dir = newResource(reference.substring(0, reference.length() - 2));
+                    // Get the raw directory reference (without the trailing glob).
+                    // This can be "/path/to/dir/*" (on unix an absolute path, on windows a relative path)
+                    // or "C:/path/to/dir/*" (windows java Path syntax)
+                    // or "C:\path\to\dir\*" (windows native syntax)
+                    // or even a URI like "file:///path/to/dir/*" (always an absolute URI)
+                    // and "file:///C:/path/to/dir/*"
+                    // and "jar:file:///C:/path/to/foo.jar!/deep/*"
+                    String rawDir = reference.substring(0, reference.length() - 2);
+                    // Convert to a URI without loading it as a Resource (yet).
+                    URI uri = URIUtil.toURI(rawDir);
+                    // Load rawDir as a Resource
+                    Resource dir = newResource(uri);
                     if (dir.isDirectory())
                     {
+                        // Loop through resource entries for content that will match glob.
                         List<Resource> expanded = dir.list();
                         expanded.sort(ResourceCollators.byName(true));
                         expanded.stream().filter(r -> FileID.isLibArchive(r.getName())).forEach(list::add);
@@ -535,28 +550,15 @@ public interface ResourceFactory
                 }
                 else
                 {
-                    // Simple reference. Could have a scheme like jar:file:, or just file:.
-                    // Or it could be a relative reference, in which case we need to
-                    // ensure it is absolute. Otherwise, comparisons between Resources
-                    // that point to the same resource but one is relative and one is absolute
-                    // will fail.
-                    if (URIUtil.hasScheme(reference))
+                    // Simple reference, could be relative, could be windows syntax, could be a URI.
+                    URI uri = URIUtil.toURI(reference);
+                    if ("jar".equals(uri.getScheme()) && unwrap)
                     {
-                        // Could be a jar:file url, ensure it is unwrapped back to the file
-                        // otherwise it will be a MountedPathResource and consume a mount point
-                        // that might be unnecessary - the caller should always decide whether to mount
-                        URI uri = new URI(reference);
-                        if (unwrap)
-                            list.add(newResource(URIUtil.unwrapContainer(uri)));
-                        else
-                            list.add(newResource(uri.toASCIIString()));
+                        list.add(newResource(URIUtil.unwrapContainer(uri)));
                     }
                     else
                     {
-                        Path p = Paths.get(reference);
-                        if (!p.isAbsolute() && LOG.isDebugEnabled())
-                            LOG.warn("Non-absolute path: {}", reference);
-                        list.add(newResource(p.toAbsolutePath()));
+                        list.add(newResource(reference));
                     }
                 }
             }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java
@@ -1071,20 +1071,28 @@ public class URIUtilTest
 
         if (OS.WINDOWS.isCurrentOs())
         {
+            Path cwd = Path.of(".").toAbsolutePath().normalize();
+            String root = cwd.getRoot().toString();
+            if (root.endsWith("\\"))
+                root = root.substring(0, root.length() - 1);
+
             // Windows format (absolute and relative)
             args.add(Arguments.of("C:\\path\\to\\foo.jar", "file:///C:/path/to/foo.jar"));
             args.add(Arguments.of("D:\\path\\to\\bogus.txt", "file:///D:/path/to/bogus.txt"));
-            args.add(Arguments.of("\\path\\to\\foo.jar", "file:///C:/path/to/foo.jar"));
-            args.add(Arguments.of("\\path\\to\\bogus.txt", "file:///C:/path/to/bogus.txt"));
-            // unix format (relative)
+            args.add(Arguments.of("\\path\\to\\foo.jar", "file:///%s/path/to/foo.jar".formatted(root)));
+            args.add(Arguments.of("\\path\\to\\bogus.txt", "file:///%s/path/to/bogus.txt".formatted(root)));
+            // java path format (absolute)
             args.add(Arguments.of("C:/path/to/foo.jar", "file:///C:/path/to/foo.jar"));
             args.add(Arguments.of("D:/path/to/bogus.txt", "file:///D:/path/to/bogus.txt"));
-            args.add(Arguments.of("/path/to/foo.jar", "file:///C:/path/to/foo.jar"));
-            args.add(Arguments.of("/path/to/bogus.txt", "file:///C:/path/to/bogus.txt"));
+            // java path format (relative)
+            args.add(Arguments.of("/path/to/foo.jar", "file:///%s/path/to/foo.jar".formatted(root)));
+            args.add(Arguments.of("/path/to/bogus.txt", "file:///%s/path/to/bogus.txt".formatted(root)));
             // URI format (absolute)
             args.add(Arguments.of("file:///D:/path/to/zed.jar", "file:///D:/path/to/zed.jar"));
             args.add(Arguments.of("file:/e:/zed/yotta.txt", "file:///e:/zed/yotta.txt"));
             args.add(Arguments.of("jar:file:///E:/path/to/bar.jar", "jar:file:///E:/path/to/bar.jar"));
+            // URI format (bad scheme case, but we preserve it)
+            args.add(Arguments.of("JAR:FILE:///E:/path/to/bar.jar", "JAR:FILE:///E:/path/to/bar.jar"));
         }
         else
         {
@@ -1094,8 +1102,13 @@ public class URIUtilTest
         }
         // URI format (absolute)
         args.add(Arguments.of("file:///path/to/zed.jar", "file:///path/to/zed.jar"));
+        args.add(Arguments.of("FILE:///path/to/zed.jar", "file:///path/to/zed.jar"));
         args.add(Arguments.of("jar:file:///path/to/bar.jar", "jar:file:///path/to/bar.jar"));
-
+        // URI format (bad scheme case, but we preserve it)
+        args.add(Arguments.of("JAR:FILE:///path/to/bar.jar", "JAR:FILE:///path/to/bar.jar"));
+        // URI format (bad URL syntax)
+        args.add(Arguments.of("file:/path/to/bad.jar", "file:///path/to/bad.jar"));
+        args.add(Arguments.of("jar:file:/path/to/bad.jar!/", "jar:file:///path/to/bad.jar!/"));
         return args.stream();
     }
 

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceFactoryTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceFactoryTest.java
@@ -342,20 +342,26 @@ public class ResourceFactoryTest
     {
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {
-            String rootDir = ""; // the default
-            if (OS.WINDOWS.isCurrentOs())
-                rootDir = "C:/";
-
             List<String> rawInputs = new ArrayList<>();
             rawInputs.add("dir/a");
             rawInputs.add("foo/b");
             rawInputs.add("bar/c");
-            rawInputs.add("jar:file://" + rootDir + "foo/bar.jar!/");
-            rawInputs.add("jar:file://" + rootDir + "foo/bar.jar");
-            rawInputs.add(rootDir + "foo/bar.jar");
+            if (OS.WINDOWS.isCurrentOs())
+            {
+                rawInputs.add("jar:file:///C:/foo/bar.jar!/");
+                rawInputs.add("jar:file:///C:/foo/bar.jar");
+                rawInputs.add("C:/foo/bar.jar");
+            }
+            else
+            {
+                rawInputs.add("jar:file:///foo/bar.jar!/");
+                rawInputs.add("jar:file:///foo/bar.jar");
+                rawInputs.add("/foo/bar.jar");
+            }
 
             String rawConfig = String.join(",", rawInputs);
             List<Resource> resources = resourceFactory.split(rawConfig, ",", true);
+            assertThat(resources.size(), is(rawInputs.size()));
 
             for (Resource r : resources)
             {
@@ -392,7 +398,7 @@ public class ResourceFactoryTest
      * with unwrap turned off, then this will not result in a Resource.
      */
     @Test
-    public void testResourceSplitNonExistentJarReferenceNotUnwrapNotMounted()
+    public void testSplitNonExistentJarReferenceNotUnwrapNotMounted()
     {
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {
@@ -405,11 +411,30 @@ public class ResourceFactoryTest
     }
 
     /**
+     * If a jar filesystem {@code jar:file://} URI string reference is used against a non-existent file,
+     * with unwrap turned on, then this will result in a Resource without being mounted.
+     */
+    @Test
+    public void testSplitNonExistentJarReferenceUnwrapNotMounted()
+    {
+        try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
+        {
+            Path file = Path.of("/foo/bar.jar").toAbsolutePath();
+            assertFalse(Files.exists(file), "File should not exist: " + file);
+            String uriReference = "jar:" + file.toUri() + "!/";
+            List<Resource> resources = resourceFactory.split(uriReference, ",", true);
+            assertThat(resources.size(), is(1));
+            assertThat(resources.get(0), not(instanceOf(MountedPathResource.class)));
+            assertThat(resources.get(0).getPath().isAbsolute(), is(true));
+        }
+    }
+
+    /**
      * If a normal filesystem {@code file://} URI string reference is used against a non-existent
      * file with unwrap turned off, then this will result in a Resource reference.
      */
     @Test
-    public void testResourceSplitNonExistentFileReferenceNotUnwrapNotMounted()
+    public void testSplitNonExistentFileReferenceNotUnwrapNotMounted()
     {
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {
@@ -428,7 +453,7 @@ public class ResourceFactoryTest
      * with unwrap turned off, then this will result in a Resource that is mounted.
      */
     @Test
-    public void testResourceSplitExistingJarFileSystemNotUnwrappedIsMounted()
+    public void testSplitExistingJarFileSystemNotUnwrappedIsMounted()
     {
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {
@@ -442,79 +467,30 @@ public class ResourceFactoryTest
         }
     }
 
-    @Test
-    public void testSplitOnComma() throws URISyntaxException
+    @ParameterizedTest(name = "{displayName} [{index}]")
+    @ValueSource(strings = {",", "|", ";"}) // one of the standard separators
+    public void testSplitRelativePaths(String separators)
     {
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {
             Path base = workDir.getEmptyPathDir();
+            System.out.println(base);
+            Assumptions.assumeFalse(base.toString().contains(separators), "Path contains separator being tested in unexpected location: " + base);
+            List<String> dirs = new ArrayList<>();
             Path dir = base.resolve("dir");
             FS.ensureDirExists(dir);
+            dirs.add(dir.toString());
             Path foo = dir.resolve("foo");
             FS.ensureDirExists(foo);
+            dirs.add(foo.toString());
             Path bar = dir.resolve("bar");
             FS.ensureDirExists(bar);
+            dirs.add(bar.toString());
 
             // This represents the user-space raw configuration
-            String config = String.format("%s,%s,%s", dir, foo, bar);
+            String config = String.join(separators, dirs);
 
-            // Split using commas
-            List<URI> uris = resourceFactory.split(config).stream().map(Resource::getURI).toList();
-
-            URI[] expected = new URI[]{
-                dir.toUri(),
-                foo.toUri(),
-                bar.toUri()
-            };
-            assertThat(uris, contains(expected));
-        }
-    }
-
-    @Test
-    public void testSplitOnPipe() throws URISyntaxException
-    {
-        try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
-        {
-            Path base = workDir.getEmptyPathDir();
-            Path dir = base.resolve("dir");
-            FS.ensureDirExists(dir);
-            Path foo = dir.resolve("foo");
-            FS.ensureDirExists(foo);
-            Path bar = dir.resolve("bar");
-            FS.ensureDirExists(bar);
-
-            // This represents the user-space raw configuration
-            String config = String.format("%s|%s|%s", dir, foo, bar);
-
-            // Split using commas
-            List<URI> uris = resourceFactory.split(config).stream().map(Resource::getURI).toList();
-
-            URI[] expected = new URI[]{
-                dir.toUri(),
-                foo.toUri(),
-                bar.toUri()
-            };
-            assertThat(uris, contains(expected));
-        }
-    }
-
-    @Test
-    public void testSplitOnSemicolon() throws URISyntaxException
-    {
-        try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
-        {
-            Path base = workDir.getEmptyPathDir();
-            Path dir = base.resolve("dir");
-            FS.ensureDirExists(dir);
-            Path foo = dir.resolve("foo");
-            FS.ensureDirExists(foo);
-            Path bar = dir.resolve("bar");
-            FS.ensureDirExists(bar);
-
-            // This represents the user-space raw configuration
-            String config = String.format("%s;%s;%s", dir, foo, bar);
-
-            // Split using commas
+            // Split using one of the default separators
             List<URI> uris = resourceFactory.split(config).stream().map(Resource::getURI).toList();
 
             URI[] expected = new URI[]{

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceFactoryTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceFactoryTest.java
@@ -34,7 +34,6 @@ import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.URIUtil;
 import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.OS;
@@ -339,27 +338,106 @@ public class ResourceFactoryTest
     }
 
     @Test
-    public void testSplitIsAbsolute() throws Exception
+    public void testSplitIsAbsolute()
     {
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {
-            String config = String.format("%s,%s,%s,%s,%s,%s", "dir/a", "foo/b", "bar/c", "jar:file:///foo/bar.jar!/", "file:///foo/bar.jar", "/foo/bar.jar");
-            List<Resource> resources = resourceFactory.split(config, ",", true);
-            resources.stream().forEach(r ->
+            String rootDir = ""; // the default
+            if (OS.WINDOWS.isCurrentOs())
+                rootDir = "C:/";
+
+            List<String> rawInputs = new ArrayList<>();
+            rawInputs.add("dir/a");
+            rawInputs.add("foo/b");
+            rawInputs.add("bar/c");
+            rawInputs.add("jar:file://" + rootDir + "foo/bar.jar!/");
+            rawInputs.add("jar:file://" + rootDir + "foo/bar.jar");
+            rawInputs.add(rootDir + "foo/bar.jar");
+
+            String rawConfig = String.join(",", rawInputs);
+            List<Resource> resources = resourceFactory.split(rawConfig, ",", true);
+
+            for (Resource r : resources)
             {
-                //Note: do not test the value of absolute resolution of the relative references as this is system dependent.
-                assertThat(r, not(instanceOf(MountedPathResource.class))); //unwrapped so cannot be mounted
-                assertThat(r.getPath().isAbsolute(), is(true)); //must be absolute
-            });
+                assertThat("Must not be mounted: " + r, r, not(instanceOf(MountedPathResource.class)));
+                assertThat("Must be absolute: " + r, r.getPath().isAbsolute(), is(true));
+            }
+        }
+    }
 
-            //test that an unwrapped jar:file will try to be mounted and fail because it isn't a real location
-            resources = resourceFactory.split("jar:file:///foo/bar.jar!/", ",", false);
+    @Test
+    public void testSplitOfJavaClassPath()
+    {
+        String classPath = System.getProperty("java.class.path");
+        Assumptions.assumeTrue(classPath != null);
+
+        int classpathCount = classPath.split(File.pathSeparator).length;
+
+        try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
+        {
+            List<Resource> resources = resourceFactory.split(classPath, File.pathSeparator, true);
+            assertThat(resources.size(), is(classpathCount));
+
+            for (Resource r : resources)
+            {
+                assertTrue(Resources.exists(r), "Must exist: " + r);
+                assertThat("Must not be mounted: " + r, r, not(instanceOf(MountedPathResource.class)));
+                assertThat("Must be absolute: " + r, r.getPath().isAbsolute(), is(true));
+            }
+        }
+    }
+
+    /**
+     * If a jar filesystem {@code jar:file://} URI string reference is used against a non-existent file,
+     * with unwrap turned off, then this will not result in a Resource.
+     */
+    @Test
+    public void testResourceSplitNonExistentJarReferenceNotUnwrapNotMounted()
+    {
+        try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
+        {
+            Path file = Path.of("/foo/bar.jar").toAbsolutePath();
+            assertFalse(Files.exists(file), "File should not exist: " + file);
+            String uriReference = "jar:" + file.toUri() + "!/";
+            List<Resource> resources = resourceFactory.split(uriReference, ",", false);
             assertThat(resources.size(), is(0));
+        }
+    }
 
-            //test that uri with a scheme, but is not unwrapped returns a Resource
-            resources = resourceFactory.split("file:///foo/bar.jar", ",", false);
+    /**
+     * If a normal filesystem {@code file://} URI string reference is used against a non-existent
+     * file with unwrap turned off, then this will result in a Resource reference.
+     */
+    @Test
+    public void testResourceSplitNonExistentFileReferenceNotUnwrapNotMounted()
+    {
+        try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
+        {
+            Path file = Path.of("/foo/bar.jar").toAbsolutePath();
+            assertFalse(Files.exists(file), "File should not exist: " + file);
+            String uriReference = file.toUri().toASCIIString();
+            List<Resource> resources = resourceFactory.split(uriReference, ",", false);
             assertThat(resources.size(), is(1));
             assertThat(resources.get(0), not(instanceOf(MountedPathResource.class)));
+            assertThat(resources.get(0).getPath().isAbsolute(), is(true));
+        }
+    }
+
+    /**
+     * If a jar filesystem {@code jar:file://} URI string reference is used against a real file that exists,
+     * with unwrap turned off, then this will result in a Resource that is mounted.
+     */
+    @Test
+    public void testResourceSplitExistingJarFileSystemNotUnwrappedIsMounted()
+    {
+        try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
+        {
+            Path jarfile = MavenPaths.findTestResourceFile("example.jar");
+            assertTrue(Files.exists(jarfile), "File should exist: " + jarfile);
+            String uriReference = "jar:" + jarfile.toUri() + "!/";
+            List<Resource> resources = resourceFactory.split(uriReference, ",", false);
+            assertThat(resources.size(), is(1));
+            assertThat(resources.get(0), instanceOf(MountedPathResource.class));
             assertThat(resources.get(0).getPath().isAbsolute(), is(true));
         }
     }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceFactoryTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceFactoryTest.java
@@ -312,7 +312,7 @@ public class ResourceFactoryTest
     }
 
     @Test
-    public void testSplitSingleJar() throws URISyntaxException
+    public void testSplitSingleJar()
     {
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {
@@ -325,7 +325,7 @@ public class ResourceFactoryTest
     }
 
     @Test
-    public void testSplitSinglePath() throws URISyntaxException
+    public void testSplitSinglePath()
     {
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {
@@ -349,14 +349,16 @@ public class ResourceFactoryTest
             if (OS.WINDOWS.isCurrentOs())
             {
                 rawInputs.add("jar:file:///C:/foo/bar.jar!/");
-                rawInputs.add("jar:file:///C:/foo/bar.jar");
-                rawInputs.add("C:/foo/bar.jar");
+                rawInputs.add("jar:file:///C:/foo/baz.jar");
+                rawInputs.add("file:///C:/foo/zed.jar");
+                rawInputs.add("C:/foo/qux.jar");
             }
             else
             {
                 rawInputs.add("jar:file:///foo/bar.jar!/");
-                rawInputs.add("jar:file:///foo/bar.jar");
-                rawInputs.add("/foo/bar.jar");
+                rawInputs.add("jar:file:///foo/baz.jar");
+                rawInputs.add("file:///foo/zed.jar");
+                rawInputs.add("/foo/qux.jar");
             }
 
             String rawConfig = String.join(",", rawInputs);


### PR DESCRIPTION
+ New testcases in `ResourceFactoryTest.testSplit*`
  - including a test for doing a split of the `java.class.path` in an expected way.
+ Restore `URIUtil.toURI(String)` for the purpose of converting a raw string reference to a URI without causing a Resource mount to occur.

The existing implementation would Mount, then unwrap, then leave the mount mounted.
This new implementation doesn't even create the mount if unwrap is true.
The responsibility is to convert String references to absolute URIs.
Then it can be used to create a Resource.
Having this all be done within Resource.newResource() results in extra mounts and reference counts for no good reason.