### PR TITLE
Restore `HttpClient` scheduler name after #13596.

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -204,6 +204,8 @@ public class HttpClient extends ContainerLifeCycle implements AutoCloseable
     @Override
     protected void doStart() throws Exception
     {
+        String name = Objects.requireNonNullElse(getName(), "%s@%x".formatted(getClass().getSimpleName(), hashCode()));
+
         Executor executor = getExecutor();
         if (executor == null)
         {


### PR DESCRIPTION
After #13596, `HttpClient.name` defaults to `null`, which makes the name of the default `Executor` to be `null` and the name of the default `Scheduler` to be `null-scheduler`, while before it was `HttpClient@h4shc0d3`.

Restored the names as they were, defaulting them in `HttpClient.doStart()`.