### PR TITLE
Fixes #13625 - Not possible to control HttpClient Accept-Encoding weights with standard API and discovered Compression.

### DIFF
--- a/documentation/jetty/modules/code/examples/pom.xml
+++ b/documentation/jetty/modules/code/examples/pom.xml
@@ -84,6 +84,14 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.compression</groupId>
+      <artifactId>jetty-compression-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.compression</groupId>
+      <artifactId>jetty-compression-gzip</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.compression</groupId>
       <artifactId>jetty-compression-server</artifactId>
     </dependency>
     <dependency>

--- a/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/client/http/HTTPClientDocs.java
+++ b/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/client/http/HTTPClientDocs.java
@@ -61,6 +61,9 @@ import org.eclipse.jetty.client.StringRequestContent;
 import org.eclipse.jetty.client.transport.HttpClientConnectionFactory;
 import org.eclipse.jetty.client.transport.HttpClientTransportDynamic;
 import org.eclipse.jetty.client.transport.HttpClientTransportOverHTTP;
+import org.eclipse.jetty.compression.client.CompressionContentDecoderFactory;
+import org.eclipse.jetty.compression.gzip.GzipCompression;
+import org.eclipse.jetty.compression.gzip.GzipDecoderConfig;
 import org.eclipse.jetty.fcgi.client.transport.HttpClientTransportOverFCGI;
 import org.eclipse.jetty.http.HttpCookie;
 import org.eclipse.jetty.http.HttpCookieStore;
@@ -441,6 +444,24 @@ public class HTTPClientDocs
         // Remove all response content decoders.
         httpClient.getContentDecoderFactories().clear();
         // end::removeDecoders[]
+    }
+
+    public void customDecoders() throws Exception
+    {
+        // tag::customDecoders[]
+        HttpClient httpClient = new HttpClient();
+        httpClient.start();
+        // Remove all the default response content decoders.
+        httpClient.getContentDecoderFactories().clear();
+
+        // Only support GZIP, customized.
+        GzipCompression gzip = new GzipCompression();
+        GzipDecoderConfig gzipDecoderConfig = new GzipDecoderConfig();
+        // Customize the decoder buffer size.
+        gzipDecoderConfig.setBufferSize(4096);
+        gzip.setDefaultDecoderConfig(gzipDecoderConfig);
+        httpClient.getContentDecoderFactories().put(new CompressionContentDecoderFactory(gzip));
+        // end::customDecoders[]
     }
 
     public void futureResponseListener() throws Exception

--- a/documentation/jetty/modules/programming-guide/pages/client/http.adoc
+++ b/documentation/jetty/modules/programming-guide/pages/client/http.adoc
@@ -515,6 +515,15 @@ If you want to remove support for automatic response content decoding (for examp
 include::code:example$src/main/java/org/eclipse/jetty/docs/programming/client/http/HTTPClientDocs.java[tags=removeDecoders]
 ----
 
+You can also provide your own implementation by implementing `ContentDecoder.Factory`.
+
+If you want to customize the implementations mentioned previously, you can do it in this way, using the utility class `CompressionContentDecoderFactory` from the `org.eclipse.jetty.compression:jetty-compression-client` Maven artifact:
+
+[,java,indent=0]
+----
+include::code:example$src/main/java/org/eclipse/jetty/docs/programming/client/http/HTTPClientDocs.java[tags=customDecoders]
+----
+
 Jetty's `HttpClient` allows applications to handle response content in different ways.
 
 You can buffer the response content in memory; this is done when using the <<blocking,blocking APIs>> and the content is buffered within a `ContentResponse` up to 2 MiB.

--- a/jetty-core/jetty-client/pom.xml
+++ b/jetty-core/jetty-client/pom.xml
@@ -35,10 +35,6 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.compression</groupId>
-      <artifactId>jetty-compression-common</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty.compression</groupId>
       <artifactId>jetty-compression-gzip</artifactId>
     </dependency>
     <dependency>

--- a/jetty-core/jetty-client/src/main/java/module-info.java
+++ b/jetty-core/jetty-client/src/main/java/module-info.java
@@ -16,7 +16,6 @@ module org.eclipse.jetty.client
     requires org.eclipse.jetty.alpn.client;
     requires org.slf4j;
 
-    requires org.eclipse.jetty.compression;
     requires org.eclipse.jetty.compression.gzip;
     requires transitive org.eclipse.jetty.http;
 

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/ContentDecoder.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/ContentDecoder.java
@@ -45,18 +45,20 @@ public interface ContentDecoder
      */
     abstract class Factory extends ContainerLifeCycle
     {
+        protected static final float NO_WEIGHT = -1F;
+
         private final String encoding;
         private final float weight;
 
         protected Factory(String encoding)
         {
-            this(encoding, -1F);
+            this(encoding, NO_WEIGHT);
         }
 
         protected Factory(String encoding, float weight)
         {
             this.encoding = Objects.requireNonNull(encoding);
-            if (weight != -1F && !(weight >= 0F && weight <= 1F))
+            if (weight != NO_WEIGHT && !(weight >= 0F && weight <= 1F))
                 throw new IllegalArgumentException("Invalid weight: " + weight);
             this.weight = weight;
         }
@@ -142,7 +144,7 @@ public interface ContentDecoder
                     header.append(", ");
                 header.append(encoding);
                 float weight = value.getWeight();
-                if (weight != -1F)
+                if (weight != Factory.NO_WEIGHT)
                     header.append(";q=").append(new DecimalFormat("#.###").format(weight));
             });
             acceptEncodingField = new HttpField(HttpHeader.ACCEPT_ENCODING, header.toString());

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -1242,6 +1242,9 @@ public class HttpClient extends ContainerLifeCycle implements AutoCloseable
         void setHttpClient(HttpClient httpClient);
     }
 
+    // A duplicate of oej.compression.client.CompressionContentDecoderFactory
+    // to avoid circular dependencies between the jetty-client and the
+    // jetty-compression client Maven modules.
     private static class CompressionContentDecoderFactory extends ContentDecoder.Factory
     {
         private final Compression compression;

--- a/jetty-core/jetty-compression/jetty-compression-client/pom.xml
+++ b/jetty-core/jetty-compression/jetty-compression-client/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.jetty.compression</groupId>
+    <artifactId>jetty-compression</artifactId>
+    <version>12.1.2-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>jetty-compression-client</artifactId>
+  <packaging>jar</packaging>
+  <name>Core :: Compression :: Client</name>
+  <description>Jetty Core Compression Client</description>
+
+  <properties>
+    <bundle-symbolic-name>${project.groupId}.client</bundle-symbolic-name>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.compression</groupId>
+      <artifactId>jetty-compression-common</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/jetty-core/jetty-compression/jetty-compression-client/src/main/java/module-info.java
+++ b/jetty-core/jetty-compression/jetty-compression-client/src/main/java/module-info.java
@@ -1,0 +1,20 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+module org.eclipse.jetty.compression.client
+{
+    requires transitive org.eclipse.jetty.client;
+    requires transitive org.eclipse.jetty.compression;
+
+    exports org.eclipse.jetty.compression.client;
+}

--- a/jetty-core/jetty-compression/jetty-compression-client/src/main/java/org/eclipse/jetty/compression/client/CompressionContentDecoderFactory.java
+++ b/jetty-core/jetty-compression/jetty-compression-client/src/main/java/org/eclipse/jetty/compression/client/CompressionContentDecoderFactory.java
@@ -1,0 +1,48 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.compression.client;
+
+import java.util.Objects;
+
+import org.eclipse.jetty.client.ContentDecoder;
+import org.eclipse.jetty.compression.Compression;
+import org.eclipse.jetty.io.Content;
+
+/**
+ * <p>Utility class that applications can use to explicitly configure
+ * a {@link Compression} implementation in
+ * {@link ContentDecoder.Factories#put(ContentDecoder.Factory)}.</p>
+ */
+public class CompressionContentDecoderFactory extends ContentDecoder.Factory
+{
+    private final Compression compression;
+
+    public CompressionContentDecoderFactory(Compression compression)
+    {
+        this(compression, NO_WEIGHT);
+    }
+
+    public CompressionContentDecoderFactory(Compression compression, float weight)
+    {
+        super(compression.getEncodingName(), weight);
+        this.compression = Objects.requireNonNull(compression);
+        installBean(compression);
+    }
+
+    @Override
+    public Content.Source newDecoderContentSource(Content.Source contentSource)
+    {
+        return compression.newDecoderSource(contentSource);
+    }
+}

--- a/jetty-core/jetty-compression/jetty-compression-server/pom.xml
+++ b/jetty-core/jetty-compression/jetty-compression-server/pom.xml
@@ -25,11 +25,6 @@
       <groupId>org.eclipse.jetty.compression</groupId>
       <artifactId>jetty-compression-common</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-slf4j-impl</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/jetty-core/jetty-compression/jetty-compression-zstandard/src/main/java/org/eclipse/jetty/compression/zstandard/ZstandardDecoderConfig.java
+++ b/jetty-core/jetty-compression/jetty-compression-zstandard/src/main/java/org/eclipse/jetty/compression/zstandard/ZstandardDecoderConfig.java
@@ -71,13 +71,13 @@ public class ZstandardDecoderConfig implements DecoderConfig
      *
      * <p>
      * Note: only applies when using
-     * {@link ZstandardCompression#newDecoderSource(Content.Source, DecoderConfig)} or
+     * {@link ZstandardCompression#newDecoderSource(Content.Source)} or
      * {@link ZstandardCompression#newDecoderSource(Content.Source, DecoderConfig)}.
      * </p>
      * <p>>
      * Note: not applied when using
-     * {@link ZstandardCompression#newDecoderInputStream(InputStream, DecoderConfig)} or
-     * {@link ZstandardCompression#newDecoderInputStream(InputStream)}
+     * {@link ZstandardCompression#newDecoderInputStream(InputStream)} or
+     * {@link ZstandardCompression#newDecoderInputStream(InputStream, DecoderConfig)}.
      * </p>
      *
      * @param flag true to enable, false is default.

--- a/jetty-core/jetty-compression/pom.xml
+++ b/jetty-core/jetty-compression/pom.xml
@@ -21,6 +21,7 @@
     <module>jetty-compression-brotli</module>
     <module>jetty-compression-zstandard</module>
     <module>jetty-compression-tests</module>
+    <module>jetty-compression-client</module>
   </modules>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -900,6 +900,11 @@
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.compression</groupId>
+        <artifactId>jetty-compression-client</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.compression</groupId>
         <artifactId>jetty-compression-common</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
* Moved HttpClient.CompressionContentDecoderFactory to a public class in new module jetty-compression-client.
* Updated documentation.