### PR TITLE
Fixes #13615 - Concurrency issue, headers from different requests are mixed in Jetty 12.0.27.

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
@@ -394,55 +394,68 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
     private void onHeaders(HeadersFrame frame, Callback callback)
     {
         MetaData metaData = frame.getMetaData();
-        boolean isTrailer = !metaData.isRequest() && !metaData.isResponse();
-        if (isTrailer)
+        Throwable metaDataFailure = MetaData.Failed.getFailure(metaData);
+        if (metaDataFailure != null)
         {
-            // In case of trailers, notify first and then offer EOF to
-            // avoid race conditions due to concurrent calls to readData().
-            boolean closed = updateClose(true, CloseState.Event.RECEIVED);
-            notifyHeaders(frame, Callback.from(() ->
-            {
-                // Offer EOF in case the application calls readData() or demand().
-                if (offer(Data.eof(getId())))
-                    processData(true);
-                if (closed)
-                    getSession().removeStream(this);
-            }, callback));
+            // Request failures are notified by the session,
+            // since the Stream.Listener won't be available yet.
+            assert !metaData.isRequest();
+
+            // It's a bad response (or trailer), response content will be dropped.
+            onFailure(new FailureFrame(ErrorCode.PROTOCOL_ERROR.code, null, metaDataFailure), callback);
         }
         else
         {
-            long length = -1;
-            HttpFields fields = metaData.getHttpFields();
-            boolean connect = HttpMethod.CONNECT.is(request.getMethod());
-            if (fields != null && !connect)
-                length = fields.getLongField(HttpHeader.CONTENT_LENGTH);
-            dataLength = length;
-
-            // Offer EOF for either the request or the response in
-            // case the application calls readData() or demand().
-            boolean eof = frame.isEndStream() && offer(Data.eof(getId()));
-
-            // Requests are notified to a Session.Listener, here only notify responses.
-            if (metaData.isRequest())
+            boolean isTrailer = !metaData.isRequest() && !metaData.isResponse();
+            if (isTrailer)
             {
-                callback.succeeded();
-            }
-            else
-            {
-                MetaData.Response response = (MetaData.Response)metaData;
-                if (connect && response.getStatus() != HttpStatus.OK_200)
-                {
-                    // A failed tunnel attempt, must close the request side.
-                    updateClose(true, CloseState.Event.AFTER_SEND);
-                }
-                boolean closed = updateClose(frame.isEndStream(), CloseState.Event.RECEIVED);
+                // In case of trailers, notify first and then offer EOF to
+                // avoid race conditions due to concurrent calls to readData().
+                boolean closed = updateClose(true, CloseState.Event.RECEIVED);
                 notifyHeaders(frame, Callback.from(() ->
                 {
-                    if (eof)
+                    // Offer EOF in case the application calls readData() or demand().
+                    if (offer(Data.eof(getId())))
                         processData(true);
                     if (closed)
                         getSession().removeStream(this);
                 }, callback));
+            }
+            else
+            {
+                long length = -1;
+                HttpFields fields = metaData.getHttpFields();
+                boolean connect = HttpMethod.CONNECT.is(request.getMethod());
+                if (fields != null && !connect)
+                    length = fields.getLongField(HttpHeader.CONTENT_LENGTH);
+                dataLength = length;
+
+                // Offer EOF for either the request or the response in
+                // case the application calls readData() or demand().
+                boolean eof = frame.isEndStream() && offer(Data.eof(getId()));
+
+                // Requests are notified to a Session.Listener, here only notify responses.
+                if (metaData.isRequest())
+                {
+                    callback.succeeded();
+                }
+                else
+                {
+                    MetaData.Response response = (MetaData.Response)metaData;
+                    if (connect && response.getStatus() != HttpStatus.OK_200)
+                    {
+                        // A failed tunnel attempt, must close the request side.
+                        updateClose(true, CloseState.Event.AFTER_SEND);
+                    }
+                    boolean closed = updateClose(frame.isEndStream(), CloseState.Event.RECEIVED);
+                    notifyHeaders(frame, Callback.from(() ->
+                    {
+                        if (eof)
+                            processData(true);
+                        if (closed)
+                            getSession().removeStream(this);
+                    }, callback));
+                }
             }
         }
     }

--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackDecoder.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackDecoder.java
@@ -17,10 +17,10 @@ import java.nio.ByteBuffer;
 import java.util.function.LongSupplier;
 
 import org.eclipse.jetty.http.HttpField;
-import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpTokens;
 import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.http.PreEncodedHttpField;
 import org.eclipse.jetty.http.compression.EncodingException;
 import org.eclipse.jetty.http.compression.HuffmanDecoder;
 import org.eclipse.jetty.http.compression.NBitIntegerDecoder;
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 public class HpackDecoder
 {
     private static final Logger LOG = LoggerFactory.getLogger(HpackDecoder.class);
+    private static final HttpField LOWER_CASE_CONTENT_LENGTH_0 = new PreEncodedHttpField(HttpHeader.CONTENT_LENGTH, "content-length", "0");
 
     private final HpackContext _context;
     private final MetaDataBuilder _builder;
@@ -123,13 +124,14 @@ public class HpackDecoder
                 if (entry == null)
                     throw new HpackException.SessionException("Unknown index %d", index);
 
+                HttpField field = entry.getHttpField();
                 if (entry.isStatic())
                 {
                     if (LOG.isDebugEnabled())
                         LOG.debug("decode IdxStatic {}", entry);
                     // emit field
                     emitted = true;
-                    _builder.emit(entry.getHttpField());
+                    _builder.emit(field);
 
                     // TODO copy and add to reference set if there is room
                     // _context.add(entry.getHttpField());
@@ -138,9 +140,18 @@ public class HpackDecoder
                 {
                     if (LOG.isDebugEnabled())
                         LOG.debug("decode Idx {}", entry);
+
+                    String name = field.getName();
+                    if (!HttpTokens.isLegalH2H3FieldName(name))
+                        _builder.streamException("Illegal header name %s", name);
+
+                    String value = field.getValue();
+                    if (!HttpTokens.isLegalFieldValue(value))
+                        _builder.streamException("Illegal header value %s", value);
+
                     // emit
                     emitted = true;
-                    _builder.emit(entry.getHttpField());
+                    _builder.emit(field);
                 }
             }
             else
@@ -248,7 +259,7 @@ public class HpackDecoder
 
                         case CONTENT_LENGTH:
                             if ("0".equals(value))
-                                field = HttpFields.CONTENT_LENGTH_0;
+                                field = LOWER_CASE_CONTENT_LENGTH_0;
                             else
                                 field = new HttpField.LongValueHttpField(header, name, value);
                             break;

--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/internal/MetaDataBuilder.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/internal/MetaDataBuilder.java
@@ -51,6 +51,23 @@ public class MetaDataBuilder
         _maxSize = maxHeadersSize;
     }
 
+    private void reset()
+    {
+        _fields.clear();
+        _size = 0;
+        _status = null;
+        _method = null;
+        _scheme = null;
+        _authority = null;
+        _path = null;
+        _protocol = null;
+        _contentLength = -1;
+        _streamException = null;
+        _request = false;
+        _response = false;
+        _beginNanoTime = Long.MIN_VALUE;
+    }
+
     /**
      * Get the maxSize.
      * @return the maxSize
@@ -235,18 +252,14 @@ public class MetaDataBuilder
 
     public MetaData build() throws HpackException.StreamException
     {
-        if (_streamException != null)
-        {
-            _streamException.addSuppressed(new Throwable());
-            throw _streamException;
-        }
-
-        if (_request && _response)
-            throw new HpackException.StreamException(true, true, "Request and Response headers");
-
-        HttpFields.Mutable fields = _fields;
         try
         {
+            if (_streamException != null)
+                throw _streamException;
+
+            if (_request && _response)
+                throw new HpackException.StreamException(true, true, "Request and Response headers");
+
             if (_request)
             {
                 if (_method == null)
@@ -264,7 +277,7 @@ public class MetaDataBuilder
 
                 if (isConnect)
                 {
-                    return new MetaData.ConnectRequest(nanoTime, _scheme, _authority, _path, fields, _protocol);
+                    return new MetaData.ConnectRequest(nanoTime, _scheme, _authority, _path, _fields, _protocol);
                 }
                 else
                 {
@@ -273,7 +286,7 @@ public class MetaDataBuilder
                         _method,
                         newHttpURI(),
                         HttpVersion.HTTP_2,
-                        fields,
+                        _fields,
                         _contentLength,
                         null);
                 }
@@ -283,24 +296,14 @@ public class MetaDataBuilder
             {
                 if (_status == null)
                     throw new HpackException.StreamException(false, true, "No Status");
-                return new MetaData.Response(_status, null, HttpVersion.HTTP_2, fields, _contentLength);
+                return new MetaData.Response(_status, null, HttpVersion.HTTP_2, _fields, _contentLength);
             }
 
-            return new MetaData(HttpVersion.HTTP_2, fields, _contentLength);
+            return new MetaData(HttpVersion.HTTP_2, _fields, _contentLength);
         }
         finally
         {
-            _fields.clear();
-            _request = false;
-            _response = false;
-            _status = null;
-            _method = null;
-            _scheme = null;
-            _authority = null;
-            _path = null;
-            _protocol = null;
-            _size = 0;
-            _contentLength = -1;
+            reset();
         }
     }
 

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/ConcurrentRequestsTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/ConcurrentRequestsTest.java
@@ -1,0 +1,299 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.http2.tests;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.http2.HTTP2Session;
+import org.eclipse.jetty.http2.RateControl;
+import org.eclipse.jetty.http2.api.Session;
+import org.eclipse.jetty.http2.api.Stream;
+import org.eclipse.jetty.http2.frames.HeadersFrame;
+import org.eclipse.jetty.http2.frames.ResetFrame;
+import org.eclipse.jetty.http2.server.AbstractHTTP2ServerConnectionFactory;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.Promise;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ConcurrentRequestsTest extends AbstractTest
+{
+    @Test
+    public void testConcurrentGoodRequestsWithBadRequestsWithSameConnection() throws Exception
+    {
+        start(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                callback.succeeded();
+                return true;
+            }
+        });
+        // Disable rate control for this test.
+        connector.getConnectionFactory(AbstractHTTP2ServerConnectionFactory.class).setRateControlFactory(new RateControl.Factory() {});
+
+        Session clientSession = newClientSession(new Session.Listener() {});
+        // The test will send an invalid header value on this connection.
+        ((HTTP2Session)clientSession).getGenerator().getHpackEncoder().setValidateEncoding(false);
+
+        testConcurrentGoodRequestsWithBadRequests(clientSession, clientSession);
+    }
+
+    @Test
+    public void testConcurrentGoodRequestsWithBadRequestsWithDifferentConnections() throws Exception
+    {
+        start(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                callback.succeeded();
+                return true;
+            }
+        });
+        // Disable rate control for this test.
+        connector.getConnectionFactory(AbstractHTTP2ServerConnectionFactory.class).setRateControlFactory(new RateControl.Factory() {});
+
+        Session goodClientSession = newClientSession(new Session.Listener() {});
+        Session badClientSession = newClientSession(new Session.Listener() {});
+        // The test will send an invalid header value on this connection.
+        ((HTTP2Session)badClientSession).getGenerator().getHpackEncoder().setValidateEncoding(false);
+
+        testConcurrentGoodRequestsWithBadRequests(goodClientSession, badClientSession);
+    }
+
+    private void testConcurrentGoodRequestsWithBadRequests(Session goodSession, Session badSession) throws Exception
+    {
+        ExecutorService executor = Executors.newCachedThreadPool();
+
+        AtomicBoolean testing = new AtomicBoolean(true);
+        List<Throwable> failures = new CopyOnWriteArrayList<>();
+
+        // Start a thread to send good requests.
+        executor.execute(() ->
+        {
+            long count = 0;
+            while (testing.get())
+            {
+                if (!sendGoodRequest(goodSession, failures, count++))
+                    break;
+            }
+        });
+
+        // Start a thread to send bad requests.
+        executor.execute(() ->
+        {
+            long count = 0;
+            while (testing.get())
+            {
+                if (!sendBadRequest(badSession, failures, count++))
+                    break;
+            }
+        });
+
+        // Let the test run for a while.
+        Thread.sleep(2000);
+
+        testing.set(false);
+        executor.shutdown();
+        assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+
+        assertThat(failures, empty());
+    }
+
+    private boolean sendGoodRequest(Session clientSession, List<Throwable> failures, long id)
+    {
+        AtomicBoolean result = new AtomicBoolean();
+        CountDownLatch requestLatch = new CountDownLatch(1);
+        MetaData.Request request = newRequest("GET", "/good-" + id, HttpFields.EMPTY);
+        clientSession.newStream(new HeadersFrame(request, null, true), new Stream.Listener()
+        {
+            @Override
+            public void onHeaders(Stream stream, HeadersFrame frame)
+            {
+                MetaData.Response response = (MetaData.Response)frame.getMetaData();
+                int status = response.getStatus();
+                result.set(status == HttpStatus.OK_200 && frame.isEndStream());
+                if (status != HttpStatus.OK_200)
+                    failures.add(new BadMessageException("expected 200, got " + status + " id=" + id));
+                if (!frame.isEndStream())
+                    stream.demand();
+                else
+                    requestLatch.countDown();
+            }
+
+            @Override
+            public void onDataAvailable(Stream stream)
+            {
+                while (true)
+                {
+                    Stream.Data data = stream.readData();
+                    if (data == null)
+                    {
+                        stream.demand();
+                        return;
+                    }
+                    data.release();
+                    if (data.frame().isEndStream())
+                    {
+                        requestLatch.countDown();
+                        return;
+                    }
+                }
+            }
+
+            @Override
+            public void onReset(Stream stream, ResetFrame frame, Callback callback)
+            {
+                failures.add(new RuntimeException(frame.toString()));
+                result.set(false);
+                requestLatch.countDown();
+            }
+
+            @Override
+            public void onIdleTimeout(Stream stream, TimeoutException x, Promise<Boolean> promise)
+            {
+                failures.add(x);
+                result.set(false);
+                requestLatch.countDown();
+                promise.succeeded(true);
+            }
+
+            @Override
+            public void onFailure(Stream stream, int error, String reason, Throwable failure, Callback callback)
+            {
+                failures.add(failure);
+                result.set(false);
+                requestLatch.countDown();
+                callback.succeeded();
+            }
+        });
+
+        try
+        {
+            Thread.sleep(1);
+            if (requestLatch.await(5, TimeUnit.SECONDS))
+                return result.get();
+            failures.add(new TimeoutException("good request id=" + id));
+            return false;
+        }
+        catch (InterruptedException x)
+        {
+            failures.add(x);
+            return false;
+        }
+    }
+
+    private boolean sendBadRequest(Session clientSession, List<Throwable> failures, long id)
+    {
+        AtomicBoolean result = new AtomicBoolean();
+        CountDownLatch requestLatch = new CountDownLatch(1);
+        HttpFields headers = HttpFields.build().put("invalid", "space_at_end ");
+        MetaData.Request request = newRequest("GET", "/bad-" + id, headers);
+        clientSession.newStream(new HeadersFrame(request, null, true), new Stream.Listener()
+        {
+            @Override
+            public void onHeaders(Stream stream, HeadersFrame frame)
+            {
+                MetaData.Response response = (MetaData.Response)frame.getMetaData();
+                int status = response.getStatus();
+                result.set(status == HttpStatus.BAD_REQUEST_400);
+                if (status != HttpStatus.BAD_REQUEST_400)
+                    failures.add(new BadMessageException("expected 400, got " + status + " id=" + id));
+                if (!frame.isEndStream())
+                    stream.demand();
+                else
+                    requestLatch.countDown();
+            }
+
+            @Override
+            public void onDataAvailable(Stream stream)
+            {
+                while (true)
+                {
+                    Stream.Data data = stream.readData();
+                    if (data == null)
+                    {
+                        stream.demand();
+                        return;
+                    }
+                    data.release();
+                    if (data.frame().isEndStream())
+                    {
+                        requestLatch.countDown();
+                        return;
+                    }
+                }
+            }
+
+            @Override
+            public void onReset(Stream stream, ResetFrame frame, Callback callback)
+            {
+                failures.add(new RuntimeException(frame.toString()));
+                requestLatch.countDown();
+                result.set(false);
+            }
+
+            @Override
+            public void onIdleTimeout(Stream stream, TimeoutException x, Promise<Boolean> promise)
+            {
+                failures.add(x);
+                requestLatch.countDown();
+                result.set(false);
+                promise.succeeded(true);
+            }
+
+            @Override
+            public void onFailure(Stream stream, int error, String reason, Throwable failure, Callback callback)
+            {
+                failures.add(failure);
+                requestLatch.countDown();
+                result.set(false);
+                callback.succeeded();
+            }
+        });
+
+        try
+        {
+            Thread.sleep(1);
+            if (requestLatch.await(5, TimeUnit.SECONDS))
+                return result.get();
+            failures.add(new TimeoutException("bad request id=" + id));
+            return false;
+        }
+        catch (InterruptedException x)
+        {
+            failures.add(x);
+            return false;
+        }
+    }
+}

--- a/jetty-core/jetty-http3/jetty-http3-client/src/main/java/org/eclipse/jetty/http3/client/HTTP3SessionClient.java
+++ b/jetty-core/jetty-http3/jetty-http3-client/src/main/java/org/eclipse/jetty/http3/client/HTTP3SessionClient.java
@@ -27,6 +27,8 @@ import org.eclipse.jetty.http3.frames.Frame;
 import org.eclipse.jetty.http3.frames.GoAwayFrame;
 import org.eclipse.jetty.http3.frames.HeadersFrame;
 import org.eclipse.jetty.http3.frames.SettingsFrame;
+import org.eclipse.jetty.http3.qpack.QpackDecoder;
+import org.eclipse.jetty.http3.qpack.QpackEncoder;
 import org.eclipse.jetty.quic.common.ProtocolSession;
 import org.eclipse.jetty.quic.common.ProtocolStreamListener;
 import org.eclipse.jetty.quic.common.StreamEndPoint;
@@ -53,6 +55,16 @@ public class HTTP3SessionClient extends HTTP3Session implements Session.Client
     private ClientHTTP3Session getClientHTTP3Session()
     {
         return (ClientHTTP3Session)getProtocolSession();
+    }
+
+    public QpackEncoder getQpackEncoder()
+    {
+        return getClientHTTP3Session().getQpackEncoder();
+    }
+
+    public QpackDecoder getQpackDecoder()
+    {
+        return getClientHTTP3Session().getQpackDecoder();
     }
 
     @Override

--- a/jetty-core/jetty-http3/jetty-http3-client/src/main/java/org/eclipse/jetty/http3/client/internal/HTTP3StreamClient.java
+++ b/jetty-core/jetty-http3/jetty-http3-client/src/main/java/org/eclipse/jetty/http3/client/internal/HTTP3StreamClient.java
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeoutException;
 
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.http3.HTTP3ErrorCode;
 import org.eclipse.jetty.http3.HTTP3Session;
 import org.eclipse.jetty.http3.HTTP3Stream;
 import org.eclipse.jetty.http3.api.Stream;
@@ -57,8 +58,16 @@ public class HTTP3StreamClient extends HTTP3Stream implements Stream.Client
 
     public void onResponse(HeadersFrame frame)
     {
-        MetaData.Response response = (MetaData.Response)frame.getMetaData();
-        int status = response.getStatus();
+        MetaData.Response metaData = (MetaData.Response)frame.getMetaData();
+        Throwable failure = MetaData.Failed.getFailure(metaData);
+        if (failure != null)
+        {
+            updateClose(true, false);
+            onFailure(HTTP3ErrorCode.PROTOCOL_ERROR.code(), failure);
+            return;
+        }
+
+        int status = metaData.getStatus();
         switch (status)
         {
             case HttpStatus.CONTINUE_100 -> validateAndUpdate(EnumSet.of(FrameState.INITIAL), FrameState.INFORMATIONAL);

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/HTTP3Stream.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/HTTP3Stream.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.http3;
 import java.util.EnumSet;
 import java.util.concurrent.TimeoutException;
 
+import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.http3.api.Stream;
 import org.eclipse.jetty.http3.frames.DataFrame;
 import org.eclipse.jetty.http3.frames.Frame;
@@ -300,6 +301,14 @@ public abstract class HTTP3Stream implements Stream, CyclicTimeouts.Expirable, A
 
     public void onTrailer(HeadersFrame frame)
     {
+        Throwable failure = MetaData.Failed.getFailure(frame.getMetaData());
+        if (failure != null)
+        {
+            updateClose(true, false);
+            onFailure(HTTP3ErrorCode.PROTOCOL_ERROR.code(), failure);
+            return;
+        }
+
         validateAndUpdate(EnumSet.of(FrameState.HEADER, FrameState.DATA), FrameState.TRAILER);
         notIdle();
         updateClose(frame.isLast(), false);

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/parser/HeadersBodyParser.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/parser/HeadersBodyParser.java
@@ -153,9 +153,17 @@ public class HeadersBodyParser extends BodyParser
 
     private void onHeaders(MetaData metaData, boolean last, boolean wasBlocked)
     {
-        HeadersFrame frame = new HeadersFrame(metaData, last);
-        reset();
-        notifyHeaders(frame, wasBlocked);
+        Throwable failure = MetaData.Failed.getFailure(metaData);
+        if (failure == null || failure instanceof QpackException.StreamException)
+        {
+            HeadersFrame frame = new HeadersFrame(metaData, last);
+            reset();
+            notifyHeaders(frame, wasBlocked);
+        }
+        else
+        {
+            notifySessionFailure(HTTP3ErrorCode.HTTP_MESSAGE_ERROR.code(), "decode_failure", failure);
+        }
     }
 
     protected void notifyHeaders(HeadersFrame frame, boolean wasBlocked)

--- a/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/QpackDecoder.java
+++ b/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/QpackDecoder.java
@@ -24,7 +24,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.LongSupplier;
 
 import org.eclipse.jetty.http.HttpField;
-import org.eclipse.jetty.http.HttpTokens;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.http.compression.NBitIntegerDecoder;
 import org.eclipse.jetty.http3.qpack.internal.QpackContext;
@@ -423,10 +422,6 @@ public class QpackDecoder implements Dumpable
             DynamicTable dynamicTable = _context.getDynamicTable();
             Entry referencedEntry = isDynamicTableIndex ? dynamicTable.getRelative(nameIndex) : staticTable.get(nameIndex);
 
-            // Verify the field value before inserting into the table.
-            if (!HttpTokens.isLegalFieldValue(value))
-                throw new QpackException.SessionException(QPACK_ENCODER_STREAM_ERROR, "Invalid header value");
-
             // Add the new Entry to the DynamicTable.
             Entry entry = new Entry(new HttpField(referencedEntry.getHttpField().getHeader(), referencedEntry.getHttpField().getName(), value));
             dynamicTable.add(entry);
@@ -441,14 +436,6 @@ public class QpackDecoder implements Dumpable
                 LOG.debug("InsertLiteralEntry: name={}, value={}", name, value);
 
             Entry entry = new Entry(new HttpField(name, value));
-
-            // Verify the field name and value before inserting into the table.
-            if (!HttpTokens.isLegalH2H3FieldName(name))
-                throw new QpackException.SessionException(QPACK_ENCODER_STREAM_ERROR, "Invalid header name: " + name);
-            if (!HttpTokens.isLegalFieldValue(value))
-                throw new QpackException.SessionException(QPACK_ENCODER_STREAM_ERROR, "Invalid header value: " + value);
-
-            // Add the new Entry to the DynamicTable.
             DynamicTable dynamicTable = _context.getDynamicTable();
             dynamicTable.add(entry);
             _instructions.add(new InsertCountIncrementInstruction(1));

--- a/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/QpackEncoder.java
+++ b/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/QpackEncoder.java
@@ -101,6 +101,7 @@ public class QpackEncoder implements Dumpable
     private int _blockedStreams;
     private int _maxHeadersSize = -1;
     private int _maxTableCapacity;
+    private boolean _validateEncoding = true;
 
     public QpackEncoder(Instruction.Handler handler)
     {
@@ -152,6 +153,16 @@ public class QpackEncoder implements Dumpable
             setTableCapacity(maxTableCapacity);
     }
 
+    public boolean isValidateEncoding()
+    {
+        return _validateEncoding;
+    }
+
+    public void setValidateEncoding(boolean validateEncoding)
+    {
+        _validateEncoding = validateEncoding;
+    }
+
     public int getTableCapacity()
     {
         return _context.getDynamicTable().getCapacity();
@@ -192,29 +203,32 @@ public class QpackEncoder implements Dumpable
         if (LOG.isDebugEnabled())
             LOG.debug("Encoding: streamId={}, metadata={}", streamId, metadata);
 
-        // Verify that we can encode without errors.
-        long totalSize = 0;
-        for (HttpField field : metadata.getHttpFields())
-         {
-            String name = field.getLowerCaseName();
-            if (!HttpTokens.isLegalH2H3FieldName(name) || name.charAt(0) == ':')
-                throw new QpackException.StreamException(metadata.isRequest(), metadata.isResponse(),
-                    H3_MESSAGE_ERROR, String.format("Invalid header name: '%s'", name));
+        if (isValidateEncoding())
+        {
+            // Verify that we can encode without errors.
+            long totalSize = 0;
+            for (HttpField field : metadata.getHttpFields())
+             {
+                String name = field.getLowerCaseName();
+                if (!HttpTokens.isLegalH2H3FieldName(name) || name.charAt(0) == ':')
+                    throw new QpackException.StreamException(metadata.isRequest(), metadata.isResponse(),
+                        H3_MESSAGE_ERROR, String.format("Invalid header name: '%s'", name));
 
-            String value = field.getValue();
-            if (!HttpTokens.isLegalFieldValue(value))
-                throw new QpackException.StreamException(metadata.isRequest(), metadata.isResponse(),
-                    H3_MESSAGE_ERROR, String.format("Invalid header value: '%s'", value));
+                String value = field.getValue();
+                if (!HttpTokens.isLegalFieldValue(value))
+                    throw new QpackException.StreamException(metadata.isRequest(), metadata.isResponse(),
+                        H3_MESSAGE_ERROR, String.format("Invalid header value: '%s'", value));
 
-            if (_maxHeadersSize > 0)
-            {
-                HttpHeader header = field.getHeader();
-                if (header == null || !header.isPseudo())
+                if (_maxHeadersSize > 0)
                 {
-                    totalSize += 32 + name.length() + value.length();
-                    if (totalSize > _maxHeadersSize)
-                        throw new QpackException.StreamException(metadata.isRequest(), metadata.isResponse(),
-                            H3_GENERAL_PROTOCOL_ERROR, String.format("Max size exceeded: %d > %d", totalSize, _maxHeadersSize));
+                    HttpHeader header = field.getHeader();
+                    if (header == null || !header.isPseudo())
+                    {
+                        totalSize += 32 + name.length() + value.length();
+                        if (totalSize > _maxHeadersSize)
+                            throw new QpackException.StreamException(metadata.isRequest(), metadata.isResponse(),
+                                H3_GENERAL_PROTOCOL_ERROR, String.format("Max size exceeded: %d > %d", totalSize, _maxHeadersSize));
+                    }
                 }
             }
         }

--- a/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/metadata/MetaDataBuilder.java
+++ b/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/metadata/MetaDataBuilder.java
@@ -52,6 +52,23 @@ public class MetaDataBuilder
         _maxSize = maxHeadersSize;
     }
 
+    private void reset()
+    {
+        _fields.clear();
+        _size = 0;
+        _status = null;
+        _method = null;
+        _scheme = null;
+        _authority = null;
+        _path = null;
+        _protocol = null;
+        _contentLength = -1;
+        _streamException = null;
+        _request = false;
+        _response = false;
+        _beginNanoTime = Long.MIN_VALUE;
+    }
+
     /**
      * Get the maxSize.
      *
@@ -242,18 +259,14 @@ public class MetaDataBuilder
 
     public MetaData build() throws QpackException.StreamException
     {
-        if (_streamException != null)
-        {
-            _streamException.addSuppressed(new Throwable());
-            throw _streamException;
-        }
-
-        if (_request && _response)
-            throw new QpackException.StreamException(true, true, H3_GENERAL_PROTOCOL_ERROR, "Request and Response headers");
-
-        HttpFields.Mutable fields = _fields;
         try
         {
+            if (_streamException != null)
+                throw _streamException;
+
+            if (_request && _response)
+                throw new QpackException.StreamException(true, true, H3_GENERAL_PROTOCOL_ERROR, "Request and Response headers");
+
             if (_request)
             {
                 if (_method == null)
@@ -269,38 +282,28 @@ public class MetaDataBuilder
                 long nanoTime = _beginNanoTime == Long.MIN_VALUE ? NanoTime.now() : _beginNanoTime;
                 _beginNanoTime = Long.MIN_VALUE;
                 if (isConnect)
-                    return new MetaData.ConnectRequest(nanoTime, _scheme, _authority, _path, fields, _protocol);
+                    return new MetaData.ConnectRequest(nanoTime, _scheme, _authority, _path, _fields, _protocol);
                 else
                     return new MetaData.Request(
                         nanoTime,
                         _method,
                         newHttpURI(),
                         HttpVersion.HTTP_3,
-                        fields,
+                        _fields,
                         _contentLength);
             }
             if (_response)
             {
                 if (_status == null)
                     throw new QpackException.StreamException(false, true, H3_GENERAL_PROTOCOL_ERROR, "No Status");
-                return new MetaData.Response(_status, null, HttpVersion.HTTP_3, fields, _contentLength);
+                return new MetaData.Response(_status, null, HttpVersion.HTTP_3, _fields, _contentLength);
             }
 
-            return new MetaData(HttpVersion.HTTP_3, fields, _contentLength);
+            return new MetaData(HttpVersion.HTTP_3, _fields, _contentLength);
         }
         finally
         {
-            _fields.clear();
-            _request = false;
-            _response = false;
-            _status = null;
-            _method = null;
-            _scheme = null;
-            _authority = null;
-            _path = null;
-            _protocol = null;
-            _size = 0;
-            _contentLength = -1;
+            reset();
         }
     }
 

--- a/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/parser/EncodedFieldSection.java
+++ b/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/parser/EncodedFieldSection.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpTokens;
+import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.http.compression.EncodingException;
 import org.eclipse.jetty.http.compression.NBitIntegerDecoder;
@@ -99,26 +100,47 @@ public class EncodedFieldSection
 
     public MetaData decode(QpackContext context, int maxHeaderSize) throws QpackException
     {
-        if (context.getDynamicTable().getInsertCount() < _requiredInsertCount)
-            throw new IllegalStateException("Required Insert Count Not Reached");
-
-        MetaDataBuilder metaDataBuilder = new MetaDataBuilder(maxHeaderSize);
-        for (EncodedField encodedField : _encodedFields)
+        try
         {
-            HttpField decodedField = encodedField.decode(context);
+            if (context.getDynamicTable().getInsertCount() < _requiredInsertCount)
+                throw new IllegalStateException("Required Insert Count Not Reached");
 
-            if (!HttpTokens.isLegalH2H3FieldName(decodedField.getName()))
-                throw new QpackException.StreamException(metaDataBuilder.isRequest(), metaDataBuilder.isResponse(),
-                H3_MESSAGE_ERROR, "Invalid field name: " + decodedField.getName());
+            MetaDataBuilder metaDataBuilder = new MetaDataBuilder(maxHeaderSize);
+            for (EncodedField encodedField : _encodedFields)
+            {
+                HttpField decodedField = encodedField.decode(context);
 
-            if (!HttpTokens.isLegalFieldValue(decodedField.getValue()))
-                throw new QpackException.StreamException(metaDataBuilder.isRequest(), metaDataBuilder.isResponse(),
-                    H3_MESSAGE_ERROR, "Invalid field value: " + decodedField.getName());
+                String name = decodedField.getName();
+                if (!HttpTokens.isLegalH2H3FieldName(name))
+                    throw new QpackException.StreamException(metaDataBuilder.isRequest(), metaDataBuilder.isResponse(),
+                        H3_MESSAGE_ERROR, "Invalid field name: '" + name + "'");
 
-            metaDataBuilder.emit(decodedField);
+                String value = decodedField.getValue();
+                if (!HttpTokens.isLegalFieldValue(value))
+                    throw new QpackException.StreamException(metaDataBuilder.isRequest(), metaDataBuilder.isResponse(),
+                        H3_MESSAGE_ERROR, "Invalid field value: '" + value + "'");
+
+                metaDataBuilder.emit(decodedField);
+            }
+            metaDataBuilder.setBeginNanoTime(_beginNanoTime);
+            return metaDataBuilder.build();
         }
-        metaDataBuilder.setBeginNanoTime(_beginNanoTime);
-        return metaDataBuilder.build();
+        catch (QpackException.StreamException x)
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("Stream decode error, stream={}", getStreamId(), x);
+            if (x.isRequest())
+                return MetaData.Failed.newFailedMetaDataRequest(HttpVersion.HTTP_3, x);
+            if (x.isResponse())
+                return MetaData.Failed.newFailedMetaDataResponse(HttpVersion.HTTP_3, x);
+            return MetaData.Failed.newFailedMetaData(HttpVersion.HTTP_3, x);
+        }
+        catch (Throwable x)
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("Stream decode failure, stream={}", getStreamId(), x);
+            return MetaData.Failed.newFailedMetaData(HttpVersion.HTTP_3, x);
+        }
     }
 
     private EncodedField parseIndexedField(ByteBuffer buffer) throws EncodingException

--- a/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HTTP3SessionServer.java
+++ b/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HTTP3SessionServer.java
@@ -24,6 +24,8 @@ import org.eclipse.jetty.http3.frames.Frame;
 import org.eclipse.jetty.http3.frames.GoAwayFrame;
 import org.eclipse.jetty.http3.frames.HeadersFrame;
 import org.eclipse.jetty.http3.frames.SettingsFrame;
+import org.eclipse.jetty.http3.qpack.QpackDecoder;
+import org.eclipse.jetty.http3.qpack.QpackEncoder;
 import org.eclipse.jetty.quic.common.StreamEndPoint;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.thread.Scheduler;
@@ -39,10 +41,19 @@ public class HTTP3SessionServer extends HTTP3Session implements Session.Server
         super(scheduler, session, listener);
     }
 
-    @Override
-    public ServerHTTP3Session getProtocolSession()
+    public QpackEncoder getQpackEncoder()
     {
-        return (ServerHTTP3Session)super.getProtocolSession();
+        return getServerHTTP3Session().getQpackEncoder();
+    }
+
+    public QpackDecoder getQpackDecoder()
+    {
+        return getServerHTTP3Session().getQpackDecoder();
+    }
+
+    private ServerHTTP3Session getServerHTTP3Session()
+    {
+        return (ServerHTTP3Session)getProtocolSession();
     }
 
     @Override
@@ -97,20 +108,20 @@ public class HTTP3SessionServer extends HTTP3Session implements Session.Server
     {
         if (LOG.isDebugEnabled())
             LOG.debug("received {} on {}", frame, this);
-        getProtocolSession().onSettings(frame);
+        getServerHTTP3Session().onSettings(frame);
         super.onSettings(frame);
     }
 
     @Override
     public void writeControlFrame(Frame frame, Callback callback)
     {
-        getProtocolSession().writeControlFrame(frame, callback);
+        getServerHTTP3Session().writeControlFrame(frame, callback);
     }
 
     @Override
     public void writeMessageFrame(StreamEndPoint streamEndPoint, Frame frame, Callback callback)
     {
-        getProtocolSession().writeMessageFrame(streamEndPoint, frame, callback);
+        getServerHTTP3Session().writeMessageFrame(streamEndPoint, frame, callback);
     }
 
     @Override

--- a/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/ClientServerTest.java
+++ b/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/ClientServerTest.java
@@ -144,15 +144,15 @@ public class ClientServerTest extends AbstractClientServerTest
         assertTrue(settingsLatch.await(5, TimeUnit.SECONDS));
 
         HTTP3SessionServer serverSession = serverSessionRef.get();
-        assertEquals(maxTableCapacity.getValue(), serverSession.getProtocolSession().getQpackEncoder().getMaxTableCapacity());
-        assertEquals(maxBlockedStreams.getValue(), serverSession.getProtocolSession().getQpackEncoder().getMaxBlockedStreams());
-        assertEquals(maxBlockedStreams.getValue(), serverSession.getProtocolSession().getQpackDecoder().getMaxBlockedStreams());
-        assertEquals(maxHeaderSize.getValue(), serverSession.getProtocolSession().getQpackDecoder().getMaxHeadersSize());
+        assertEquals(maxTableCapacity.getValue(), serverSession.getQpackEncoder().getMaxTableCapacity());
+        assertEquals(maxBlockedStreams.getValue(), serverSession.getQpackEncoder().getMaxBlockedStreams());
+        assertEquals(maxBlockedStreams.getValue(), serverSession.getQpackDecoder().getMaxBlockedStreams());
+        assertEquals(maxHeaderSize.getValue(), serverSession.getQpackDecoder().getMaxHeadersSize());
 
-        assertEquals(maxTableCapacity.getValue(), ((ClientHTTP3Session)clientSession.getProtocolSession()).getQpackEncoder().getMaxTableCapacity());
-        assertEquals(maxBlockedStreams.getValue(), ((ClientHTTP3Session)clientSession.getProtocolSession()).getQpackEncoder().getMaxBlockedStreams());
-        assertEquals(maxBlockedStreams.getValue(), ((ClientHTTP3Session)clientSession.getProtocolSession()).getQpackDecoder().getMaxBlockedStreams());
-        assertEquals(maxHeaderSize.getValue(), ((ClientHTTP3Session)clientSession.getProtocolSession()).getQpackDecoder().getMaxHeadersSize());
+        assertEquals(maxTableCapacity.getValue(), clientSession.getQpackEncoder().getMaxTableCapacity());
+        assertEquals(maxBlockedStreams.getValue(), clientSession.getQpackEncoder().getMaxBlockedStreams());
+        assertEquals(maxBlockedStreams.getValue(), clientSession.getQpackDecoder().getMaxBlockedStreams());
+        assertEquals(maxHeaderSize.getValue(), clientSession.getQpackDecoder().getMaxHeadersSize());
     }
 
     @ParameterizedTest

--- a/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/ConcurrentRequestsTest.java
+++ b/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/ConcurrentRequestsTest.java
@@ -1,0 +1,279 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.http3.tests;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.http3.api.Session;
+import org.eclipse.jetty.http3.api.Stream;
+import org.eclipse.jetty.http3.client.HTTP3SessionClient;
+import org.eclipse.jetty.http3.frames.HeadersFrame;
+import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.Promise;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ConcurrentRequestsTest extends AbstractClientServerTest
+{
+    @ParameterizedTest
+    @MethodSource("transports")
+    public void testConcurrentGoodRequestsWithBadRequestsWithSameConnection(TransportType transportType) throws Exception
+    {
+        start(transportType, new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                callback.succeeded();
+                return true;
+            }
+        });
+
+        Session.Client clientSession = newSession(new Session.Client.Listener() {});
+        // The test will send an invalid header value on this connection.
+        ((HTTP3SessionClient)clientSession).getQpackEncoder().setValidateEncoding(false);
+
+        testConcurrentGoodRequestsWithBadRequests(clientSession, clientSession);
+    }
+
+    @ParameterizedTest
+    @MethodSource("transports")
+    public void testConcurrentGoodRequestsWithBadRequestsWithDifferentConnections(TransportType transportType) throws Exception
+    {
+        start(transportType, new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                callback.succeeded();
+                return true;
+            }
+        });
+
+        Session.Client goodClientSession = newSession(new Session.Client.Listener() {});
+        Session.Client badClientSession = newSession(new Session.Client.Listener() {});
+        // The test will send an invalid header value on this connection.
+        ((HTTP3SessionClient)badClientSession).getQpackEncoder().setValidateEncoding(false);
+
+        testConcurrentGoodRequestsWithBadRequests(goodClientSession, badClientSession);
+    }
+
+    private void testConcurrentGoodRequestsWithBadRequests(Session.Client goodSession, Session.Client badSession) throws Exception
+    {
+        ExecutorService executor = Executors.newCachedThreadPool();
+
+        AtomicBoolean testing = new AtomicBoolean(true);
+        List<Throwable> failures = new CopyOnWriteArrayList<>();
+
+        // Start a thread to send good requests.
+        executor.execute(() ->
+        {
+            long count = 0;
+            while (testing.get())
+            {
+                if (!sendGoodRequest(goodSession, failures, count++))
+                    break;
+            }
+        });
+
+        // Start a thread to send bad requests.
+        executor.execute(() ->
+        {
+            long count = 0;
+            while (testing.get())
+            {
+                if (!sendBadRequest(badSession, failures, count++))
+                    break;
+            }
+        });
+
+        // Let the test run for a while.
+        Thread.sleep(500);
+
+        testing.set(false);
+        executor.shutdown();
+        assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+
+        assertThat(failures, empty());
+    }
+
+    private boolean sendGoodRequest(Session.Client clientSession, List<Throwable> failures, long id)
+    {
+        AtomicBoolean result = new AtomicBoolean();
+        CountDownLatch requestLatch = new CountDownLatch(1);
+        MetaData.Request request = newRequest(HttpMethod.GET, "/good-" + id, HttpFields.EMPTY);
+        clientSession.newRequest(new HeadersFrame(request, true), new Stream.Client.Listener()
+        {
+            @Override
+            public void onResponse(Stream.Client stream, HeadersFrame frame)
+            {
+                MetaData.Response response = (MetaData.Response)frame.getMetaData();
+                int status = response.getStatus();
+                result.set(status == HttpStatus.OK_200 && frame.isLast());
+                if (status != HttpStatus.OK_200)
+                    failures.add(new BadMessageException("expected 200, got " + status + " id=" + id));
+                if (!frame.isLast())
+                    stream.demand();
+                else
+                    requestLatch.countDown();
+            }
+
+            @Override
+            public void onDataAvailable(Stream.Client stream)
+            {
+                while (true)
+                {
+                    Content.Chunk chunk = stream.read();
+                    if (chunk == null)
+                    {
+                        stream.demand();
+                        return;
+                    }
+                    chunk.release();
+                    if (chunk.isLast())
+                    {
+                        requestLatch.countDown();
+                        return;
+                    }
+                }
+            }
+
+            @Override
+            public void onIdleTimeout(Stream.Client stream, Throwable failure, Promise<Boolean> promise)
+            {
+                failures.add(failure);
+                result.set(false);
+                requestLatch.countDown();
+                promise.succeeded(true);
+            }
+
+            @Override
+            public void onFailure(Stream.Client stream, long error, Throwable failure)
+            {
+                failures.add(failure);
+                result.set(false);
+                requestLatch.countDown();
+            }
+        }, Promise.Invocable.noop());
+
+        try
+        {
+            Thread.sleep(1);
+            if (requestLatch.await(5, TimeUnit.SECONDS))
+                return result.get();
+            failures.add(new TimeoutException("good request id=" + id));
+            return false;
+        }
+        catch (InterruptedException x)
+        {
+            failures.add(x);
+            return false;
+        }
+    }
+
+    private boolean sendBadRequest(Session.Client clientSession, List<Throwable> failures, long id)
+    {
+        AtomicBoolean result = new AtomicBoolean();
+        CountDownLatch requestLatch = new CountDownLatch(1);
+        HttpFields headers = HttpFields.build().put("invalid", "space_at_end ");
+        MetaData.Request request = newRequest(HttpMethod.GET, "/bad-" + id, headers);
+        clientSession.newRequest(new HeadersFrame(request, true), new Stream.Client.Listener()
+        {
+            @Override
+            public void onResponse(Stream.Client stream, HeadersFrame frame)
+            {
+                MetaData.Response response = (MetaData.Response)frame.getMetaData();
+                int status = response.getStatus();
+                result.set(status == HttpStatus.BAD_REQUEST_400);
+                if (status != HttpStatus.BAD_REQUEST_400)
+                    failures.add(new BadMessageException("expected 400, got " + status + " id=" + id));
+                if (!frame.isLast())
+                    stream.demand();
+                else
+                    requestLatch.countDown();
+            }
+
+            @Override
+            public void onDataAvailable(Stream.Client stream)
+            {
+                while (true)
+                {
+                    Content.Chunk chunk = stream.read();
+                    if (chunk == null)
+                    {
+                        stream.demand();
+                        return;
+                    }
+                    chunk.release();
+                    if (chunk.isLast())
+                    {
+                        requestLatch.countDown();
+                        return;
+                    }
+                }
+            }
+
+            @Override
+            public void onIdleTimeout(Stream.Client stream, Throwable failure, Promise<Boolean> promise)
+            {
+                failures.add(failure);
+                requestLatch.countDown();
+                result.set(false);
+                promise.succeeded(true);
+            }
+
+            @Override
+            public void onFailure(Stream.Client stream, long error, Throwable failure)
+            {
+                failures.add(failure);
+                requestLatch.countDown();
+                result.set(false);
+            }
+        }, Promise.Invocable.noop());
+
+        try
+        {
+            Thread.sleep(1);
+            if (requestLatch.await(5, TimeUnit.SECONDS))
+                return result.get();
+            failures.add(new TimeoutException("bad request id=" + id));
+            return false;
+        }
+        catch (InterruptedException x)
+        {
+            failures.add(x);
+            return false;
+        }
+    }
+}

--- a/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/GoAwayTest.java
+++ b/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/GoAwayTest.java
@@ -126,7 +126,7 @@ public class GoAwayTest extends AbstractClientServerTest
         HTTP3SessionServer serverSession = serverSessionRef.get();
         assertTrue(serverSession.isClosed());
         assertTrue(serverSession.getStreams().isEmpty());
-        ServerHTTP3Session serverProtocolSession = serverSession.getProtocolSession();
+        ServerHTTP3Session serverProtocolSession = (ServerHTTP3Session)serverSession.getProtocolSession();
         // While HTTP/3 is completely closed, QUIC may still be exchanging packets, so we need to await().
         await().atMost(3, TimeUnit.SECONDS).until(() -> serverProtocolSession.getStreamEndPoints().isEmpty());
         await().atMost(3, TimeUnit.SECONDS).until(() -> serverProtocolSession.getSession().getStreams().isEmpty());
@@ -1028,7 +1028,7 @@ public class GoAwayTest extends AbstractClientServerTest
         HTTP3SessionServer serverSession = (HTTP3SessionServer)serverSessionRef.get();
         assertTrue(serverSession.isClosed());
         assertTrue(serverSession.getStreams().isEmpty());
-        ServerHTTP3Session serverProtocolSession = serverSession.getProtocolSession();
+        ServerHTTP3Session serverProtocolSession = (ServerHTTP3Session)serverSession.getProtocolSession();
         // While HTTP/3 is completely closed, QUIC may still be exchanging packets, so we need to await().
         await().atMost(1, TimeUnit.SECONDS).until(() -> serverProtocolSession.getStreamEndPoints().isEmpty());
         await().atMost(1, TimeUnit.SECONDS).until(() -> serverProtocolSession.getSession().getStreams().isEmpty());


### PR DESCRIPTION
* Added handling failed MetaData in HTTP2Stream.onHeaders(), in case the response contains bad headers.
* Properly resetting at the end of MetaDataBuilder.build(): before the _streamException field was not reset, leading to failing also the next requests/responses.
* Made sure MetaDataBuilder.build() resets even when a failure is detected early at the beginning of the method.
* Added checks in HpackDecoder for indexed entries that may have been stored with invalid header name/value.
* HpackDecoder now stores a lower-case "content-length: 0", so that subsequent retrievals do not fail the checks added above.
* Added test cases for concurrent good and bad responses.
* Similar changes for HTTP/3.


See https://github.com/jetty/jetty.project/pull/13700 for the 12.0 PR.