### PR TITLE
Call completeStream only once on failure.

### DIFF
--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientFailureTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientFailureTest.java
@@ -175,7 +175,7 @@ public class HttpClientFailureTest
                     completed.incrementAndGet();
                     assertThat(result.getRequestFailure(), notNullValue());
                     assertThat(result.getResponseFailure(), nullValue());
-                    assertThat(result.getResponse().getStatus(), is(HttpStatus.OK_200));
+                    assertThat(result.getResponse().getStatus(), is(HttpStatus.INTERNAL_SERVER_ERROR_500));
                     resultLatch.countDown();
                 });
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -803,7 +803,7 @@ public class HttpChannelState implements HttpChannel, Components
         @Override
         public InvocationType getInvocationType()
         {
-            return getConnectionMetaData().getConnector().getServer().getInvocationType();
+            return InvocationType.NON_BLOCKING;
         }
     }
 
@@ -1638,15 +1638,13 @@ public class HttpChannelState implements HttpChannel, Components
                         else
                         {
                             // There has been no last write, but we will just fail the stream instead.
-
                             httpChannelState._streamSendState = StreamSendState.FAILED;
                             completeStream = true;
                         }
                     }
                     else
                     {
-                        // We are still handling, sof for the most part
-                        // let the HandlerInvoker deal with completion
+                        // We are still handling, so for the most part let the HandlerInvoker deal with completion
 
                         // But if we are writing
                         if (response.lockedIsWriting())
@@ -1672,8 +1670,7 @@ public class HttpChannelState implements HttpChannel, Components
 
             if (failedCallback != null)
                 failedCallback.failed(Objects.requireNonNullElseGet(failure, IOException::new));
-
-            if (errorResponse != null)
+            else if (errorResponse != null)
                 Response.writeError(request, errorResponse, new ErrorCallback(request, errorResponse, stream, failure), failure);
             else if (doLastStreamSend)
                 stream.send(_request._metaData, responseMetaData, true, null, response);

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -746,7 +746,7 @@ public class HttpChannelState implements HttpChannel, Components
             {
                 assert _callbackCompleted;
                 _streamSendState = StreamSendState.LAST_COMPLETE;
-                completeStream = _handling == null;
+                completeStream = _handling == null; // if we have not handled yet or have completed handling
                 stream = _stream;
                 failure = _callbackFailure = ExceptionUtil.combine(_callbackFailure, failure);
             }
@@ -1308,7 +1308,7 @@ public class HttpChannelState implements HttpChannel, Components
 
                 if (writeFailure == NOTHING_TO_SEND)
                 {
-                    httpChannelState._writeInvoker.run(callback::succeeded);
+                    httpChannelState._writeInvoker.run(new ReadyTask(callback.getInvocationType(), callback::succeeded));
                     return;
                 }
                 // Have we failed in some way?
@@ -1603,7 +1603,7 @@ public class HttpChannelState implements HttpChannel, Components
                     httpChannelState._callbackFailure = failure;
 
                     // Can we and should we generate an error response?
-                    if (!stream.isCommitted() && !ExceptionUtil.isAssociated(failure, Request.Handler.AbortException.class))
+                    if (!stream.isCommitted() && !ExceptionUtil.hasAssociated(failure, Request.Handler.AbortException.class))
                     {
                         // We are not committed, so we can send an error response.
                         errorResponse = new ErrorResponse(request);
@@ -1618,21 +1618,41 @@ public class HttpChannelState implements HttpChannel, Components
                         }
                         else if (response.lockedIsWriting())
                         {
-                            // We are currently writing, so let the completion of that write handle the failure
-                            httpChannelState._callbackFailure = failure;
+                            // We are currently writing so fail the app callback now and let the write completion handle the failure
+                            // TODO If we don't want to wait for write completion then do
+                            //      Runnable task = response.lockedFailWrite(failure);
+                            //      failedCallback = Callback.from(task, httpChannelState._handlerInvoker);
                             failedCallback = response._writeCallback;
                             response._writeCallback = httpChannelState._handlerInvoker;
                         }
                         else
                         {
                             // There has been no last write, but we will just fail the stream instead.
+
+                            httpChannelState._streamSendState = StreamSendState.FAILED;
                             completeStream = true;
                         }
                     }
-                    else if (!httpChannelState.lockedIsLastStreamSendCompleted() && !response.lockedIsWriting())
+                    else
                     {
-                        // last write is not going to happen after failure, so we can just fail anyway
-                        httpChannelState._streamSendState = StreamSendState.LAST_COMPLETE;
+                        // We are still handling, sof for the most part
+                        // let the HandlerInvoker deal with completion
+
+                        // But if we are writing
+                        if (response.lockedIsWriting())
+                        {
+                            // We are currently writing so fail the app callback now and let the write completion handle the failure
+                            // TODO If we don't want to wait for write completion then do
+                            //      Runnable task = response.lockedFailWrite(failure);
+                            //      failedCallback = Callback.from(task, httpChannelState._handlerInvoker);
+                            failedCallback = response._writeCallback;
+                            response._writeCallback = httpChannelState._handlerInvoker;
+                        }
+                        else if (!httpChannelState.lockedIsLastStreamSendCompleted())
+                        {
+                            // last write it is not going to happen after failure, so we can just fail anyway
+                            httpChannelState._streamSendState = StreamSendState.FAILED;
+                        }
                     }
                 }
             }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -1576,7 +1576,7 @@ public class HttpChannelState implements HttpChannel, Components
                     if (!stream.isCommitted())
                         errorResponse = new ErrorResponse(request);
                     else
-                        completeStream = true;
+                        completeStream = httpChannelState._handling == null;
                 }
             }
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -1629,11 +1629,8 @@ public class HttpChannelState implements HttpChannel, Components
                         else if (response.lockedIsWriting())
                         {
                             // We are currently writing so fail the app callback now and let the write completion handle the failure
-                            // TODO If we don't want to wait for write completion then do
-                            //      Runnable task = response.lockedFailWrite(failure);
-                            //      failedCallback = Callback.from(task, httpChannelState._handlerInvoker);
-                            failedCallback = response._writeCallback;
-                            response._writeCallback = httpChannelState._lastWriteCallback;
+                            Runnable task = response.lockedFailWrite(failure);
+                            failedCallback = Callback.from(task, httpChannelState._lastWriteCallback);
                         }
                         else
                         {
@@ -1650,11 +1647,8 @@ public class HttpChannelState implements HttpChannel, Components
                         if (response.lockedIsWriting())
                         {
                             // We are currently writing so fail the app callback now and let the write completion handle the failure
-                            // TODO If we don't want to wait for write completion then do
-                            //      Runnable task = response.lockedFailWrite(failure);
-                            //      failedCallback = Callback.from(task, httpChannelState._handlerInvoker);
-                            failedCallback = response._writeCallback;
-                            response._writeCallback = httpChannelState._lastWriteCallback;
+                            Runnable task = response.lockedFailWrite(failure);
+                            failedCallback = Callback.from(task, httpChannelState._lastWriteCallback);
                         }
                         else if (!httpChannelState.lockedIsLastStreamSendCompleted())
                         {

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -1574,9 +1574,14 @@ public class HttpChannelState implements HttpChannel, Components
                 {
                     httpChannelState._callbackFailure = failure;
                     if (!stream.isCommitted())
+                        // We are not committed, so we can send an error response.
                         errorResponse = new ErrorResponse(request);
+                    else if (httpChannelState._handling == null)
+                        // We are committed, but no longer handling, so will complete here, ignoring any pending reads/writes
+                        completeStream = true;
                     else
-                        completeStream = httpChannelState._handling == null;
+                        // We are committed and still handling, so let the HandlerInvoker complete, ignoring any pending reads/writes.
+                        httpChannelState._streamSendState = StreamSendState.LAST_COMPLETE;
                 }
             }
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -1601,7 +1601,9 @@ public class HttpChannelState implements HttpChannel, Components
                 {
                     // We are failing...
                     httpChannelState._callbackFailure = failure;
-                    if (!stream.isCommitted())
+
+                    // Can we and should we generate an error response?
+                    if (!stream.isCommitted() && !ExceptionUtil.isAssociated(failure, Request.Handler.AbortException.class))
                     {
                         // We are not committed, so we can send an error response.
                         errorResponse = new ErrorResponse(request);

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -93,7 +93,10 @@ public class HttpChannelState implements HttpChannel, Components
         LAST_SENDING,
 
         /** Last content sent and completed */
-        LAST_COMPLETE
+        LAST_COMPLETE,
+
+        /** Failing, so last send will never happen */
+        FAILED
     }
 
     private static final Logger LOG = LoggerFactory.getLogger(HttpChannelState.class);
@@ -575,6 +578,8 @@ public class HttpChannelState implements HttpChannel, Components
             case LAST_SENDING, LAST_COMPLETE -> (length > 0)
                 ? new IllegalStateException("last already written")
                 : NOTHING_TO_SEND;
+
+            case FAILED -> null;
         };
     }
 
@@ -588,7 +593,7 @@ public class HttpChannelState implements HttpChannel, Components
     private boolean lockedIsLastStreamSendCompleted()
     {
         assert _lock.isHeldByCurrentThread();
-        return _streamSendState == StreamSendState.LAST_COMPLETE;
+        return _streamSendState == StreamSendState.LAST_COMPLETE || _streamSendState == StreamSendState.FAILED;
     }
 
     private boolean lockedLastStreamSend()
@@ -698,7 +703,7 @@ public class HttpChannelState implements HttpChannel, Components
                 failure = _callbackFailure;
                 callbackCompleted = _callbackCompleted;
                 lastStreamSendComplete = lockedIsLastStreamSendCompleted();
-                completeStream = callbackCompleted && (lastStreamSendComplete || failure != null);
+                completeStream = callbackCompleted && lastStreamSendComplete;
 
                 if (LOG.isDebugEnabled())
                     LOG.debug("handler invoked: completeStream={} failure={} callbackCompleted={} {}", completeStream, failure, callbackCompleted, HttpChannelState.this);
@@ -1559,6 +1564,8 @@ public class HttpChannelState implements HttpChannel, Components
                 else
                 {
                     Throwable unconsumed = stream.consumeAvailable();
+                    if (failure != null)
+                        ExceptionUtil.addSuppressedIfNotAssociated(failure, unconsumed);
                     if (LOG.isDebugEnabled())
                         LOG.debug("consumeAvailable: {} {} ", unconsumed == null, httpChannelState);
                 }
@@ -1619,6 +1626,11 @@ public class HttpChannelState implements HttpChannel, Components
                             // There has been no last write, but we will just fail the stream instead.
                             completeStream = true;
                         }
+                    }
+                    else if (!httpChannelState.lockedIsLastStreamSendCompleted() && !response.lockedIsWriting())
+                    {
+                        // last write is not going to happen after failure, so we can just fail anyway
+                        httpChannelState._streamSendState = StreamSendState.LAST_COMPLETE;
                     }
                 }
             }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -698,7 +698,7 @@ public class HttpChannelState implements HttpChannel, Components
                 failure = _callbackFailure;
                 callbackCompleted = _callbackCompleted;
                 lastStreamSendComplete = lockedIsLastStreamSendCompleted();
-                completeStream = callbackCompleted && lastStreamSendComplete;
+                completeStream = callbackCompleted && (lastStreamSendComplete || failure != null);
 
                 if (LOG.isDebugEnabled())
                     LOG.debug("handler invoked: completeStream={} failure={} callbackCompleted={} {}", completeStream, failure, callbackCompleted, HttpChannelState.this);

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -340,7 +340,7 @@ public class HttpChannelState implements HttpChannel, Components
     }
 
     @Override
-    public Invocable.InvocationType getInvocationType()
+    public InvocationType getInvocationType()
     {
         // TODO Can this actually be done, as we may need to invoke other Runnables after onContent?
         //      Could we at least avoid the lock???
@@ -619,7 +619,9 @@ public class HttpChannelState implements HttpChannel, Components
         }
     }
 
-    private class HandlerInvoker implements Invocable.Task, Callback
+    // HandlerInvoker is used as the Response's _writeCallback when ChannelCallback is succeeded and the last send still
+    // needs to be done, i.e.: _streamSendState set to LAST_SENDING by lockedLastStreamSend().
+    private class HandlerInvoker implements Task, Callback
     {
         @Override
         public void run()
@@ -719,18 +721,7 @@ public class HttpChannelState implements HttpChannel, Components
         @Override
         public void succeeded()
         {
-            HttpStream stream;
-            boolean completeStream;
-            try (AutoLock ignored = _lock.lock())
-            {
-                assert _callbackCompleted;
-                _streamSendState = StreamSendState.LAST_COMPLETE;
-                completeStream = _handling == null;
-                stream = _stream;
-            }
-
-            if (completeStream)
-                completeStream(stream, null);
+            completeLastWrite(null);
         }
 
         /**
@@ -738,6 +729,11 @@ public class HttpChannelState implements HttpChannel, Components
          */
         @Override
         public void failed(Throwable failure)
+        {
+            completeLastWrite(failure);
+        }
+
+        private void completeLastWrite(Throwable failure)
         {
             HttpStream stream;
             boolean completeStream;
@@ -1353,7 +1349,7 @@ public class HttpChannelState implements HttpChannel, Components
                 httpChannel.lockedStreamSendCompleted(true);
             }
             if (callback != null)
-                httpChannel._writeInvoker.run(callback::succeeded);
+                httpChannel._writeInvoker.run(new ReadyTask(callback.getInvocationType(), callback::succeeded));
         }
 
         /**
@@ -1517,85 +1513,7 @@ public class HttpChannelState implements HttpChannel, Components
         @Override
         public void succeeded()
         {
-            // Called when the request/response cycle is completing successfully.
-            HttpStream stream;
-            boolean needLastStreamSend;
-            HttpChannelState httpChannelState;
-            Throwable failure = null;
-            ChannelRequest request;
-            ChannelResponse response;
-            MetaData.Response responseMetaData = null;
-            boolean completeStream;
-            ErrorResponse errorResponse = null;
-
-            try (AutoLock ignored = _request._lock.lock())
-            {
-                if (lockedCompleteCallback())
-                    return;
-
-                request = _request;
-                httpChannelState = _request._httpChannelState;
-                response = httpChannelState._response;
-                stream = httpChannelState._stream;
-
-                // We convert a call to succeeded with pending demand/write into a call to failed.
-                if (httpChannelState._onContentAvailable != null)
-                    failure = ExceptionUtil.combine(failure, new IllegalStateException("demand pending"));
-                if (response.lockedIsWriting())
-                    failure = ExceptionUtil.combine(failure, new IllegalStateException("write pending"));
-
-                assert httpChannelState._callbackFailure == null;
-
-                needLastStreamSend = httpChannelState.lockedLastStreamSend();
-                completeStream = !needLastStreamSend && httpChannelState._handling == null && httpChannelState.lockedIsLastStreamSendCompleted();
-                if (needLastStreamSend)
-                    response._writeCallback = httpChannelState._handlerInvoker;
-
-                if (httpChannelState._responseHeaders.commit())
-                    responseMetaData = response.lockedPrepareResponse(httpChannelState, true);
-
-                long totalWritten = response._contentBytesWritten;
-                long committedContentLength = httpChannelState._committedContentLength;
-
-                if (committedContentLength >= 0 &&
-                    committedContentLength != totalWritten &&
-                    !(totalWritten == 0 && (HttpMethod.HEAD.is(_request.getMethod()) || response.getStatus() == HttpStatus.NOT_MODIFIED_304)))
-                    failure = ExceptionUtil.combine(failure, new IOException("content-length %d != %d written".formatted(committedContentLength, totalWritten)));
-
-                // Is the request fully consumed?
-                Throwable unconsumed = stream.consumeAvailable();
-                if (LOG.isDebugEnabled())
-                    LOG.debug("consumeAvailable: {} {} ", unconsumed == null, httpChannelState);
-
-                if (unconsumed != null && httpChannelState.getConnectionMetaData().isPersistent())
-                    failure = ExceptionUtil.combine(failure, unconsumed);
-
-                if (failure != null)
-                {
-                    httpChannelState._callbackFailure = failure;
-                    if (!stream.isCommitted())
-                        // We are not committed, so we can send an error response.
-                        errorResponse = new ErrorResponse(request);
-                    else if (httpChannelState._handling == null)
-                        // We are committed, but no longer handling, so will complete here, ignoring any pending reads/writes
-                        completeStream = true;
-                    else
-                        // We are committed and still handling, so let the HandlerInvoker complete, ignoring any pending reads/writes.
-                        httpChannelState._streamSendState = StreamSendState.LAST_COMPLETE;
-                }
-            }
-
-            if (LOG.isDebugEnabled())
-                LOG.debug("succeeded: failure={} needLastStreamSend={} {}", failure, needLastStreamSend, this);
-
-            if (errorResponse != null)
-                Response.writeError(request, errorResponse, new ErrorCallback(request, errorResponse, stream, failure), failure);
-            else if (needLastStreamSend)
-                stream.send(_request._metaData, responseMetaData, true, null, response);
-            else if (completeStream)
-                httpChannelState._handlerInvoker.completeStream(stream, failure);
-            else if (LOG.isDebugEnabled())
-                LOG.debug("No action on succeeded {}", this);
+            completeChannelCallback(null);
         }
 
         /**
@@ -1606,49 +1524,119 @@ public class HttpChannelState implements HttpChannel, Components
         @Override
         public void failed(Throwable failure)
         {
-            try
+            completeChannelCallback(failure);
+        }
+
+        private void completeChannelCallback(Throwable failure)
+        {
+            // Called when the request/response cycle is completing.
+            HttpStream stream;
+            boolean doLastStreamSend = false;
+            HttpChannelState httpChannelState;
+            ChannelRequest request;
+            ChannelResponse response;
+            MetaData.Response responseMetaData = null;
+            boolean completeStream = false;
+            ErrorResponse errorResponse = null;
+            Callback failedCallback = null;
+
+            try (AutoLock ignored = _request._lock.lock())
             {
-                // Called when the request/response cycle is completing with a failure.
-                HttpStream stream;
-                ChannelRequest request;
-                HttpChannelState httpChannelState;
-                ErrorResponse errorResponse = null;
-                try (AutoLock ignored = _request._lock.lock())
+                if (lockedCompleteCallback())
+                    return;
+
+                request = _request;
+                httpChannelState = _request._httpChannelState;
+                response = httpChannelState._response;
+                stream = httpChannelState._stream;
+                assert httpChannelState._callbackFailure == null;
+
+                // Turn pending demand or unconsumed input on persistent connections into failure
+                if (httpChannelState._onContentAvailable != null)
+                    failure = ExceptionUtil.combine(failure, new IllegalStateException("demand pending"));
+                else if (httpChannelState.getConnectionMetaData().isPersistent())
+                    failure = ExceptionUtil.combine(failure, stream.consumeAvailable());
+                else
                 {
-                    if (lockedCompleteCallback())
-                        return;
-                    httpChannelState = _request._httpChannelState;
-                    stream = httpChannelState._stream;
-                    request = _request;
-
-                    assert httpChannelState._callbackFailure == null;
-
-                    httpChannelState._callbackFailure = failure;
-
-                    if (!stream.isCommitted() && !(failure instanceof Request.Handler.AbortException))
-                    {
-                        // Consume any input.
-                        Throwable unconsumed = stream.consumeAvailable();
-                        ExceptionUtil.addSuppressedIfNotAssociated(failure, unconsumed);
-
-                        ChannelResponse response = httpChannelState._response;
-                        if (LOG.isDebugEnabled())
-                            LOG.debug("failed stream.isCommitted={}, response.isCommitted={} {}", stream.isCommitted(), response.isCommitted(), this);
-
-                        errorResponse = new ErrorResponse(request);
-                    }
+                    Throwable unconsumed = stream.consumeAvailable();
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("consumeAvailable: {} {} ", unconsumed == null, httpChannelState);
                 }
 
-                if (errorResponse != null)
-                    Response.writeError(request, errorResponse, new ErrorCallback(request, errorResponse, stream, failure), failure);
+                // Pending writes are also failures
+                if (response.lockedIsWriting())
+                    failure = ExceptionUtil.combine(failure, new IllegalStateException("write pending"));
+
+                // If we are not failing (yet) and not committed, then commit and check headers
+                if (failure == null && httpChannelState._responseHeaders.commit())
+                {
+                    responseMetaData = response.lockedPrepareResponse(httpChannelState, true);
+                    // Check the response headers against the content written.
+                    long totalWritten = response._contentBytesWritten;
+                    long committedContentLength = httpChannelState._committedContentLength;
+                    if (committedContentLength >= 0 &&
+                        committedContentLength != totalWritten &&
+                        !(totalWritten == 0 && (HttpMethod.HEAD.is(_request.getMethod()) || response.getStatus() == HttpStatus.NOT_MODIFIED_304)))
+                        failure = ExceptionUtil.combine(failure, new IOException("content-length %d != %d written".formatted(committedContentLength, totalWritten)));
+                }
+
+                // If we are still not failing, is a last stream send needed or can we complete?
+                if (failure == null)
+                {
+                    doLastStreamSend = httpChannelState.lockedLastStreamSend();
+                    if (doLastStreamSend)
+                        response._writeCallback = httpChannelState._handlerInvoker;
+                    // or complete the stream if everything is done.
+                    else if (httpChannelState.lockedIsLastStreamSendCompleted())
+                        completeStream = httpChannelState._handled;
+                }
                 else
-                    _request.getHttpChannelState()._handlerInvoker.failed(failure);
+                {
+                    // We are failing...
+                    httpChannelState._callbackFailure = failure;
+                    if (!stream.isCommitted())
+                    {
+                        // We are not committed, so we can send an error response.
+                        errorResponse = new ErrorResponse(request);
+                    }
+                    else if (httpChannelState._handled)
+                    {
+                        // Callback and handling are completed, so it is just a matter of the last write
+                        if (httpChannelState.lockedIsLastStreamSendCompleted())
+                        {
+                            // We are committed, handling completed, and last write completed, so complete the stream now.
+                            completeStream = true;
+                        }
+                        else if (response.lockedIsWriting())
+                        {
+                            // We are currently writing, so let the completion of that write handle the failure
+                            httpChannelState._callbackFailure = failure;
+                            failedCallback = response._writeCallback;
+                            response._writeCallback = httpChannelState._handlerInvoker;
+                        }
+                        else
+                        {
+                            // There has been no last write, but we will just fail the stream instead.
+                            completeStream = true;
+                        }
+                    }
+                }
             }
-            catch (Throwable t)
-            {
-                ExceptionUtil.addSuppressedIfNotAssociated(t, failure);
-                throw t;
-            }
+
+            if (LOG.isDebugEnabled())
+                LOG.debug("succeeded: failure={} doLastStreamSend={} {}", failure, doLastStreamSend, this);
+
+            if (failedCallback != null)
+                failedCallback.failed(Objects.requireNonNullElseGet(failure, IOException::new));
+
+            if (errorResponse != null)
+                Response.writeError(request, errorResponse, new ErrorCallback(request, errorResponse, stream, failure), failure);
+            else if (doLastStreamSend)
+                stream.send(_request._metaData, responseMetaData, true, null, response);
+            else if (completeStream)
+                httpChannelState._handlerInvoker.completeStream(stream, failure);
+            else if (LOG.isDebugEnabled())
+                LOG.debug("No action on succeeded {}", this);
         }
 
         private boolean lockedCompleteCallback()
@@ -1690,7 +1678,7 @@ public class HttpChannelState implements HttpChannel, Components
 
     /**
      * Used as the {@link Response} when writing the error response
-     * from {@link HttpChannelState.ChannelCallback#failed(Throwable)}.
+     * from {@link ChannelCallback#failed(Throwable)}.
      */
     private static class ErrorResponse extends ChannelResponse
     {
@@ -1731,7 +1719,7 @@ public class HttpChannelState implements HttpChannel, Components
 
     /**
      * Used as the {@link Response} and {@link Callback} when writing the error response
-     * from {@link HttpChannelState.ChannelCallback#failed(Throwable)}.
+     * from {@link ChannelCallback#failed(Throwable)}.
      */
     private static class ErrorCallback implements Callback
     {
@@ -1749,7 +1737,7 @@ public class HttpChannelState implements HttpChannel, Components
         }
 
         /**
-         * Called when the error write in {@link HttpChannelState.ChannelCallback#failed(Throwable)} succeeds.
+         * Called when the error write in {@link ChannelCallback#failed(Throwable)} succeeds.
          */
         @Override
         public void succeeded()
@@ -1788,7 +1776,7 @@ public class HttpChannelState implements HttpChannel, Components
         }
 
         /**
-         * Called when the error write in {@link HttpChannelState.ChannelCallback#failed(Throwable)} fails.
+         * Called when the error write in {@link ChannelCallback#failed(Throwable)} fails.
          *
          * @param x The reason for the failure.
          */

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -106,6 +106,7 @@ public class HttpChannelState implements HttpChannel, Components
 
     private final AutoLock _lock = new AutoLock();
     private final HandlerInvoker _handlerInvoker = new HandlerInvoker();
+    private final LastWriteCallback _lastWriteCallback = new LastWriteCallback();
     private final ConnectionMetaData _connectionMetaData;
     private final SerializedInvoker _readInvoker;
     private final SerializedInvoker _writeInvoker;
@@ -624,9 +625,45 @@ public class HttpChannelState implements HttpChannel, Components
         }
     }
 
+    private void completeStream(HttpStream stream, Throwable failure)
+    {
+        try
+        {
+            RequestLog requestLog = getServer().getRequestLog();
+            if (requestLog != null)
+            {
+                if (LOG.isDebugEnabled())
+                    LOG.debug("logging {}", HttpChannelState.this);
+
+                requestLog.log(_request.getLoggedRequest(), _response);
+            }
+
+            // Clean up any multipart tmp files and release any associated resources.
+            Parts parts = (Parts)_request.getAttribute(Parts.class.getName());
+            if (parts != null)
+                parts.close();
+
+            long idleTO = getHttpConfiguration().getIdleTimeout();
+            if (idleTO > 0 && _oldIdleTimeout != idleTO)
+                stream.setIdleTimeout(_oldIdleTimeout);
+        }
+        finally
+        {
+            ComplianceViolation.Listener listener = getComplianceViolationListener();
+            if (listener != null)
+                listener.onRequestEnd(_request);
+
+            // This is THE ONLY PLACE the stream is succeeded or failed.
+            if (failure == null)
+                stream.succeeded();
+            else
+                stream.failed(failure);
+        }
+    }
+
     // HandlerInvoker is used as the Response's _writeCallback when ChannelCallback is succeeded and the last send still
     // needs to be done, i.e.: _streamSendState set to LAST_SENDING by lockedLastStreamSend().
-    private class HandlerInvoker implements Task, Callback
+    private class HandlerInvoker implements Task
     {
         @Override
         public void run()
@@ -720,6 +757,15 @@ public class HttpChannelState implements HttpChannel, Components
             }
         }
 
+        @Override
+        public InvocationType getInvocationType()
+        {
+            return getConnectionMetaData().getConnector().getServer().getInvocationType();
+        }
+    }
+
+    private class LastWriteCallback implements Callback
+    {
         /**
          * Called only as {@link Callback} by last write from {@link ChannelCallback#succeeded}
          */
@@ -752,42 +798,6 @@ public class HttpChannelState implements HttpChannel, Components
             }
             if (completeStream)
                 completeStream(stream, failure);
-        }
-
-        private void completeStream(HttpStream stream, Throwable failure)
-        {
-            try
-            {
-                RequestLog requestLog = getServer().getRequestLog();
-                if (requestLog != null)
-                {
-                    if (LOG.isDebugEnabled())
-                        LOG.debug("logging {}", HttpChannelState.this);
-
-                    requestLog.log(_request.getLoggedRequest(), _response);
-                }
-
-                // Clean up any multipart tmp files and release any associated resources.
-                Parts parts = (Parts)_request.getAttribute(Parts.class.getName());
-                if (parts != null)
-                    parts.close();
-
-                long idleTO = getHttpConfiguration().getIdleTimeout();
-                if (idleTO > 0 && _oldIdleTimeout != idleTO)
-                    stream.setIdleTimeout(_oldIdleTimeout);
-            }
-            finally
-            {
-                ComplianceViolation.Listener listener = getComplianceViolationListener();
-                if (listener != null)
-                    listener.onRequestEnd(_request);
-
-                // This is THE ONLY PLACE the stream is succeeded or failed.
-                if (failure == null)
-                    stream.succeeded();
-                else
-                    stream.failed(failure);
-            }
         }
 
         @Override
@@ -1592,7 +1602,7 @@ public class HttpChannelState implements HttpChannel, Components
                 {
                     doLastStreamSend = httpChannelState.lockedLastStreamSend();
                     if (doLastStreamSend)
-                        response._writeCallback = httpChannelState._handlerInvoker;
+                        response._writeCallback = httpChannelState._lastWriteCallback;
                     // or complete the stream if everything is done.
                     else if (httpChannelState.lockedIsLastStreamSendCompleted())
                         completeStream = httpChannelState._handled;
@@ -1623,7 +1633,7 @@ public class HttpChannelState implements HttpChannel, Components
                             //      Runnable task = response.lockedFailWrite(failure);
                             //      failedCallback = Callback.from(task, httpChannelState._handlerInvoker);
                             failedCallback = response._writeCallback;
-                            response._writeCallback = httpChannelState._handlerInvoker;
+                            response._writeCallback = httpChannelState._lastWriteCallback;
                         }
                         else
                         {
@@ -1646,7 +1656,7 @@ public class HttpChannelState implements HttpChannel, Components
                             //      Runnable task = response.lockedFailWrite(failure);
                             //      failedCallback = Callback.from(task, httpChannelState._handlerInvoker);
                             failedCallback = response._writeCallback;
-                            response._writeCallback = httpChannelState._handlerInvoker;
+                            response._writeCallback = httpChannelState._lastWriteCallback;
                         }
                         else if (!httpChannelState.lockedIsLastStreamSendCompleted())
                         {
@@ -1668,7 +1678,7 @@ public class HttpChannelState implements HttpChannel, Components
             else if (doLastStreamSend)
                 stream.send(_request._metaData, responseMetaData, true, null, response);
             else if (completeStream)
-                httpChannelState._handlerInvoker.completeStream(stream, failure);
+                httpChannelState.completeStream(stream, failure);
             else if (LOG.isDebugEnabled())
                 LOG.debug("No action on succeeded {}", this);
         }
@@ -1796,16 +1806,16 @@ public class HttpChannelState implements HttpChannel, Components
             if (needLastWrite)
             {
                 _stream.send(_request._metaData, responseMetaData, true, null,
-                    Callback.from(() -> httpChannelState._handlerInvoker.failed(failure),
+                    Callback.from(() -> httpChannelState._lastWriteCallback.failed(failure),
                         x ->
                         {
                             ExceptionUtil.addSuppressedIfNotAssociated(failure, x);
-                            httpChannelState._handlerInvoker.failed(failure);
+                            httpChannelState._lastWriteCallback.failed(failure);
                         }));
             }
             else
             {
-                HttpChannelState.failed(httpChannelState._handlerInvoker, failure);
+                HttpChannelState.failed(httpChannelState._lastWriteCallback, failure);
             }
         }
 
@@ -1828,7 +1838,7 @@ public class HttpChannelState implements HttpChannel, Components
                 httpChannelState._response._status = _errorResponse._status;
             }
             ExceptionUtil.addSuppressedIfNotAssociated(failure, x);
-            HttpChannelState.failed(httpChannelState._handlerInvoker, failure);
+            HttpChannelState.failed(httpChannelState._lastWriteCallback, failure);
         }
 
         @Override

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/StatisticsHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/StatisticsHandlerTest.java
@@ -48,7 +48,6 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
-import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -360,9 +359,13 @@ public class StatisticsHandlerTest
             \r
             """;
 
-        String response = _connector.getResponse(request);
-        assertThat(response, is(nullValue()));
-        await().atMost(5, TimeUnit.SECONDS).until(_statsHandler::getResponses5xx, is(1));
+        try (StacklessLogging ignored = new StacklessLogging(Response.class))
+        {
+            String response = _connector.getResponse(request);
+            assertThat(response, containsString("HTTP/1.1 500 "));
+            assertThat(response, containsString("content-length 1 != 0 written"));
+            await().atMost(5, TimeUnit.SECONDS).until(_statsHandler::getResponses5xx, is(1));
+        }
     }
 
     @Test

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ExceptionUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ExceptionUtil.java
@@ -192,6 +192,34 @@ public class ExceptionUtil
     }
 
     /**
+     * Checks if a given {@link Throwable} is associated with a specific type of {@link Throwable}.
+     * The association is determined by whether the provided type matches the throwable or any of its causes
+     * or suppressed exceptions.
+     *
+     * @param failure The {@link Throwable} to check for association. Can be null.
+     * @param throwable The type of {@link Throwable} class to check association against. Can be null.
+     * @return true if the {@link Throwable} is associated with the provided type; otherwise, false.
+     */
+    public static boolean isAssociated(Throwable failure, Class<? extends Throwable> throwable)
+    {
+        if (failure == null || throwable == null)
+            return false;
+
+        Throwable cause = failure;
+        while (cause != null)
+        {
+            if (throwable.isInstance(cause))
+                return true;
+            cause = cause.getCause();
+        }
+
+        for (Throwable s : failure.getSuppressed())
+            if (isAssociated(s, throwable))
+                return true;
+        return false;
+    }
+
+    /**
      * Add a suppressed exception if it is not associated.
      * @see #areNotAssociated(Throwable, Throwable)
      * @param throwable The main Throwable

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ExceptionUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ExceptionUtil.java
@@ -192,7 +192,7 @@ public class ExceptionUtil
     }
 
     /**
-     * Checks if a given {@link Throwable} is associated with a specific type of {@link Throwable}.
+     * Checks if a given {@link Throwable} has an association with a specific type of {@link Throwable}.
      * The association is determined by whether the provided type matches the throwable or any of its causes
      * or suppressed exceptions.
      *
@@ -200,7 +200,7 @@ public class ExceptionUtil
      * @param throwable The type of {@link Throwable} class to check association against. Can be null.
      * @return true if the {@link Throwable} is associated with the provided type; otherwise, false.
      */
-    public static boolean isAssociated(Throwable failure, Class<? extends Throwable> throwable)
+    public static boolean hasAssociated(Throwable failure, Class<? extends Throwable> throwable)
     {
         if (failure == null || throwable == null)
             return false;
@@ -214,7 +214,7 @@ public class ExceptionUtil
         }
 
         for (Throwable s : failure.getSuppressed())
-            if (isAssociated(s, throwable))
+            if (hasAssociated(s, throwable))
                 return true;
         return false;
     }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ExceptionUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ExceptionUtil.java
@@ -305,6 +305,8 @@ public class ExceptionUtil
     {
         if (t1 == null)
             return t2;
+        if (t2 == null)
+            return t1;
         addSuppressedIfNotAssociated(t1, t2);
         return t1;
     }

--- a/jetty-ee10/jetty-ee10-servlets/src/main/java/org/eclipse/jetty/ee10/servlets/EventSourceServlet.java
+++ b/jetty-ee10/jetty-ee10-servlets/src/main/java/org/eclipse/jetty/ee10/servlets/EventSourceServlet.java
@@ -50,6 +50,7 @@ import org.eclipse.jetty.util.thread.AutoLock;
 public abstract class EventSourceServlet extends HttpServlet
 {
     private static final byte[] CRLF = new byte[]{'\r', '\n'};
+    private static final byte[] CRLF_CRLF = new byte[]{'\r', '\n', '\r', '\n'};
     private static final byte[] EVENT_FIELD = "event: ".getBytes(StandardCharsets.UTF_8);
     private static final byte[] DATA_FIELD = "data: ".getBytes(StandardCharsets.UTF_8);
     private static final byte[] COMMENT_FIELD = ": ".getBytes(StandardCharsets.UTF_8);
@@ -76,7 +77,6 @@ public abstract class EventSourceServlet extends HttpServlet
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
     {
-        @SuppressWarnings("unchecked")
         Enumeration<String> acceptValues = request.getHeaders("Accept");
         while (acceptValues.hasMoreElements())
         {
@@ -92,11 +92,11 @@ public abstract class EventSourceServlet extends HttpServlet
                 {
                     respond(request, response);
                     AsyncContext async = request.startAsync();
-                    // Infinite timeout because the continuation is never resumed,
+                    // Infinite timeout because the continuation is never resumed
                     // but only completed on close
                     async.setTimeout(0);
                     EventSourceEmitter emitter = new EventSourceEmitter(eventSource, async);
-                    emitter.scheduleHeartBeat();
+                    emitter.heartBeat = scheduler.schedule(emitter, heartBeatPeriod, TimeUnit.SECONDS);
                     open(eventSource, emitter);
                 }
                 return;
@@ -145,10 +145,12 @@ public abstract class EventSourceServlet extends HttpServlet
         {
             try (AutoLock l = lock.lock())
             {
+                if (closed)
+                    throw new IOException("closed");
                 output.write(EVENT_FIELD);
                 output.write(name.getBytes(StandardCharsets.UTF_8));
                 output.write(CRLF);
-                data(data);
+                lockedData(data);
             }
         }
 
@@ -157,17 +159,26 @@ public abstract class EventSourceServlet extends HttpServlet
         {
             try (AutoLock l = lock.lock())
             {
-                BufferedReader reader = new BufferedReader(new StringReader(data));
-                String line;
-                while ((line = reader.readLine()) != null)
-                {
-                    output.write(DATA_FIELD);
-                    output.write(line.getBytes(StandardCharsets.UTF_8));
-                    output.write(CRLF);
-                }
-                output.write(CRLF);
-                flush();
+                if (closed)
+                    throw new IOException("closed");
+                lockedData(data);
             }
+        }
+
+        private void lockedData(String data) throws IOException
+        {
+            assert lock.isHeldByCurrentThread();
+
+            BufferedReader reader = new BufferedReader(new StringReader(data));
+            String line;
+            while ((line = reader.readLine()) != null)
+            {
+                output.write(DATA_FIELD);
+                output.write(line.getBytes(StandardCharsets.UTF_8));
+                output.write(CRLF);
+            }
+            output.write(CRLF);
+            flush();
         }
 
         @Override
@@ -175,10 +186,11 @@ public abstract class EventSourceServlet extends HttpServlet
         {
             try (AutoLock l = lock.lock())
             {
+                if (closed)
+                    throw new IOException("closed");
                 output.write(COMMENT_FIELD);
                 output.write(comment.getBytes(StandardCharsets.UTF_8));
-                output.write(CRLF);
-                output.write(CRLF);
+                output.write(CRLF_CRLF);
                 flush();
             }
         }
@@ -189,17 +201,17 @@ public abstract class EventSourceServlet extends HttpServlet
             // If the other peer closes the connection, the first
             // flush() should generate a TCP reset that is detected
             // on the second flush()
-            try
+            try (AutoLock l = lock.lock())
             {
-                try (AutoLock l = lock.lock())
-                {
-                    output.write('\r');
-                    flush();
-                    output.write('\n');
-                    flush();
-                }
+                if (closed)
+                    return;
+                output.write('\r');
+                flush();
+                output.write('\n');
+                flush();
+
                 // We could write, reschedule heartbeat
-                scheduleHeartBeat();
+                heartBeat = scheduler.schedule(this, heartBeatPeriod, TimeUnit.SECONDS);
             }
             catch (Throwable x)
             {
@@ -228,19 +240,12 @@ public abstract class EventSourceServlet extends HttpServlet
         {
             try (AutoLock l = lock.lock())
             {
+                if (closed)
+                    return;
                 closed = true;
                 heartBeat.cancel(false);
             }
             async.complete();
-        }
-
-        private void scheduleHeartBeat()
-        {
-            try (AutoLock l = lock.lock())
-            {
-                if (!closed)
-                    heartBeat = scheduler.schedule(this, heartBeatPeriod, TimeUnit.SECONDS);
-            }
         }
     }
 }


### PR DESCRIPTION
Fix #13470 by calling completeStream only once even when there is a failure in the channel callback.