### PR TITLE
Issue #13886 - fix servlet filter mappings with quickstart

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/FilterMapping.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/FilterMapping.java
@@ -151,9 +151,6 @@ public class FilterMapping implements Dumpable
      */
     boolean appliesTo(int type)
     {
-        FilterHolder holder = _holder;
-        if (_holder == null)
-            return false;
         if (_dispatches == 0)
             return type == REQUEST || type == ASYNC && (_holder != null && _holder.isAsyncSupported());
         return (_dispatches & type) != 0;

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-quickstart/src/test/java/org/eclipse/jetty/ee10/quickstart/QuickStartTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-quickstart/src/test/java/org/eclipse/jetty/ee10/quickstart/QuickStartTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -80,7 +81,7 @@ public class QuickStartTest
         URL url = new URL("http://127.0.0.1:" + server.getBean(NetworkConnector.class).getLocalPort() + "/index.html");
         HttpURLConnection connection = (HttpURLConnection)url.openConnection();
         assertEquals(200, connection.getResponseCode());
-        assertThat(IO.toString((InputStream)connection.getContent()), Matchers.containsString("<p>Contents of no-web-xml</p>"));
+        assertThat(IO.toString((InputStream)connection.getContent()), containsString("<p>Contents of no-web-xml</p>"));
 
         server.stop();
     }
@@ -132,7 +133,7 @@ public class QuickStartTest
         URL url = new URL("http://127.0.0.1:" + server.getBean(NetworkConnector.class).getLocalPort() + "/test/dump/info");
         HttpURLConnection connection = (HttpURLConnection)url.openConnection();
         assertEquals(200, connection.getResponseCode());
-        assertThat(IO.toString((InputStream)connection.getContent()), Matchers.containsString("Dump Servlet"));
+        assertThat(IO.toString((InputStream)connection.getContent()), containsString("Dump Servlet"));
 
         server.stop();
     }
@@ -188,7 +189,7 @@ public class QuickStartTest
         HttpURLConnection connection = (HttpURLConnection)url.openConnection();
         assertEquals(200, connection.getResponseCode());
         String content = IO.toString((InputStream)connection.getContent());
-        assertThat(content, Matchers.containsString("Welcome to a Fragment"));
+        assertThat(content, containsString("Welcome to a Fragment"));
 
         //test annotations etc
         url = new URL("http://127.0.0.1:" + server.getBean(NetworkConnector.class).getLocalPort() + "/test/");
@@ -197,8 +198,8 @@ public class QuickStartTest
         
         assertEquals(200, connection.getResponseCode());
         content = IO.toString((InputStream)connection.getContent());
-        assertThat(content, Matchers.containsString("Results"));
-        assertThat(content, Matchers.not(Matchers.containsString("FAIL")));
+        assertThat(content, containsString("Results"));
+        assertThat(content, Matchers.not(containsString("FAIL")));
         server.stop();
     }
 
@@ -252,8 +253,43 @@ public class QuickStartTest
         HttpURLConnection connection = (HttpURLConnection)url.openConnection();
         String content = IO.toString((InputStream)connection.getContent());
         assertEquals(200, connection.getResponseCode());
-        assertThat(content, Matchers.containsString("JNDI Demo WebApp"));
+        assertThat(content, containsString("JNDI Demo WebApp"));
 
         server.stop();
     }
+
+    @Test
+    public void testFilterMappings() throws Exception
+    {
+        Path workdir = MavenPaths.targetTestDir(PreconfigureSpecWar.class.getSimpleName());
+        FS.ensureEmpty(workdir);
+        Path target = workdir.resolve("test-filter-mappings");
+        FS.ensureEmpty(target);
+        FS.ensureDirExists(target.resolve("WEB-INF"));
+
+        Path sourceWebXml = MavenPaths.findTestResourceFile("filter-web.xml");
+        Files.copy(sourceWebXml, target.resolve("WEB-INF/web.xml"));
+        System.setProperty("jetty.home", target.toString());
+
+        PreconfigureQuickStartWar.main(target.toString());
+
+        Path quickStartXml = target.resolve("WEB-INF/quickstart-web.xml");
+        String quickStartContents = Files.readString(quickStartXml);
+        assertThat(quickStartContents, containsString("""
+              <filter>
+                <filter-name>CustomFilter</filter-name>
+                <filter-class>org.example.CustomFilter</filter-class>
+                <async-supported>false</async-supported>
+              </filter>
+              <filter-mapping>
+                <filter-name>CustomFilter</filter-name>
+                <url-pattern>/foo/*</url-pattern>
+                <dispatcher>REQUEST</dispatcher>
+                <dispatcher>ERROR</dispatcher>
+                <dispatcher>FORWARD</dispatcher>
+                <dispatcher>INCLUDE</dispatcher>
+              </filter-mapping>
+            """));
+    }
+
 }

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-quickstart/src/test/resources/filter-web.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-quickstart/src/test/resources/filter-web.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://xmlns.jcp.org/xml/ns/javaee" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd" version="3.1">
-  <filter>
+<web-app
+  xmlns="https://jakarta.ee/xml/ns/jakartaee"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+  version="6.0">  <filter>
     <filter-name>CustomFilter</filter-name>
     <filter-class>org.example.CustomFilter</filter-class>
   </filter>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-quickstart/src/test/resources/filter-web.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-quickstart/src/test/resources/filter-web.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://xmlns.jcp.org/xml/ns/javaee" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd" version="3.1">
+  <filter>
+    <filter-name>CustomFilter</filter-name>
+    <filter-class>org.example.CustomFilter</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>CustomFilter</filter-name>
+    <url-pattern>/foo/*</url-pattern>
+    <dispatcher>REQUEST</dispatcher>
+    <dispatcher>FORWARD</dispatcher>
+    <dispatcher>INCLUDE</dispatcher>
+    <dispatcher>ERROR</dispatcher>
+  </filter-mapping>
+</web-app>

--- a/jetty-ee9/jetty-ee9-servlet/src/main/java/org/eclipse/jetty/ee9/servlet/FilterMapping.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/main/java/org/eclipse/jetty/ee9/servlet/FilterMapping.java
@@ -151,9 +151,6 @@ public class FilterMapping implements Dumpable
      */
     boolean appliesTo(int type)
     {
-        FilterHolder holder = _holder;
-        if (_holder == null)
-            return false;
         if (_dispatches == 0)
             return type == REQUEST || type == ASYNC && (_holder != null && _holder.isAsyncSupported());
         return (_dispatches & type) != 0;

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-quickstart/src/test/java/org/eclipse/jetty/ee9/quickstart/QuickStartTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-quickstart/src/test/java/org/eclipse/jetty/ee9/quickstart/QuickStartTest.java
@@ -28,7 +28,6 @@ import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
-import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.xml.XmlConfiguration;
@@ -39,6 +38,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -256,5 +256,39 @@ public class QuickStartTest
         assertThat(content, Matchers.containsString("JNDI Demo WebApp"));
 
         server.stop();
+    }
+
+    @Test
+    public void testFilterMappings() throws Exception
+    {
+        Path workdir = MavenPaths.targetTestDir(PreconfigureSpecWar.class.getSimpleName());
+        FS.ensureEmpty(workdir);
+        Path target = workdir.resolve("test-filter-mappings");
+        FS.ensureEmpty(target);
+        FS.ensureDirExists(target.resolve("WEB-INF"));
+
+        Path sourceWebXml = MavenPaths.findTestResourceFile("filter-web.xml");
+        Files.copy(sourceWebXml, target.resolve("WEB-INF/web.xml"));
+        System.setProperty("jetty.home", target.toString());
+
+        PreconfigureQuickStartWar.main(target.toString());
+
+        Path quickStartXml = target.resolve("WEB-INF/quickstart-web.xml");
+        String quickStartContents = Files.readString(quickStartXml);
+        assertThat(quickStartContents, containsString("""
+              <filter>
+                <filter-name>CustomFilter</filter-name>
+                <filter-class>org.example.CustomFilter</filter-class>
+                <async-supported>false</async-supported>
+              </filter>
+              <filter-mapping>
+                <filter-name>CustomFilter</filter-name>
+                <url-pattern>/foo/*</url-pattern>
+                <dispatcher>REQUEST</dispatcher>
+                <dispatcher>ERROR</dispatcher>
+                <dispatcher>FORWARD</dispatcher>
+                <dispatcher>INCLUDE</dispatcher>
+              </filter-mapping>
+            """));
     }
 }

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-quickstart/src/test/resources/filter-web.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-quickstart/src/test/resources/filter-web.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://xmlns.jcp.org/xml/ns/javaee" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd" version="3.1">
+<web-app
+  xmlns="https://jakarta.ee/xml/ns/jakartaee"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
+  version="5.0">
   <filter>
     <filter-name>CustomFilter</filter-name>
     <filter-class>org.example.CustomFilter</filter-class>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-quickstart/src/test/resources/filter-web.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-quickstart/src/test/resources/filter-web.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://xmlns.jcp.org/xml/ns/javaee" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd" version="3.1">
+  <filter>
+    <filter-name>CustomFilter</filter-name>
+    <filter-class>org.example.CustomFilter</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>CustomFilter</filter-name>
+    <url-pattern>/foo/*</url-pattern>
+    <dispatcher>REQUEST</dispatcher>
+    <dispatcher>FORWARD</dispatcher>
+    <dispatcher>INCLUDE</dispatcher>
+    <dispatcher>ERROR</dispatcher>
+  </filter-mapping>
+</web-app>


### PR DESCRIPTION
### Closes #13886

Fixes the use of servlet filters with quickstart.

This change originally was added in PR https://github.com/jetty/jetty.project/pull/3702 