### PR TITLE
Issue #13626 restore ,;| as separators for setExtraClasspath

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
@@ -492,6 +492,11 @@ public interface ResourceFactory
         return split(str, ",;|", false);
     }
 
+    default List<Resource> split(String str, boolean unwrap)
+    {
+        return split(str, ",;|", unwrap);
+    }
+
     default List<Resource> split(String str, String delim)
     {
         return split(str, delim, false);

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.ee10.webapp;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -1259,7 +1258,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
         //convert classpath into Resources. Any jar:file: references will be
         //unwrapped, because we need the location of the file, not the contents
         //of the file
-        setExtraClasspath(getResourceFactory().split(extraClasspath, File.pathSeparator, true));
+        setExtraClasspath(getResourceFactory().split(extraClasspath, true));
     }
 
     public void setExtraClasspath(List<Resource> extraClasspath)

--- a/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/WebAppContext.java
+++ b/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/WebAppContext.java
@@ -1144,7 +1144,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
         //convert classpath into Resources. Any jar:file: references will be
         //unwrapped, because we need the location of the file, not the contents
         //of the file
-        setExtraClasspath(getResourceFactory().split(extraClasspath, File.pathSeparator, true));
+        setExtraClasspath(getResourceFactory().split(extraClasspath, true));
     }
 
     public void setExtraClasspath(List<Resource> extraClasspath)

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
@@ -1323,7 +1323,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
         //convert classpath into Resources. Any jar:file: references will be
         //unwrapped, because we need the location of the file, not the contents
         //of the file
-        setExtraClasspath(getResourceFactory().split(extraClasspath, File.pathSeparator, true));
+        setExtraClasspath(getResourceFactory().split(extraClasspath, true));
     }
 
     public void setExtraClasspath(List<Resource> extraClasspath)


### PR DESCRIPTION
Closes #13626 

Previous PR changed the acceptable separators for the extra classpath to just be the `File.pathSeparator`. This PR just restores them back to `,;|`.