### PR TITLE
12.0.x: Make `ContextHandler` catch and ignore exceptions thrown by `Thread.setContextClassLoader()` 

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -74,7 +74,7 @@ import org.slf4j.LoggerFactory;
 public class ContextHandler extends Handler.Wrapper implements Attributes, AliasCheck
 {
     private static final Logger LOG = LoggerFactory.getLogger(ContextHandler.class);
-    private static final ThreadLocal<Context> __context = new ThreadLocal<>();
+    private static final ThreadLocal<Context> CURRENT_CONTEXT = new ThreadLocal<>();
 
     public static final String MANAGED_ATTRIBUTES = "org.eclipse.jetty.server.context.ManagedAttributes";
 
@@ -92,7 +92,7 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
      */
     public static Context getCurrentContext()
     {
-        return __context.get();
+        return CURRENT_CONTEXT.get();
     }
 
     /**
@@ -103,7 +103,7 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
      */
     public static Context getCurrentContext(Server server)
     {
-        Context context = __context.get();
+        Context context = CURRENT_CONTEXT.get();
         return context == null ? (server == null ? null : server.getContext()) : context;
     }
 
@@ -450,6 +450,11 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
         return _classLoader;
     }
 
+    /**
+     * The {@link ClassLoader} to set as the {@link Thread#setContextClassLoader(ClassLoader) thread's context classloader}
+     * when the thread executing this handler enters the scope of this context.
+     * @param contextLoader the {@link ClassLoader} or {@code null} to avoid changing the thread's context classloader.
+     */
     public void setClassLoader(ClassLoader contextLoader)
     {
         if (isStarted())
@@ -592,8 +597,8 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
             if (listener instanceof ContextScopeListener contextScopeListener)
             {
                 _contextListeners.add(contextScopeListener);
-                if (__context.get() != null)
-                    contextScopeListener.enterScope(__context.get(), null);
+                if (CURRENT_CONTEXT.get() != null)
+                    contextScopeListener.enterScope(CURRENT_CONTEXT.get(), null);
             }
             return true;
         }
@@ -608,8 +613,8 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
             if (listener instanceof ContextScopeListener contextScopeListener)
             {
                 _contextListeners.remove(contextScopeListener);
-                if (__context.get() != null)
-                    contextScopeListener.exitScope(__context.get(), null);
+                if (CURRENT_CONTEXT.get() != null)
+                    contextScopeListener.exitScope(CURRENT_CONTEXT.get(), null);
             }
             return true;
         }
@@ -618,10 +623,21 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
 
     protected ClassLoader enterScope(Request contextRequest)
     {
+        CURRENT_CONTEXT.set(_context);
+
         ClassLoader lastLoader = Thread.currentThread().getContextClassLoader();
-        __context.set(_context);
-        if (_classLoader != null)
-            Thread.currentThread().setContextClassLoader(_classLoader);
+        if (_classLoader != null && _classLoader != lastLoader)
+        {
+            try
+            {
+                Thread.currentThread().setContextClassLoader(_classLoader);
+            }
+            catch (Throwable x)
+            {
+                if (LOG.isDebugEnabled())
+                    LOG.debug("error setting a context classloader on thread {}", Thread.currentThread(), x);
+            }
+        }
         notifyEnterScope(contextRequest);
         return lastLoader;
     }
@@ -644,11 +660,20 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
         }
     }
 
-    protected void exitScope(Request request, Context lastContext, ClassLoader lastLoader)
+    /**
+     * <p>Exits the scope of the {@link Context}.</p>
+     *
+     * @param contextRequest the context's {@link Request}
+     * @param lastContext the previous context to restore as the current one.
+     * @param lastLoader the previous {@link Thread#getContextClassLoader() thread's context classloader} to restore
+     */
+    protected void exitScope(Request contextRequest, Context lastContext, ClassLoader lastLoader)
     {
-        notifyExitScope(request);
-        __context.set(lastContext);
-        Thread.currentThread().setContextClassLoader(lastLoader);
+        CURRENT_CONTEXT.set(lastContext);
+
+        notifyExitScope(contextRequest);
+        if (Thread.currentThread().getContextClassLoader() != lastLoader)
+            Thread.currentThread().setContextClassLoader(lastLoader);
     }
 
     /**
@@ -1452,7 +1477,7 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
 
         public void call(Invocable.Callable callable, Request request) throws Exception
         {
-            Context lastContext = __context.get();
+            Context lastContext = CURRENT_CONTEXT.get();
             if (lastContext == this)
                 callable.call();
             else
@@ -1471,7 +1496,7 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
 
         public <T> boolean test(Predicate<T> predicate, T t, Request request)
         {
-            Context lastContext = __context.get();
+            Context lastContext = CURRENT_CONTEXT.get();
             if (lastContext == this)
                 return predicate.test(t);
 
@@ -1488,7 +1513,7 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
 
         public void accept(Consumer<Throwable> consumer, Throwable t, Request request)
         {
-            Context lastContext = __context.get();
+            Context lastContext = CURRENT_CONTEXT.get();
             if (lastContext == this)
                 consumer.accept(t);
             else
@@ -1513,7 +1538,7 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
 
         public void run(Runnable runnable, Request request)
         {
-            Context lastContext = __context.get();
+            Context lastContext = CURRENT_CONTEXT.get();
             if (lastContext == this)
                 runnable.run();
             else

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
@@ -19,6 +19,10 @@ import java.io.Writer;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.ByteBuffer;
+import java.nio.channels.AsynchronousFileChannel;
+import java.nio.channels.CompletionHandler;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -66,6 +70,7 @@ import org.eclipse.jetty.server.TunnelSupport;
 import org.eclipse.jetty.server.internal.HttpChannelState;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.util.Blocker;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.IO;
@@ -107,7 +112,7 @@ public class ContextHandlerTest
     AtomicBoolean _inContext;
 
     @BeforeEach
-    public void beforeEach() throws Exception
+    public void beforeEach()
     {
         _server = new Server();
         _loader = new URLClassLoader(new URL[0], this.getClass().getClassLoader());
@@ -168,6 +173,132 @@ public class ContextHandlerTest
         assertThat(stream.getFailure(), nullValue());
         assertThat(stream.getResponse(), notNullValue());
         assertThat(stream.getResponse().getStatus(), equalTo(404));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testThreadRefusingContextClassLoader(boolean withClassLoader) throws Exception
+    {
+        LocalConnector connector = new LocalConnector(_server);
+        _server.addConnector(connector);
+        _contextHandler.setClassLoader(withClassLoader ? _loader : null);
+        _contextHandler.setHandler(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            {
+                CountDownLatch latch = new CountDownLatch(1);
+                var t = new Thread()
+                {
+                    @Override
+                    public void run()
+                    {
+                        try (Blocker.Callback cb = Blocker.callback())
+                        {
+                            // When a classloader is configured, Response.write() tries to set it as the context classloader.
+                            response.write(true, ByteBuffer.allocate(32), cb);
+                            cb.block();
+                        }
+                        catch (IOException e)
+                        {
+                            throw new RuntimeException(e);
+                        }
+                        finally
+                        {
+                            latch.countDown();
+                        }
+                    }
+
+                    @Override
+                    public void setContextClassLoader(ClassLoader cl)
+                    {
+                        throw new ArithmeticException();
+                    }
+                };
+                t.start();
+                assertTrue(latch.await(5, TimeUnit.SECONDS));
+
+                callback.succeeded();
+                return true;
+            }
+        });
+        _server.start();
+
+        String rawRequest = """
+            GET /ctx/ HTTP/1.1
+            Host: local
+            Connection: close
+            
+            """;
+
+        String rawResponse = connector.getResponse(rawRequest);
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(200));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testAIOAndClassLoader(boolean withClassLoader) throws Exception
+    {
+        LocalConnector connector = new LocalConnector(_server);
+        _server.addConnector(connector);
+        _contextHandler.setClassLoader(withClassLoader ? _loader : null);
+        _contextHandler.setHandler(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            {
+                Path tempFile = request.getContext().getTempDirectory().toPath().resolve("file.bin");
+                try (AsynchronousFileChannel afc = AsynchronousFileChannel.open(tempFile, StandardOpenOption.CREATE, StandardOpenOption.WRITE))
+                {
+                    CountDownLatch latch = new CountDownLatch(1);
+                    // In JDK 25, The CompletionHandler gets called by an InnocuousThread that throws when trying to set the context classloader.
+                    afc.write(ByteBuffer.allocate(32), 0L, null, new CompletionHandler<>()
+                    {
+                        @Override
+                        public void completed(Integer result, Object attachment)
+                        {
+                            try (Blocker.Callback cb = Blocker.callback())
+                            {
+                                // When a classloader is configured, Response.write() tries to set it as the context classloader.
+                                response.write(true, ByteBuffer.allocate(32), cb);
+                                cb.block();
+                            }
+                            catch (IOException e)
+                            {
+                                throw new RuntimeException(e);
+                            }
+                            finally
+                            {
+                                latch.countDown();
+                            }
+                        }
+
+                        @Override
+                        public void failed(Throwable exc, Object attachment)
+                        {
+                            latch.countDown();
+                        }
+                    });
+                    assertTrue(latch.await(5, TimeUnit.SECONDS));
+                }
+
+                callback.succeeded();
+                return true;
+            }
+        });
+        _server.start();
+
+        String rawRequest = """
+            GET /ctx/ HTTP/1.1
+            Host: local
+            Connection: close
+            
+            """;
+
+        String rawResponse = connector.getResponse(rawRequest);
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(200));
     }
 
     @Test


### PR DESCRIPTION
Backport of https://github.com/jetty/jetty.project/pull/13677 to 12.0.