### PR TITLE
Fixes #13634 - Avoid sending RST_STREAM for closed streams.

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-client/src/main/java/org/eclipse/jetty/http2/client/internal/HTTP2ClientSession.java
+++ b/jetty-core/jetty-http2/jetty-http2-client/src/main/java/org/eclipse/jetty/http2/client/internal/HTTP2ClientSession.java
@@ -61,7 +61,7 @@ public class HTTP2ClientSession extends HTTP2Session
         else
         {
             if (LOG.isDebugEnabled())
-                LOG.debug("Stream #{} not found", streamId);
+                LOG.debug("Stream #{} not found on {}", streamId, this);
             if (isClientStream(streamId))
             {
                 // Normal stream.

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -349,13 +349,22 @@ public abstract class HTTP2Session extends AbstractLifeCycle implements Session,
         {
             if (LOG.isDebugEnabled())
                 LOG.debug("Stream #{} not found on {}", streamId, this);
+
             // We must enlarge the session flow control window,
             // otherwise other requests will be stalled.
             dataConsumed(null, flowControlLength);
+
             if (isStreamClosed(streamId))
-                reset(null, new ResetFrame(streamId, ErrorCode.STREAM_CLOSED_ERROR.code), Callback.NOOP);
+            {
+                // SPEC: this case must not be treated as an error.
+                // However, we want to rate control it.
+                if (!rateControlOnEvent(frame))
+                    onSessionFailure(ErrorCode.ENHANCE_YOUR_CALM_ERROR.code, "invalid_data_frame_rate", Callback.NOOP);
+            }
             else
+            {
                 onSessionFailure(ErrorCode.PROTOCOL_ERROR.code, "unexpected_data_frame", Callback.NOOP);
+            }
         }
     }
 

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HTTP2ServerSession.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HTTP2ServerSession.java
@@ -153,7 +153,7 @@ public class HTTP2ServerSession extends HTTP2Session implements ServerParser.Lis
             else
             {
                 if (LOG.isDebugEnabled())
-                    LOG.debug("Stream #{} not found", streamId);
+                    LOG.debug("Stream #{} not found on {}", streamId, this);
                 onConnectionFailure(ErrorCode.PROTOCOL_ERROR.code, "unexpected_headers_frame");
             }
         }

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/StreamCountTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/StreamCountTest.java
@@ -144,7 +144,7 @@ public class StreamCountTest extends AbstractTest
             }
         });
 
-        CountDownLatch sessionResetLatch = new CountDownLatch(2);
+        CountDownLatch sessionResetLatch = new CountDownLatch(1);
         Session session = newClientSession(new Session.Listener()
         {
             @Override
@@ -204,7 +204,7 @@ public class StreamCountTest extends AbstractTest
         generator.control(accumulator, frame3);
         generator.data(accumulator, data3, data3.remaining());
         accumulator.writeTo(((HTTP2Session)session).getEndPoint(), false, Callback.from(accumulator::release));
-        // Expect 2 RST_STREAM frames.
+        // Expect 1 RST_STREAM frame.
         assertTrue(sessionResetLatch.await(5, TimeUnit.SECONDS));
 
         stream1.data(new DataFrame(stream1.getId(), BufferUtil.EMPTY_BUFFER, true), Callback.NOOP);

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/StreamResetTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/StreamResetTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Exchanger;
 import java.util.concurrent.TimeUnit;
@@ -1201,6 +1202,67 @@ public class StreamResetTest extends AbstractTest
 
         // The client session window should be open.
         await().atMost(5, TimeUnit.SECONDS).until(() -> ((HTTP2Session)stream.getSession()).updateSendWindow(0), greaterThan(0));
+    }
+
+    @Test
+    public void testClientResetThenDoesNotResetInFlightFrames() throws Exception
+    {
+        CountDownLatch clientResetLatch = new CountDownLatch(1);
+        start(new ServerSessionListener()
+        {
+            @Override
+            public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
+            {
+                try
+                {
+                    if (clientResetLatch.await(5, TimeUnit.SECONDS))
+                    {
+                        MetaData.Response response = new MetaData.Response(200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
+                        HeadersFrame responseFrame = new HeadersFrame(stream.getId(), response, null, false);
+                        stream.headers(responseFrame)
+                            .thenCompose(s -> s.data(new DataFrame(s.getId(), ByteBuffer.allocate(128), false)))
+                            .thenCompose(s -> s.data(new DataFrame(s.getId(), ByteBuffer.allocate(64), true)));
+                    }
+                    return null;
+                }
+                catch (InterruptedException x)
+                {
+                    throw new RuntimeException(x);
+                }
+            }
+        });
+
+        List<Frame> inFrames = new CopyOnWriteArrayList<>();
+        List<Frame> outFrames = new CopyOnWriteArrayList<>();
+        http2Client.addBean(new HTTP2Session.FrameListener()
+        {
+            @Override
+            public void onIncomingFrame(Session session, Frame frame)
+            {
+                inFrames.add(frame);
+            }
+
+            @Override
+            public void onOutgoingFrame(Session session, Frame frame)
+            {
+                outFrames.add(frame);
+            }
+        });
+
+        Session client = newClientSession(new Session.Listener() {});
+        MetaData.Request request = newRequest("GET", HttpFields.EMPTY);
+        HeadersFrame requestFrame = new HeadersFrame(request, null, true);
+        client.newStream(requestFrame, new Stream.Listener() {})
+            .thenCompose(s -> s.reset(new ResetFrame(s.getId(), ErrorCode.ENHANCE_YOUR_CALM_ERROR.code)))
+            .thenRun(clientResetLatch::countDown);
+
+        // Wait until received all the frames from the server.
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() ->
+            assertTrue(inFrames.stream().anyMatch(f -> f instanceof DataFrame d && d.isEndStream()), inFrames.toString()));
+
+        // Verify that we only sent 1 RST_STREAM frame.
+        await().during(1, TimeUnit.SECONDS).atMost(5, TimeUnit.SECONDS).untilAsserted(() ->
+            assertEquals(1L, outFrames.stream().filter(f -> f instanceof ResetFrame).count(), outFrames.toString()));
     }
 
     private void waitUntilTCPCongested(Supplier<SelectableChannelEndPoint> selectableChannelEndPointRef)


### PR DESCRIPTION
Avoid sending RST_STREAM in case a DATA frame is received for a closed stream -- the DATA frame is just rate controlled and then dropped.