### PR TITLE
Fixes #13615 - Concurrency issue, headers from different requests are mixed in Jetty 12.0.27.

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
@@ -390,44 +390,57 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
     private void onHeaders(HeadersFrame frame, Callback callback)
     {
         MetaData metaData = frame.getMetaData();
-        boolean isTrailer = !metaData.isRequest() && !metaData.isResponse();
-        if (isTrailer)
+
+        Throwable metaDataFailure = MetaData.Failed.getFailure(metaData);
+        if (metaDataFailure != null)
         {
-            // In case of trailers, notify first and then offer EOF to
-            // avoid race conditions due to concurrent calls to readData().
-            boolean closed = updateClose(true, CloseState.Event.RECEIVED);
-            notifyHeaders(this, frame);
-            // Offer EOF in case the application calls readData() or demand().
-            if (offer(Data.eof(getId())))
-                processData(true);
-            if (closed)
-                getSession().removeStream(this);
+            // Request failures are notified by the session,
+            // since the Stream.Listener won't be available yet.
+            assert !metaData.isRequest();
+
+            // It's a bad response (or trailer), response content will be dropped.
+            onFailure(new FailureFrame(ErrorCode.PROTOCOL_ERROR.code, null, metaDataFailure), callback);
         }
         else
         {
-            HttpFields fields = metaData.getHttpFields();
-            long length = -1;
-            if (fields != null && !HttpMethod.CONNECT.is(request.getMethod()))
-                length = fields.getLongField(HttpHeader.CONTENT_LENGTH);
-            dataLength = length;
-
-            // Offer EOF for either the request or the response in
-            // case the application calls readData() or demand().
-            boolean eof = frame.isEndStream() && offer(Data.eof(getId()));
-
-            // Requests are notified to a Session.Listener, here only notify responses.
-            if (metaData.isResponse())
+            boolean isTrailer = !metaData.isRequest() && !metaData.isResponse();
+            if (isTrailer)
             {
-                boolean closed = updateClose(frame.isEndStream(), CloseState.Event.RECEIVED);
+                // In case of trailers, notify first and then offer EOF to
+                // avoid race conditions due to concurrent calls to readData().
+                boolean closed = updateClose(true, CloseState.Event.RECEIVED);
                 notifyHeaders(this, frame);
-                if (eof)
+                // Offer EOF in case the application calls readData() or demand().
+                if (offer(Data.eof(getId())))
                     processData(true);
                 if (closed)
                     getSession().removeStream(this);
             }
-        }
+            else
+            {
+                HttpFields fields = metaData.getHttpFields();
+                long length = -1;
+                if (fields != null && !HttpMethod.CONNECT.is(request.getMethod()))
+                    length = fields.getLongField(HttpHeader.CONTENT_LENGTH);
+                dataLength = length;
 
-        callback.succeeded();
+                // Offer EOF for either the request or the response in
+                // case the application calls readData() or demand().
+                boolean eof = frame.isEndStream() && offer(Data.eof(getId()));
+
+                // Requests are notified to a Session.Listener, here only notify responses.
+                if (metaData.isResponse())
+                {
+                    boolean closed = updateClose(frame.isEndStream(), CloseState.Event.RECEIVED);
+                    notifyHeaders(this, frame);
+                    if (eof)
+                        processData(true);
+                    if (closed)
+                        getSession().removeStream(this);
+                }
+            }
+            callback.succeeded();
+        }
     }
 
     private void onData(Data data)

--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackDecoder.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackDecoder.java
@@ -17,10 +17,10 @@ import java.nio.ByteBuffer;
 import java.util.function.LongSupplier;
 
 import org.eclipse.jetty.http.HttpField;
-import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpTokens;
 import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.http.PreEncodedHttpField;
 import org.eclipse.jetty.http.compression.EncodingException;
 import org.eclipse.jetty.http.compression.HuffmanDecoder;
 import org.eclipse.jetty.http.compression.NBitIntegerDecoder;
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 public class HpackDecoder
 {
     private static final Logger LOG = LoggerFactory.getLogger(HpackDecoder.class);
+    private static final HttpField LOWER_CASE_CONTENT_LENGTH_0 = new PreEncodedHttpField(HttpHeader.CONTENT_LENGTH, "content-length", "0");
 
     private final HpackContext _context;
     private final MetaDataBuilder _builder;
@@ -123,13 +124,14 @@ public class HpackDecoder
                 if (entry == null)
                     throw new HpackException.SessionException("Unknown index %d", index);
 
+                HttpField field = entry.getHttpField();
                 if (entry.isStatic())
                 {
                     if (LOG.isDebugEnabled())
                         LOG.debug("decode IdxStatic {}", entry);
                     // emit field
                     emitted = true;
-                    _builder.emit(entry.getHttpField());
+                    _builder.emit(field);
 
                     // TODO copy and add to reference set if there is room
                     // _context.add(entry.getHttpField());
@@ -138,9 +140,18 @@ public class HpackDecoder
                 {
                     if (LOG.isDebugEnabled())
                         LOG.debug("decode Idx {}", entry);
+
+                    String name = field.getName();
+                    if (!HttpTokens.isLegalH2H3FieldName(name))
+                        _builder.streamException("Illegal header name %s", name);
+
+                    String value = field.getValue();
+                    if (!HttpTokens.isLegalFieldValue(value))
+                        _builder.streamException("Illegal header value %s", value);
+
                     // emit
                     emitted = true;
-                    _builder.emit(entry.getHttpField());
+                    _builder.emit(field);
                 }
             }
             else
@@ -248,7 +259,7 @@ public class HpackDecoder
 
                         case CONTENT_LENGTH:
                             if ("0".equals(value))
-                                field = HttpFields.CONTENT_LENGTH_0;
+                                field = LOWER_CASE_CONTENT_LENGTH_0;
                             else
                                 field = new HttpField.LongValueHttpField(header, name, value);
                             break;

--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/internal/MetaDataBuilder.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/internal/MetaDataBuilder.java
@@ -51,6 +51,23 @@ public class MetaDataBuilder
         _maxSize = maxHeadersSize;
     }
 
+    private void reset()
+    {
+        _fields.clear();
+        _size = 0;
+        _status = null;
+        _method = null;
+        _scheme = null;
+        _authority = null;
+        _path = null;
+        _protocol = null;
+        _contentLength = -1;
+        _streamException = null;
+        _request = false;
+        _response = false;
+        _beginNanoTime = Long.MIN_VALUE;
+    }
+
     /**
      * Get the maxSize.
      * @return the maxSize
@@ -235,18 +252,14 @@ public class MetaDataBuilder
 
     public MetaData build() throws HpackException.StreamException
     {
-        if (_streamException != null)
-        {
-            _streamException.addSuppressed(new Throwable());
-            throw _streamException;
-        }
-
-        if (_request && _response)
-            throw new HpackException.StreamException(true, true, "Request and Response headers");
-
-        HttpFields.Mutable fields = _fields;
         try
         {
+            if (_streamException != null)
+                throw _streamException;
+
+            if (_request && _response)
+                throw new HpackException.StreamException(true, true, "Request and Response headers");
+
             if (_request)
             {
                 if (_method == null)
@@ -264,7 +277,7 @@ public class MetaDataBuilder
 
                 if (isConnect)
                 {
-                    return new MetaData.ConnectRequest(nanoTime, _scheme, _authority, _path, fields, _protocol);
+                    return new MetaData.ConnectRequest(nanoTime, _scheme, _authority, _path, _fields, _protocol);
                 }
                 else
                 {
@@ -273,7 +286,7 @@ public class MetaDataBuilder
                         _method,
                         newHttpURI(),
                         HttpVersion.HTTP_2,
-                        fields,
+                        _fields,
                         _contentLength,
                         null);
                 }
@@ -283,24 +296,14 @@ public class MetaDataBuilder
             {
                 if (_status == null)
                     throw new HpackException.StreamException(false, true, "No Status");
-                return new MetaData.Response(_status, null, HttpVersion.HTTP_2, fields, _contentLength);
+                return new MetaData.Response(_status, null, HttpVersion.HTTP_2, _fields, _contentLength);
             }
 
-            return new MetaData(HttpVersion.HTTP_2, fields, _contentLength);
+            return new MetaData(HttpVersion.HTTP_2, _fields, _contentLength);
         }
         finally
         {
-            _fields.clear();
-            _request = false;
-            _response = false;
-            _status = null;
-            _method = null;
-            _scheme = null;
-            _authority = null;
-            _path = null;
-            _protocol = null;
-            _size = 0;
-            _contentLength = -1;
+            reset();
         }
     }
 

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/ConcurrentRequestsTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/ConcurrentRequestsTest.java
@@ -1,0 +1,299 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.http2.tests;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.http2.HTTP2Session;
+import org.eclipse.jetty.http2.RateControl;
+import org.eclipse.jetty.http2.api.Session;
+import org.eclipse.jetty.http2.api.Stream;
+import org.eclipse.jetty.http2.frames.HeadersFrame;
+import org.eclipse.jetty.http2.frames.ResetFrame;
+import org.eclipse.jetty.http2.server.AbstractHTTP2ServerConnectionFactory;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.Promise;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ConcurrentRequestsTest extends AbstractTest
+{
+    @Test
+    public void testConcurrentGoodRequestsWithBadRequestsWithSameConnection() throws Exception
+    {
+        start(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                callback.succeeded();
+                return true;
+            }
+        });
+        // Disable rate control for this test.
+        connector.getConnectionFactory(AbstractHTTP2ServerConnectionFactory.class).setRateControlFactory(new RateControl.Factory() {});
+
+        Session clientSession = newClientSession(new Session.Listener() {});
+        // The test will send an invalid header value on this connection.
+        ((HTTP2Session)clientSession).getGenerator().getHpackEncoder().setValidateEncoding(false);
+
+        testConcurrentGoodRequestsWithBadRequests(clientSession, clientSession);
+    }
+
+    @Test
+    public void testConcurrentGoodRequestsWithBadRequestsWithDifferentConnections() throws Exception
+    {
+        start(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                callback.succeeded();
+                return true;
+            }
+        });
+        // Disable rate control for this test.
+        connector.getConnectionFactory(AbstractHTTP2ServerConnectionFactory.class).setRateControlFactory(new RateControl.Factory() {});
+
+        Session goodClientSession = newClientSession(new Session.Listener() {});
+        Session badClientSession = newClientSession(new Session.Listener() {});
+        // The test will send an invalid header value on this connection.
+        ((HTTP2Session)badClientSession).getGenerator().getHpackEncoder().setValidateEncoding(false);
+
+        testConcurrentGoodRequestsWithBadRequests(goodClientSession, badClientSession);
+    }
+
+    private void testConcurrentGoodRequestsWithBadRequests(Session goodSession, Session badSession) throws Exception
+    {
+        ExecutorService executor = Executors.newCachedThreadPool();
+
+        AtomicBoolean testing = new AtomicBoolean(true);
+        List<Throwable> failures = new CopyOnWriteArrayList<>();
+
+        // Start a thread to send good requests.
+        executor.execute(() ->
+        {
+            long count = 0;
+            while (testing.get())
+            {
+                if (!sendGoodRequest(goodSession, failures, count++))
+                    break;
+            }
+        });
+
+        // Start a thread to send bad requests.
+        executor.execute(() ->
+        {
+            long count = 0;
+            while (testing.get())
+            {
+                if (!sendBadRequest(badSession, failures, count++))
+                    break;
+            }
+        });
+
+        // Let the test run for a while.
+        Thread.sleep(2000);
+
+        testing.set(false);
+        executor.shutdown();
+        assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+
+        assertThat(failures, empty());
+    }
+
+    private boolean sendGoodRequest(Session clientSession, List<Throwable> failures, long id)
+    {
+        AtomicBoolean result = new AtomicBoolean();
+        CountDownLatch requestLatch = new CountDownLatch(1);
+        MetaData.Request request = newRequest("GET", "/good-" + id, HttpFields.EMPTY);
+        clientSession.newStream(new HeadersFrame(request, null, true), new Stream.Listener()
+        {
+            @Override
+            public void onHeaders(Stream stream, HeadersFrame frame)
+            {
+                MetaData.Response response = (MetaData.Response)frame.getMetaData();
+                int status = response.getStatus();
+                result.set(status == HttpStatus.OK_200 && frame.isEndStream());
+                if (status != HttpStatus.OK_200)
+                    failures.add(new BadMessageException("expected 200, got " + status + " id=" + id));
+                if (!frame.isEndStream())
+                    stream.demand();
+                else
+                    requestLatch.countDown();
+            }
+
+            @Override
+            public void onDataAvailable(Stream stream)
+            {
+                while (true)
+                {
+                    Stream.Data data = stream.readData();
+                    if (data == null)
+                    {
+                        stream.demand();
+                        return;
+                    }
+                    data.release();
+                    if (data.frame().isEndStream())
+                    {
+                        requestLatch.countDown();
+                        return;
+                    }
+                }
+            }
+
+            @Override
+            public void onReset(Stream stream, ResetFrame frame, Callback callback)
+            {
+                failures.add(new RuntimeException(frame.toString()));
+                result.set(false);
+                requestLatch.countDown();
+            }
+
+            @Override
+            public void onIdleTimeout(Stream stream, TimeoutException x, Promise<Boolean> promise)
+            {
+                failures.add(x);
+                result.set(false);
+                requestLatch.countDown();
+                promise.succeeded(true);
+            }
+
+            @Override
+            public void onFailure(Stream stream, int error, String reason, Throwable failure, Callback callback)
+            {
+                failures.add(failure);
+                result.set(false);
+                requestLatch.countDown();
+                callback.succeeded();
+            }
+        });
+
+        try
+        {
+            Thread.sleep(1);
+            if (requestLatch.await(5, TimeUnit.SECONDS))
+                return result.get();
+            failures.add(new TimeoutException("good request id=" + id));
+            return false;
+        }
+        catch (InterruptedException x)
+        {
+            failures.add(x);
+            return false;
+        }
+    }
+
+    private boolean sendBadRequest(Session clientSession, List<Throwable> failures, long id)
+    {
+        AtomicBoolean result = new AtomicBoolean();
+        CountDownLatch requestLatch = new CountDownLatch(1);
+        HttpFields headers = HttpFields.build().put("invalid", "space_at_end ");
+        MetaData.Request request = newRequest("GET", "/bad-" + id, headers);
+        clientSession.newStream(new HeadersFrame(request, null, true), new Stream.Listener()
+        {
+            @Override
+            public void onHeaders(Stream stream, HeadersFrame frame)
+            {
+                MetaData.Response response = (MetaData.Response)frame.getMetaData();
+                int status = response.getStatus();
+                result.set(status == HttpStatus.BAD_REQUEST_400);
+                if (status != HttpStatus.BAD_REQUEST_400)
+                    failures.add(new BadMessageException("expected 400, got " + status + " id=" + id));
+                if (!frame.isEndStream())
+                    stream.demand();
+                else
+                    requestLatch.countDown();
+            }
+
+            @Override
+            public void onDataAvailable(Stream stream)
+            {
+                while (true)
+                {
+                    Stream.Data data = stream.readData();
+                    if (data == null)
+                    {
+                        stream.demand();
+                        return;
+                    }
+                    data.release();
+                    if (data.frame().isEndStream())
+                    {
+                        requestLatch.countDown();
+                        return;
+                    }
+                }
+            }
+
+            @Override
+            public void onReset(Stream stream, ResetFrame frame, Callback callback)
+            {
+                failures.add(new RuntimeException(frame.toString()));
+                requestLatch.countDown();
+                result.set(false);
+            }
+
+            @Override
+            public void onIdleTimeout(Stream stream, TimeoutException x, Promise<Boolean> promise)
+            {
+                failures.add(x);
+                requestLatch.countDown();
+                result.set(false);
+                promise.succeeded(true);
+            }
+
+            @Override
+            public void onFailure(Stream stream, int error, String reason, Throwable failure, Callback callback)
+            {
+                failures.add(failure);
+                requestLatch.countDown();
+                result.set(false);
+                callback.succeeded();
+            }
+        });
+
+        try
+        {
+            Thread.sleep(1);
+            if (requestLatch.await(5, TimeUnit.SECONDS))
+                return result.get();
+            failures.add(new TimeoutException("bad request id=" + id));
+            return false;
+        }
+        catch (InterruptedException x)
+        {
+            failures.add(x);
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
* Added handling failed MetaData in HTTP2Stream.onHeaders(), in case the response contains bad headers.
* Properly resetting at the end of MetaDataBuilder.build(): before the _streamException field was not reset, leading to failing also the next requests/responses.
* Made sure MetaDataBuilder.build() resets even when a failure is detected early at the beginning of the method.
* Added checks in HpackDecoder for indexed entries that may have been stored with invalid header name/value.
* HpackDecoder now stores a lower-case "content-length: 0", so that subsequent retrievals do not fail the checks added above.
* Added test cases for concurrent good and bad responses.

See https://github.com/jetty/jetty.project/pull/13767 for the 12.1 PR.