### PR TITLE
Issue #13683 - UrlParameterDecoder fixed for mixed bytes/chars pct-encoding usage. [12.0.x]

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/CharsetStringBuilder.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/CharsetStringBuilder.java
@@ -22,13 +22,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Objects;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * <p>Build a string from a sequence of bytes and/or characters.</p>
  * <p>Implementations of this interface are optimized for processing a mix of calls to already decoded
- * character based appends (e.g. {@link #append(char)} and calls to undecoded byte methods (e.g. {@link #append(byte)}.
+ * character based appends (e.g. {@link #append(char)}) and calls to undecoded byte methods (e.g. {@link #append(byte)}).
  * This is particularly useful for decoding % encoded strings that are mostly already decoded but may contain
  * escaped byte sequences that are not decoded.  The standard {@link CharsetDecoder} API is not well suited for this
  * use-case.</p>
@@ -274,10 +271,9 @@ public interface CharsetStringBuilder
 
     class DecoderStringBuilder implements CharsetStringBuilder
     {
-        private static final Logger LOG = LoggerFactory.getLogger(DecoderStringBuilder.class);
         private final CharsetDecoder _decoder;
         private final StringBuilder _stringBuilder = new StringBuilder(32);
-        private ByteBuffer _buffer = ByteBuffer.allocate(32);
+        private ByteBuffer _buffer;
         
         public DecoderStringBuilder(CharsetDecoder charsetDecoder, CodingErrorAction onMalformedInput, CodingErrorAction onUnmappableCharacter)
         {
@@ -288,11 +284,18 @@ public interface CharsetStringBuilder
 
         private void ensureSpace(int needed)
         {
-            int space = _buffer.remaining();
-            if (space < needed)
+            if (_buffer == null)
             {
-                int position = _buffer.position();
-                _buffer = ByteBuffer.wrap(Arrays.copyOf(_buffer.array(), _buffer.capacity() + needed - space + 32)).position(position);
+                _buffer = ByteBuffer.allocate(needed + 32);
+            }
+            else
+            {
+                int space = _buffer.remaining();
+                if (space < needed)
+                {
+                    int position = _buffer.position();
+                    _buffer = ByteBuffer.wrap(Arrays.copyOf(_buffer.array(), _buffer.capacity() + needed - space + 32)).position(position);
+                }
             }
         }
 
@@ -306,43 +309,51 @@ public interface CharsetStringBuilder
         @Override
         public void append(char c)
         {
-            if (_buffer.position() > 0)
+            if (_buffer != null && _buffer.position() > 0)
             {
-                try
+                // If we have seen a byte append, then assume all following character appends are mistakes,
+                // but try to decode safely if we can.
+                if (c > 0xFF)
                 {
-                    // Append any data already in the decoder
-                    _stringBuilder.append(_decoder.decode(_buffer.flip()));
-                    _buffer.clear();
+                    // Try to decode and continue
+                    try
+                    {
+                        CharSequence decoded = _decoder.decode(_buffer.flip());
+                        _buffer.clear();
+                        _stringBuilder.append(decoded);
+                        _stringBuilder.append(c);
+                    }
+                    catch (CharacterCodingException e)
+                    {
+                        if (_decoder.malformedInputAction() == CodingErrorAction.IGNORE)
+                            return;
+                        if (_decoder.malformedInputAction() == CodingErrorAction.REPLACE)
+                        {
+                            _buffer.clear();
+                            _stringBuilder.append(_decoder.replacement());
+                            return;
+                        }
+                        throw new IllegalArgumentException("Invalid character " + Integer.toHexString(c), e);
+                    }
                 }
-                catch (CharacterCodingException e)
+                else
                 {
-                    // This will be thrown only if the decoder is configured to REPORT,
-                    // otherwise errors will be ignored or replaced and we will not catch here.
-                    throw new RuntimeException(e);
+                    // This only works for charsets that are true supersets of USASCII
+                    ensureSpace(1);
+                    _buffer.put((byte)c);
                 }
             }
-            _stringBuilder.append(c);
+            else
+            {
+                _stringBuilder.append(c);
+            }
         }
 
         @Override
         public void append(CharSequence chars, int offset, int length)
         {
-            if (_buffer.position() > 0)
-            {
-                try
-                {
-                    // Append any data already in the decoder
-                    _stringBuilder.append(_decoder.decode(_buffer.flip()));
-                    _buffer.clear();
-                }
-                catch (CharacterCodingException e)
-                {
-                    // This will be thrown only if the decoder is configured to REPORT,
-                    // otherwise errors will be ignored or replaced and we will not catch here.
-                    throw new RuntimeException(e);
-                }
-            }
-            _stringBuilder.append(chars, offset, offset + length);
+            for (int idx = offset; idx < offset + length; idx++)
+                append(chars.charAt(idx));
         }
 
         @Override
@@ -368,7 +379,7 @@ public interface CharsetStringBuilder
             // and onUnmappableCharacter(CodingErrorAction)
             try
             {
-                if (_buffer.position() > 0)
+                if (_buffer != null && _buffer.position() > 0)
                 {
                     CharSequence decoded = _decoder.decode(_buffer.flip());
                     _buffer.clear();
@@ -394,6 +405,8 @@ public interface CharsetStringBuilder
         public void reset()
         {
             _stringBuilder.setLength(0);
+            if (_buffer != null)
+                _buffer.clear();
         }
     }
 }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/CharsetStringBuilderTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/CharsetStringBuilderTest.java
@@ -14,10 +14,16 @@
 package org.eclipse.jetty.util;
 
 import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
+import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -25,6 +31,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 // @checkstyle-disable-check : AvoidEscapedUnicodeCharactersCheck
 public class CharsetStringBuilderTest
@@ -51,7 +58,9 @@ public class CharsetStringBuilderTest
         assertThat(builder.build(), equalTo(test));
 
         for (byte b : bytes)
+        {
             builder.append(b);
+        }
         assertThat(builder.build(), equalTo(test));
 
         builder.append(bytes[0]);
@@ -71,34 +80,210 @@ public class CharsetStringBuilderTest
 
     @ParameterizedTest
     @MethodSource("charsets")
-    public void testBasicApi(Charset charset) throws Exception
+    public void testAppendByteBuffersOnly(Charset charset) throws Exception
+    {
+        String input = "123456789ABC";
+        // Generate a ByteBuffer encoded with the provided charset of the input String.
+        CharsetEncoder encoder = charset.newEncoder();
+        ByteBuffer bb = ByteBuffer.allocate(input.length() * 4);
+        encoder.encode(CharBuffer.wrap(input), bb, true);
+        bb.flip();
+
+        // using only append(ByteBuffer) recreate the input
+        CharsetStringBuilder builder = CharsetStringBuilder.forCharset(charset);
+        int sliceSize = 3;
+        int len = bb.remaining();
+        int offset = 0;
+        while (offset < len)
+        {
+            ByteBuffer slice = bb.slice();
+            slice.position(offset);
+            int limit = Math.min(slice.position() + sliceSize, len);
+            slice.limit(limit);
+            builder.append(slice);
+            offset = slice.position();
+        }
+
+        assertThat(builder.build(), is(input));
+    }
+
+    @ParameterizedTest
+    @MethodSource("charsets")
+    public void testAppendByteOnly(Charset charset) throws Exception
+    {
+        String input = "123456789ABC";
+
+        // Generate a byte buffer encoded with the provided charset of the input String.
+        byte[] buf = input.getBytes(charset);
+
+        // using only append(byte) recreate the input
+        CharsetStringBuilder builder = CharsetStringBuilder.forCharset(charset);
+        for (byte b : buf)
+        {
+            builder.append(b);
+        }
+
+        assertThat(builder.build(), is(input));
+    }
+
+    @ParameterizedTest
+    @MethodSource("charsets")
+    public void testAppendByteOffsetLengthOnly(Charset charset) throws Exception
+    {
+        String input = "123456789ABC";
+
+        // Generate a byte buffer encoded with the provided charset of the input String.
+        byte[] buf = input.getBytes(charset);
+
+        // using only append(byte, offset, length) recreate the input
+        CharsetStringBuilder builder = CharsetStringBuilder.forCharset(charset);
+        int sliceSize = 3;
+        int offset = 0;
+        while (offset < buf.length)
+        {
+            int len = Math.min(sliceSize, buf.length - offset);
+            builder.append(buf, offset, len);
+            offset += sliceSize;
+        }
+
+        assertThat(builder.build(), is(input));
+    }
+
+    @ParameterizedTest
+    @MethodSource("charsets")
+    public void testAppendCharOnly(Charset charset) throws Exception
+    {
+        String input = "123456789ABC";
+
+        // using only append(char) recreate the input
+        CharsetStringBuilder builder = CharsetStringBuilder.forCharset(charset);
+        for (char c : input.toCharArray())
+        {
+            builder.append(c);
+        }
+
+        assertThat(builder.build(), is(input));
+    }
+
+    @ParameterizedTest
+    @MethodSource("charsets")
+    public void testAppendCharSequenceOffsetLengthOnly(Charset charset) throws Exception
+    {
+        String input = "123456789ABC";
+
+        // using only append(CharSequence, offset, length) recreate the input
+        CharsetStringBuilder builder = CharsetStringBuilder.forCharset(charset);
+        char[] chars = input.toCharArray();
+        int sliceSize = 3;
+        int offset = 0;
+        while (offset < chars.length)
+        {
+            int len = Math.min(sliceSize, chars.length - offset);
+            builder.append(input, offset, len);
+            offset += sliceSize;
+        }
+
+        assertThat(builder.build(), is(input));
+    }
+
+    @Test
+    public void testSjisEncoding() throws CharacterCodingException
+    {
+        Charset sjisCharset = Charset.forName("Shift_JIS");
+        CharsetStringBuilder builder = CharsetStringBuilder.forCharset(sjisCharset);
+
+        builder.append((byte)0x83);
+        builder.append((char)'z');
+
+        assertEquals("ホ", builder.build());
+    }
+
+    public static Stream<Arguments> japaneseCharsetTests()
+    {
+        List<Arguments> args = new ArrayList<>();
+        for (Charset charset : List.of(
+            StandardCharsets.UTF_8,
+            StandardCharsets.UTF_16,
+            Charset.forName("Shift_JIS"),
+            Charset.forName("EUC-JP")
+        ))
+        {
+            for (String string : List.of(
+                // Has ASCII 'O' (0x30) in UTF-16
+                "ホ",
+                // Has ASCII 'O' (0x30) in UTF-16
+                // Has ASCII 'J' (0x4A), ASCII '^' (0x5E), and ASCII 'i' (0x69) in Shift_JIS
+                "カタカナ",
+                // Has ASCII 'v' (0x76) in UTF-16
+                "ｶﾞｯﾂﾎﾟｰｽﾞ"
+            ))
+            {
+                args.add(Arguments.of(charset, string));
+            }
+        }
+        return args.stream();
+    }
+
+    /**
+     * Paranoid test, showing badly mixed API usage.
+     */
+    @ParameterizedTest
+    @MethodSource("japaneseCharsetTests")
+    public void testJapaneseCharsetsMixedAppend(Charset charset, String string) throws Exception
     {
         CharsetStringBuilder builder = CharsetStringBuilder.forCharset(charset);
-        ByteBuffer encoded = charset.encode("1");
-        while (encoded.hasRemaining())
-            builder.append(encoded.get());
+        byte[] bytes = string.getBytes(charset);
+        for (byte b : bytes)
+        {
+            // if a raw byte is one of the ASCII characters, add it as a character??
+            if (b >= 'a' && b <= 'z' || b >= 'A' && b <= 'Z' || b >= '0' && b <= '9')
+                builder.append((char)b);
+            else
+                builder.append(b);
+        }
+        assertThat(builder.build(), is(string));
+    }
 
-        builder.append('2');
+    /**
+     * This mimics the usage behavior as seen in ContentSourceString.
+     */
+    @ParameterizedTest
+    @MethodSource("japaneseCharsetTests")
+    public void testJapaneseCharsetsAppendByteBufferOnly(Charset charset, String string) throws Exception
+    {
+        CharsetStringBuilder builder = CharsetStringBuilder.forCharset(charset);
+        byte[] bytes = string.getBytes(charset);
+        ByteBuffer buf = ByteBuffer.wrap(bytes);
 
-        builder.append(charset.encode("34"));
+        // Let's write it in two ByteBuffer's
+        int midway = buf.remaining() / 2;
 
-        encoded = charset.encode("abc");
-        int offset = encoded.remaining();
-        encoded = charset.encode("abc56");
-        int length = encoded.remaining() - offset;
-        encoded = charset.encode("abc56xyz");
-        byte[] bytes = new byte[1028];
-        encoded.get(bytes, 0, encoded.remaining());
-        builder.append(bytes, offset, length);
+        ByteBuffer slice1 = buf.slice();
+        slice1.position(0);
+        slice1.limit(midway);
 
-        encoded = charset.encode("abc78xyz");
-        encoded.position(offset);
-        encoded.limit(offset + length);
-        builder.append(encoded);
+        ByteBuffer slice2 = buf.slice();
+        slice2.position(midway);
 
-        builder.append("9A", 0, 2);
-        builder.append("xyzBCpqy", 3, 2);
+        builder.append(slice1);
+        builder.append(slice2);
 
-        assertThat(builder.build(), is("123456789ABC"));
+        assertThat(builder.build(), is(string));
+    }
+
+    /**
+     * This mimics how the UrlParameterDecoder operates.
+     * (char by char, not byte by byte)
+     */
+    @ParameterizedTest
+    @MethodSource("japaneseCharsetTests")
+    public void testJapaneseCharsetsAppendCharOnly(Charset charset, String string) throws Exception
+    {
+        CharsetStringBuilder builder = CharsetStringBuilder.forCharset(charset);
+        for (char c: string.toCharArray())
+        {
+            builder.append(c);
+        }
+        assertThat(builder.build(), is(string));
     }
 }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/UrlParameterDecoderTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/UrlParameterDecoderTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.US_ASCII;
@@ -259,13 +260,16 @@ public class UrlParameterDecoderTest
         assertEquals("Euro-€-Symbol", field.getValue(), "Fields[Name]");
     }
 
-    @Test
-    public void testUtf16EncodedString() throws IOException
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "name\n=value+%00%30&name1=&name2&nãme3=value+3", // without BOM
+        "name\n=value+%FE%FF%00%30&name1=&name2&nãme3=value+3" // with BOM
+    })
+    public void testUtf16EncodedString(String input) throws IOException
     {
         Fields fields = new Fields();
         CharsetStringBuilder charsetStringBuilder = CharsetStringBuilder.forCharset(UTF_16);
         UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add);
-        String input = "name\n=value+%FE%FF%00%30&name1=&name2&nãme3=value+3";
         assertFalse(decoder.parse(input), "No coding errors");
 
         assertThat("Field count", fields.getSize(), is(4));
@@ -284,6 +288,36 @@ public class UrlParameterDecoderTest
         field = fields.get("nãme3");
         assertNotNull(field, "Fields[nãme3]");
         assertEquals("value 3", field.getValue(), "Fields[nãme3]");
+    }
+
+    /**
+     * Test of non-standard encoding of Shift_JIS.
+     * This tests a 2 byte sequence making up 1 Shift_JIS character.
+     * But only the first byte is pct-encoded, other byte is "in the raw" and not encoded.
+     * Both bytes are required for the KATAKANA LETTER HO: ホ to be decoded.
+     * See https://unicodeplus.com/U+30DB
+     */
+    @Test
+    public void testSjisNonStandardForm() throws IOException
+    {
+        // Actual x-www-form-urlencoded sent from Google Chrome 1.141 with Shift-JIS encoding.
+        // The same form data is sent from Firefox 143.0.4
+        // The same form data is also what is sent from Apache HttpClient 4.5.x and 5.x
+        // The properly encoded form of this character would be "a=%83%7A"
+        // Note: "%7A" is the ASCII "z"
+        String input = "a=%83z";
+        Charset shiftJis = Charset.forName("Shift_JIS");
+
+        Fields fields = new Fields();
+        CharsetStringBuilder charsetStringBuilder = CharsetStringBuilder.forCharset(shiftJis);
+        UrlParameterDecoder decoder = new UrlParameterDecoder(charsetStringBuilder, fields::add);
+
+        assertFalse(decoder.parse(input), "No coding errors");
+
+        assertThat("Field count", fields.getSize(), is(1));
+        Fields.Field field = fields.get("a");
+        assertNotNull(field, "Fields[a]");
+        assertEquals("ホ", field.getValue(), "Fields[a]");
     }
 
     public static Stream<Arguments> queryBehaviorsBadUtf8AllowedGood()


### PR DESCRIPTION
Backport of PR #13684 for Jetty 12.0.x

* Cleanup CharsetStringBuilder.DecoderStringBuilder
* Introduce more CharsetStringBuilderTest methods
* Introduce UrlParameterDecoderTest.testSjisNonStandardForm()
