### PR TITLE
Issue #13683 - UrlParameterDecoder fixed for mixed bytes/chars pct-encoding usage.

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/CharsetStringBuilder.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/CharsetStringBuilder.java
@@ -22,13 +22,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Objects;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * <p>Build a string from a sequence of bytes and/or characters.</p>
  * <p>Implementations of this interface are optimized for processing a mix of calls to already decoded
- * character based appends (e.g. {@link #append(char)} and calls to undecoded byte methods (e.g. {@link #append(byte)}.
+ * character based appends (e.g. {@link #append(char)}) and calls to undecoded byte methods (e.g. {@link #append(char)}).
  * This is particularly useful for decoding % encoded strings that are mostly already decoded but may contain
  * escaped byte sequences that are not decoded.  The standard {@link CharsetDecoder} API is not well suited for this
  * use-case.</p>
@@ -274,7 +271,6 @@ public interface CharsetStringBuilder
 
     class DecoderStringBuilder implements CharsetStringBuilder
     {
-        private static final Logger LOG = LoggerFactory.getLogger(DecoderStringBuilder.class);
         private final CharsetDecoder _decoder;
         private final StringBuilder _stringBuilder = new StringBuilder(32);
         private ByteBuffer _buffer = ByteBuffer.allocate(32);
@@ -308,6 +304,17 @@ public interface CharsetStringBuilder
         {
             if (_buffer.position() > 0)
             {
+                // We have a (possible) sequence started, need to continue it.
+                if (c > 0xFF)
+                {
+                    ensureSpace(2);
+                    _buffer.putChar(c);
+                }
+                else
+                {
+                    ensureSpace(1);
+                    _buffer.put((byte)c);
+                }
                 try
                 {
                     // Append any data already in the decoder
@@ -321,28 +328,19 @@ public interface CharsetStringBuilder
                     throw new RuntimeException(e);
                 }
             }
-            _stringBuilder.append(c);
+            else
+            {
+                _stringBuilder.append(c);
+            }
         }
 
         @Override
         public void append(CharSequence chars, int offset, int length)
         {
-            if (_buffer.position() > 0)
+            for (int idx = offset; idx < offset + length; idx++)
             {
-                try
-                {
-                    // Append any data already in the decoder
-                    _stringBuilder.append(_decoder.decode(_buffer.flip()));
-                    _buffer.clear();
-                }
-                catch (CharacterCodingException e)
-                {
-                    // This will be thrown only if the decoder is configured to REPORT,
-                    // otherwise errors will be ignored or replaced and we will not catch here.
-                    throw new RuntimeException(e);
-                }
+                append(chars.charAt(idx));
             }
-            _stringBuilder.append(chars, offset, offset + length);
         }
 
         @Override

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/CharsetStringBuilder.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/CharsetStringBuilder.java
@@ -286,7 +286,7 @@ public interface CharsetStringBuilder
         {
             if (_buffer == null)
             {
-                _buffer = ByteBuffer.allocate(32 * ((needed + 32) % 32));
+                _buffer = ByteBuffer.allocate(needed + 32);
             }
             else
             {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/CharsetStringBuilder.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/CharsetStringBuilder.java
@@ -315,18 +315,6 @@ public interface CharsetStringBuilder
                     ensureSpace(1);
                     _buffer.put((byte)c);
                 }
-                try
-                {
-                    // Append any data already in the decoder
-                    _stringBuilder.append(_decoder.decode(_buffer.flip()));
-                    _buffer.clear();
-                }
-                catch (CharacterCodingException e)
-                {
-                    // This will be thrown only if the decoder is configured to REPORT,
-                    // otherwise errors will be ignored or replaced and we will not catch here.
-                    throw new RuntimeException(e);
-                }
             }
             else
             {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/CharsetStringBuilder.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/CharsetStringBuilder.java
@@ -273,7 +273,7 @@ public interface CharsetStringBuilder
     {
         private final CharsetDecoder _decoder;
         private final StringBuilder _stringBuilder = new StringBuilder(32);
-        private ByteBuffer _buffer = ByteBuffer.allocate(32);
+        private ByteBuffer _buffer;
         
         public DecoderStringBuilder(CharsetDecoder charsetDecoder, CodingErrorAction onMalformedInput, CodingErrorAction onUnmappableCharacter)
         {
@@ -284,11 +284,18 @@ public interface CharsetStringBuilder
 
         private void ensureSpace(int needed)
         {
-            int space = _buffer.remaining();
-            if (space < needed)
+            if (_buffer == null)
             {
-                int position = _buffer.position();
-                _buffer = ByteBuffer.wrap(Arrays.copyOf(_buffer.array(), _buffer.capacity() + needed - space + 32)).position(position);
+                _buffer = ByteBuffer.allocate(32 * ((needed + 32) % 32));
+            }
+            else
+            {
+                int space = _buffer.remaining();
+                if (space < needed)
+                {
+                    int position = _buffer.position();
+                    _buffer = ByteBuffer.wrap(Arrays.copyOf(_buffer.array(), _buffer.capacity() + needed - space + 32)).position(position);
+                }
             }
         }
 
@@ -302,19 +309,37 @@ public interface CharsetStringBuilder
         @Override
         public void append(char c)
         {
-            if (_buffer.position() > 0)
+            if (_buffer != null && _buffer.position() > 0)
             {
-                // We have a (possible) sequence started, need to continue it.
+                // If we have seen a byte append, then assume all following character appends are mistakes,
+                // but try to decode safely if we can.
                 if (c > 0xFF)
                 {
-                    ensureSpace(2);
-                    _buffer.putChar(c);
+                    // Try to decode and continue
+                    try
+                    {
+                        CharSequence decoded = _decoder.decode(_buffer.flip());
+                        _buffer.clear();
+                        _stringBuilder.append(decoded);
+                        _stringBuilder.append(c);
+                    }
+                    catch (CharacterCodingException e)
+                    {
+                        if (_decoder.malformedInputAction() == CodingErrorAction.IGNORE)
+                            return;
+                        if (_decoder.malformedInputAction() == CodingErrorAction.REPLACE)
+                        {
+                            _buffer.clear();
+                            _stringBuilder.append("�");
+                            return;
+                        }
+                        throw new IllegalArgumentException("Invalid character " + Integer.toHexString(c), e);
+                    }
+                    return;
                 }
-                else
-                {
-                    ensureSpace(1);
-                    _buffer.put((byte)c);
-                }
+                // This only works for charsets that are true supersets of USASCII
+                ensureSpace(1);
+                _buffer.put((byte)c);
             }
             else
             {
@@ -326,9 +351,7 @@ public interface CharsetStringBuilder
         public void append(CharSequence chars, int offset, int length)
         {
             for (int idx = offset; idx < offset + length; idx++)
-            {
                 append(chars.charAt(idx));
-            }
         }
 
         @Override
@@ -354,7 +377,7 @@ public interface CharsetStringBuilder
             // and onUnmappableCharacter(CodingErrorAction)
             try
             {
-                if (_buffer.position() > 0)
+                if (_buffer != null && _buffer.position() > 0)
                 {
                     CharSequence decoded = _decoder.decode(_buffer.flip());
                     _buffer.clear();
@@ -380,6 +403,8 @@ public interface CharsetStringBuilder
         public void reset()
         {
             _stringBuilder.setLength(0);
+            if (_buffer != null)
+                _buffer.clear();
         }
     }
 }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/CharsetStringBuilder.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/CharsetStringBuilder.java
@@ -330,16 +330,18 @@ public interface CharsetStringBuilder
                         if (_decoder.malformedInputAction() == CodingErrorAction.REPLACE)
                         {
                             _buffer.clear();
-                            _stringBuilder.append("�");
+                            _stringBuilder.append(_decoder.replacement());
                             return;
                         }
                         throw new IllegalArgumentException("Invalid character " + Integer.toHexString(c), e);
                     }
-                    return;
                 }
-                // This only works for charsets that are true supersets of USASCII
-                ensureSpace(1);
-                _buffer.put((byte)c);
+                else
+                {
+                    // This only works for charsets that are true supersets of USASCII
+                    ensureSpace(1);
+                    _buffer.put((byte)c);
+                }
             }
             else
             {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/CharsetStringBuilder.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/CharsetStringBuilder.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 /**
  * <p>Build a string from a sequence of bytes and/or characters.</p>
  * <p>Implementations of this interface are optimized for processing a mix of calls to already decoded
- * character based appends (e.g. {@link #append(char)}) and calls to undecoded byte methods (e.g. {@link #append(char)}).
+ * character based appends (e.g. {@link #append(char)}) and calls to undecoded byte methods (e.g. {@link #append(byte)}).
  * This is particularly useful for decoding % encoded strings that are mostly already decoded but may contain
  * escaped byte sequences that are not decoded.  The standard {@link CharsetDecoder} API is not well suited for this
  * use-case.</p>

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/CharsetStringBuilderTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/CharsetStringBuilderTest.java
@@ -238,9 +238,7 @@ public class CharsetStringBuilderTest
             // if a raw byte is one of the ASCII characters, add it as a character??
             // if (b > 'a' && b < 'z' || b > 'A' && b < 'Z' || b > '0' && b < '9')
             if (b >= 'a' && b <= 'z' || b >= 'A' && b <= 'Z' || b >= '0' && b <= '9')
-            {
                 builder.append((char)b);
-            }
             else
                 builder.append(b);
         }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/CharsetStringBuilderTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/CharsetStringBuilderTest.java
@@ -15,11 +15,15 @@ package org.eclipse.jetty.util;
 
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -27,6 +31,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 // @checkstyle-disable-check : AvoidEscapedUnicodeCharactersCheck
 public class CharsetStringBuilderTest
@@ -179,5 +184,109 @@ public class CharsetStringBuilderTest
         }
 
         assertThat(builder.build(), is(input));
+    }
+
+    @Test
+    public void testSjisEncoding() throws CharacterCodingException
+    {
+        Charset sjisCharset = Charset.forName("Shift_JIS");
+        CharsetStringBuilder builder = CharsetStringBuilder.forCharset(sjisCharset);
+
+        builder.append((byte)0x83);
+        builder.append((char)'z');
+
+        assertEquals("ホ", builder.build());
+    }
+
+    public static Stream<Arguments> japaneseCharsetTests()
+    {
+        List<Arguments> args = new ArrayList<>();
+        for (Charset charset : List.of(
+            StandardCharsets.UTF_8,
+            StandardCharsets.UTF_16,
+            Charset.forName("Shift_JIS"),
+            Charset.forName("EUC-JP")
+        ))
+        {
+            for (String string : List.of(
+                // Has ASCII 'O' (0x30) in UTF-16
+                "ホ",
+                // Has ASCII 'O' (0x30) in UTF-16
+                // Has ASCII 'J' (0x4A), ASCII '^' (0x5E), and ASCII 'i' (0x69) in Shift_JIS
+                "カタカナ",
+                // Has ASCII 'v' (0x76) in UTF-16
+                "ｶﾞｯﾂﾎﾟｰｽﾞ"
+            ))
+            {
+                args.add(Arguments.of(charset, string));
+            }
+        }
+        return args.stream();
+    }
+
+    /**
+     * Paranoid test, showing badly mixed API usage.
+     */
+    @ParameterizedTest
+    @MethodSource("japaneseCharsetTests")
+    public void testJapaneseCharsetsMixedAppend(Charset charset, String string) throws Exception
+    {
+        CharsetStringBuilder builder = CharsetStringBuilder.forCharset(charset);
+        byte[] bytes = string.getBytes(charset);
+        for (byte b : bytes)
+        {
+            // if a raw byte is one of the ASCII characters, add it as a character??
+            // if (b > 'a' && b < 'z' || b > 'A' && b < 'Z' || b > '0' && b < '9')
+            if (b >= 'a' && b <= 'z' || b >= 'A' && b <= 'Z' || b >= '0' && b <= '9')
+            {
+                builder.append((char)b);
+            }
+            else
+                builder.append(b);
+        }
+        assertThat(builder.build(), is(string));
+    }
+
+    /**
+     * This mimics the usage behavior as seen in ContentSourceString.
+     */
+    @ParameterizedTest
+    @MethodSource("japaneseCharsetTests")
+    public void testJapaneseCharsetsAppendByteBufferOnly(Charset charset, String string) throws Exception
+    {
+        CharsetStringBuilder builder = CharsetStringBuilder.forCharset(charset);
+        byte[] bytes = string.getBytes(charset);
+        ByteBuffer buf = ByteBuffer.wrap(bytes);
+
+        // Let's write it in two ByteBuffer's
+        int midway = buf.remaining() / 2;
+
+        ByteBuffer slice1 = buf.slice();
+        slice1.position(0);
+        slice1.limit(midway);
+
+        ByteBuffer slice2 = buf.slice();
+        slice2.position(midway);
+
+        builder.append(slice1);
+        builder.append(slice2);
+
+        assertThat(builder.build(), is(string));
+    }
+
+    /**
+     * This mimics how the UrlParameterDecoder operates.
+     * (char by char, not byte by byte)
+     */
+    @ParameterizedTest
+    @MethodSource("japaneseCharsetTests")
+    public void testJapaneseCharsetsAppendCharOnly(Charset charset, String string) throws Exception
+    {
+        CharsetStringBuilder builder = CharsetStringBuilder.forCharset(charset);
+        for (char c: string.toCharArray())
+        {
+            builder.append(c);
+        }
+        assertThat(builder.build(), is(string));
     }
 }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/CharsetStringBuilderTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/CharsetStringBuilderTest.java
@@ -14,7 +14,9 @@
 package org.eclipse.jetty.util;
 
 import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
 import java.nio.charset.Charset;
+import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 
@@ -51,7 +53,9 @@ public class CharsetStringBuilderTest
         assertThat(builder.build(), equalTo(test));
 
         for (byte b : bytes)
+        {
             builder.append(b);
+        }
         assertThat(builder.build(), equalTo(test));
 
         builder.append(bytes[0]);
@@ -71,34 +75,109 @@ public class CharsetStringBuilderTest
 
     @ParameterizedTest
     @MethodSource("charsets")
-    public void testBasicApi(Charset charset) throws Exception
+    public void testAppendByteBuffersOnly(Charset charset) throws Exception
     {
+        String input = "123456789ABC";
+        // Generate a ByteBuffer encoded with the provided charset of the input String.
+        CharsetEncoder encoder = charset.newEncoder();
+        ByteBuffer bb = ByteBuffer.allocate(input.length() * 4);
+        encoder.encode(CharBuffer.wrap(input), bb, true);
+        bb.flip();
+
+        // using only append(ByteBuffer) recreate the input
         CharsetStringBuilder builder = CharsetStringBuilder.forCharset(charset);
-        ByteBuffer encoded = charset.encode("1");
-        while (encoded.hasRemaining())
-            builder.append(encoded.get());
+        int sliceSize = 3;
+        int len = bb.remaining();
+        int offset = 0;
+        while (offset < len)
+        {
+            ByteBuffer slice = bb.slice();
+            slice.position(offset);
+            int limit = Math.min(slice.position() + sliceSize, len);
+            slice.limit(limit);
+            builder.append(slice);
+            offset = slice.position();
+        }
 
-        builder.append('2');
+        assertThat(builder.build(), is(input));
+    }
 
-        builder.append(charset.encode("34"));
+    @ParameterizedTest
+    @MethodSource("charsets")
+    public void testAppendByteOnly(Charset charset) throws Exception
+    {
+        String input = "123456789ABC";
 
-        encoded = charset.encode("abc");
-        int offset = encoded.remaining();
-        encoded = charset.encode("abc56");
-        int length = encoded.remaining() - offset;
-        encoded = charset.encode("abc56xyz");
-        byte[] bytes = new byte[1028];
-        encoded.get(bytes, 0, encoded.remaining());
-        builder.append(bytes, offset, length);
+        // Generate a byte buffer encoded with the provided charset of the input String.
+        byte[] buf = input.getBytes(charset);
 
-        encoded = charset.encode("abc78xyz");
-        encoded.position(offset);
-        encoded.limit(offset + length);
-        builder.append(encoded);
+        // using only append(byte) recreate the input
+        CharsetStringBuilder builder = CharsetStringBuilder.forCharset(charset);
+        for (byte b : buf)
+        {
+            builder.append(b);
+        }
 
-        builder.append("9A", 0, 2);
-        builder.append("xyzBCpqy", 3, 2);
+        assertThat(builder.build(), is(input));
+    }
 
-        assertThat(builder.build(), is("123456789ABC"));
+    @ParameterizedTest
+    @MethodSource("charsets")
+    public void testAppendByteOffsetLengthOnly(Charset charset) throws Exception
+    {
+        String input = "123456789ABC";
+
+        // Generate a byte buffer encoded with the provided charset of the input String.
+        byte[] buf = input.getBytes(charset);
+
+        // using only append(byte, offset, length) recreate the input
+        CharsetStringBuilder builder = CharsetStringBuilder.forCharset(charset);
+        int sliceSize = 3;
+        int offset = 0;
+        while (offset < buf.length)
+        {
+            int len = Math.min(sliceSize, buf.length - offset);
+            builder.append(buf, offset, len);
+            offset += sliceSize;
+        }
+
+        assertThat(builder.build(), is(input));
+    }
+
+    @ParameterizedTest
+    @MethodSource("charsets")
+    public void testAppendCharOnly(Charset charset) throws Exception
+    {
+        String input = "123456789ABC";
+
+        // using only append(char) recreate the input
+        CharsetStringBuilder builder = CharsetStringBuilder.forCharset(charset);
+        for (char c : input.toCharArray())
+        {
+            builder.append(c);
+        }
+
+        assertThat(builder.build(), is(input));
+    }
+
+    @ParameterizedTest
+    @MethodSource("charsets")
+    public void testAppendCharSequenceOffsetLengthOnly(Charset charset) throws Exception
+    {
+        String input = "123456789ABC";
+
+        // using only append(CharSequence, offset, length) recreate the input
+        CharsetStringBuilder builder = CharsetStringBuilder.forCharset(charset);
+        char[] chars = input.toCharArray();
+        int sliceSize = 3;
+        int offset = 0;
+        while (offset < chars.length)
+        {
+            int len = Math.min(sliceSize, chars.length - offset);
+            builder.append(input, offset, len);
+            offset += sliceSize;
+        }
+
+        assertThat(builder.build(), is(input));
     }
 }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/CharsetStringBuilderTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/CharsetStringBuilderTest.java
@@ -236,7 +236,6 @@ public class CharsetStringBuilderTest
         for (byte b : bytes)
         {
             // if a raw byte is one of the ASCII characters, add it as a character??
-            // if (b > 'a' && b < 'z' || b > 'A' && b < 'Z' || b > '0' && b < '9')
             if (b >= 'a' && b <= 'z' || b >= 'A' && b <= 'Z' || b >= '0' && b <= '9')
                 builder.append((char)b);
             else

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URLEncodedTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URLEncodedTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.util;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -33,6 +34,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
@@ -301,5 +303,34 @@ public class URLEncodedTest
             MultiMap<String> map = new MultiMap<>();
             UrlEncoded.decodeTo(inputString, map, charset);
         });
+    }
+
+    /**
+     * Test of non-standard encoding of Shift_JIS.
+     * This tests a 2 byte sequence making up 1 Shift_JIS character.
+     * But only the first byte is pct-encoded, other byte is "in the raw" and not encoded.
+     * Both bytes are required for the KATAKANA LETTER HO: ホ to be decoded.
+     * See https://unicodeplus.com/U+30DB
+     */
+    @Test
+    public void testSjisNonStandardForm() throws IOException
+    {
+        // Actual x-www-form-urlencoded sent from Google Chrome 1.141 with Shift-JIS encoding.
+        // The same form data is sent from Firefox 143.0.4
+        // The same form data is also what is sent from Apache HttpClient 4.5.x and 5.x
+        // The properly encoded form of this character would be "a=%83%7A"
+        // Note: "%7A" is the ASCII "z"
+        String sjis = "a=%83z";
+        Charset shiftJis = Charset.forName("Shift_JIS");
+        byte[] bytes = sjis.getBytes(shiftJis);
+        try (ByteArrayInputStream in = new ByteArrayInputStream(bytes))
+        {
+            MultiMap<String> map = new MultiMap<>();
+            UrlEncoded.decodeTo(in, map, shiftJis, 500, 500);
+            List<String> result = map.get("a");
+            assertNotNull(result);
+            assertEquals(1, result.size());
+            assertEquals("ホ", result.get(0));
+        }
     }
 }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URLEncodedTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/URLEncodedTest.java
@@ -14,7 +14,6 @@
 package org.eclipse.jetty.util;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -34,7 +33,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
@@ -303,34 +301,5 @@ public class URLEncodedTest
             MultiMap<String> map = new MultiMap<>();
             UrlEncoded.decodeTo(inputString, map, charset);
         });
-    }
-
-    /**
-     * Test of non-standard encoding of Shift_JIS.
-     * This tests a 2 byte sequence making up 1 Shift_JIS character.
-     * But only the first byte is pct-encoded, other byte is "in the raw" and not encoded.
-     * Both bytes are required for the KATAKANA LETTER HO: ホ to be decoded.
-     * See https://unicodeplus.com/U+30DB
-     */
-    @Test
-    public void testSjisNonStandardForm() throws IOException
-    {
-        // Actual x-www-form-urlencoded sent from Google Chrome 1.141 with Shift-JIS encoding.
-        // The same form data is sent from Firefox 143.0.4
-        // The same form data is also what is sent from Apache HttpClient 4.5.x and 5.x
-        // The properly encoded form of this character would be "a=%83%7A"
-        // Note: "%7A" is the ASCII "z"
-        String sjis = "a=%83z";
-        Charset shiftJis = Charset.forName("Shift_JIS");
-        byte[] bytes = sjis.getBytes(shiftJis);
-        try (ByteArrayInputStream in = new ByteArrayInputStream(bytes))
-        {
-            MultiMap<String> map = new MultiMap<>();
-            UrlEncoded.decodeTo(in, map, shiftJis, 500, 500);
-            List<String> result = map.get("a");
-            assertNotNull(result);
-            assertEquals(1, result.size());
-            assertEquals("ホ", result.get(0));
-        }
     }
 }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/UrlParameterDecoderTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/UrlParameterDecoderTest.java
@@ -290,6 +290,36 @@ public class UrlParameterDecoderTest
         assertEquals("value 3", field.getValue(), "Fields[nãme3]");
     }
 
+    /**
+     * Test of non-standard encoding of Shift_JIS.
+     * This tests a 2 byte sequence making up 1 Shift_JIS character.
+     * But only the first byte is pct-encoded, other byte is "in the raw" and not encoded.
+     * Both bytes are required for the KATAKANA LETTER HO: ホ to be decoded.
+     * See https://unicodeplus.com/U+30DB
+     */
+    @Test
+    public void testSjisNonStandardForm() throws IOException
+    {
+        // Actual x-www-form-urlencoded sent from Google Chrome 1.141 with Shift-JIS encoding.
+        // The same form data is sent from Firefox 143.0.4
+        // The same form data is also what is sent from Apache HttpClient 4.5.x and 5.x
+        // The properly encoded form of this character would be "a=%83%7A"
+        // Note: "%7A" is the ASCII "z"
+        String input = "a=%83z";
+        Charset shiftJis = Charset.forName("Shift_JIS");
+
+        Fields fields = new Fields();
+        CharsetStringBuilder charsetStringBuilder = CharsetStringBuilder.forCharset(shiftJis);
+        UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add);
+
+        assertFalse(decoder.parse(input), "No coding errors");
+
+        assertThat("Field count", fields.getSize(), is(1));
+        Fields.Field field = fields.get("a");
+        assertNotNull(field, "Fields[a]");
+        assertEquals("ホ", field.getValue(), "Fields[a]");
+    }
+
     public static Stream<Arguments> queryBehaviorsBadUtf8AllowedGood()
     {
         List<Arguments> cases = new ArrayList<>();

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/UrlParameterDecoderTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/UrlParameterDecoderTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.US_ASCII;
@@ -259,13 +260,16 @@ public class UrlParameterDecoderTest
         assertEquals("Euro-€-Symbol", field.getValue(), "Fields[Name]");
     }
 
-    @Test
-    public void testUtf16EncodedString() throws IOException
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "name\n=value+%00%30&name1=&name2&nãme3=value+3", // without BOM
+        "name\n=value+%FE%FF%00%30&name1=&name2&nãme3=value+3" // with BOM
+    })
+    public void testUtf16EncodedString(String input) throws IOException
     {
         Fields fields = new Fields();
         CharsetStringBuilder charsetStringBuilder = CharsetStringBuilder.forCharset(UTF_16);
         UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add);
-        String input = "name\n=value+%FE%FF%00%30&name1=&name2&nãme3=value+3";
         assertFalse(decoder.parse(input), "No coding errors");
 
         assertThat("Field count", fields.getSize(), is(4));


### PR DESCRIPTION
Fixed `DecoderStringBuilder.append(char c)` to handle incoming chars with an existing ByteBuffer as just extra bytes for the CharsetDecoder to consume.

More unit tests