### PR TITLE
Fix: avoid SecurityException on JDK 25 when ContextHandler runs in InnocuousThread

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -760,7 +760,27 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
     {
         notifyExitScope(request);
         __context.set(lastContext);
-        Thread.currentThread().setContextClassLoader(lastLoader);
+
+        Thread thread = Thread.currentThread();
+
+        // Avoid SecurityException on JDK 25 when running in InnocuousThread
+        try 
+        {
+            thread.setContextClassLoader(lastLoader);
+        } 
+        catch (SecurityException ex) 
+        {
+            // Jetty async may run on JDK internal InnocuousThread which forbids changing the context classloader
+            if (thread.getClass().getName().contains("InnocuousThread")) 
+            {
+                // Log once or silently ignore – context restore is not allowed here
+                LOG.debug("Skipping setContextClassLoader on InnocuousThread: {}", thread, ex);
+            }
+            else 
+            {
+                throw ex; // rethrow if it's not the restricted thread case
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
`Description`
This pull request fixes a java.lang.SecurityException: setContextClassLoader that occurs when ContextHandler.exitScope() is invoked from an InnocuousThread on JDK 25.

This issue was first observed in Spring Framework’s tests:
https://github.com/spring-projects/spring-framework/issues/35531

`Background`
Starting with JDK 25, InnocuousThread enforces stricter security rules that prevent changing its context class loader.
In some asynchronous scenarios (such as async servlet I/O or reactive pipelines), Jetty operations may be executed under such threads — triggering the following error:
```
java.lang.SecurityException: setContextClassLoader
    at jdk.internal.misc.InnocuousThread.setContextClassLoader(InnocuousThread.java:130)
    at org.eclipse.jetty.server.handler.ContextHandler.exitScope(ContextHandler.java:754)
```

This issue can be reproduced by running Spring Framework’s integration tests (e.g.
MultipartWebClientIntegrationTests#transferTo) under JDK 25, where the Jetty server is used as the embedded HTTP server.


`Cause`
ContextHandler.exitScope() unconditionally calls Thread.currentThread().setContextClassLoader(lastLoader).
However, under JDK 25, this operation is prohibited for InnocuousThread, which leads to an exception and prematurely closes the HTTP connection.

`Fix`
This patch introduces a guard in exitScope() that detects InnocuousThread instances and safely skips setting the context class loader.

