### PR TITLE
Issue #13603 - Params only parsing from HttpFields.getValueList() is broken

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/QuotedCSV.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/QuotedCSV.java
@@ -128,8 +128,21 @@ public class QuotedCSV extends QuotedCSVParser implements Iterable<String>
     protected void parsedParam(StringBuilder buffer, int valueLength, int paramName, int paramValue)
     {
         // Handle no value on the first parameter
-        if (valueLength == 0 && paramName == 0)
-            _values.add(buffer.toString());
+        if (valueLength == 0)
+        {
+            if (paramName == 0)
+            {
+                _values.add(buffer.toString());
+            }
+            else if (paramName > 0)
+            {
+                // append param to last value
+                int idx = size() - 1;
+                String last = _values.get(idx);
+                last += ";" + buffer.substring(paramName);
+                _values.set(idx, last);
+            }
+        }
     }
 
     public int size()

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/QuotedCSV.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/QuotedCSV.java
@@ -136,11 +136,9 @@ public class QuotedCSV extends QuotedCSVParser implements Iterable<String>
             }
             else if (paramName > 0)
             {
-                // append param to last value
-                int idx = size() - 1;
-                String last = _values.get(idx);
-                last += ";" + buffer.substring(paramName);
-                _values.set(idx, last);
+                // replace last value
+                int lastIdx = size() - 1;
+                _values.set(lastIdx, buffer.toString());
             }
         }
     }

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldTest.java
@@ -21,6 +21,8 @@ import java.util.Map;
 import org.eclipse.jetty.util.BufferUtil;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -141,6 +143,20 @@ public class HttpFieldTest
         field = new HttpField("name", "no;q=0.0000,Yes;Q=0.0001,no; Q = 0.00000");
         assertTrue(field.contains("yes"));
         assertFalse(field.contains("no"));
+    }
+
+    @ParameterizedTest
+    @CsvSource(delimiter = '|',
+        textBlock = """
+        foo; zed=1; b=j     | foo;zed=1;b=j
+        foo=bar; zed=1; b=j | foo=bar;zed=1;b=j
+        """)
+    public void testValueList(String input, String expected)
+    {
+        HttpField field = new HttpField("name", input);
+        List<String> result = field.getValueList();
+        assertThat(result.size(), is(1));
+        assertThat(result.get(0), is(expected));
     }
 
     @Test

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/QuotedCSVTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/QuotedCSVTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.eclipse.jetty.http.HttpCompliance.Violation.WHITESPACE_IN_PARAMETER;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -141,10 +142,12 @@ public class QuotedCSVTest
     {
         QuotedCSV values = new QuotedCSV(false);
         values.addValue("for=192.0.2.43, for=\"[2001:db8:cafe::17]\", for=unknown");
-        assertThat(values, Matchers.contains(
+        String[] expected = {
             "for=192.0.2.43",
             "for=[2001:db8:cafe::17]",
-            "for=unknown"));
+            "for=unknown"
+        };
+        assertThat(values, contains(expected));
     }
 
     /**
@@ -158,7 +161,7 @@ public class QuotedCSVTest
     {
         QuotedCSV values = new QuotedCSV();
         values.addValue("foo=bar; name=zed");
-        assertEquals(values.size(), 1);
+        assertEquals(1, values.size());
         String result = values.iterator().next();
         assertThat(result, is("foo=bar;name=zed"));
     }

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/QuotedCSVTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/QuotedCSVTest.java
@@ -13,9 +13,7 @@
 
 package org.eclipse.jetty.http;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 
 import org.eclipse.jetty.util.StringUtil;
 import org.hamcrest.Matchers;
@@ -140,18 +138,9 @@ public class QuotedCSVTest
     @Test
     public void testParamsOnly()
     {
-        List<String> params = new ArrayList<>();
-        QuotedCSV values = new QuotedCSV(false)
-        {
-            @Override
-            protected void parsedParam(StringBuilder buffer, int valueLength, int paramName, int paramValue)
-            {
-                params.add(buffer.substring(paramName));
-            }
-        };
+        QuotedCSV values = new QuotedCSV(false);
         values.addValue("for=192.0.2.43, for=\"[2001:db8:cafe::17]\", for=unknown");
-        assertThat(values.size(), is(0));
-        assertThat(params, Matchers.contains(
+        assertThat(values, Matchers.contains(
             "for=192.0.2.43",
             "for=[2001:db8:cafe::17]",
             "for=unknown"));

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/QuotedCSVTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/QuotedCSVTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class QuotedCSVTest
@@ -144,6 +145,22 @@ public class QuotedCSVTest
             "for=192.0.2.43",
             "for=[2001:db8:cafe::17]",
             "for=unknown"));
+    }
+
+    /**
+     * When parsing a value with a parameter, the parameter should be preserved.
+     * This is what we would see if using QuotedCSV with parsing a request 'Cookie' header
+     * (which uses `;` to separate cookies instead of `,`)
+     * Eg: The HttpFields.getValueList("Cookie") should return the entire Cookie header.
+     */
+    @Test
+    public void testValueWithParams()
+    {
+        QuotedCSV values = new QuotedCSV();
+        values.addValue("foo=bar; name=zed");
+        assertEquals(values.size(), 1);
+        String result = values.iterator().next();
+        assertThat(result, is("foo=bar;name=zed"));
     }
 
     @Test

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/QuotedCSVTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/QuotedCSVTest.java
@@ -118,7 +118,7 @@ public class QuotedCSVTest
     }
 
     @Test
-    public void testQuotedNoQuotes()
+    public void testQuotedNoQuotesWithComma()
     {
         QuotedCSV values = new QuotedCSV(false);
         values.addValue("A;p=\"v\",B,\"C, D\"");
@@ -126,6 +126,17 @@ public class QuotedCSVTest
             "A;p=v",
             "B",
             "C, D"));
+    }
+
+    @Test
+    public void testQuotedNoQuotesWithSemicolon()
+    {
+        QuotedCSV values = new QuotedCSV(false);
+        values.addValue("A;p=\"v\",B,\"C; D\"");
+        assertThat(values, Matchers.contains(
+            "A;p=v",
+            "B",
+            "C; D"));
     }
 
     @Test
@@ -138,7 +149,31 @@ public class QuotedCSVTest
     }
 
     @Test
-    public void testParamsOnly()
+    public void testListParamedWithNoParamedOnly()
+    {
+        QuotedCSV values = new QuotedCSV(false);
+        values.addValue("for=192.0.2.60; proto=http;by=203.0.113.43, for=192.0.2.43");
+        String[] expected = {
+            "for=192.0.2.60;proto=http;by=203.0.113.43",
+            "for=192.0.2.43"
+        };
+        assertThat(values, contains(expected));
+    }
+
+    @Test
+    public void testListNoParamedWithParamedOnly()
+    {
+        QuotedCSV values = new QuotedCSV(false);
+        values.addValue("for=192.0.2.43, for=192.0.2.60;proto=http;by=203.0.113.43");
+        String[] expected = {
+            "for=192.0.2.43",
+            "for=192.0.2.60;proto=http;by=203.0.113.43"
+        };
+        assertThat(values, contains(expected));
+    }
+
+    @Test
+    public void testListForwardedRules()
     {
         QuotedCSV values = new QuotedCSV(false);
         values.addValue("for=192.0.2.43, for=\"[2001:db8:cafe::17]\", for=unknown");
@@ -160,10 +195,25 @@ public class QuotedCSVTest
     public void testValueWithParams()
     {
         QuotedCSV values = new QuotedCSV();
-        values.addValue("foo=bar; name=zed");
+        values.addValue("foo=bar; name=zed; b=j");
         assertEquals(1, values.size());
         String result = values.iterator().next();
-        assertThat(result, is("foo=bar;name=zed"));
+        assertThat(result, is("foo=bar;name=zed;b=j"));
+    }
+
+    /**
+     * When parsing a value with a parameter, the parameter should be preserved.
+     */
+    @Test
+    public void testListValueWithParams()
+    {
+        QuotedCSV values = new QuotedCSV();
+        values.addValue("foo=bar; name=zed; b=j, color=red; type");
+        String[] expected = {
+            "foo=bar;name=zed;b=j",
+            "color=red;type"
+        };
+        assertThat(values, contains(expected));
     }
 
     @Test


### PR DESCRIPTION
+ This breaks HttpFields.getValueList("Cookie") for example.
+ Adding testcase

Fixes: #13603 