### PR TITLE
Change `*FileMappedHttpContent` to delegate last modified to wrapped resource

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/FileMappingHttpContentFactory.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/FileMappingHttpContentFactory.java
@@ -16,7 +16,6 @@ package org.eclipse.jetty.http.content;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
-import java.time.Instant;
 import java.util.Objects;
 
 import org.eclipse.jetty.http.HttpField;
@@ -130,18 +129,6 @@ public class FileMappingHttpContentFactory implements HttpContent.Factory
         {
             return _buffer.remaining();
         }
-
-        @Override
-        public Instant getLastModifiedInstant()
-        {
-            return getWrapped().getLastModifiedInstant();
-        }
-
-        @Override
-        public HttpField getLastModified()
-        {
-            return getWrapped().getLastModified();
-        }
     }
 
     private static class MultiBufferFileMappedHttpContent extends HttpContent.Wrapper
@@ -251,18 +238,6 @@ public class FileMappingHttpContentFactory implements HttpContent.Factory
         public long getContentLengthValue()
         {
             return _contentLengthValue;
-        }
-
-        @Override
-        public Instant getLastModifiedInstant()
-        {
-            return getWrapped().getLastModifiedInstant();
-        }
-
-        @Override
-        public HttpField getLastModified()
-        {
-            return getWrapped().getLastModified();
         }
     }
 }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/FileMappingHttpContentFactory.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/FileMappingHttpContentFactory.java
@@ -93,8 +93,6 @@ public class FileMappingHttpContentFactory implements HttpContent.Factory
     {
         private final ByteBuffer _buffer;
         private final HttpField _contentLength;
-        private final HttpField _lastModified;
-        private final Instant _lastModifiedInstant;
 
         private SingleBufferFileMappedHttpContent(HttpContent content) throws IOException
         {
@@ -106,8 +104,6 @@ public class FileMappingHttpContentFactory implements HttpContent.Factory
             if (_buffer == null)
                 throw new IOException("Cannot memory map Content (not supported by underlying FileSystem): " + content.getResource());
             _contentLength = new HttpField(HttpHeader.CONTENT_LENGTH, Integer.toString(_buffer.remaining()));
-            _lastModified = content.getLastModified();
-            _lastModifiedInstant = content.getLastModifiedInstant();
         }
 
         @Override
@@ -115,7 +111,7 @@ public class FileMappingHttpContentFactory implements HttpContent.Factory
         {
             try
             {
-                sink.write(true, BufferUtil.slice(_buffer, (int)offset, (int)length), callback);
+                sink.write(true, BufferUtil.slice(_buffer, Math.toIntExact(offset), Math.toIntExact(length)), callback);
             }
             catch (Throwable x)
             {
@@ -138,13 +134,13 @@ public class FileMappingHttpContentFactory implements HttpContent.Factory
         @Override
         public Instant getLastModifiedInstant()
         {
-            return _lastModifiedInstant;
+            return getWrapped().getLastModifiedInstant();
         }
 
         @Override
         public HttpField getLastModified()
         {
-            return _lastModified;
+            return getWrapped().getLastModified();
         }
     }
 
@@ -154,8 +150,6 @@ public class FileMappingHttpContentFactory implements HttpContent.Factory
         private final int maxBufferSize;
         private final HttpField _contentLength;
         private final long _contentLengthValue;
-        private final HttpField _lastModified;
-        private final Instant _lastModifiedInstant;
 
         private MultiBufferFileMappedHttpContent(HttpContent content, int maxBufferSize) throws IOException
         {
@@ -187,8 +181,6 @@ public class FileMappingHttpContentFactory implements HttpContent.Factory
             }
             _contentLengthValue = total;
             _contentLength = new HttpField(HttpHeader.CONTENT_LENGTH, Long.toString(total));
-            _lastModified = content.getLastModified();
-            _lastModifiedInstant = content.getLastModifiedInstant();
         }
 
         @Override
@@ -264,13 +256,13 @@ public class FileMappingHttpContentFactory implements HttpContent.Factory
         @Override
         public Instant getLastModifiedInstant()
         {
-            return _lastModifiedInstant;
+            return getWrapped().getLastModifiedInstant();
         }
 
         @Override
         public HttpField getLastModified()
         {
-            return _lastModified;
+            return getWrapped().getLastModified();
         }
     }
 }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/HttpContent.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/HttpContent.java
@@ -90,6 +90,7 @@ public interface HttpContent
 
     /**
      * Get the last modified instant of this resource.
+     * Always return the most up-to-date value.
      *
      * @return the last modified instant, or null if that instant of this content is not known.
      * @see #getLastModified()

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/ValidatingCachingHttpContentFactory.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/ValidatingCachingHttpContentFactory.java
@@ -38,6 +38,10 @@ import org.eclipse.jetty.util.thread.Scheduler;
  * a positive value indicates the number of milliseconds of the minimum time between validation checks.
  * </p>
  * <p>
+ * When the wrapped {@link HttpContent}'s {@link HttpContent#getLastModifiedInstant() last modification time} did not change,
+ * it is considered that the resource did not change too and is therefore not refreshed.
+ * </p>
+ * <p>
  * This also remember a missed entry for the time set by {@code validationTime}ms. After this has
  * elapsed the entry will be invalid and will be evicted from the cache at the next access.
  * </p>

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/content/FileMappingHttpContentFactoryTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/content/FileMappingHttpContentFactoryTest.java
@@ -57,8 +57,8 @@ public class FileMappingHttpContentFactoryTest
         HttpContent content = fileMappingHttpContentFactory.getContent("file.txt");
         Instant originalLastModifiedInstant = content.getLastModifiedInstant();
 
-        // Set the file's last modified time to 100ms into the future.
-        Files.setLastModifiedTime(file, FileTime.from(Instant.now().plusMillis(100)));
+        // Set the file's last modified time to 10s into the future.
+        Files.setLastModifiedTime(file, FileTime.from(Instant.now().plusSeconds(10)));
 
         assertThat(originalLastModifiedInstant, lessThan(content.getLastModifiedInstant()));
     }
@@ -74,8 +74,8 @@ public class FileMappingHttpContentFactoryTest
         HttpContent content = fileMappingHttpContentFactory.getContent("file.txt");
         Instant originalLastModifiedInstant = content.getLastModifiedInstant();
 
-        // Set the file's last modified time to 100ms into the future.
-        Files.setLastModifiedTime(file, FileTime.from(Instant.now().plusMillis(100)));
+        // Set the file's last modified time to 10s into the future.
+        Files.setLastModifiedTime(file, FileTime.from(Instant.now().plusSeconds(10)));
 
         assertThat(originalLastModifiedInstant, lessThan(content.getLastModifiedInstant()));
     }

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/content/FileMappingHttpContentFactoryTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/content/FileMappingHttpContentFactoryTest.java
@@ -20,9 +20,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-
 import java.nio.file.attribute.FileTime;
 import java.time.Instant;
+
 import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.Content;

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/content/FileMappingHttpContentFactoryTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/content/FileMappingHttpContentFactoryTest.java
@@ -21,6 +21,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
 import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.Content;
@@ -37,12 +39,48 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(WorkDirExtension.class)
 public class FileMappingHttpContentFactoryTest
 {
     public WorkDir workDir;
+
+    @Test
+    public void testSingleBufferFileMappedLastModified() throws Exception
+    {
+        Path file = Files.writeString(workDir.getEmptyPathDir().resolve("file.txt"), "0123456789abcdefghijABCDEFGHIJ");
+        FileMappingHttpContentFactory fileMappingHttpContentFactory = new FileMappingHttpContentFactory(
+            new ResourceHttpContentFactory(ResourceFactory.root().newResource(file.getParent()), MimeTypes.DEFAULTS, ByteBufferPool.SIZED_NON_POOLING));
+
+        HttpContent content = fileMappingHttpContentFactory.getContent("file.txt");
+        Instant lastModifiedInstant1 = content.getLastModifiedInstant();
+
+        Thread.sleep(100);
+        Files.setLastModifiedTime(file, FileTime.from(Instant.now()));
+
+        Instant lastModifiedInstant2 = content.getLastModifiedInstant();
+        assertThat(lastModifiedInstant1, lessThan(lastModifiedInstant2));
+    }
+
+    @Test
+    public void testMultiBufferFileMappedLastModified() throws Exception
+    {
+        Path file = Files.writeString(workDir.getEmptyPathDir().resolve("file.txt"), "0123456789abcdefghijABCDEFGHIJ");
+        FileMappingHttpContentFactory fileMappingHttpContentFactory = new FileMappingHttpContentFactory(
+            new ResourceHttpContentFactory(ResourceFactory.root().newResource(file.getParent()), MimeTypes.DEFAULTS, ByteBufferPool.SIZED_NON_POOLING),
+            0, 10);
+
+        HttpContent content = fileMappingHttpContentFactory.getContent("file.txt");
+        Instant lastModifiedInstant1 = content.getLastModifiedInstant();
+
+        Thread.sleep(100);
+        Files.setLastModifiedTime(file, FileTime.from(Instant.now()));
+
+        Instant lastModifiedInstant2 = content.getLastModifiedInstant();
+        assertThat(lastModifiedInstant1, lessThan(lastModifiedInstant2));
+    }
 
     @Test
     public void testMultiBufferFileMappedOffsetAndLength() throws Exception

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/content/FileMappingHttpContentFactoryTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/content/FileMappingHttpContentFactoryTest.java
@@ -55,13 +55,12 @@ public class FileMappingHttpContentFactoryTest
             new ResourceHttpContentFactory(ResourceFactory.root().newResource(file.getParent()), MimeTypes.DEFAULTS, ByteBufferPool.SIZED_NON_POOLING));
 
         HttpContent content = fileMappingHttpContentFactory.getContent("file.txt");
-        Instant lastModifiedInstant1 = content.getLastModifiedInstant();
+        Instant originalLastModifiedInstant = content.getLastModifiedInstant();
 
-        Thread.sleep(100);
-        Files.setLastModifiedTime(file, FileTime.from(Instant.now()));
+        // Set the file's last modified time to 100ms into the future.
+        Files.setLastModifiedTime(file, FileTime.from(Instant.now().plusMillis(100)));
 
-        Instant lastModifiedInstant2 = content.getLastModifiedInstant();
-        assertThat(lastModifiedInstant1, lessThan(lastModifiedInstant2));
+        assertThat(originalLastModifiedInstant, lessThan(content.getLastModifiedInstant()));
     }
 
     @Test
@@ -73,13 +72,12 @@ public class FileMappingHttpContentFactoryTest
             0, 10);
 
         HttpContent content = fileMappingHttpContentFactory.getContent("file.txt");
-        Instant lastModifiedInstant1 = content.getLastModifiedInstant();
+        Instant originalLastModifiedInstant = content.getLastModifiedInstant();
 
-        Thread.sleep(100);
-        Files.setLastModifiedTime(file, FileTime.from(Instant.now()));
+        // Set the file's last modified time to 100ms into the future.
+        Files.setLastModifiedTime(file, FileTime.from(Instant.now().plusMillis(100)));
 
-        Instant lastModifiedInstant2 = content.getLastModifiedInstant();
-        assertThat(lastModifiedInstant1, lessThan(lastModifiedInstant2));
+        assertThat(originalLastModifiedInstant, lessThan(content.getLastModifiedInstant()));
     }
 
     @Test


### PR DESCRIPTION
Let `*FileMappedHttpContent` delegate the last modified accessors and specify that the javadoc, as well as the fact that `ValidatingCachingHttpContentFactory` uses that data to check if a resource needs to be refreshed.

Fixes #13850

