### PR TITLE
Fixes #13936 - Version12.1.3 breaks BINARY compatibility with 12.0.29: HttpContent.getByteBuffer() and more.

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/ResourceHttpContent.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/ResourceHttpContent.java
@@ -43,6 +43,11 @@ public class ResourceHttpContent implements HttpContent
     final HttpField _etag;
     final ByteBufferPool.Sized _sizedBufferPool;
 
+    public ResourceHttpContent(Resource resource, String contentType)
+    {
+        this(resource, contentType, null);
+    }
+
     public ResourceHttpContent(Resource resource, String contentType, ByteBufferPool.Sized sizedByteBufferPool)
     {
         _resource = resource;

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ResourceService.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ResourceService.java
@@ -678,7 +678,7 @@ public class ResourceService
         response.getOutputStream().write(data);
     }
 
-    protected void sendData(HttpServletRequest request,
+    protected boolean sendData(HttpServletRequest request,
                                HttpServletResponse response,
                                boolean include,
                                final HttpContent content,
@@ -764,7 +764,7 @@ public class ResourceService
                             return String.format("ResourceService@%x$CB", ResourceService.this.hashCode());
                         }
                     });
-                    return;
+                    return false;
                 }
                 // otherwise write content blocking
                 ((HttpOutput)out).sendContent(content);
@@ -782,7 +782,7 @@ public class ResourceService
                 response.setHeader(HttpHeader.CONTENT_RANGE.asString(),
                     InclusiveByteRange.to416HeaderRangeString(content_length));
                 sendStatus(response, HttpServletResponse.SC_REQUESTED_RANGE_NOT_SATISFIABLE, null);
-                return;
+                return true;
             }
 
             //  if there is only a single valid range (must be satisfiable
@@ -798,7 +798,7 @@ public class ResourceService
                 response.setHeader(HttpHeader.CONTENT_RANGE.asString(),
                     singleSatisfiableRange.toHeaderRangeString(content_length));
                 writeContent(content, out, singleSatisfiableRange.getFirst(), singleLength);
-                return;
+                return true;
             }
 
             //  multiple non-overlapping valid ranges cause a multipart
@@ -858,6 +858,7 @@ public class ResourceService
 
             multi.close();
         }
+        return true;
     }
 
     private static void writeContent(HttpContent content, OutputStream out, long start, long contentLength) throws IOException


### PR DESCRIPTION
* Restored constructor `ResourceHttpContent(Resource, String)`.
* Restored return type of EE9's `ResourceService.sendData(HttpServletRequest, HttpServletResponse, boolean, HttpContent, Enumeration<String>)`.