### PR TITLE
Review the lifecycle of WebSocket beans

### DIFF
--- a/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/ComponentDocs.java
+++ b/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/ComponentDocs.java
@@ -45,7 +45,7 @@ public class ComponentDocs
             public Root()
             {
                 // The Monitor life cycle is managed by Root.
-                addManaged(monitor);
+                addBeanAndEnsure(this, monitor);
             }
         }
 

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -516,7 +516,7 @@ public class HttpClient extends ContainerLifeCycle implements AutoCloseable
             {
                 HttpDestination newDestination = (HttpDestination)getHttpClientTransport().newDestination(k);
                 // Start the destination before it's published to other threads.
-                addManaged(newDestination);
+                addBeanAndEnsure(this, newDestination);
                 if (destinationSweeper != null)
                     destinationSweeper.offer(newDestination);
                 if (LOG.isDebugEnabled())

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTLSTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTLSTest.java
@@ -67,6 +67,7 @@ import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.toolchain.test.Net;
 import org.eclipse.jetty.util.Pool;
 import org.eclipse.jetty.util.StringUtil;
+import org.eclipse.jetty.util.component.ContainerLifeCycle;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.ExecutorThreadPool;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
@@ -1370,7 +1371,7 @@ public class HttpClientTLSTest
                 latch.countDown();
             }
         };
-        connector.addManaged(serverStats);
+        ContainerLifeCycle.addBeanAndEnsure(connector, serverStats);
 
         SslContextFactory.Client clientTLSFactory = createClientSslContextFactory();
         startClient(clientTLSFactory);
@@ -1383,7 +1384,7 @@ public class HttpClientTLSTest
                 latch.countDown();
             }
         };
-        client.addManaged(clientStats);
+        ContainerLifeCycle.addBeanAndEnsure(client, clientStats);
 
         ContentResponse response = client.newRequest("https://localhost:" + connector.getLocalPort())
             .headers(httpFields -> httpFields.put(HttpHeader.CONNECTION, HttpHeaderValue.CLOSE.asString()))

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-client/src/main/java/org/eclipse/jetty/quic/quiche/client/QuicheTransport.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-client/src/main/java/org/eclipse/jetty/quic/quiche/client/QuicheTransport.java
@@ -37,6 +37,7 @@ import org.eclipse.jetty.quic.quiche.client.internal.ClientQuicheSession;
 import org.eclipse.jetty.quic.util.ErrorCode;
 import org.eclipse.jetty.util.Promise;
 import org.eclipse.jetty.util.component.Container;
+import org.eclipse.jetty.util.component.ContainerLifeCycle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -114,7 +115,7 @@ public class QuicheTransport extends Transport.Wrapper
             {
                 ClientQuicheSession qSession = (ClientQuicheSession)session;
                 ProtocolSession pSession = newProtocolSession(qSession);
-                qSession.addManaged(pSession);
+                ContainerLifeCycle.addBeanAndEnsure(qSession, pSession);
                 protocolSession.set(pSession);
                 context.put(ClientConnector.APPLICATION_PROTOCOL_CONTEXT_KEY, qSession.getNegotiatedProtocol());
             }

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-server/src/main/java/org/eclipse/jetty/quic/quiche/server/QuicheServerConnectionFactory.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-server/src/main/java/org/eclipse/jetty/quic/quiche/server/QuicheServerConnectionFactory.java
@@ -89,7 +89,7 @@ public class QuicheServerConnectionFactory extends AbstractQuicheServerConnectio
             {
                 ServerQuicheSession qSession = (ServerQuicheSession)session;
                 ProtocolSession pSession = newProtocolSession(qSession);
-                qSession.addManaged(pSession);
+                addBeanAndEnsure(qSession, pSession);
                 protocolSession.set(pSession);
             }
             catch (Throwable x)

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -1422,7 +1422,7 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
     {
         _aliasChecks.add(check);
         if (check instanceof LifeCycle)
-            addManaged((LifeCycle)check);
+            addBeanAndEnsure(this, (LifeCycle)check);
         else
             addBean(check);
     }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/HotSwapHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/HotSwapHandler.java
@@ -71,7 +71,7 @@ public class HotSwapHandler extends Handler.AbstractContainer implements Handler
             if (handler != null)
             {
                 handler.setServer(server);
-                addManaged(handler);
+                addBeanAndEnsure(this, handler);
             }
             _handler = handler;
             if (oldHandler != null)

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/ContainerLifeCycle.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/ContainerLifeCycle.java
@@ -473,14 +473,30 @@ public class ContainerLifeCycle extends AbstractLifeCycle implements Container, 
      * wrapped as RuntimeExceptions
      *
      * @param lifecycle the managed lifecycle to add
+     * @deprecated use {@link #addBeanAndEnsure(ContainerLifeCycle, LifeCycle)} instead.
      */
+    @Deprecated(forRemoval = true, since = "jetty-12.1.3")
     public void addManaged(LifeCycle lifecycle)
     {
-        addBean(lifecycle, true);
+        addBeanAndEnsure(this, lifecycle);
+    }
+
+    /**
+     * Adds a managed lifecycle.
+     * <p>This is a convenience method that uses addBean(lifecycle,true)
+     * and then ensures that the added bean is started iff this container
+     * is running.  Exception from nested calls to start are caught and
+     * wrapped as RuntimeExceptions
+     *
+     * @param lifecycle the managed lifecycle to add
+     */
+    public static void addBeanAndEnsure(ContainerLifeCycle container, LifeCycle lifecycle)
+    {
+        container.addBean(lifecycle, true);
         try
         {
-            if (isRunning() && !lifecycle.isRunning())
-                start(lifecycle);
+            if (container.isRunning() && !lifecycle.isRunning())
+                container.start(lifecycle);
         }
         catch (RuntimeException | Error e)
         {

--- a/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/WebSocketMappings.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/WebSocketMappings.java
@@ -63,20 +63,21 @@ public class WebSocketMappings implements Dumpable, LifeCycle.Listener
         WebSocketMappings mappings = getMappings(contextHandler);
         if (mappings == null)
         {
+            mappings = contextHandler.getBean(WebSocketMappings.class);
+            if (mappings != null)
+            {
+                contextHandler.setAttribute(WEBSOCKET_MAPPING_ATTRIBUTE, mappings);
+
+                // The listener only persists through restarts if it is "durable" (if it is added before starting).
+                if (!contextHandler.getEventListeners().contains(mappings))
+                    contextHandler.addEventListener(mappings);
+            }
+        }
+        if (mappings == null)
+        {
             mappings = new WebSocketMappings(WebSocketServerComponents.getWebSocketComponents(contextHandler));
             contextHandler.setAttribute(WEBSOCKET_MAPPING_ATTRIBUTE, mappings);
             contextHandler.addBean(mappings);
-            WebSocketMappings m = mappings;
-            contextHandler.addEventListener(new LifeCycle.Listener()
-            {
-                @Override
-                public void lifeCycleStopping(LifeCycle event)
-                {
-                    contextHandler.removeAttribute(WEBSOCKET_MAPPING_ATTRIBUTE);
-                    contextHandler.removeEventListener(this);
-                    contextHandler.removeBean(m);
-                }
-            });
         }
 
         return mappings;

--- a/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/WebSocketServerComponents.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/WebSocketServerComponents.java
@@ -21,7 +21,6 @@ import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.Attributes;
 import org.eclipse.jetty.util.DecoratedObjectFactory;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
-import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.compression.DeflaterPool;
 import org.eclipse.jetty.util.compression.InflaterPool;
 import org.eclipse.jetty.websocket.core.WebSocketComponents;
@@ -99,6 +98,13 @@ public class WebSocketServerComponents extends WebSocketComponents
         if (components != null)
             return components;
 
+        components = container.getBean(WebSocketServerComponents.class);
+        if (components != null)
+        {
+            attributes.setAttribute(WEBSOCKET_COMPONENTS_ATTRIBUTE, components);
+            return components;
+        }
+
         InflaterPool inflaterPool = (InflaterPool)attributes.getAttribute(WEBSOCKET_INFLATER_POOL_ATTRIBUTE);
         if (inflaterPool == null)
             inflaterPool = InflaterPool.ensurePool(server);
@@ -116,44 +122,24 @@ public class WebSocketServerComponents extends WebSocketComponents
             executor = server.getThreadPool();
 
         DecoratedObjectFactory objectFactory = (DecoratedObjectFactory)attributes.getAttribute(DecoratedObjectFactory.ATTR);
-        WebSocketComponents serverComponents = new WebSocketServerComponents(inflaterPool, deflaterPool, bufferPool, objectFactory, executor);
+        components = new WebSocketServerComponents(inflaterPool, deflaterPool, bufferPool, objectFactory, executor);
         if (objectFactory != null)
-            serverComponents.unmanage(objectFactory);
+            components.unmanage(objectFactory);
 
         // These components may be managed by the server but not yet started.
         // In this case we don't want them to be managed by the components as well.
         if (server.contains(inflaterPool))
-            serverComponents.unmanage(inflaterPool);
+            components.unmanage(inflaterPool);
         if (server.contains(deflaterPool))
-            serverComponents.unmanage(deflaterPool);
+            components.unmanage(deflaterPool);
         if (server.contains(bufferPool))
-            serverComponents.unmanage(bufferPool);
+            components.unmanage(bufferPool);
         if (executor != null)
-            serverComponents.unmanage(executor);
+            components.unmanage(executor);
 
-        // Set to be managed as persistent attribute and bean on ContextHandler.
-        container.addManaged(serverComponents);
-        attributes.setAttribute(WEBSOCKET_COMPONENTS_ATTRIBUTE, serverComponents);
-
-        // Stop the WebSocketComponents when the ContextHandler stops and remove the WebSocketComponents attribute.
-        container.addEventListener(new LifeCycle.Listener()
-        {
-            @Override
-            public void lifeCycleStopping(LifeCycle event)
-            {
-                attributes.removeAttribute(WEBSOCKET_COMPONENTS_ATTRIBUTE);
-                container.removeBean(serverComponents);
-                container.removeEventListener(this);
-            }
-
-            @Override
-            public String toString()
-            {
-                return String.format("%sCleanupListener", WebSocketServerComponents.class.getSimpleName());
-            }
-        });
-
-        return serverComponents;
+        addBeanAndEnsure(container, components);
+        attributes.setAttribute(WEBSOCKET_COMPONENTS_ATTRIBUTE, components);
+        return components;
     }
 
     public static WebSocketComponents getWebSocketComponents(ContextHandler contextHandler)

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-client/src/main/java/org/eclipse/jetty/websocket/client/WebSocketClient.java
@@ -79,7 +79,7 @@ public class WebSocketClient extends ContainerLifeCycle implements Configurable,
     public WebSocketClient(HttpClient httpClient)
     {
         coreClient = new WebSocketCoreClient(httpClient, null);
-        addManaged(coreClient);
+        addBeanAndEnsure(this, coreClient);
         frameHandlerFactory = new JettyWebSocketFrameHandlerFactory(this, coreClient.getWebSocketComponents());
         sessionListeners.add(sessionTracker);
         installBean(sessionTracker);

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/ServerWebSocketContainer.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/ServerWebSocketContainer.java
@@ -83,7 +83,7 @@ public class ServerWebSocketContainer extends ContainerLifeCycle implements WebS
             WebSocketMappings mappings = new WebSocketMappings(components);
             container = new ServerWebSocketContainer(context, mappings);
             ContainerLifeCycle parent = contextHandler == null ? server : contextHandler;
-            parent.addManaged(container);
+            addBeanAndEnsure(parent, container);
         }
         return container;
     }

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/ServerWebSocketContainer.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-server/src/main/java/org/eclipse/jetty/websocket/server/ServerWebSocketContainer.java
@@ -81,7 +81,7 @@ public class ServerWebSocketContainer extends ContainerLifeCycle implements WebS
                 ? WebSocketServerComponents.ensureWebSocketComponents(server)
                 : WebSocketServerComponents.ensureWebSocketComponents(server, contextHandler);
             WebSocketMappings mappings = new WebSocketMappings(components);
-            container = new ServerWebSocketContainer(context, mappings);
+            container = new ServerWebSocketContainer(context, components, mappings);
             ContainerLifeCycle parent = contextHandler == null ? server : contextHandler;
             addBeanAndEnsure(parent, container);
         }
@@ -127,13 +127,14 @@ public class ServerWebSocketContainer extends ContainerLifeCycle implements WebS
     private final FrameHandlerFactory factory;
     private InvocationType invocationType = InvocationType.BLOCKING;
 
-    ServerWebSocketContainer(Context context, WebSocketMappings mappings)
+    ServerWebSocketContainer(Context context, WebSocketComponents components, WebSocketMappings mappings)
     {
         this.context = context;
         this.mappings = mappings;
-        installBean(mappings);
         this.factory = new ServerFrameHandlerFactory(this, mappings.getWebSocketComponents());
         addSessionListener(sessionTracker);
+        installBean(components);
+        installBean(mappings);
         installBean(sessionTracker);
     }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
@@ -395,6 +395,8 @@ public class ServletContextHandler extends ContextHandler
     {
         if (super.removeEventListener(listener))
         {
+            _durableListeners.remove(listener);
+
             if (listener instanceof ServletContextScopeListener)
                 _contextListeners.remove(listener);
 
@@ -911,6 +913,9 @@ public class ServletContextHandler extends ContextHandler
     {
         if (super.addEventListener(listener))
         {
+            if (isRunning() && contains(listener))
+                _durableListeners.add(listener);
+
             if ((listener instanceof HttpSessionActivationListener) ||
                 (listener instanceof HttpSessionAttributeListener) ||
                 (listener instanceof HttpSessionBindingListener) ||

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/support/XmlBasedJettyServer.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/support/XmlBasedJettyServer.java
@@ -28,6 +28,7 @@ import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.util.component.ContainerLifeCycle;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
@@ -151,7 +152,7 @@ public class XmlBasedJettyServer
 
     public void start() throws Exception
     {
-        _server.addManaged(_resourceFactory);
+        ContainerLifeCycle.addBeanAndEnsure(_server, _resourceFactory);
         _server.start();
     }
 

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-client/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/client/JakartaWebSocketClientContainer.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-client/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/client/JakartaWebSocketClientContainer.java
@@ -116,7 +116,7 @@ public class JakartaWebSocketClientContainer extends JakartaWebSocketContainer i
         if (coreClient == null)
         {
             coreClient = coreClientFactory.apply(components);
-            addManaged(coreClient);
+            addBeanAndEnsure(this, coreClient);
         }
 
         return coreClient;
@@ -332,7 +332,7 @@ public class JakartaWebSocketClientContainer extends JakartaWebSocketContainer i
         ContainerLifeCycle container = SHUTDOWN_MAP.get(cl);
         if (container != null)
         {
-            container.addManaged(this);
+            addBeanAndEnsure(container, this);
             if (LOG.isDebugEnabled())
                 LOG.debug("{} registered for WebApp shutdown to {}", this, container);
             return;

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-common/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/common/JakartaWebSocketContainer.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-common/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/common/JakartaWebSocketContainer.java
@@ -48,6 +48,7 @@ public abstract class JakartaWebSocketContainer extends ContainerLifeCycle imple
         this.components = components;
         addSessionListener(sessionTracker);
         installBean(sessionTracker);
+        installBean(components);
     }
 
     public abstract Executor getExecutor();

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/server/JakartaWebSocketServerContainer.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/server/JakartaWebSocketServerContainer.java
@@ -111,7 +111,7 @@ public class JakartaWebSocketServerContainer extends JakartaWebSocketClientConta
             coreClientSupplier);
 
         // Manage the lifecycle of the Container.
-        contextHandler.addManaged(container);
+        addBeanAndEnsure(contextHandler, container);
         contextHandler.addEventListener(container);
         contextHandler.addEventListener(new LifeCycle.Listener()
         {

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/JettyWebSocketServerContainer.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee10/websocket/server/JettyWebSocketServerContainer.java
@@ -72,41 +72,22 @@ public class JettyWebSocketServerContainer extends ContainerLifeCycle implements
             throw new IllegalStateException("Server has not been set on the ServletContextHandler");
 
         // If we find a container in the servlet context return it.
-        JettyWebSocketServerContainer containerFromServletContext = getContainer(servletContext);
-        if (containerFromServletContext != null)
-            return containerFromServletContext;
+        JettyWebSocketServerContainer container = getContainer(servletContext);
+        if (container != null)
+            return container;
 
-        // Find Pre-Existing executor.
-        Executor executor = (Executor)servletContext.getAttribute("org.eclipse.jetty.server.Executor");
-        if (executor == null)
-            executor = contextHandler.getServer().getThreadPool();
+        container = contextHandler.getBean(JettyWebSocketServerContainer.class);
+        if (container != null)
+        {
+            servletContext.setAttribute(JETTY_WEBSOCKET_CONTAINER_ATTRIBUTE, container);
+            return container;
+        }
 
         // Create the Jetty ServerContainer implementation.
         WebSocketMappings mappings = WebSocketMappings.ensureMappings(contextHandler);
         WebSocketComponents components = WebSocketServerComponents.getWebSocketComponents(contextHandler);
-        JettyWebSocketServerContainer container = new JettyWebSocketServerContainer(contextHandler, mappings, components, executor);
-
-        // Manage the lifecycle of the Container.
-        contextHandler.addManaged(container);
-        contextHandler.addEventListener(container);
-        contextHandler.addEventListener(new LifeCycle.Listener()
-        {
-            @Override
-            public void lifeCycleStopping(LifeCycle event)
-            {
-                contextHandler.getServletContext().removeAttribute(JETTY_WEBSOCKET_CONTAINER_ATTRIBUTE);
-                contextHandler.removeBean(container);
-                contextHandler.removeEventListener(container);
-                contextHandler.removeEventListener(this);
-            }
-
-            @Override
-            public String toString()
-            {
-                return String.format("%sCleanupListener", JettyWebSocketServerContainer.class.getSimpleName());
-            }
-        });
-
+        container = new JettyWebSocketServerContainer(contextHandler, mappings, components);
+        addBeanAndEnsure(contextHandler, container);
         servletContext.setAttribute(JETTY_WEBSOCKET_CONTAINER_ATTRIBUTE, container);
         return container;
     }
@@ -117,7 +98,6 @@ public class JettyWebSocketServerContainer extends ContainerLifeCycle implements
     private final WebSocketMappings webSocketMappings;
     private final WebSocketComponents components;
     private final JettyServerFrameHandlerFactory frameHandlerFactory;
-    private final Executor executor;
     private final Configuration.ConfigurationCustomizer customizer = new Configuration.ConfigurationCustomizer();
 
     private final List<WebSocketSessionListener> sessionListeners = new ArrayList<>();
@@ -127,18 +107,18 @@ public class JettyWebSocketServerContainer extends ContainerLifeCycle implements
      * Main entry point for {@link JettyWebSocketServletContainerInitializer}.
      *
      * @param webSocketMappings the {@link WebSocketMappings} that this container belongs to
-     * @param executor the {@link Executor} to use
      */
-    JettyWebSocketServerContainer(ServletContextHandler contextHandler, WebSocketMappings webSocketMappings, WebSocketComponents components, Executor executor)
+    JettyWebSocketServerContainer(ServletContextHandler contextHandler, WebSocketMappings webSocketMappings, WebSocketComponents components)
     {
         this.contextHandler = contextHandler;
         this.webSocketMappings = webSocketMappings;
         this.components = components;
-        this.executor = executor;
         this.frameHandlerFactory = new JettyServerFrameHandlerFactory(this, components);
-        installBean(frameHandlerFactory);
 
         addSessionListener(sessionTracker);
+        installBean(webSocketMappings);
+        installBean(components);
+        installBean(frameHandlerFactory);
         installBean(sessionTracker);
     }
 
@@ -247,7 +227,7 @@ public class JettyWebSocketServerContainer extends ContainerLifeCycle implements
     @Override
     public Executor getExecutor()
     {
-        return this.executor;
+        return this.components.getExecutor();
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee10/websocket/tests/JettyWebSocketRestartTest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee10/websocket/tests/JettyWebSocketRestartTest.java
@@ -24,17 +24,23 @@ import org.eclipse.jetty.ee10.websocket.server.config.JettyWebSocketServletConta
 import org.eclipse.jetty.ee10.websocket.servlet.WebSocketUpgradeFilter;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.websocket.api.Callback;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.eclipse.jetty.websocket.core.WebSocketComponents;
+import org.eclipse.jetty.websocket.core.server.WebSocketMappings;
 import org.eclipse.jetty.websocket.core.server.WebSocketServerComponents;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -102,6 +108,80 @@ public class JettyWebSocketRestartTest
         assertThat(contextHandler.getContainedBeans(WebSocketServerComponents.class).size(), is(0));
         assertNull(contextHandler.getServletContext().getAttribute(WebSocketServerComponents.WEBSOCKET_COMPONENTS_ATTRIBUTE));
         assertNull(contextHandler.getServletContext().getAttribute(JettyWebSocketServerContainer.JETTY_WEBSOCKET_CONTAINER_ATTRIBUTE));
+        assertThat(contextHandler.getServletHandler().getFilters().length, is(0));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testContextRestart(boolean earlyInitWebSocketComponents) throws Exception
+    {
+        if (earlyInitWebSocketComponents)
+            WebSocketServerComponents.ensureWebSocketComponents(server, contextHandler);
+        JettyWebSocketServletContainerInitializer.configure(contextHandler, (context, container) ->
+            container.addMapping("/", EchoSocket.class));
+        server.start();
+        WebSocketComponents components = WebSocketServerComponents.getWebSocketComponents(contextHandler);
+
+        int initialNumEventListeners = contextHandler.getEventListeners().size();
+        for (int i = 0; i < 100; i++)
+        {
+            assertThat(contextHandler.getEventListeners().size(), is(initialNumEventListeners));
+            assertThat(contextHandler.getContext().getAttribute(WebSocketServerComponents.WEBSOCKET_COMPONENTS_ATTRIBUTE), sameInstance(components));
+            assertThat(contextHandler.getBean(WebSocketServerComponents.class), sameInstance(components));
+
+            contextHandler.stop();
+
+            // The CompressionPools should still be running because they are a resource managed by the server.
+            assertTrue(components.getDeflaterPool().isRunning());
+            assertTrue(components.getInflaterPool().isRunning());
+
+            // Even though the components is now stopped the executor is still running as it has been taken from the server.
+            assertTrue(components.isStopped());
+            assertThat(components.getExecutor(), instanceOf(QueuedThreadPool.class));
+            assertTrue(((QueuedThreadPool)components.getExecutor()).isRunning());
+
+            // The components now persists as a bean though restarts.
+            assertNull(contextHandler.getContext().getAttribute(WebSocketServerComponents.WEBSOCKET_COMPONENTS_ATTRIBUTE));
+            assertThat(contextHandler.getBean(WebSocketServerComponents.class), sameInstance(components));
+
+            contextHandler.start();
+            testEchoMessage();
+        }
+
+        // Verify we have not accumulated websocket resources by restarting.
+        assertThat(contextHandler.getEventListeners().size(), is(initialNumEventListeners));
+        assertThat(contextHandler.getContainedBeans(JettyWebSocketServerContainer.class).size(), is(1));
+        assertThat(contextHandler.getContainedBeans(WebSocketServerComponents.class).size(), is(1));
+        assertNotNull(contextHandler.getServletContext().getAttribute(WebSocketServerComponents.WEBSOCKET_COMPONENTS_ATTRIBUTE));
+        assertNotNull(contextHandler.getServletContext().getAttribute(JettyWebSocketServerContainer.JETTY_WEBSOCKET_CONTAINER_ATTRIBUTE));
+
+        // We have one filter, and it is a WebSocketUpgradeFilter.
+        FilterHolder[] filters = contextHandler.getServletHandler().getFilters();
+        assertThat(filters.length, is(1));
+        assertThat(filters[0].getFilter(), instanceOf(WebSocketUpgradeFilter.class));
+
+        // Verify the state after stopping the server.
+        contextHandler.stop();
+        assertThat(contextHandler.getEventListeners().size(), is(2));
+
+        // Server managed components should still be running.
+        assertThat(contextHandler.getContainedBeans(WebSocketServerComponents.class).size(), is(1));
+        assertThat(contextHandler.getBean(WebSocketServerComponents.class), sameInstance(components));
+        assertTrue(components.getInflaterPool().isRunning());
+        assertTrue(components.getDeflaterPool().isRunning());
+        assertTrue(((QueuedThreadPool)components.getExecutor()).isRunning());
+
+        // The other components should now be stopped.
+        assertThat(contextHandler.getContainedBeans(JettyWebSocketServerContainer.class).size(), is(1));
+        assertThat(contextHandler.getContainedBeans(WebSocketMappings.class).size(), is(1));
+        assertTrue(contextHandler.getBean(JettyWebSocketServerContainer.class).isStopped());
+        assertTrue(components.isStopped());
+
+        // Attributes should be removed.
+        assertNull(contextHandler.getServletContext().getAttribute(WebSocketServerComponents.WEBSOCKET_COMPONENTS_ATTRIBUTE));
+        assertNull(contextHandler.getServletContext().getAttribute(JettyWebSocketServerContainer.JETTY_WEBSOCKET_CONTAINER_ATTRIBUTE));
+
+        // The WebSocketUpgradeFilter should be removed.
         assertThat(contextHandler.getServletHandler().getFilters().length, is(0));
     }
 

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee10/websocket/tests/JettyWebSocketRestartTest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee10/websocket/tests/JettyWebSocketRestartTest.java
@@ -103,9 +103,9 @@ public class JettyWebSocketRestartTest
 
         // After stopping the websocket resources are cleaned up.
         server.stop();
-        assertThat(contextHandler.getEventListeners().size(), is(0));
-        assertThat(contextHandler.getContainedBeans(JettyWebSocketServerContainer.class).size(), is(0));
-        assertThat(contextHandler.getContainedBeans(WebSocketServerComponents.class).size(), is(0));
+        assertThat(contextHandler.getEventListeners().size(), is(2));
+        assertThat(contextHandler.getContainedBeans(JettyWebSocketServerContainer.class).size(), is(1));
+        assertThat(contextHandler.getContainedBeans(WebSocketServerComponents.class).size(), is(1));
         assertNull(contextHandler.getServletContext().getAttribute(WebSocketServerComponents.WEBSOCKET_COMPONENTS_ATTRIBUTE));
         assertNull(contextHandler.getServletContext().getAttribute(JettyWebSocketServerContainer.JETTY_WEBSOCKET_CONTAINER_ATTRIBUTE));
         assertThat(contextHandler.getServletHandler().getFilters().length, is(0));

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextHandler.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextHandler.java
@@ -392,6 +392,8 @@ public class ServletContextHandler extends ContextHandler
     {
         if (super.removeEventListener(listener))
         {
+            _durableListeners.remove(listener);
+
             if (listener instanceof ServletContextScopeListener)
                 _contextListeners.remove(listener);
 
@@ -907,6 +909,9 @@ public class ServletContextHandler extends ContextHandler
     {
         if (super.addEventListener(listener))
         {
+            if (isRunning() && contains(listener))
+                _durableListeners.add(listener);
+
             if ((listener instanceof HttpSessionActivationListener) ||
                 (listener instanceof HttpSessionAttributeListener) ||
                 (listener instanceof HttpSessionBindingListener) ||

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/java/org/eclipse/jetty/ee11/test/support/XmlBasedJettyServer.java
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/java/org/eclipse/jetty/ee11/test/support/XmlBasedJettyServer.java
@@ -28,6 +28,7 @@ import org.eclipse.jetty.ee11.servlet.ServletContextHandler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.util.component.ContainerLifeCycle;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
@@ -151,7 +152,7 @@ public class XmlBasedJettyServer
 
     public void start() throws Exception
     {
-        _server.addManaged(_resourceFactory);
+        ContainerLifeCycle.addBeanAndEnsure(_server, _resourceFactory);
         _server.start();
     }
 

--- a/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-client/src/main/java/org/eclipse/jetty/ee11/websocket/jakarta/client/JakartaWebSocketClientContainer.java
+++ b/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-client/src/main/java/org/eclipse/jetty/ee11/websocket/jakarta/client/JakartaWebSocketClientContainer.java
@@ -116,7 +116,7 @@ public class JakartaWebSocketClientContainer extends JakartaWebSocketContainer i
         if (coreClient == null)
         {
             coreClient = coreClientFactory.apply(components);
-            addManaged(coreClient);
+            addBeanAndEnsure(this, coreClient);
         }
 
         return coreClient;
@@ -327,7 +327,7 @@ public class JakartaWebSocketClientContainer extends JakartaWebSocketContainer i
         ContainerLifeCycle container = SHUTDOWN_MAP.get(cl);
         if (container != null)
         {
-            container.addManaged(this);
+            addBeanAndEnsure(container, this);
             if (LOG.isDebugEnabled())
                 LOG.debug("{} registered for WebApp shutdown to {}", this, container);
             return;

--- a/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-common/src/main/java/org/eclipse/jetty/ee11/websocket/jakarta/common/JakartaWebSocketContainer.java
+++ b/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-common/src/main/java/org/eclipse/jetty/ee11/websocket/jakarta/common/JakartaWebSocketContainer.java
@@ -49,6 +49,7 @@ public abstract class JakartaWebSocketContainer extends ContainerLifeCycle imple
         this.components = components;
         addSessionListener(sessionTracker);
         installBean(sessionTracker);
+        installBean(components);
     }
 
     public abstract Executor getExecutor();

--- a/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee11/websocket/jakarta/server/JakartaWebSocketServerContainer.java
+++ b/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee11/websocket/jakarta/server/JakartaWebSocketServerContainer.java
@@ -111,7 +111,7 @@ public class JakartaWebSocketServerContainer extends JakartaWebSocketClientConta
             coreClientSupplier);
 
         // Manage the lifecycle of the Container.
-        contextHandler.addManaged(container);
+        addBeanAndEnsure(contextHandler, container);
         contextHandler.addEventListener(container);
         contextHandler.addEventListener(new LifeCycle.Listener()
         {

--- a/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee11/websocket/server/JettyWebSocketServerContainer.java
+++ b/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee11/websocket/server/JettyWebSocketServerContainer.java
@@ -72,41 +72,22 @@ public class JettyWebSocketServerContainer extends ContainerLifeCycle implements
             throw new IllegalStateException("Server has not been set on the ServletContextHandler");
 
         // If we find a container in the servlet context return it.
-        JettyWebSocketServerContainer containerFromServletContext = getContainer(servletContext);
-        if (containerFromServletContext != null)
-            return containerFromServletContext;
+        JettyWebSocketServerContainer container = getContainer(servletContext);
+        if (container != null)
+            return container;
 
-        // Find Pre-Existing executor.
-        Executor executor = (Executor)servletContext.getAttribute("org.eclipse.jetty.server.Executor");
-        if (executor == null)
-            executor = contextHandler.getServer().getThreadPool();
+        container = contextHandler.getBean(JettyWebSocketServerContainer.class);
+        if (container != null)
+        {
+            servletContext.setAttribute(JETTY_WEBSOCKET_CONTAINER_ATTRIBUTE, container);
+            return container;
+        }
 
         // Create the Jetty ServerContainer implementation.
         WebSocketMappings mappings = WebSocketMappings.ensureMappings(contextHandler);
         WebSocketComponents components = WebSocketServerComponents.getWebSocketComponents(contextHandler);
-        JettyWebSocketServerContainer container = new JettyWebSocketServerContainer(contextHandler, mappings, components, executor);
-
-        // Manage the lifecycle of the Container.
-        contextHandler.addManaged(container);
-        contextHandler.addEventListener(container);
-        contextHandler.addEventListener(new LifeCycle.Listener()
-        {
-            @Override
-            public void lifeCycleStopping(LifeCycle event)
-            {
-                contextHandler.getServletContext().removeAttribute(JETTY_WEBSOCKET_CONTAINER_ATTRIBUTE);
-                contextHandler.removeBean(container);
-                contextHandler.removeEventListener(container);
-                contextHandler.removeEventListener(this);
-            }
-
-            @Override
-            public String toString()
-            {
-                return String.format("%sCleanupListener", JettyWebSocketServerContainer.class.getSimpleName());
-            }
-        });
-
+        container = new JettyWebSocketServerContainer(contextHandler, mappings, components);
+        addBeanAndEnsure(contextHandler, container);
         servletContext.setAttribute(JETTY_WEBSOCKET_CONTAINER_ATTRIBUTE, container);
         return container;
     }
@@ -117,7 +98,6 @@ public class JettyWebSocketServerContainer extends ContainerLifeCycle implements
     private final WebSocketMappings webSocketMappings;
     private final WebSocketComponents components;
     private final JettyServerFrameHandlerFactory frameHandlerFactory;
-    private final Executor executor;
     private final Configuration.ConfigurationCustomizer customizer = new Configuration.ConfigurationCustomizer();
 
     private final List<WebSocketSessionListener> sessionListeners = new ArrayList<>();
@@ -127,18 +107,18 @@ public class JettyWebSocketServerContainer extends ContainerLifeCycle implements
      * Main entry point for {@link JettyWebSocketServletContainerInitializer}.
      *
      * @param webSocketMappings the {@link WebSocketMappings} that this container belongs to
-     * @param executor the {@link Executor} to use
      */
-    JettyWebSocketServerContainer(ServletContextHandler contextHandler, WebSocketMappings webSocketMappings, WebSocketComponents components, Executor executor)
+    JettyWebSocketServerContainer(ServletContextHandler contextHandler, WebSocketMappings webSocketMappings, WebSocketComponents components)
     {
         this.contextHandler = contextHandler;
         this.webSocketMappings = webSocketMappings;
         this.components = components;
-        this.executor = executor;
         this.frameHandlerFactory = new JettyServerFrameHandlerFactory(this, components);
-        installBean(frameHandlerFactory);
 
         addSessionListener(sessionTracker);
+        installBean(webSocketMappings);
+        installBean(components);
+        installBean(frameHandlerFactory);
         installBean(sessionTracker);
     }
 
@@ -247,7 +227,7 @@ public class JettyWebSocketServerContainer extends ContainerLifeCycle implements
     @Override
     public Executor getExecutor()
     {
-        return this.executor;
+        return this.components.getExecutor();
     }
 
     @Override

--- a/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee11/websocket/tests/JettyWebSocketRestartTest.java
+++ b/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee11/websocket/tests/JettyWebSocketRestartTest.java
@@ -103,9 +103,9 @@ public class JettyWebSocketRestartTest
 
         // After stopping the websocket resources are cleaned up.
         server.stop();
-        assertThat(contextHandler.getEventListeners().size(), is(0));
-        assertThat(contextHandler.getContainedBeans(JettyWebSocketServerContainer.class).size(), is(0));
-        assertThat(contextHandler.getContainedBeans(WebSocketServerComponents.class).size(), is(0));
+        assertThat(contextHandler.getEventListeners().size(), is(2));
+        assertThat(contextHandler.getContainedBeans(JettyWebSocketServerContainer.class).size(), is(1));
+        assertThat(contextHandler.getContainedBeans(WebSocketServerComponents.class).size(), is(1));
         assertNull(contextHandler.getServletContext().getAttribute(WebSocketServerComponents.WEBSOCKET_COMPONENTS_ATTRIBUTE));
         assertNull(contextHandler.getServletContext().getAttribute(JettyWebSocketServerContainer.JETTY_WEBSOCKET_CONTAINER_ATTRIBUTE));
         assertThat(contextHandler.getServletHandler().getFilters().length, is(0));

--- a/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee11/websocket/tests/JettyWebSocketRestartTest.java
+++ b/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee11/websocket/tests/JettyWebSocketRestartTest.java
@@ -24,17 +24,23 @@ import org.eclipse.jetty.ee11.websocket.server.config.JettyWebSocketServletConta
 import org.eclipse.jetty.ee11.websocket.servlet.WebSocketUpgradeFilter;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.websocket.api.Callback;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.eclipse.jetty.websocket.core.WebSocketComponents;
+import org.eclipse.jetty.websocket.core.server.WebSocketMappings;
 import org.eclipse.jetty.websocket.core.server.WebSocketServerComponents;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -102,6 +108,80 @@ public class JettyWebSocketRestartTest
         assertThat(contextHandler.getContainedBeans(WebSocketServerComponents.class).size(), is(0));
         assertNull(contextHandler.getServletContext().getAttribute(WebSocketServerComponents.WEBSOCKET_COMPONENTS_ATTRIBUTE));
         assertNull(contextHandler.getServletContext().getAttribute(JettyWebSocketServerContainer.JETTY_WEBSOCKET_CONTAINER_ATTRIBUTE));
+        assertThat(contextHandler.getServletHandler().getFilters().length, is(0));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testContextRestart(boolean earlyInitWebSocketComponents) throws Exception
+    {
+        if (earlyInitWebSocketComponents)
+            WebSocketServerComponents.ensureWebSocketComponents(server, contextHandler);
+        JettyWebSocketServletContainerInitializer.configure(contextHandler, (context, container) ->
+            container.addMapping("/", EchoSocket.class));
+        server.start();
+        WebSocketComponents components = WebSocketServerComponents.getWebSocketComponents(contextHandler);
+
+        int initialNumEventListeners = contextHandler.getEventListeners().size();
+        for (int i = 0; i < 100; i++)
+        {
+            assertThat(contextHandler.getEventListeners().size(), is(initialNumEventListeners));
+            assertThat(contextHandler.getContext().getAttribute(WebSocketServerComponents.WEBSOCKET_COMPONENTS_ATTRIBUTE), sameInstance(components));
+            assertThat(contextHandler.getBean(WebSocketServerComponents.class), sameInstance(components));
+
+            contextHandler.stop();
+
+            // The CompressionPools should still be running because they are a resource managed by the server.
+            assertTrue(components.getDeflaterPool().isRunning());
+            assertTrue(components.getInflaterPool().isRunning());
+
+            // Even though the components is now stopped the executor is still running as it has been taken from the server.
+            assertTrue(components.isStopped());
+            assertThat(components.getExecutor(), instanceOf(QueuedThreadPool.class));
+            assertTrue(((QueuedThreadPool)components.getExecutor()).isRunning());
+
+            // The components now persists as a bean though restarts.
+            assertNull(contextHandler.getContext().getAttribute(WebSocketServerComponents.WEBSOCKET_COMPONENTS_ATTRIBUTE));
+            assertThat(contextHandler.getBean(WebSocketServerComponents.class), sameInstance(components));
+
+            contextHandler.start();
+            testEchoMessage();
+        }
+
+        // Verify we have not accumulated websocket resources by restarting.
+        assertThat(contextHandler.getEventListeners().size(), is(initialNumEventListeners));
+        assertThat(contextHandler.getContainedBeans(JettyWebSocketServerContainer.class).size(), is(1));
+        assertThat(contextHandler.getContainedBeans(WebSocketServerComponents.class).size(), is(1));
+        assertNotNull(contextHandler.getServletContext().getAttribute(WebSocketServerComponents.WEBSOCKET_COMPONENTS_ATTRIBUTE));
+        assertNotNull(contextHandler.getServletContext().getAttribute(JettyWebSocketServerContainer.JETTY_WEBSOCKET_CONTAINER_ATTRIBUTE));
+
+        // We have one filter, and it is a WebSocketUpgradeFilter.
+        FilterHolder[] filters = contextHandler.getServletHandler().getFilters();
+        assertThat(filters.length, is(1));
+        assertThat(filters[0].getFilter(), instanceOf(WebSocketUpgradeFilter.class));
+
+        // Verify the state after stopping the server.
+        contextHandler.stop();
+        assertThat(contextHandler.getEventListeners().size(), is(2));
+
+        // Server managed components should still be running.
+        assertThat(contextHandler.getContainedBeans(WebSocketServerComponents.class).size(), is(1));
+        assertThat(contextHandler.getBean(WebSocketServerComponents.class), sameInstance(components));
+        assertTrue(components.getInflaterPool().isRunning());
+        assertTrue(components.getDeflaterPool().isRunning());
+        assertTrue(((QueuedThreadPool)components.getExecutor()).isRunning());
+
+        // The other components should now be stopped.
+        assertThat(contextHandler.getContainedBeans(JettyWebSocketServerContainer.class).size(), is(1));
+        assertThat(contextHandler.getContainedBeans(WebSocketMappings.class).size(), is(1));
+        assertTrue(contextHandler.getBean(JettyWebSocketServerContainer.class).isStopped());
+        assertTrue(components.isStopped());
+
+        // Attributes should be removed.
+        assertNull(contextHandler.getServletContext().getAttribute(WebSocketServerComponents.WEBSOCKET_COMPONENTS_ATTRIBUTE));
+        assertNull(contextHandler.getServletContext().getAttribute(JettyWebSocketServerContainer.JETTY_WEBSOCKET_CONTAINER_ATTRIBUTE));
+
+        // The WebSocketUpgradeFilter should be removed.
         assertThat(contextHandler.getServletHandler().getFilters().length, is(0));
     }
 

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/support/XmlBasedJettyServer.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/support/XmlBasedJettyServer.java
@@ -28,6 +28,7 @@ import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.util.component.ContainerLifeCycle;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
@@ -151,7 +152,7 @@ public class XmlBasedJettyServer
 
     public void start() throws Exception
     {
-        _server.addManaged(_resourceFactory);
+        ContainerLifeCycle.addBeanAndEnsure(_server, _resourceFactory);
         _server.start();
     }
 

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-client/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/client/JakartaWebSocketClientContainer.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-client/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/client/JakartaWebSocketClientContainer.java
@@ -116,7 +116,7 @@ public class JakartaWebSocketClientContainer extends JakartaWebSocketContainer i
         if (coreClient == null)
         {
             coreClient = coreClientFactory.apply(components);
-            addManaged(coreClient);
+            addBeanAndEnsure(this, coreClient);
         }
 
         return coreClient;
@@ -332,7 +332,7 @@ public class JakartaWebSocketClientContainer extends JakartaWebSocketContainer i
         ContainerLifeCycle container = SHUTDOWN_MAP.get(cl);
         if (container != null)
         {
-            container.addManaged(this);
+            addBeanAndEnsure(container, this);
             if (LOG.isDebugEnabled())
                 LOG.debug("{} registered for Context shutdown to {}", this, container);
             return;

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-common/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/common/JakartaWebSocketContainer.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-common/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/common/JakartaWebSocketContainer.java
@@ -48,6 +48,7 @@ public abstract class JakartaWebSocketContainer extends ContainerLifeCycle imple
         this.components = components;
         addSessionListener(sessionTracker);
         installBean(sessionTracker);
+        installBean(components);
     }
 
     public abstract Executor getExecutor();

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/server/JakartaWebSocketServerContainer.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-server/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/server/JakartaWebSocketServerContainer.java
@@ -110,7 +110,7 @@ public class JakartaWebSocketServerContainer extends JakartaWebSocketClientConta
             coreClientSupplier);
 
         // Manage the lifecycle of the Container.
-        contextHandler.addManaged(container);
+        addBeanAndEnsure(contextHandler, container);
         contextHandler.addEventListener(container);
         contextHandler.addEventListener(new LifeCycle.Listener()
         {

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-client/src/main/java/org/eclipse/jetty/ee9/websocket/client/WebSocketClient.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-client/src/main/java/org/eclipse/jetty/ee9/websocket/client/WebSocketClient.java
@@ -82,7 +82,7 @@ public class WebSocketClient extends ContainerLifeCycle implements WebSocketPoli
     public WebSocketClient(HttpClient httpClient)
     {
         coreClient = new WebSocketCoreClient(httpClient, components);
-        addManaged(coreClient);
+        addBeanAndEnsure(this, coreClient);
         frameHandlerFactory = new JettyWebSocketFrameHandlerFactory(this, components);
         sessionListeners.add(sessionTracker);
         installBean(sessionTracker);

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/JettyWebSocketServerContainer.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee9/websocket/server/JettyWebSocketServerContainer.java
@@ -88,7 +88,7 @@ public class JettyWebSocketServerContainer extends ContainerLifeCycle implements
         JettyWebSocketServerContainer container = new JettyWebSocketServerContainer(contextHandler, mappings, components, executor);
 
         // Manage the lifecycle of the Container.
-        contextHandler.addManaged(container);
+        addBeanAndEnsure(contextHandler, container);
         contextHandler.addEventListener(container);
         contextHandler.addEventListener(new LifeCycle.Listener()
         {

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/JettyWebSocketRestartTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/JettyWebSocketRestartTest.java
@@ -98,7 +98,7 @@ public class JettyWebSocketRestartTest
         server.stop();
         assertThat(contextHandler.getEventListeners().size(), is(0));
         assertThat(contextHandler.getContainedBeans(JettyWebSocketServerContainer.class).size(), is(0));
-        assertThat(contextHandler.getCoreContextHandler().getContainedBeans(WebSocketServerComponents.class).size(), is(0));
+        assertThat(contextHandler.getCoreContextHandler().getContainedBeans(WebSocketServerComponents.class).size(), is(1));
         assertNull(contextHandler.getServletContext().getAttribute(WebSocketServerComponents.WEBSOCKET_COMPONENTS_ATTRIBUTE));
         assertNull(contextHandler.getServletContext().getAttribute(JettyWebSocketServerContainer.JETTY_WEBSOCKET_CONTAINER_ATTRIBUTE));
         assertThat(contextHandler.getServletHandler().getFilters().length, is(0));


### PR DESCRIPTION
This is an attempt to "embrace the pattern" following comment posted by @gregw in [#13550](https://github.com/jetty/jetty.project/pull/13550/files#r2350852620)

> Jetty's component mechanism can handle this.  If the components are managed by the server, then it will be started by server and the auto beans in the containers will be unmanaged.
> 
> 
> 
> Embrace the pattern! 



- the websocket objects such as `WebSocketComponents` the `WebSocketServerContainer`, `WebSocketMappings` etc are no longer removed as beans from the server is stopped.
- the `WebSocketComponents` are now added as beans by the WebSocketServerContainers instead of only on the context handler.

I could not get rid of this logic from `WebSocketServerComponents.ensure` without breaking tests
```java
if (server.contains(inflaterPool))
    components.unmanage(inflaterPool);
if (server.contains(deflaterPool))
    components.unmanage(deflaterPool);
if (server.contains(bufferPool))
    components.unmanage(bufferPool);
if (executor != null)
    components.unmanage(executor);
```