### PR TITLE
Fixes #13682 - HttpClient.[maxRequest|request]HeadersSize should be consistent.

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -882,7 +882,11 @@ public class HttpClient extends ContainerLifeCycle implements AutoCloseable
      */
     public void setRequestBufferSize(int requestBufferSize)
     {
+        if (requestBufferSize <= 0)
+            throw new IllegalArgumentException("Invalid request buffer size " + requestBufferSize);
         this.requestBufferSize = requestBufferSize;
+        if (requestBufferSize > getMaxRequestHeadersSize())
+            setMaxRequestHeadersSize(requestBufferSize);
     }
 
     /**
@@ -1094,6 +1098,8 @@ public class HttpClient extends ContainerLifeCycle implements AutoCloseable
     public void setMaxRequestHeadersSize(int maxRequestHeadersSize)
     {
         this.maxRequestHeadersSize = maxRequestHeadersSize;
+        if (maxRequestHeadersSize > 0 && maxRequestHeadersSize < getRequestBufferSize())
+            setRequestBufferSize(maxRequestHeadersSize);
     }
 
     /**

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpSenderOverHTTP.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpSenderOverHTTP.java
@@ -156,6 +156,7 @@ public class HttpSenderOverHTTP extends HttpSender
             HttpExchange exchange = getHttpExchange();
             ByteBufferPool bufferPool = httpClient.getByteBufferPool();
             int requestHeadersSize = httpClient.getRequestBufferSize();
+            int maxRequestHeadersSize = httpClient.getMaxRequestHeadersSize();
             boolean useDirectByteBuffers = httpClient.isUseOutputDirectByteBuffers();
             while (true)
             {
@@ -172,14 +173,16 @@ public class HttpSenderOverHTTP extends HttpSender
                 {
                     case NEED_HEADER:
                     {
-                        generator.setMaxHeaderBytes(getHttpChannel().getHttpDestination().getHttpClient().getMaxRequestHeadersSize());
+                        int maxHeadersSize = maxRequestHeadersSize;
+                        if (maxHeadersSize < 0)
+                            maxHeadersSize = requestHeadersSize;
+                        generator.setMaxHeaderBytes(maxHeadersSize);
                         headerBuffer = bufferPool.acquire(requestHeadersSize, useDirectByteBuffers);
                         break;
                     }
                     case HEADER_OVERFLOW:
                     {
-                        int maxRequestHeadersSize = httpClient.getMaxRequestHeadersSize();
-                        if (maxRequestHeadersSize > requestHeadersSize)
+                        if (maxRequestHeadersSize > 0 && maxRequestHeadersSize > requestHeadersSize)
                         {
                             generator.reset();
                             headerBuffer.release();

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
@@ -94,6 +94,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -803,8 +804,10 @@ public class HttpClientTest extends AbstractHttpClientServerTest
 
         assertThrows(IOException.class, () ->
         {
-            Socket socket = new Socket();
-            socket.connect(new InetSocketAddress(host, port), 1000);
+            try (Socket socket = new Socket())
+            {
+                socket.connect(new InetSocketAddress(host, port), 1000);
+            }
         }, "Host must not be resolvable");
 
         start(scenario, new EmptyServerHandler());
@@ -815,7 +818,7 @@ public class HttpClientTest extends AbstractHttpClientServerTest
             {
                 assertTrue(result.isFailed());
                 Throwable failure = result.getFailure();
-                assertTrue(failure instanceof UnknownHostException);
+                assertInstanceOf(UnknownHostException.class, failure);
                 latch.countDown();
             });
         assertTrue(latch.await(10, TimeUnit.SECONDS));
@@ -1546,9 +1549,10 @@ public class HttpClientTest extends AbstractHttpClientServerTest
                 consume(input, false);
 
                 // HTTP/1.0 response, the client must not close the connection.
-                String httpResponse =
-                    "HTTP/1.0 200 OK\r\n" +
-                        "\r\n";
+                String httpResponse = """
+                    HTTP/1.0 200 OK
+                    
+                    """;
                 OutputStream output = socket.getOutputStream();
                 output.write(httpResponse.getBytes(UTF_8));
                 output.flush();
@@ -1572,10 +1576,11 @@ public class HttpClientTest extends AbstractHttpClientServerTest
 
                 consume(input, false);
 
-                httpResponse =
-                    "HTTP/1.1 200 OK\r\n" +
-                        "Content-Length: 0\r\n" +
-                        "\r\n";
+                httpResponse = """
+                    HTTP/1.1 200 OK
+                    Content-Length: 0
+                    
+                    """;
                 output.write(httpResponse.getBytes(UTF_8));
                 output.flush();
 
@@ -1716,10 +1721,10 @@ public class HttpClientTest extends AbstractHttpClientServerTest
                 consume(input, false);
 
                 // Send a bad response.
-                String httpResponse =
-                    "HTTP/1.1 204 No Content\r\n" +
-                        "\r\n" +
-                        "No Content";
+                String httpResponse = """
+                    HTTP/1.1 204 No Content
+                    
+                    No Content""";
                 OutputStream output = socket.getOutputStream();
                 output.write(httpResponse.getBytes(UTF_8));
                 output.flush();
@@ -1739,10 +1744,11 @@ public class HttpClientTest extends AbstractHttpClientServerTest
 
                 consume(input, false);
 
-                httpResponse =
-                    "HTTP/1.1 200 OK\r\n" +
-                        "Content-Length: 0\r\n" +
-                        "\r\n";
+                httpResponse = """
+                    HTTP/1.1 200 OK
+                    Content-Length: 0
+                    
+                    """;
                 output.write(httpResponse.getBytes(UTF_8));
                 output.flush();
 
@@ -1806,11 +1812,12 @@ public class HttpClientTest extends AbstractHttpClientServerTest
     @ArgumentsSource(ScenarioProvider.class)
     public void testUnsolicitedResponseBytesFromServer(Scenario scenario) throws Exception
     {
-        String response = "" +
-            "HTTP/1.1 408 Request Timeout\r\n" +
-            "Content-Length: 0\r\n" +
-            "Connection: close\r\n" +
-            "\r\n";
+        String response = """
+            HTTP/1.1 408 Request Timeout
+            Content-Length: 0
+            Connection: close
+            
+            """;
         testUnsolicitedBytesFromServer(scenario, response);
     }
 
@@ -2066,12 +2073,39 @@ public class HttpClientTest extends AbstractHttpClientServerTest
 
     @ParameterizedTest
     @ArgumentsSource(ScenarioProvider.class)
+    public void testMaxRequestHeadersSizeSmallerThanRequestHeadersSize(Scenario scenario) throws Exception
+    {
+        start(scenario, new EmptyServerHandler());
+
+        RetainableByteBuffer buffer = client.getByteBufferPool().acquire(client.getRequestBufferSize(), false);
+        int capacity = buffer.capacity();
+        buffer.release();
+        client.setMaxRequestHeadersSize(capacity / 4);
+
+        ContentResponse response = client.newRequest("localhost", connector.getLocalPort())
+            .scheme(scenario.getScheme())
+            .agent("A".repeat((capacity / 8)))
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+
+        assertThrows(ExecutionException.class, () -> client.newRequest("localhost", connector.getLocalPort())
+            .scheme(scenario.getScheme())
+            // Overflow the max request headers size.
+            .agent("A".repeat(capacity / 2))
+            .timeout(5, TimeUnit.SECONDS)
+            .send());
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
     public void testMaxResponseHeadersSize(Scenario scenario) throws Exception
     {
         start(scenario, new EmptyServerHandler()
         {
             @Override
-            protected void service(org.eclipse.jetty.server.Request request, org.eclipse.jetty.server.Response response) throws Throwable
+            protected void service(org.eclipse.jetty.server.Request request, org.eclipse.jetty.server.Response response)
             {
                 int capacity = (int)request.getHeaders().getLongField("X-Capacity");
                 // Overflow the max request headers size, should generate a 500.

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java
@@ -458,7 +458,11 @@ public class HttpConfiguration implements Dumpable
      */
     public void setResponseHeaderSize(int responseHeaderSize)
     {
+        if (responseHeaderSize <= 0)
+            throw new IllegalArgumentException("Invalid response headers size " + responseHeaderSize);
         _responseHeaderSize = responseHeaderSize;
+        if (responseHeaderSize > getMaxResponseHeaderSize())
+            setMaxResponseHeaderSize(responseHeaderSize);
     }
 
     /**
@@ -473,6 +477,8 @@ public class HttpConfiguration implements Dumpable
     public void setMaxResponseHeaderSize(int maxResponseHeaderSize)
     {
         _maxResponseHeaderSize = maxResponseHeaderSize;
+        if (maxResponseHeaderSize > 0 && maxResponseHeaderSize < getResponseHeaderSize())
+            setResponseHeaderSize(maxResponseHeaderSize);
     }
 
     /**

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -786,7 +786,7 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
                     {
                         int maxHeaderBytes = maxResponseHeadersSize;
                         if (maxHeaderBytes < 0)
-                            maxHeaderBytes = getHttpConfiguration().getResponseHeaderSize();
+                            maxHeaderBytes = responseHeadersSize;
                         _generator.setMaxHeaderBytes(maxHeaderBytes);
                         _header = _bufferPool.acquire(responseHeadersSize, useDirectByteBuffers);
                         continue;


### PR DESCRIPTION
Now setting `HttpClient.requestHeadersSize` may also set `maxRequestHeadersSize` to keep them consistent. Similarly for `HttpConfiguration.responseHeaderSize`.

Backport of #13695.