### PR TITLE
Issue #13812 - NPE from CompressionHandler when using Content.Sink.asOutputStream

### DIFF
--- a/jetty-core/jetty-compression/jetty-compression-brotli/src/main/java/org/eclipse/jetty/compression/brotli/internal/BrotliEncoderSink.java
+++ b/jetty-core/jetty-compression/jetty-compression-brotli/src/main/java/org/eclipse/jetty/compression/brotli/internal/BrotliEncoderSink.java
@@ -80,7 +80,7 @@ public class BrotliEncoderSink extends EncoderSink
                 {
                     try
                     {
-                        while (content != null && content.hasRemaining())
+                        while (BufferUtil.hasContent(content))
                         {
                             // only encode if inputBuffer is full.
                             if (!inputBuffer.hasRemaining())

--- a/jetty-core/jetty-compression/jetty-compression-brotli/src/main/java/org/eclipse/jetty/compression/brotli/internal/BrotliEncoderSink.java
+++ b/jetty-core/jetty-compression/jetty-compression-brotli/src/main/java/org/eclipse/jetty/compression/brotli/internal/BrotliEncoderSink.java
@@ -80,7 +80,7 @@ public class BrotliEncoderSink extends EncoderSink
                 {
                     try
                     {
-                        while (content.hasRemaining())
+                        while (content != null && content.hasRemaining())
                         {
                             // only encode if inputBuffer is full.
                             if (!inputBuffer.hasRemaining())

--- a/jetty-core/jetty-compression/jetty-compression-gzip/src/main/java/org/eclipse/jetty/compression/gzip/internal/GzipEncoderSink.java
+++ b/jetty-core/jetty-compression/jetty-compression-gzip/src/main/java/org/eclipse/jetty/compression/gzip/internal/GzipEncoderSink.java
@@ -143,7 +143,7 @@ public class GzipEncoderSink extends EncoderSink
                     case BODY ->
                     {
                         // Processing input
-                        if (content != null && content.hasRemaining())
+                        if (BufferUtil.hasContent(content))
                         {
                             if (output == null)
                                 output = compression.acquireByteBuffer(bufferSize);

--- a/jetty-core/jetty-compression/jetty-compression-gzip/src/main/java/org/eclipse/jetty/compression/gzip/internal/GzipEncoderSink.java
+++ b/jetty-core/jetty-compression/jetty-compression-gzip/src/main/java/org/eclipse/jetty/compression/gzip/internal/GzipEncoderSink.java
@@ -143,7 +143,7 @@ public class GzipEncoderSink extends EncoderSink
                     case BODY ->
                     {
                         // Processing input
-                        if (content.hasRemaining())
+                        if (content != null && content.hasRemaining())
                         {
                             if (output == null)
                                 output = compression.acquireByteBuffer(bufferSize);

--- a/jetty-core/jetty-compression/jetty-compression-tests/src/test/java/org/eclipse/jetty/compression/CompressionHandlerTest.java
+++ b/jetty-core/jetty-compression/jetty-compression-tests/src/test/java/org/eclipse/jetty/compression/CompressionHandlerTest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.jetty.compression;
 
+import java.io.IOException;
+import java.io.OutputStream;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
@@ -732,6 +734,51 @@ public class CompressionHandlerTest extends AbstractCompressionTest
             assertNotNull(response.getHeaders().get(HttpHeader.CONTENT_ENCODING));
         else
             assertThat(response.getHeaders().get(HttpHeader.CONTENT_ENCODING), is(expectedEncoding));
+    }
+
+    @ParameterizedTest
+    @MethodSource("compressions")
+    public void testContentSinkOutputStream(Class<Compression> compressionClass) throws Exception
+    {
+        newCompression(compressionClass);
+        String message = "Hello Jetty!\n".repeat(10);
+
+        CompressionHandler compressionHandler = new CompressionHandler();
+        compressionHandler.putCompression(compression);
+        compressionHandler.setHandler(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) throws IOException
+            {
+                response.setStatus(200);
+                response.getHeaders().put(HttpHeader.CONTENT_TYPE, "text/plain;charset=utf-8");
+                try (OutputStream out = Content.Sink.asOutputStream(response))
+                {
+                    out.write(message.getBytes(UTF_8));
+                }
+                callback.succeeded();
+                return true;
+            }
+        });
+
+        startServer(compressionHandler);
+
+        URI serverURI = server.getURI();
+        client.getContentDecoderFactories().clear();
+
+        ContentResponse response = client.newRequest(serverURI.getHost(), serverURI.getPort())
+            .method(HttpMethod.GET)
+            .headers((headers) ->
+            {
+                headers.put(HttpHeader.ACCEPT_ENCODING, compression.getEncodingName());
+            })
+            .path("/hello")
+            .send();
+        dumpResponse(response);
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.getHeaders().get(HttpHeader.CONTENT_ENCODING), is(compression.getEncodingName()));
+        String content = new String(decompress(response.getContent()), UTF_8);
+        assertThat(content, is(message));
     }
 
     private void dumpResponse(org.eclipse.jetty.client.Response response)

--- a/jetty-core/jetty-compression/jetty-compression-zstandard/src/main/java/org/eclipse/jetty/compression/zstandard/internal/ZstandardEncoderSink.java
+++ b/jetty-core/jetty-compression/jetty-compression-zstandard/src/main/java/org/eclipse/jetty/compression/zstandard/internal/ZstandardEncoderSink.java
@@ -126,7 +126,7 @@ public class ZstandardEncoderSink extends EncoderSink
         RetainableByteBuffer outputBuf = compression.acquireByteBuffer(bufferSize);
 
         // process content (input) buffer using zstd-jni CONTINUE directive
-        while (content.hasRemaining())
+        while (content != null && content.hasRemaining())
         {
             // content must be a direct bytebuffer, and we have to assume that the size
             // of the content buffer can be huge (multi megabyte or bigger), so lets

--- a/jetty-core/jetty-compression/jetty-compression-zstandard/src/main/java/org/eclipse/jetty/compression/zstandard/internal/ZstandardEncoderSink.java
+++ b/jetty-core/jetty-compression/jetty-compression-zstandard/src/main/java/org/eclipse/jetty/compression/zstandard/internal/ZstandardEncoderSink.java
@@ -126,7 +126,7 @@ public class ZstandardEncoderSink extends EncoderSink
         RetainableByteBuffer outputBuf = compression.acquireByteBuffer(bufferSize);
 
         // process content (input) buffer using zstd-jni CONTINUE directive
-        while (content != null && content.hasRemaining())
+        while (BufferUtil.hasContent(content))
         {
             // content must be a direct bytebuffer, and we have to assume that the size
             // of the content buffer can be huge (multi megabyte or bigger), so lets


### PR DESCRIPTION
+ Be null content resistant in the various Compression Encoders
+ Add unit tests

Closes #13812