### PR TITLE
Fix `EncoderSink` double release

### DIFF
--- a/jetty-core/jetty-compression/jetty-compression-brotli/src/main/java/org/eclipse/jetty/compression/brotli/internal/BrotliEncoderSink.java
+++ b/jetty-core/jetty-compression/jetty-compression-brotli/src/main/java/org/eclipse/jetty/compression/brotli/internal/BrotliEncoderSink.java
@@ -70,7 +70,7 @@ public class BrotliEncoderSink extends EncoderSink
     protected WriteRecord encode(boolean last, ByteBuffer content)
     {
         if (encoder.isFinished())
-            return null;
+            throw new IllegalStateException("Already released");
 
         while (true)
         {

--- a/jetty-core/jetty-compression/jetty-compression-brotli/src/test/java/org/eclipse/jetty/compression/brotli/BrotliEncoderSinkTest.java
+++ b/jetty-core/jetty-compression/jetty-compression-brotli/src/test/java/org/eclipse/jetty/compression/brotli/BrotliEncoderSinkTest.java
@@ -30,6 +30,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -76,6 +78,7 @@ public class BrotliEncoderSinkTest extends AbstractBrotliTest
             Callback.Completable callback1 = new Callback.Completable();
             encoderSink.write(true, ByteBuffer.wrap("Hello World!".getBytes(UTF_8)), callback1);
             callback1.get();
+            assertThat(new String(decompress(baos.toByteArray()), UTF_8), is("Hello World!"));
 
             Callback.Completable callback2 = new Callback.Completable();
             encoderSink.write(true, ByteBuffer.wrap("Hello again!".getBytes(UTF_8)), callback2);

--- a/jetty-core/jetty-compression/jetty-compression-brotli/src/test/java/org/eclipse/jetty/compression/brotli/BrotliEncoderSinkTest.java
+++ b/jetty-core/jetty-compression/jetty-compression-brotli/src/test/java/org/eclipse/jetty/compression/brotli/BrotliEncoderSinkTest.java
@@ -14,19 +14,25 @@
 package org.eclipse.jetty.compression.brotli;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.util.Callback;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BrotliEncoderSinkTest extends AbstractBrotliTest
 {
@@ -55,5 +61,26 @@ public class BrotliEncoderSinkTest extends AbstractBrotliTest
         String decompressed = new String(decompress(compressed), StandardCharsets.UTF_8);
         String expected = Files.readString(uncompressed, StandardCharsets.UTF_8);
         assertEquals(expected, decompressed);
+    }
+
+    @Test
+    public void testWriteLastTwice() throws Exception
+    {
+        startBrotli();
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream())
+        {
+            Content.Sink fileSink = Content.Sink.from(baos);
+            Content.Sink encoderSink = brotli.newEncoderSink(fileSink);
+
+            Callback.Completable callback1 = new Callback.Completable();
+            encoderSink.write(true, ByteBuffer.wrap("Hello World!".getBytes(UTF_8)), callback1);
+            callback1.get();
+
+            Callback.Completable callback2 = new Callback.Completable();
+            encoderSink.write(true, ByteBuffer.wrap("Hello again!".getBytes(UTF_8)), callback2);
+            ExecutionException thrown = assertThrows(ExecutionException.class, callback2::get);
+            assertInstanceOf(IllegalStateException.class, thrown.getCause());
+        }
     }
 }

--- a/jetty-core/jetty-compression/jetty-compression-common/src/main/java/org/eclipse/jetty/compression/EncoderSink.java
+++ b/jetty-core/jetty-compression/jetty-compression-common/src/main/java/org/eclipse/jetty/compression/EncoderSink.java
@@ -104,7 +104,7 @@ public abstract class EncoderSink implements Content.Sink
             if (writeRecord.last)
             {
                 state.set(State.FINISHING);
-                callback = Callback.combine(Callback.from(this::finished), callback);
+                callback = Callback.combine(Callback.from(callback.getInvocationType(), this::finished), callback);
             }
             if (writeRecord.callback != null)
                 callback = Callback.combine(callback, writeRecord.callback);
@@ -114,6 +114,11 @@ public abstract class EncoderSink implements Content.Sink
         protected void finished()
         {
             state.set(State.FINISHED);
+        }
+
+        @Override
+        protected void onSuccess()
+        {
             release();
         }
 

--- a/jetty-core/jetty-compression/jetty-compression-common/src/main/java/org/eclipse/jetty/compression/EncoderSink.java
+++ b/jetty-core/jetty-compression/jetty-compression-common/src/main/java/org/eclipse/jetty/compression/EncoderSink.java
@@ -36,13 +36,25 @@ public abstract class EncoderSink implements Content.Sink
     public void write(boolean last, ByteBuffer content, Callback callback)
     {
         if (content != null || last)
-            new EncodeBufferCallback(last, content, callback).iterate();
+            new EncodeBufferCallback(last, content, last ? Callback.from(callback, this::release) : callback).iterate();
         else
             callback.succeeded();
     }
 
+    /**
+     * Creates a {@link WriteRecord} with the given {@code last} flag and {@code content} buffer.
+     * @param last the {@code last} flag to eventually pass to {@link org.eclipse.jetty.io.Content.Sink#write(boolean, ByteBuffer, Callback)}.
+     * @param content the buffer to eventually pass to {@link org.eclipse.jetty.io.Content.Sink#write(boolean, ByteBuffer, Callback)}.
+     * @return the {@link WriteRecord}.
+     * @throws IllegalStateException if {@link #release()} has already been called.
+     */
     protected abstract WriteRecord encode(boolean last, ByteBuffer content);
 
+    /**
+     * <p>Release all resources held by this instance. Any further {@link #write(boolean, ByteBuffer, Callback) write attempt}
+     * fails once this method has been called.</p>
+     * <p>Implementation must be idempotent.</p>
+     */
     protected void release()
     {
     }
@@ -114,18 +126,6 @@ public abstract class EncoderSink implements Content.Sink
         protected void finished()
         {
             state.set(State.FINISHED);
-        }
-
-        @Override
-        protected void onSuccess()
-        {
-            release();
-        }
-
-        @Override
-        protected void onCompleteFailure(Throwable x)
-        {
-            release();
         }
 
         @Override

--- a/jetty-core/jetty-compression/jetty-compression-common/src/main/java/org/eclipse/jetty/compression/EncoderSink.java
+++ b/jetty-core/jetty-compression/jetty-compression-common/src/main/java/org/eclipse/jetty/compression/EncoderSink.java
@@ -104,7 +104,7 @@ public abstract class EncoderSink implements Content.Sink
             if (writeRecord.last)
             {
                 state.set(State.FINISHING);
-                callback = Callback.combine(Callback.from(callback.getInvocationType(), this::finished), callback);
+                callback = Callback.from(this::finished, callback);
             }
             if (writeRecord.callback != null)
                 callback = Callback.combine(callback, writeRecord.callback);

--- a/jetty-core/jetty-compression/jetty-compression-common/src/test/java/org/eclipse/jetty/compression/EncoderSinkTest.java
+++ b/jetty-core/jetty-compression/jetty-compression-common/src/test/java/org/eclipse/jetty/compression/EncoderSinkTest.java
@@ -2,6 +2,7 @@ package org.eclipse.jetty.compression;
 
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.util.Blocker;
 import org.eclipse.jetty.util.Callback;

--- a/jetty-core/jetty-compression/jetty-compression-common/src/test/java/org/eclipse/jetty/compression/EncoderSinkTest.java
+++ b/jetty-core/jetty-compression/jetty-compression-common/src/test/java/org/eclipse/jetty/compression/EncoderSinkTest.java
@@ -1,3 +1,16 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
 package org.eclipse.jetty.compression;
 
 import java.nio.ByteBuffer;

--- a/jetty-core/jetty-compression/jetty-compression-common/src/test/java/org/eclipse/jetty/compression/EncoderSinkTest.java
+++ b/jetty-core/jetty-compression/jetty-compression-common/src/test/java/org/eclipse/jetty/compression/EncoderSinkTest.java
@@ -1,0 +1,45 @@
+package org.eclipse.jetty.compression;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.util.Blocker;
+import org.eclipse.jetty.util.Callback;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class EncoderSinkTest
+{
+    @Test
+    public void testDelegateSinkWriteFailureReleaseCount()
+    {
+        Content.Sink sink = (last, byteBuffer, callback) -> callback.failed(new ArithmeticException());
+        var encoderSink = new EncoderSink(sink)
+        {
+            final AtomicInteger releaseCounter = new AtomicInteger();
+
+            @Override
+            protected WriteRecord encode(boolean last, ByteBuffer content)
+            {
+                return new WriteRecord(last, content, Callback.NOOP);
+            }
+
+            @Override
+            protected void release()
+            {
+                releaseCounter.incrementAndGet();
+            }
+        };
+
+        try (Blocker.Callback cb = Blocker.callback())
+        {
+            encoderSink.write(true, ByteBuffer.allocate(128), cb);
+            assertThrows(ArithmeticException.class, cb::block);
+        }
+
+        assertThat(encoderSink.releaseCounter.get(), is(1));
+    }
+}

--- a/jetty-core/jetty-compression/jetty-compression-common/src/test/resources/jetty-logging.properties
+++ b/jetty-core/jetty-compression/jetty-compression-common/src/test/resources/jetty-logging.properties
@@ -1,0 +1,2 @@
+# Jetty Logging using jetty-slf4j-impl
+#org.eclipse.jetty.server.LEVEL=DEBUG

--- a/jetty-core/jetty-compression/jetty-compression-gzip/src/main/java/org/eclipse/jetty/compression/gzip/internal/GzipEncoderSink.java
+++ b/jetty-core/jetty-compression/jetty-compression-gzip/src/main/java/org/eclipse/jetty/compression/gzip/internal/GzipEncoderSink.java
@@ -27,6 +27,7 @@ import org.eclipse.jetty.io.RetainableByteBuffer;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.compression.CompressionPool;
+import org.eclipse.jetty.util.thread.Invocable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -144,7 +145,7 @@ public class GzipEncoderSink extends EncoderSink
                                 output = compression.acquireByteBuffer(bufferSize);
                             if (encode(content, output.getByteBuffer()))
                             {
-                                WriteRecord writeRecord = new WriteRecord(false, output.getByteBuffer(), Callback.from(output::release));
+                                WriteRecord writeRecord = new WriteRecord(false, output.getByteBuffer(), Callback.from(Invocable.InvocationType.NON_BLOCKING, output::release));
                                 output = null;
                                 return writeRecord;
                             }
@@ -171,7 +172,7 @@ public class GzipEncoderSink extends EncoderSink
                             state.compareAndSet(State.FLUSHING, State.TRAILERS);
                         if (output.hasRemaining())
                         {
-                            WriteRecord writeRecord = new WriteRecord(false, output.getByteBuffer(), Callback.from(output::release));
+                            WriteRecord writeRecord = new WriteRecord(false, output.getByteBuffer(), Callback.from(Invocable.InvocationType.NON_BLOCKING, output::release));
                             output = null;
                             return writeRecord;
                         }
@@ -182,7 +183,7 @@ public class GzipEncoderSink extends EncoderSink
                             output = compression.acquireByteBuffer(16);
                         trailers(output.getByteBuffer());
                         state.compareAndSet(State.TRAILERS, State.FINISHED);
-                        WriteRecord writeRecord = new WriteRecord(true, output.getByteBuffer(), Callback.from(output::release));
+                        WriteRecord writeRecord = new WriteRecord(true, output.getByteBuffer(), Callback.from(Invocable.InvocationType.NON_BLOCKING, output::release));
                         output = null;
                         return writeRecord;
                     }

--- a/jetty-core/jetty-compression/jetty-compression-gzip/src/main/java/org/eclipse/jetty/compression/gzip/internal/GzipEncoderSink.java
+++ b/jetty-core/jetty-compression/jetty-compression-gzip/src/main/java/org/eclipse/jetty/compression/gzip/internal/GzipEncoderSink.java
@@ -85,6 +85,7 @@ public class GzipEncoderSink extends EncoderSink
     private final int bufferSize;
     private final CRC32 crc = new CRC32();
     private final AtomicReference<State> state = new AtomicReference<>(State.HEADERS);
+    private boolean released;
 
     public GzipEncoderSink(GzipCompression compression, Content.Sink sink, GzipEncoderConfig config)
     {
@@ -123,6 +124,9 @@ public class GzipEncoderSink extends EncoderSink
     {
         if (LOG.isDebugEnabled())
             LOG.debug("encode() last={}, content={}", last, BufferUtil.toDetailString(content));
+
+        if (released)
+            throw new IllegalStateException("Already released");
 
         RetainableByteBuffer output = null;
         try
@@ -204,6 +208,9 @@ public class GzipEncoderSink extends EncoderSink
     @Override
     protected void release()
     {
+        if (released)
+            return;
+        released = true;
         inputBuffer.release();
         deflaterEntry.release();
     }

--- a/jetty-core/jetty-compression/jetty-compression-gzip/src/test/java/org/eclipse/jetty/compression/gzip/GzipEncoderSinkTest.java
+++ b/jetty-core/jetty-compression/jetty-compression-gzip/src/test/java/org/eclipse/jetty/compression/gzip/GzipEncoderSinkTest.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.compression.gzip;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.ExecutionException;
@@ -95,6 +96,7 @@ public class GzipEncoderSinkTest extends AbstractGzipTest
             Callback.Completable callback1 = new Callback.Completable();
             encoderSink.write(true, ByteBuffer.wrap("Hello World!".getBytes(UTF_8)), callback1);
             callback1.get();
+            assertThat(new String(decompress(baos.toByteArray()), UTF_8), is("Hello World!"));
 
             Callback.Completable callback2 = new Callback.Completable();
             encoderSink.write(true, ByteBuffer.wrap("Hello again!".getBytes(UTF_8)), callback2);

--- a/jetty-core/jetty-compression/jetty-compression-gzip/src/test/java/org/eclipse/jetty/compression/gzip/GzipEncoderSinkTest.java
+++ b/jetty-core/jetty-compression/jetty-compression-gzip/src/test/java/org/eclipse/jetty/compression/gzip/GzipEncoderSinkTest.java
@@ -15,7 +15,6 @@ package org.eclipse.jetty.compression.gzip;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.ExecutionException;

--- a/jetty-core/jetty-compression/jetty-compression-gzip/src/test/java/org/eclipse/jetty/compression/gzip/GzipEncoderSinkTest.java
+++ b/jetty-core/jetty-compression/jetty-compression-gzip/src/test/java/org/eclipse/jetty/compression/gzip/GzipEncoderSinkTest.java
@@ -17,6 +17,7 @@ import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.ExecutionException;
 import java.util.zip.Deflater;
 
 import org.eclipse.jetty.io.Content;
@@ -36,6 +37,8 @@ import static java.nio.file.StandardOpenOption.WRITE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class GzipEncoderSinkTest extends AbstractGzipTest
 {
@@ -75,6 +78,29 @@ public class GzipEncoderSinkTest extends AbstractGzipTest
         String decompressed = new String(decompress(compressed), UTF_8);
         String expected = Files.readString(uncompressed, UTF_8);
         assertEquals(expected, decompressed);
+    }
+
+    @Test
+    public void testWriteLastTwice() throws Exception
+    {
+        startGzip();
+        gzip.getDefaultEncoderConfig().setCompressionLevel(Deflater.BEST_COMPRESSION);
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream())
+        {
+            Content.Sink fileSink = Content.Sink.from(baos);
+            Content.Sink writeLogger = new WriteLoggerSink(fileSink);
+            Content.Sink encoderSink = gzip.newEncoderSink(writeLogger);
+
+            Callback.Completable callback1 = new Callback.Completable();
+            encoderSink.write(true, ByteBuffer.wrap("Hello World!".getBytes(UTF_8)), callback1);
+            callback1.get();
+
+            Callback.Completable callback2 = new Callback.Completable();
+            encoderSink.write(true, ByteBuffer.wrap("Hello again!".getBytes(UTF_8)), callback2);
+            ExecutionException thrown = assertThrows(ExecutionException.class, callback2::get);
+            assertInstanceOf(IllegalStateException.class, thrown.getCause());
+        }
     }
 
     @Test

--- a/jetty-core/jetty-compression/jetty-compression-zstandard/src/main/java/org/eclipse/jetty/compression/zstandard/internal/ZstandardEncoderSink.java
+++ b/jetty-core/jetty-compression/jetty-compression-zstandard/src/main/java/org/eclipse/jetty/compression/zstandard/internal/ZstandardEncoderSink.java
@@ -26,6 +26,7 @@ import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.RetainableByteBuffer;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.thread.Invocable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -138,7 +139,7 @@ public class ZstandardEncoderSink extends EncoderSink
                 outputBuf.getByteBuffer().flip();
                 if (outputBuf.getByteBuffer().hasRemaining())
                 {
-                    Callback writeCallback = Callback.from(outputBuf::release);
+                    Callback writeCallback = Callback.from(Invocable.InvocationType.NON_BLOCKING, outputBuf::release);
                     if (inputBuf.hasRemaining())
                     {
                         // rollback unprocessed inputBuf to content buffer position.
@@ -171,7 +172,7 @@ public class ZstandardEncoderSink extends EncoderSink
         outputBuf.getByteBuffer().flip();
         if (outputBuf.getByteBuffer().hasRemaining())
         {
-            Callback writeCallback = Callback.from(outputBuf::release);
+            Callback writeCallback = Callback.from(Invocable.InvocationType.NON_BLOCKING, outputBuf::release);
             return new WriteRecord(false, outputBuf.getByteBuffer(), writeCallback);
         }
         outputBuf.release();
@@ -193,7 +194,7 @@ public class ZstandardEncoderSink extends EncoderSink
         {
             if (actualLast)
                 state.compareAndSet(State.FLUSH, State.FINISHED);
-            Callback writeCallback = Callback.from(outputBuf::release);
+            Callback writeCallback = Callback.from(Invocable.InvocationType.NON_BLOCKING, outputBuf::release);
             return new WriteRecord(actualLast, outputBuf.getByteBuffer(), writeCallback);
         }
 

--- a/jetty-core/jetty-compression/jetty-compression-zstandard/src/main/java/org/eclipse/jetty/compression/zstandard/internal/ZstandardEncoderSink.java
+++ b/jetty-core/jetty-compression/jetty-compression-zstandard/src/main/java/org/eclipse/jetty/compression/zstandard/internal/ZstandardEncoderSink.java
@@ -68,7 +68,7 @@ public class ZstandardEncoderSink extends EncoderSink
     {
         State initialState = state.get();
         if (initialState == State.FINISHED)
-            return null;
+            throw new IllegalStateException("Already released");
 
         boolean done = false;
         WriteRecord writeRecord = null;

--- a/jetty-core/jetty-compression/jetty-compression-zstandard/src/test/java/org/eclipse/jetty/compression/zstandard/ZstandardEncoderSinkTest.java
+++ b/jetty-core/jetty-compression/jetty-compression-zstandard/src/test/java/org/eclipse/jetty/compression/zstandard/ZstandardEncoderSinkTest.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -73,6 +75,7 @@ public class ZstandardEncoderSinkTest extends AbstractZstdTest
             Callback.Completable callback1 = new Callback.Completable();
             encoderSink.write(true, ByteBuffer.wrap("Hello World!".getBytes(UTF_8)), callback1);
             callback1.get();
+            assertThat(new String(decompress(baos.toByteArray()), UTF_8), is("Hello World!"));
 
             Callback.Completable callback2 = new Callback.Completable();
             encoderSink.write(true, ByteBuffer.wrap("Hello again!".getBytes(UTF_8)), callback2);

--- a/jetty-core/jetty-compression/jetty-compression-zstandard/src/test/java/org/eclipse/jetty/compression/zstandard/ZstandardEncoderSinkTest.java
+++ b/jetty-core/jetty-compression/jetty-compression-zstandard/src/test/java/org/eclipse/jetty/compression/zstandard/ZstandardEncoderSinkTest.java
@@ -18,8 +18,8 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-
 import java.util.concurrent.ExecutionException;
+
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.util.Callback;

--- a/jetty-core/jetty-compression/jetty-compression-zstandard/src/test/java/org/eclipse/jetty/compression/zstandard/ZstandardEncoderSinkTest.java
+++ b/jetty-core/jetty-compression/jetty-compression-zstandard/src/test/java/org/eclipse/jetty/compression/zstandard/ZstandardEncoderSinkTest.java
@@ -14,17 +14,23 @@
 package org.eclipse.jetty.compression.zstandard;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import java.util.concurrent.ExecutionException;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.util.Callback;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ZstandardEncoderSinkTest extends AbstractZstdTest
 {
@@ -52,5 +58,26 @@ public class ZstandardEncoderSinkTest extends AbstractZstdTest
         String decompressed = new String(decompress(compressed), StandardCharsets.UTF_8);
         String expected = Files.readString(uncompressed, StandardCharsets.UTF_8);
         assertEquals(expected, decompressed);
+    }
+
+    @Test
+    public void testWriteLastTwice() throws Exception
+    {
+        startZstd();
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream())
+        {
+            Content.Sink fileSink = Content.Sink.from(baos);
+            Content.Sink encoderSink = zstd.newEncoderSink(fileSink);
+
+            Callback.Completable callback1 = new Callback.Completable();
+            encoderSink.write(true, ByteBuffer.wrap("Hello World!".getBytes(UTF_8)), callback1);
+            callback1.get();
+
+            Callback.Completable callback2 = new Callback.Completable();
+            encoderSink.write(true, ByteBuffer.wrap("Hello again!".getBytes(UTF_8)), callback2);
+            ExecutionException thrown = assertThrows(ExecutionException.class, callback2::get);
+            assertInstanceOf(IllegalStateException.class, thrown.getCause());
+        }
     }
 }


### PR DESCRIPTION
When `EncoderSink` (any of its subclasses) fails to do the last write to the wrapped sink, `release()` is called twice: once from the callback wrapper that calls `finished()` plus once from `onCompleteFailure()`.

Moving the releasing responsibility from `EncodeBufferCallback` to `EncoderSink` to make the responsibilities more obvious.

Fixes #13679