### PR TITLE
Upgraded grpc, netty, testcontainers-keycloak, added grpc-netty-shaded to remove CVE-2025-55163, CVE-2025-58057, CVE-2024-10039, CVE-2024-7318, CVE-2024-4028

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
     <findbugs.jsr305.version>3.0.2</findbugs.jsr305.version>
     <flatten.maven.plugin.version>1.7.0</flatten.maven.plugin.version>
     <groovy.version>4.0.26</groovy.version>
-    <grpc.version>1.72.0</grpc.version>
+    <grpc.version>1.76.0</grpc.version>
     <gson.version>2.13.1</gson.version>
     <guava.version>33.4.8-jre</guava.version>
     <guice.version>7.0.0</guice.version>
@@ -465,6 +465,11 @@
         <groupId>io.grpc</groupId>
         <artifactId>grpc-core</artifactId>
         <version>${grpc.version}</version>
+      </dependency>
+      <dependency>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-netty-shaded</artifactId>
+          <version>${grpc.version}</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.common</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -298,7 +298,7 @@
     <modify-sources-plugin.version>1.0.13</modify-sources-plugin.version>
     <mongo.docker.version>5.0.26</mongo.docker.version>
     <mongodb.version>5.6.1</mongodb.version>
-    <netty.version>4.2.0.Final</netty.version>
+    <netty.version>4.2.5.Final</netty.version>
     <njord.version>0.8.2</njord.version>
     <openpojo.version>0.9.1</openpojo.version>
     <org.osgi.annotation.version>8.1.0</org.osgi.annotation.version>

--- a/tests/test-distribution/test-distribution-common/pom.xml
+++ b/tests/test-distribution/test-distribution-common/pom.xml
@@ -18,7 +18,7 @@
     <junit.jupiter.execution.parallel.config.dynamic.factor>0.4</junit.jupiter.execution.parallel.config.dynamic.factor>
     <junit.jupiter.execution.parallel.config.fixed.parallelism>2</junit.jupiter.execution.parallel.config.fixed.parallelism>
     <!--    <junit.jupiter.execution.parallel.config.strategy>fixed</junit.jupiter.execution.parallel.config.strategy>-->
-    <testcontainers-keycloak.version>3.4.0</testcontainers-keycloak.version>
+    <testcontainers-keycloak.version>3.5.1</testcontainers-keycloak.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
 ## Summary
 
1. Why:
To remove CVEs:
     - [CVE-2025-55163](https://avd.aquasec.com/nvd/cve-2025-55163)
     - [CVE-2025-58057](https://avd.aquasec.com/nvd/2025/cve-2025-58057)
     - CVE-2024-10039
     - [CVE-2024-7318](https://avd.aquasec.com/nvd/2024/cve-2024-7318)
     - [CVE-2024-4028](https://avd.aquasec.com/nvd/2024/cve-2024-4028)


2. What:

     - Upgrade grpc to 1.76.0 and added grpc-netty-shaded dependency to remove [CVE-2025-55163](https://avd.aquasec.com/nvd/cve-2025-55163)

     - Upgrade netty version to 4.2.5.Final to remove [CVE-2025-58057](https://avd.aquasec.com/nvd/2025/cve-2025-58057)
     
     - Upgraded testcontainers-keycloak version to 3.5.1 to remove CVE-2024-10039, [CVE-2024-7318](https://avd.aquasec.com/nvd/2024/cve-2024-7318), [CVE-2024-4028](https://avd.aquasec.com/nvd/2024/cve-2024-4028)
 
 ## Additional evidence
 
 Partial output from security scanner Trivy:
<img width="3080" height="185" alt="grpc-netty-shaded2" src="https://github.com/user-attachments/assets/5e013f31-243f-4774-ade5-6912b98edc61" />
<img width="1217" height="72" alt="netty-codec-compression" src="https://github.com/user-attachments/assets/8802a26e-b794-4757-b5b9-f5812c7ca7ff" />
<img width="1177" height="230" alt="keycloak-core" src="https://github.com/user-attachments/assets/a81f2e9e-e023-48e8-bfd5-caf0f9d02082" />



 ## Categorization
 

- [x] security/CVE