### PR TITLE
Fixes #13896 - listener.onContent(...) clears that ByteBuffer before the call.

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpSender.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpSender.java
@@ -480,7 +480,7 @@ public abstract class HttpSender
         private volatile boolean expect100;
         // Fields only used internally.
         private Content.Chunk chunk;
-        private ByteBuffer contentBuffer;
+        private ByteBuffer notifyBuffer;
         private boolean committed;
         private boolean success;
         private boolean complete;
@@ -494,7 +494,7 @@ public abstract class HttpSender
             proceedAction = null;
             expect100 = false;
             chunk = null;
-            contentBuffer = null;
+            notifyBuffer = null;
             committed = false;
             success = false;
             complete = false;
@@ -567,7 +567,8 @@ public abstract class HttpSender
             }
 
             ByteBuffer buffer = chunk.getByteBuffer();
-            contentBuffer = buffer.asReadOnlyBuffer();
+            // Save the buffer used to notify request content listeners.
+            notifyBuffer = buffer.slice().asReadOnlyBuffer();
             boolean last = chunk.isLast();
             if (committed)
                 sendContent(exchange, buffer, last, this);
@@ -590,8 +591,8 @@ public abstract class HttpSender
                 boolean proceed = true;
                 if (committed)
                 {
-                    if (contentBuffer.hasRemaining())
-                        proceed = someToContent(exchange, contentBuffer);
+                    if (notifyBuffer.hasRemaining())
+                        proceed = someToContent(exchange, notifyBuffer);
                 }
                 else
                 {
@@ -600,8 +601,8 @@ public abstract class HttpSender
                     if (proceed)
                     {
                         // Was any content sent while committing?
-                        if (contentBuffer.hasRemaining())
-                            proceed = someToContent(exchange, contentBuffer);
+                        if (notifyBuffer.hasRemaining())
+                            proceed = someToContent(exchange, notifyBuffer);
                     }
                 }
 

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
@@ -1140,7 +1140,59 @@ public class HttpClientTest extends AbstractHttpClientServerTest
 
     @ParameterizedTest
     @ArgumentsSource(ScenarioProvider.class)
-    public void setOnCompleteCallbackWithBlockingSend(Scenario scenario) throws Exception
+    public void testRequestContentListenerBytesCounting(Scenario scenario) throws Exception
+    {
+        start(scenario, new EmptyServerHandler());
+
+        int length = 41;
+        ByteBuffer requestByteBuffer = BufferUtil.allocate(length * 2).limit(length);
+        AtomicInteger requestContentLength = new AtomicInteger();
+
+        class NonSlicingRequestContent implements Request.Content
+        {
+            private boolean read;
+
+            @Override
+            public Content.Chunk read()
+            {
+                if (read)
+                    return Content.Chunk.EOF;
+                read = true;
+                return Content.Chunk.from(requestByteBuffer, true);
+            }
+
+            @Override
+            public void demand(Runnable demandCallback)
+            {
+                demandCallback.run();
+            }
+
+            @Override
+            public long getLength()
+            {
+                return length;
+            }
+
+            @Override
+            public void fail(Throwable failure)
+            {
+            }
+        }
+
+        ContentResponse response = client.newRequest("localhost", connector.getLocalPort())
+            .scheme(scenario.getScheme())
+            .onRequestContent((rq, bb) -> requestContentLength.addAndGet(bb.remaining()))
+            .body(new NonSlicingRequestContent())
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        assertThat(requestContentLength.get(), is(length));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testSetOnCompleteCallbackWithBlockingSend(Scenario scenario) throws Exception
     {
         byte[] content = new byte[512];
         new Random().nextBytes(content);


### PR DESCRIPTION
Now the buffer used to notify request content listener is sliced, so that the clear() performed before invoking the listeners has no effect.