### PR TITLE
Issue #13768 - Sanitizing HTTP/1.x Header Name and Value better

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpGenerator.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpGenerator.java
@@ -1014,7 +1014,7 @@ public class HttpGenerator
 
             // Do not allow 8-bit, or CTRL (except HTAB)
             if (c > 0xff || (c >= 0x00 && c <= 0x1F && c != '\t'))
-                buffer.put((byte)'?'); // replacement char has to satisfy RFC9110 Field Value ABNF.
+                buffer.put((byte)' '); // replacement char has to satisfy RFC9110 Field Value ABNF.
             else
                 buffer.put((byte)(0xff & c));
         }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpGenerator.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpGenerator.java
@@ -998,7 +998,7 @@ public class HttpGenerator
             char c = s.charAt(i);
 
             // Do not allow 8-bit, colon (:), or CTRL (except HTAB)
-            if (c > 0xff || c == ':' || (c >= 0x00 && c <= 0x1F && c != '\t'))
+            if (c == ':' || c > 0xff || (c <= 0x1F && c != '\t'))
                 buffer.put((byte)'.'); // replacement char has to satisfy RFC9110 Field Name ABNF (aka Token).
             else
                 buffer.put((byte)(0xff & c));
@@ -1013,7 +1013,7 @@ public class HttpGenerator
             char c = s.charAt(i);
 
             // Do not allow 8-bit, or CTRL (except HTAB)
-            if (c > 0xff || (c >= 0x00 && c <= 0x1F && c != '\t'))
+            if (c > 0xff || (c <= 0x1F && c != '\t'))
                 buffer.put((byte)' '); // replacement char has to satisfy RFC9110 Field Value ABNF.
             else
                 buffer.put((byte)(0xff & c));

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpGenerator.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpGenerator.java
@@ -997,8 +997,9 @@ public class HttpGenerator
         {
             char c = s.charAt(i);
 
-            if (c > 0xff || c == '\r' || c == '\n' || c == ':')
-                buffer.put((byte)'?');
+            // Do not allow 8-bit, colon (:), or CTRL (except HTAB)
+            if (c > 0xff || c == ':' || (c >= 0x00 && c <= 0x1F && c != '\t'))
+                buffer.put((byte)'.'); // replacement char has to satisfy RFC9110 Field Name ABNF (aka Token).
             else
                 buffer.put((byte)(0xff & c));
         }
@@ -1011,8 +1012,9 @@ public class HttpGenerator
         {
             char c = s.charAt(i);
 
-            if (c > 0xff || c == '\r' || c == '\n')
-                buffer.put((byte)' ');
+            // Do not allow 8-bit, or CTRL (except HTAB)
+            if (c > 0xff || (c >= 0x00 && c <= 0x1F && c != '\t'))
+                buffer.put((byte)'?'); // replacement char has to satisfy RFC9110 Field Value ABNF.
             else
                 buffer.put((byte)(0xff & c));
         }

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
@@ -429,8 +429,8 @@ public class HttpFieldsTest
         BufferUtil.flipToFlush(buffer, 0);
         String out = BufferUtil.toString(buffer);
         assertThat(out, containsString("name0: value  0"));
-        assertThat(out, containsString("name??1: value1"));
-        assertThat(out, containsString("name?2: value:  2"));
+        assertThat(out, containsString("name..1: value1"));
+        assertThat(out, containsString("name.2: value:  2"));
     }
 
     @ParameterizedTest

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ResponseTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ResponseTest.java
@@ -907,4 +907,56 @@ public class ResponseTest
             "name=test1; Domain=customized; SameSite=Lax",
             "other=test2; Domain=customized; SameSite=Lax; Attr=x"));
     }
+
+    @Test
+    public void testNullInHeaderName() throws Exception
+    {
+        server.setHandler(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                response.setStatus(200);
+                response.getHeaders().add("X-Te\u0000st", "value");
+                Content.Sink.write(response, true, "OK", callback);
+                return true;
+            }
+        });
+        server.start();
+
+        String request = """
+                POST /test HTTP/1.0\r
+                Host: hostname\r
+                \r
+                """;
+        HttpTester.Response response = HttpTester.parseResponse(connector.getResponse(request));
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+        assertThat(response.get("X-Te.st"), is("value"));
+    }
+
+    @Test
+    public void testNullInHeaderValue() throws Exception
+    {
+        server.setHandler(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                response.setStatus(200);
+                response.getHeaders().add("X-Test", "val\u0000ue");
+                Content.Sink.write(response, true, "OK", callback);
+                return true;
+            }
+        });
+        server.start();
+
+        String request = """
+                POST /test HTTP/1.0\r
+                Host: hostname\r
+                \r
+                """;
+        HttpTester.Response response = HttpTester.parseResponse(connector.getResponse(request));
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+        assertThat(response.get("X-Test"), is("val?ue"));
+    }
 }

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ResponseTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ResponseTest.java
@@ -957,6 +957,6 @@ public class ResponseTest
                 """;
         HttpTester.Response response = HttpTester.parseResponse(connector.getResponse(request));
         assertEquals(HttpStatus.OK_200, response.getStatus());
-        assertThat(response.get("X-Test"), is("val?ue"));
+        assertThat(response.get("X-Test"), is("val ue"));
     }
 }


### PR DESCRIPTION
+ Excluding all CTRL (except HTAB) from allowed characters in `HttpGenerator.putSanitisedName` `HttpGenerator.putSanitisedValue`
+ Changing replacement character for the above two sanitization methods to fit into RFC9110 rules
+ Adding unit test.

Closes #13768