### PR TITLE
Added grpc-netty-shaded to dependencyManagement and bumped version to1.76.0 to fix CVE-2025-55163

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -447,6 +447,11 @@
         <version>${grpc.version}</version>
       </dependency>
       <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-netty-shaded</artifactId>
+        <version>${grpc.version}</version>
+      </dependency>
+      <dependency>
         <groupId>io.smallrye.common</groupId>
         <artifactId>smallrye-common-annotation</artifactId>
         <version>${smallrye-common.version}</version>


### PR DESCRIPTION
**Why**
To fix the following vulnerability detected in the transitive grpc-netty-shaded dependency:

**CVE-2025-55163** – Netty MadeYouReset HTTP/2 DDoS Vulnerability

The vulnerable version (1.71.0) was being pulled transitively through other dependencies (e.g., Google Cloud libraries).

**What**
Explicitly added grpc-netty-shaded under dependencyManagement to ensure the fixed version (1.76.0) is used across all modules, overriding the vulnerable transitive dependency.

**Impact**

-  No functional or behavioral changes to Jetty.
-  Ensures consistent use of the secure grpc-netty-shaded version to mitigate CVE-2025-55163.