### PR TITLE
Issue #13689 unnecessary eeX-annotation dependency in demo mock resources

### DIFF
--- a/jetty-demos/jetty-servlet4-demos/jetty-servlet4-demo-mock-resources/src/main/config/modules/ee8-demo-mock-resources.mod
+++ b/jetty-demos/jetty-servlet4-demos/jetty-servlet4-demo-mock-resources/src/main/config/modules/ee8-demo-mock-resources.mod
@@ -11,7 +11,6 @@ demo
 
 [depends]
 jdbc
-ee8-annotations
 
 [files]
 maven://org.eclipse.jetty.demos/jetty-servlet4-demo-mock-resources/${jetty.version}/jar|lib/ee8/ee8-demo-mock-resources-${jetty.version}.jar

--- a/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-mock-resources/src/main/config/modules/ee10-demo-mock-resources.mod
+++ b/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-mock-resources/src/main/config/modules/ee10-demo-mock-resources.mod
@@ -11,7 +11,6 @@ demo
 
 [depends]
 jdbc
-ee10-annotations
 
 [files]
 maven://org.eclipse.jetty.demos/jetty-servlet5-demo-mock-resources/${jetty.version}/jar|lib/ee10/jetty-servlet5-demo-mock-resources-${jetty.version}.jar

--- a/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-mock-resources/src/main/config/modules/ee11-demo-mock-resources.mod
+++ b/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-mock-resources/src/main/config/modules/ee11-demo-mock-resources.mod
@@ -11,7 +11,6 @@ demo
 
 [depends]
 jdbc
-ee11-annotations
 
 [files]
 maven://org.eclipse.jetty.demos/jetty-servlet5-demo-mock-resources/${jetty.version}/jar|lib/ee11/jetty-servlet5-demo-mock-resources-${jetty.version}.jar

--- a/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-mock-resources/src/main/config/modules/ee9-demo-mock-resources.mod
+++ b/jetty-demos/jetty-servlet5-demos/jetty-servlet5-demo-mock-resources/src/main/config/modules/ee9-demo-mock-resources.mod
@@ -11,7 +11,6 @@ demo
 
 [depends]
 jdbc
-ee9-annotations
 
 [files]
 maven://org.eclipse.jetty.demos/jetty-servlet5-demo-mock-resources/${jetty.version}/jar|lib/ee9/jetty-servlet5-demo-mock-resources-${jetty.version}.jar


### PR DESCRIPTION
Closes #13689

Remove unneeded dependency on `eeX-annotations` from `eeX-demo-mock-resources`.