### PR TITLE
Fixes #13681 - QUICHE_ERR_STREAM_LIMIT with Jetty 12.1.2 on HTTP/3.

### DIFF
--- a/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/server/http/HTTPServerDocs.java
+++ b/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/server/http/HTTPServerDocs.java
@@ -57,6 +57,7 @@ import org.eclipse.jetty.http.pathmap.PathSpec;
 import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
 import org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory;
 import org.eclipse.jetty.http3.server.HTTP3ServerConnectionFactory;
+import org.eclipse.jetty.http3.server.HTTP3ServerQuicConfiguration;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.ssl.SslHandshakeListener;
 import org.eclipse.jetty.quic.quiche.server.QuicheServerConnector;
@@ -247,7 +248,7 @@ public class HTTPServerDocs
 
         // Create a QuicServerConnector instance.
         Path pemWorkDir = Path.of("/path/to/pem/dir");
-        QuicheServerQuicConfiguration serverQuicConfig = new QuicheServerQuicConfiguration(pemWorkDir);
+        QuicheServerQuicConfiguration serverQuicConfig = HTTP3ServerQuicConfiguration.configure(new QuicheServerQuicConfiguration(pemWorkDir));
         QuicheServerConnector connector = new QuicheServerConnector(server, sslContextFactory, serverQuicConfig, new HTTP3ServerConnectionFactory());
 
         // The port to listen to.
@@ -339,7 +340,7 @@ public class HTTPServerDocs
 
         // Third, create the connector for HTTP/3.
         Path pemWorkDir = Path.of("/path/to/pem/dir");
-        QuicheServerQuicConfiguration serverQuicConfig = new QuicheServerQuicConfiguration(pemWorkDir);
+        QuicheServerQuicConfiguration serverQuicConfig = HTTP3ServerQuicConfiguration.configure(new QuicheServerQuicConfiguration(pemWorkDir));
         QuicheServerConnector http3Connector = new QuicheServerConnector(server, sslContextFactory, serverQuicConfig, new HTTP3ServerConnectionFactory());
         server.addConnector(http3Connector);
 
@@ -595,7 +596,7 @@ public class HTTPServerDocs
         // Create and configure the HTTP/3 connector.
         // It is mandatory to configure the PEM directory.
         Path pemWorkDir = Path.of("/path/to/pem/dir");
-        QuicheServerQuicConfiguration serverQuicConfig = new QuicheServerQuicConfiguration(pemWorkDir);
+        QuicheServerQuicConfiguration serverQuicConfig = HTTP3ServerQuicConfiguration.configure(new QuicheServerQuicConfiguration(pemWorkDir));
         QuicheServerConnector connector = new QuicheServerConnector(server, sslContextFactory, serverQuicConfig, new HTTP3ServerConnectionFactory());
         connector.setPort(843);
 

--- a/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/server/http3/HTTP3ServerDocs.java
+++ b/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/server/http3/HTTP3ServerDocs.java
@@ -31,6 +31,7 @@ import org.eclipse.jetty.http3.api.Stream;
 import org.eclipse.jetty.http3.frames.DataFrame;
 import org.eclipse.jetty.http3.frames.HeadersFrame;
 import org.eclipse.jetty.http3.frames.SettingsFrame;
+import org.eclipse.jetty.http3.server.HTTP3ServerQuicConfiguration;
 import org.eclipse.jetty.http3.server.RawHTTP3ServerConnectionFactory;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.quic.quiche.server.QuicheServerConnector;
@@ -58,7 +59,7 @@ public class HTTP3ServerDocs
         // The listener for session events.
         Session.Server.Listener sessionListener = new Session.Server.Listener() {};
 
-        QuicheServerQuicConfiguration serverQuicConfig = new QuicheServerQuicConfiguration(Path.of("/path/to/pem/dir"));
+        QuicheServerQuicConfiguration serverQuicConfig = HTTP3ServerQuicConfiguration.configure(new QuicheServerQuicConfiguration(Path.of("/path/to/pem/dir")));
         // Configure the max number of requests per QUIC connection.
         serverQuicConfig.setBidirectionalMaxStreams(1024 * 1024);
 

--- a/jetty-core/jetty-http3/jetty-http3-client/src/main/java/org/eclipse/jetty/http3/client/HTTP3Client.java
+++ b/jetty-core/jetty-http3/jetty-http3-client/src/main/java/org/eclipse/jetty/http3/client/HTTP3Client.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  * <p>Typical usage:</p>
  * <pre> {@code
  * // Client-side QUIC configuration to configure QUIC properties.
- * QuicheClientQuicConfiguration clientQuicConfig = new QuicheClientQuicConfiguration();
+ * QuicheClientQuicConfiguration clientQuicConfig = HTTP3ClientQuicConfiguration.configure(new QuicheClientQuicConfiguration());
  *
  * // Create the HTTP3Client instance.
  * HTTP3Client http3Client = new HTTP3Client(clientQuicConfig);

--- a/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/IdleTimeoutTest.java
+++ b/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/IdleTimeoutTest.java
@@ -87,7 +87,7 @@ public class IdleTimeoutTest
         SslContextFactory.Server sslServer = new SslContextFactory.Server();
         sslServer.setKeyStorePath("src/test/resources/keystore.p12");
         sslServer.setKeyStorePassword("storepwd");
-        QuicheServerQuicConfiguration serverQuicConfig = new QuicheServerQuicConfiguration(workDir.getEmptyPathDir());
+        QuicheServerQuicConfiguration serverQuicConfig = HTTP3ServerQuicConfiguration.configure(new QuicheServerQuicConfiguration(workDir.getEmptyPathDir()));
         AtomicBoolean established = new AtomicBoolean();
         CountDownLatch disconnectLatch = new CountDownLatch(1);
         RawHTTP3ServerConnectionFactory h3 = new RawHTTP3ServerConnectionFactory(new Session.Server.Listener()
@@ -106,7 +106,7 @@ public class IdleTimeoutTest
         });
 
         CountDownLatch closeLatch = new CountDownLatch(1);
-        QuicheServerConnector connector = new QuicheServerConnector(server, sslServer, HTTP3ServerQuicConfiguration.configure(serverQuicConfig), h3)
+        QuicheServerConnector connector = new QuicheServerConnector(server, sslServer, serverQuicConfig, h3)
         {
             @Override
             protected Connection newConnection(EndPoint endpoint)

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/ManyConnectorsTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/ManyConnectorsTest.java
@@ -17,6 +17,7 @@ import java.nio.channels.DatagramChannel;
 import java.nio.channels.ServerSocketChannel;
 
 import org.eclipse.jetty.http3.server.HTTP3ServerConnectionFactory;
+import org.eclipse.jetty.http3.server.HTTP3ServerQuicConfiguration;
 import org.eclipse.jetty.quic.quiche.server.QuicheServerConnector;
 import org.eclipse.jetty.quic.quiche.server.QuicheServerQuicConfiguration;
 import org.eclipse.jetty.server.HttpConfiguration;
@@ -60,7 +61,7 @@ public class ManyConnectorsTest
         SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
         sslContextFactory.setKeyStorePath(MavenPaths.findTestResourceFile("keystore.p12").toString());
         sslContextFactory.setKeyStorePassword("storepwd");
-        QuicheServerQuicConfiguration serverQuicConfig = new QuicheServerQuicConfiguration(workDir.getEmptyPathDir());
+        QuicheServerQuicConfiguration serverQuicConfig = HTTP3ServerQuicConfiguration.configure(new QuicheServerQuicConfiguration(workDir.getEmptyPathDir()));
         QuicheServerConnector connector2 = new QuicheServerConnector(server, sslContextFactory, serverQuicConfig, new HTTP3ServerConnectionFactory(httpConfig));
         server.addConnector(connector2);
 

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/AbstractTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/AbstractTest.java
@@ -44,6 +44,7 @@ import org.eclipse.jetty.http3.client.HTTP3ClientQuicConfiguration;
 import org.eclipse.jetty.http3.client.transport.HttpClientTransportOverHTTP3;
 import org.eclipse.jetty.http3.server.AbstractHTTP3ServerConnectionFactory;
 import org.eclipse.jetty.http3.server.HTTP3ServerConnectionFactory;
+import org.eclipse.jetty.http3.server.HTTP3ServerQuicConfiguration;
 import org.eclipse.jetty.io.ClientConnector;
 import org.eclipse.jetty.quic.quiche.client.QuicheClientQuicConfiguration;
 import org.eclipse.jetty.quic.quiche.client.QuicheTransport;
@@ -205,7 +206,7 @@ public class AbstractTest
             case H3_QUICHE ->
             {
                 Path serverPemDirectory = Files.createDirectories(pemDir.resolve("server"));
-                QuicheServerQuicConfiguration serverQuicConfig = new QuicheServerQuicConfiguration(serverPemDirectory);
+                QuicheServerQuicConfiguration serverQuicConfig = HTTP3ServerQuicConfiguration.configure(new QuicheServerQuicConfiguration(serverPemDirectory));
                 yield new QuicheServerConnector(server, sslContextFactoryServer, serverQuicConfig, newServerConnectionFactory(transportType));
             }
         };

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/AbstractTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/src/test/java/org/eclipse/jetty/ee9/test/client/transport/AbstractTest.java
@@ -47,6 +47,7 @@ import org.eclipse.jetty.http3.client.HTTP3ClientQuicConfiguration;
 import org.eclipse.jetty.http3.client.transport.HttpClientTransportOverHTTP3;
 import org.eclipse.jetty.http3.server.AbstractHTTP3ServerConnectionFactory;
 import org.eclipse.jetty.http3.server.HTTP3ServerConnectionFactory;
+import org.eclipse.jetty.http3.server.HTTP3ServerQuicConfiguration;
 import org.eclipse.jetty.io.ClientConnector;
 import org.eclipse.jetty.quic.quiche.client.QuicheClientQuicConfiguration;
 import org.eclipse.jetty.quic.quiche.client.QuicheTransport;
@@ -203,7 +204,7 @@ public class AbstractTest
                 yield new ServerConnector(server, 1, 1, newServerConnectionFactory(transportType));
             case H3_QUICHE:
                 Path serverPemDirectory = Files.createDirectories(pemDir.resolve("server"));
-                QuicheServerQuicConfiguration serverQuicConfig = new QuicheServerQuicConfiguration(serverPemDirectory);
+                QuicheServerQuicConfiguration serverQuicConfig = HTTP3ServerQuicConfiguration.configure(new QuicheServerQuicConfiguration(serverPemDirectory));
                 yield new QuicheServerConnector(server, sslContextFactoryServer, serverQuicConfig, newServerConnectionFactory(transportType));
         };
     }


### PR DESCRIPTION
Updated documentation, javadocs and tests to wrap `QuicheServerQuicConfiguration` with `HTTP3ServerQuicConfiguration.configure()` when using HTTP/3. 
The wrapping is not necessary when using just QUIC, for example with HTTP/1 or HTTP/2.