### PR TITLE
CVE Upgrades for 9.4.x

### DIFF
--- a/jetty-client/pom.xml
+++ b/jetty-client/pom.xml
@@ -128,7 +128,7 @@
     <dependency>
       <groupId>net.minidev</groupId>
       <artifactId>json-smart</artifactId>
-      <version>2.5.1</version>
+      <version>2.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/jetty-jaas/pom.xml
+++ b/jetty-jaas/pom.xml
@@ -12,7 +12,7 @@
     <bundle-symbolic-name>${project.groupId}.jaas</bundle-symbolic-name>
     <!-- 2.0.0.AM25 is breaking surefire -->
     <apacheds.version>2.0.0.AM26</apacheds.version>
-    <apache.directory.api.version>2.1.5</apache.directory.api.version>
+    <apache.directory.api.version>2.1.7</apache.directory.api.version>
     <spotbugs.onlyAnalyze>org.eclipse.jetty.jaas.*</spotbugs.onlyAnalyze>
   </properties>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -27,26 +27,27 @@
     <alpn.api.version>1.1.3.v20160715</alpn.api.version>
     <ant.version>1.10.15</ant.version>
     <apache.avro.version>1.11.4</apache.avro.version>
-    <mina.core.version>2.2.3</mina.core.version>
+    <mina.core.version>2.2.4</mina.core.version>
     <asm.version>9.7.1</asm.version>
+    <bitbucket.jose4j.version>0.9.4</bitbucket.jose4j.version>
     <bndlib.version>6.4.1</bndlib.version>
     <build-support.version>1.5</build-support.version>
     <checkstyle.version>9.3</checkstyle.version>
     <commons-codec.version>1.17.1</commons-codec.version>
     <commons.compress.version>1.27.1</commons.compress.version>
     <commons.io.version>2.18.0</commons.io.version>
-    <commons.lang3.version>3.17.0</commons.lang3.version>
+    <commons.lang3.version>3.19.0</commons.lang3.version>
     <conscrypt.version>2.5.2</conscrypt.version>
     <disruptor.version>3.4.4</disruptor.version>
     <findbugs.jsr305.version>3.0.2</findbugs.jsr305.version>
-    <google.errorprone.version>2.36.0</google.errorprone.version>
-    <grpc.version>1.68.2</grpc.version>
-    <gson.version>2.11.0</gson.version>
+    <google.errorprone.version>2.41.0</google.errorprone.version>
+    <grpc.version>1.75.0</grpc.version>
+    <gson.version>2.13.2</gson.version>
     <guava.version>33.3.1-jre</guava.version>
     <guice.version>7.0.0</guice.version>
     <hawtio.version>3.0.2</hawtio.version>
     <hazelcast.version>3.12.12</hazelcast.version>
-    <infinispan.protostream.version>4.4.4.Final</infinispan.protostream.version>
+    <infinispan.protostream.version>4.4.5.Final</infinispan.protostream.version>
     <infinispan.version>11.0.19.Final</infinispan.version>
     <jackson.annotations.version>2.18.2</jackson.annotations.version>
     <jackson.core.version>2.18.2</jackson.core.version>
@@ -75,11 +76,12 @@
     <jsp.version>8.5.100</jsp.version>
     <junit.version>5.10.5</junit.version>
     <log4j2.version>2.17.1</log4j2.version>
-    <logback.version>1.2.13</logback.version>
+    <logback.version>1.3.15</logback.version>
     <maven.plugin-tools.version>3.12.0</maven.plugin-tools.version>
     <maven.resolver.version>1.9.22</maven.resolver.version>
     <maven.version>3.9.0</maven.version>
     <mongodb.version>2.14.3</mongodb.version>
+    <netty.version>4.1.125.Final</netty.version>
     <njord.version>0.8.3</njord.version>
     <osgi.annotation.version>8.1.0</osgi.annotation.version>
     <osgi.core.version>6.0.0</osgi.core.version>
@@ -88,14 +90,15 @@
     <plexus-container.version>2.1.1</plexus-container.version>
     <plexus-utils.version>4.0.2</plexus-utils.version>
     <plexus-xml.version>4.0.4</plexus-xml.version>
-    <slf4j.version>1.7.36</slf4j.version>
+    <slf4j.version>2.0.15</slf4j.version>
     <taglibs-standard-impl.version>1.2.5</taglibs-standard-impl.version>
     <taglibs-standard-spec.version>1.2.5</taglibs-standard-spec.version>
     <testcontainers.version>1.20.4</testcontainers.version>
     <weld.version>3.1.9.Final</weld.version>
     <!-- Stay on 2.2.x as 2.3.x is for Java 11 -->
-    <wildfly.elytron.version>2.2.7.Final</wildfly.elytron.version>
+    <wildfly.elytron.version>2.2.9.Final</wildfly.elytron.version>
     <wildfly.common.version>1.6.0.Final</wildfly.common.version>
+    <xalan.version>2.7.3</xalan.version>
     <xmemcached.version>2.4.8</xmemcached.version>
 
     <!-- some maven plugins versions -->
@@ -1280,6 +1283,21 @@
         <version>${grpc.version}</version>
       </dependency>
       <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-netty-shaded</artifactId>
+        <version>${grpc.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>xalan</groupId>
+        <artifactId>xalan</artifactId>
+        <version>${xalan.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.ant</groupId>
         <artifactId>ant</artifactId>
         <version>${ant.version}</version>
@@ -1324,6 +1342,11 @@
         <artifactId>jolokia-war</artifactId>
         <version>${jolokia.version}</version>
         <type>war</type>
+      </dependency>
+      <dependency>
+        <groupId>org.bitbucket.b_c</groupId>
+        <artifactId>jose4j</artifactId>
+        <version>${bitbucket.jose4j.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Upgraded Commons Lang3 from 3.17.0 to 3.19.0, Commons IO from 2.4 to 2.18, Apache Mina from 2.2.3 to 2.2.4, GRPC Netty from 1.68.1 to 1.75.0, Netty from 4.1.58.Final to 4.1.125.Final, WildFly Elytron from 2.2.7.Final to 2.2.9.Final, GSON from 2.6.2 to 2.13.2, Xalan from 2.7.2 to 2.7.3 to resolve CVE-2021-29425, CVE-2021-37136, CVE-2021-37137, CVE-2022-25647, CVE-2022-34169, CVE-2023-34462, CVE-2023-35887, CVE-2024-12369, CVE-2024-41909, CVE-2024-47535, CVE-2024-47554, CVE-2024-52046, CVE-2025-25193, CVE-2025-41249, CVE-2025-48924, CVE-2025-55163 and CVE-2025-58057