### PR TITLE
12.0.x: Fix invalid persistence check before `consumeAll()` when completing the `ChannelCallback`

### DIFF
--- a/jenkins-mimir-daemon.properties
+++ b/jenkins-mimir-daemon.properties
@@ -1,3 +1,4 @@
 # Mimir Daemon properties
+mimir.daemon.autoupdate=false
 mimir.enabled=false
 mimir.file.mayLink=false

--- a/jenkins-mimir-daemon.properties
+++ b/jenkins-mimir-daemon.properties
@@ -1,3 +1,3 @@
 # Mimir Daemon properties
-
+mimir.enabled=false
 mimir.file.mayLink=false

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientFailureTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientFailureTest.java
@@ -175,7 +175,7 @@ public class HttpClientFailureTest
                     completed.incrementAndGet();
                     assertThat(result.getRequestFailure(), notNullValue());
                     assertThat(result.getResponseFailure(), nullValue());
-                    assertThat(result.getResponse().getStatus(), is(HttpStatus.INTERNAL_SERVER_ERROR_500));
+                    assertThat(result.getResponse().getStatus(), is(HttpStatus.OK_200));
                     resultLatch.countDown();
                 });
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -1568,13 +1568,16 @@ public class HttpChannelState implements HttpChannel, Components
 
                 // Turn pending demand or unconsumed input on persistent connections into failure
                 if (httpChannelState._onContentAvailable != null)
+                {
                     failure = ExceptionUtil.combine(failure, new IllegalStateException("demand pending"));
-                else if (httpChannelState.getConnectionMetaData().isPersistent())
-                    failure = ExceptionUtil.combine(failure, stream.consumeAvailable());
+                }
                 else
                 {
+                    // Consume available content before checking if the connection is persistent.
                     Throwable unconsumed = stream.consumeAvailable();
-                    if (failure != null)
+                    if (httpChannelState.getConnectionMetaData().isPersistent())
+                        failure = ExceptionUtil.combine(failure, unconsumed);
+                    else if (failure != null)
                         ExceptionUtil.addSuppressedIfNotAssociated(failure, unconsumed);
                     if (LOG.isDebugEnabled())
                         LOG.debug("consumeAvailable: {} {} ", unconsumed == null, httpChannelState);

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -1571,16 +1571,16 @@ public class HttpChannelState implements HttpChannel, Components
                 {
                     failure = ExceptionUtil.combine(failure, new IllegalStateException("demand pending"));
                 }
-                else
+                else if (httpChannelState.getConnectionMetaData().isPersistent())
                 {
-                    // consumeAvailable() makes the connection non-persistent and returns an exception
-                    // when the content cannot be consumed, this must not result in an error according
-                    // to RFC2616 section 8.2.3.
+                    // If consumeAvailable() cannot consume all the content, then it
+                    // makes the connection non-persistent and returns an exception.
+                    // This must not result in an error according to RFC2616 section 8.2.3.
                     Throwable unconsumed = stream.consumeAvailable();
-                    if (failure != null)
+                    if (failure != null && unconsumed != null)
                         ExceptionUtil.addSuppressedIfNotAssociated(failure, unconsumed);
                     if (LOG.isDebugEnabled())
-                        LOG.debug("consumeAvailable: {} {} ", unconsumed == null, httpChannelState, failure);
+                        LOG.atDebug().setCause(failure).log("consumeAvailable: {} {}", unconsumed == null, httpChannelState);
                 }
 
                 // Pending writes are also failures

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -1566,21 +1566,21 @@ public class HttpChannelState implements HttpChannel, Components
                 stream = httpChannelState._stream;
                 assert httpChannelState._callbackFailure == null;
 
-                // Turn pending demand or unconsumed input on persistent connections into failure
+                // Turn pending demand into failure.
                 if (httpChannelState._onContentAvailable != null)
                 {
                     failure = ExceptionUtil.combine(failure, new IllegalStateException("demand pending"));
                 }
                 else
                 {
-                    // Consume available content before checking if the connection is persistent.
+                    // consumeAvailable() makes the connection non-persistent and returns an exception
+                    // when the content cannot be consumed, this must not result in an error according
+                    // to RFC2616 section 8.2.3.
                     Throwable unconsumed = stream.consumeAvailable();
-                    if (httpChannelState.getConnectionMetaData().isPersistent())
-                        failure = ExceptionUtil.combine(failure, unconsumed);
-                    else if (failure != null)
+                    if (failure != null)
                         ExceptionUtil.addSuppressedIfNotAssociated(failure, unconsumed);
                     if (LOG.isDebugEnabled())
-                        LOG.debug("consumeAvailable: {} {} ", unconsumed == null, httpChannelState);
+                        LOG.debug("consumeAvailable: {} {} ", unconsumed == null, httpChannelState, failure);
                 }
 
                 // Pending writes are also failures

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -1571,13 +1571,18 @@ public class HttpChannelState implements HttpChannel, Components
                 {
                     failure = ExceptionUtil.combine(failure, new IllegalStateException("demand pending"));
                 }
-                else if (httpChannelState.getConnectionMetaData().isPersistent())
+                else
                 {
                     // If consumeAvailable() cannot consume all the content, then it
                     // makes the connection non-persistent and returns an exception.
                     // This must not result in an error according to RFC2616 section 8.2.3.
+                    // Also, consumeAvailable must be called even when the connection is not
+                    // persistent otherwise RequestLog.log() would be able to read
+                    // x-www-form-urlencoded parameters in one case and not the other.
                     Throwable unconsumed = stream.consumeAvailable();
-                    if (failure != null && unconsumed != null)
+                    if (httpChannelState.getConnectionMetaData().isPersistent() && !httpChannelState._expects100Continue)
+                        failure = ExceptionUtil.combine(failure, unconsumed);
+                    else if (failure != null && unconsumed != null)
                         ExceptionUtil.addSuppressedIfNotAssociated(failure, unconsumed);
                     if (LOG.isDebugEnabled())
                         LOG.atDebug().setCause(failure).log("consumeAvailable: {} {}", unconsumed == null, httpChannelState);

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
@@ -796,8 +796,7 @@ public class HttpChannelTest
         task.run();
 
         assertThat(stream.isComplete(), is(true));
-        assertThat(stream.getFailure(), notNullValue());
-        assertThat(stream.getFailure().getMessage(), containsString("Unconsumed request content"));
+        assertThat(stream.getFailure(), nullValue());
         assertThat(stream.getResponse(), notNullValue());
         assertThat(stream.getResponse().getStatus(), equalTo(200));
         assertThat(stream.getResponseHeaders().get(HttpHeader.CONTENT_TYPE), equalTo(MimeTypes.Type.TEXT_PLAIN_UTF_8.asString()));

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/MockHttpStream.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/MockHttpStream.java
@@ -231,9 +231,10 @@ public class MockHttpStream implements HttpStream
     @Override
     public Throwable consumeAvailable()
     {
-        if (_channel.getConnectionMetaData() instanceof MockConnectionMetaData mock)
+        Throwable throwable = HttpStream.consumeAvailable(this, new HttpConfiguration());
+        if (throwable != null && _channel.getConnectionMetaData() instanceof MockConnectionMetaData mock)
             mock.notPersistent();
-        return HttpStream.consumeAvailable(this, new HttpConfiguration());
+        return throwable;
     }
 
     public boolean isComplete()

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/MockHttpStream.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/MockHttpStream.java
@@ -231,6 +231,8 @@ public class MockHttpStream implements HttpStream
     @Override
     public Throwable consumeAvailable()
     {
+        if (_channel.getConnectionMetaData() instanceof MockConnectionMetaData mock)
+            mock.notPersistent();
         return HttpStream.consumeAvailable(this, new HttpConfiguration());
     }
 

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/PartialRFC2616Test.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/PartialRFC2616Test.java
@@ -550,7 +550,7 @@ public class PartialRFC2616Test
     }
 
     @Test
-    public void test824() throws Exception
+    public void test823No100Response() throws Exception
     {
         // Expect 100 not sent
         int offset = 0;

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/PartialRFC2616Test.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/PartialRFC2616Test.java
@@ -550,7 +550,6 @@ public class PartialRFC2616Test
     }
 
     @Test
-    @Disabled // TODO
     public void test824() throws Exception
     {
         // Expect 100 not sent

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestLogTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestLogTest.java
@@ -33,6 +33,7 @@ import org.eclipse.jetty.util.Fields;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -137,12 +138,13 @@ public class RequestLogTest
      * The RequestLog accidentally attempts to read the Request body content due to the use of Request.getParameterNames() API.
      */
     @ParameterizedTest
-    @ValueSource(strings = {"/hello", "/hello?a=b"})
-    public void testNormalPostFormRequest(String requestPath) throws Exception
+    @CsvSource({"/hello,true", "/hello,false", "/hello?a=b,true", "/hello?a=b,false"})
+    public void testNormalPostFormRequest(String requestPath, boolean persistent) throws Exception
     {
         Server server = null;
         try
         {
+            int parameterCount = 9;
             BlockingArrayQueue<String> requestLogLines = new BlockingArrayQueue<>();
 
             server = createServer((request, response1) ->
@@ -170,9 +172,9 @@ public class RequestLogTest
                  InputStream in = socket.getInputStream())
             {
                 StringBuilder form = new StringBuilder();
-                for (int i = 'a'; i < 'j'; i++)
+                for (int i = 0; i < parameterCount; i++)
                 {
-                    form.append((char)i).append("=").append(i).append("&");
+                    form.append((char)('a' + i)).append("=").append(i).append("&");
                 }
 
                 byte[] bufForm = form.toString().getBytes(UTF_8);
@@ -182,9 +184,9 @@ public class RequestLogTest
                     Host: %s
                     Content-Type: application/x-www-form-urlencoded
                     Content-Length: %d
-                    Connection: close
+                    Connection: %s
                     
-                    """.formatted(requestPath, baseURI.getRawAuthority(), bufForm.length);
+                    """.formatted(requestPath, baseURI.getRawAuthority(), bufForm.length, persistent ? "keepalive" : "close");
 
                 out.write(rawRequest.getBytes(UTF_8));
                 out.write(bufForm);
@@ -200,9 +202,17 @@ public class RequestLogTest
                 assertThat("Body Content", response.getContent(), containsString("Got POST to " + expectedURI));
 
                 String reqlog = requestLogLines.poll(5, TimeUnit.SECONDS);
-                int querySize = 0;
-                if (requestPath.contains("?"))
-                    querySize = 1; // assuming that parameterized version only has 1 query value
+                int querySize;
+                if (persistent)
+                {
+                    querySize = 0;
+                    if (requestPath.contains("?"))
+                        querySize = 1; // assuming that parameterized version only has 1 query value
+                }
+                else
+                {
+                    querySize = parameterCount;
+                }
                 assertThat("RequestLog", reqlog, containsString("method:POST|uri:%s|params.size:%d|status:200"
                     .formatted(expectedURI, querySize)
                 ));

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestLogTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestLogTest.java
@@ -33,7 +33,7 @@ import org.eclipse.jetty.util.Fields;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -137,8 +137,8 @@ public class RequestLogTest
      * The RequestLog accidentally attempts to read the Request body content due to the use of Request.getParameterNames() API.
      */
     @ParameterizedTest
-    @ValueSource(strings = {"/hello", "/hello?a=b"})
-    public void testNormalPostFormRequest(String requestPath) throws Exception
+    @CsvSource({"/hello,true", "/hello,false", "/hello?a=b,true", "/hello?a=b,false"})
+    public void testNormalPostFormRequest(String requestPath, boolean persistent) throws Exception
     {
         Server server = null;
         try
@@ -182,9 +182,9 @@ public class RequestLogTest
                     Host: %s
                     Content-Type: application/x-www-form-urlencoded
                     Content-Length: %d
-                    Connection: close
+                    Connection: %s
                     
-                    """.formatted(requestPath, baseURI.getRawAuthority(), bufForm.length);
+                    """.formatted(requestPath, baseURI.getRawAuthority(), bufForm.length, persistent ? "keepalive" : "close");
 
                 out.write(rawRequest.getBytes(UTF_8));
                 out.write(bufForm);

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestLogTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RequestLogTest.java
@@ -33,7 +33,6 @@ import org.eclipse.jetty.util.Fields;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -138,13 +137,12 @@ public class RequestLogTest
      * The RequestLog accidentally attempts to read the Request body content due to the use of Request.getParameterNames() API.
      */
     @ParameterizedTest
-    @CsvSource({"/hello,true", "/hello,false", "/hello?a=b,true", "/hello?a=b,false"})
-    public void testNormalPostFormRequest(String requestPath, boolean persistent) throws Exception
+    @ValueSource(strings = {"/hello", "/hello?a=b"})
+    public void testNormalPostFormRequest(String requestPath) throws Exception
     {
         Server server = null;
         try
         {
-            int parameterCount = 9;
             BlockingArrayQueue<String> requestLogLines = new BlockingArrayQueue<>();
 
             server = createServer((request, response1) ->
@@ -172,9 +170,9 @@ public class RequestLogTest
                  InputStream in = socket.getInputStream())
             {
                 StringBuilder form = new StringBuilder();
-                for (int i = 0; i < parameterCount; i++)
+                for (int i = 'a'; i < 'j'; i++)
                 {
-                    form.append((char)('a' + i)).append("=").append(i).append("&");
+                    form.append((char)i).append("=").append(i).append("&");
                 }
 
                 byte[] bufForm = form.toString().getBytes(UTF_8);
@@ -184,9 +182,9 @@ public class RequestLogTest
                     Host: %s
                     Content-Type: application/x-www-form-urlencoded
                     Content-Length: %d
-                    Connection: %s
+                    Connection: close
                     
-                    """.formatted(requestPath, baseURI.getRawAuthority(), bufForm.length, persistent ? "keepalive" : "close");
+                    """.formatted(requestPath, baseURI.getRawAuthority(), bufForm.length);
 
                 out.write(rawRequest.getBytes(UTF_8));
                 out.write(bufForm);
@@ -202,17 +200,9 @@ public class RequestLogTest
                 assertThat("Body Content", response.getContent(), containsString("Got POST to " + expectedURI));
 
                 String reqlog = requestLogLines.poll(5, TimeUnit.SECONDS);
-                int querySize;
-                if (persistent)
-                {
-                    querySize = 0;
-                    if (requestPath.contains("?"))
-                        querySize = 1; // assuming that parameterized version only has 1 query value
-                }
-                else
-                {
-                    querySize = parameterCount;
-                }
+                int querySize = 0;
+                if (requestPath.contains("?"))
+                    querySize = 1; // assuming that parameterized version only has 1 query value
                 assertThat("RequestLog", reqlog, containsString("method:POST|uri:%s|params.size:%d|status:200"
                     .formatted(expectedURI, querySize)
                 ));


### PR DESCRIPTION
Fix for the #13933 bug that was introduced in #13814