### PR TITLE
12.0.x: invalid persistence check before consumeAll() for expecting requests

### DIFF
--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientFailureTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientFailureTest.java
@@ -175,7 +175,7 @@ public class HttpClientFailureTest
                     completed.incrementAndGet();
                     assertThat(result.getRequestFailure(), notNullValue());
                     assertThat(result.getResponseFailure(), nullValue());
-                    assertThat(result.getResponse().getStatus(), is(HttpStatus.OK_200));
+                    assertThat(result.getResponse().getStatus(), is(HttpStatus.INTERNAL_SERVER_ERROR_500));
                     resultLatch.countDown();
                 });
 

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientFailureTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientFailureTest.java
@@ -175,7 +175,7 @@ public class HttpClientFailureTest
                     completed.incrementAndGet();
                     assertThat(result.getRequestFailure(), notNullValue());
                     assertThat(result.getResponseFailure(), nullValue());
-                    assertThat(result.getResponse().getStatus(), is(HttpStatus.INTERNAL_SERVER_ERROR_500));
+                    assertThat(result.getResponse().getStatus(), is(HttpStatus.OK_200));
                     resultLatch.countDown();
                 });
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -1571,19 +1571,22 @@ public class HttpChannelState implements HttpChannel, Components
                 {
                     failure = ExceptionUtil.combine(failure, new IllegalStateException("demand pending"));
                 }
-                // Else failure for a persistent non expecting request to not consume the request
-                else if (httpChannelState.getConnectionMetaData().isPersistent() && !httpChannelState._expects100Continue)
-                    failure = ExceptionUtil.combine(failure, stream.consumeAvailable());
                 else
                 {
-                    // Else we consumeAvailable, but if the content cannot be fully consumed, then
-                    // consumeAvailable() makes the connection non-persistent and returns an exception.
-                    // This must not result in an error according to RFC2616 section 8.2.3.
+                    // ensure the request is fully consumed or failed.
                     Throwable unconsumed = stream.consumeAvailable();
-                    if (failure != null)
-                        ExceptionUtil.addSuppressedIfNotAssociated(failure, unconsumed);
                     if (LOG.isDebugEnabled())
                         LOG.atDebug().setCause(failure).log("consumeAvailable: {} {}", unconsumed == null, httpChannelState);
+                    if (unconsumed != null)
+                    {
+                        // If the connection is persistent, and we are not closing due to expectations...
+                        if (httpChannelState.getConnectionMetaData().isPersistent() && !httpChannelState._expects100Continue)
+                            // then unconsumed input is a real failure
+                            failure = ExceptionUtil.combine(failure, unconsumed);
+                        else if (failure != null)
+                            // otherwise the failure is just associated with any existing failure else ignored
+                            ExceptionUtil.addSuppressedIfNotAssociated(failure, unconsumed);
+                    }
                 }
 
                 // Pending writes are also failures

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -1568,13 +1568,16 @@ public class HttpChannelState implements HttpChannel, Components
 
                 // Turn pending demand or unconsumed input on persistent connections into failure
                 if (httpChannelState._onContentAvailable != null)
+                {
                     failure = ExceptionUtil.combine(failure, new IllegalStateException("demand pending"));
-                else if (httpChannelState.getConnectionMetaData().isPersistent())
-                    failure = ExceptionUtil.combine(failure, stream.consumeAvailable());
+                }
                 else
                 {
+                    // Consume available content before checking if the connection is persistent.
                     Throwable unconsumed = stream.consumeAvailable();
-                    if (failure != null)
+                    if (httpChannelState.getConnectionMetaData().isPersistent())
+                        failure = ExceptionUtil.combine(failure, unconsumed);
+                    else if (failure != null)
                         ExceptionUtil.addSuppressedIfNotAssociated(failure, unconsumed);
                     if (LOG.isDebugEnabled())
                         LOG.debug("consumeAvailable: {} {} ", unconsumed == null, httpChannelState);

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -1571,16 +1571,19 @@ public class HttpChannelState implements HttpChannel, Components
                 {
                     failure = ExceptionUtil.combine(failure, new IllegalStateException("demand pending"));
                 }
+                // Else failure for a persistent non expecting request to not consume the request
+                else if (httpChannelState.getConnectionMetaData().isPersistent() && !httpChannelState._expects100Continue)
+                    failure = ExceptionUtil.combine(failure, stream.consumeAvailable());
                 else
                 {
-                    // consumeAvailable() makes the connection non-persistent and returns an exception
-                    // when the content cannot be consumed, this must not result in an error according
-                    // to RFC2616 section 8.2.3.
+                    // Else we consumeAvailable, but if the content cannot be fully consumed, then
+                    // consumeAvailable() makes the connection non-persistent and returns an exception.
+                    // This must not result in an error according to RFC2616 section 8.2.3.
                     Throwable unconsumed = stream.consumeAvailable();
                     if (failure != null)
                         ExceptionUtil.addSuppressedIfNotAssociated(failure, unconsumed);
                     if (LOG.isDebugEnabled())
-                        LOG.debug("consumeAvailable: {} {} ", unconsumed == null, httpChannelState, failure);
+                        LOG.atDebug().setCause(failure).log("consumeAvailable: {} {}", unconsumed == null, httpChannelState);
                 }
 
                 // Pending writes are also failures

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -1566,21 +1566,21 @@ public class HttpChannelState implements HttpChannel, Components
                 stream = httpChannelState._stream;
                 assert httpChannelState._callbackFailure == null;
 
-                // Turn pending demand or unconsumed input on persistent connections into failure
+                // Turn pending demand into failure.
                 if (httpChannelState._onContentAvailable != null)
                 {
                     failure = ExceptionUtil.combine(failure, new IllegalStateException("demand pending"));
                 }
                 else
                 {
-                    // Consume available content before checking if the connection is persistent.
+                    // consumeAvailable() makes the connection non-persistent and returns an exception
+                    // when the content cannot be consumed, this must not result in an error according
+                    // to RFC2616 section 8.2.3.
                     Throwable unconsumed = stream.consumeAvailable();
-                    if (httpChannelState.getConnectionMetaData().isPersistent())
-                        failure = ExceptionUtil.combine(failure, unconsumed);
-                    else if (failure != null)
+                    if (failure != null)
                         ExceptionUtil.addSuppressedIfNotAssociated(failure, unconsumed);
                     if (LOG.isDebugEnabled())
-                        LOG.debug("consumeAvailable: {} {} ", unconsumed == null, httpChannelState);
+                        LOG.debug("consumeAvailable: {} {} ", unconsumed == null, httpChannelState, failure);
                 }
 
                 // Pending writes are also failures

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/PartialRFC2616Test.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/PartialRFC2616Test.java
@@ -550,7 +550,7 @@ public class PartialRFC2616Test
     }
 
     @Test
-    public void test824() throws Exception
+    public void test823No100Response() throws Exception
     {
         // Expect 100 not sent
         int offset = 0;

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/PartialRFC2616Test.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/PartialRFC2616Test.java
@@ -550,7 +550,6 @@ public class PartialRFC2616Test
     }
 
     @Test
-    @Disabled // TODO
     public void test824() throws Exception
     {
         // Expect 100 not sent

--- a/jetty-ee10/jetty-ee10-servlets/src/main/java/org/eclipse/jetty/ee10/servlets/CrossOriginFilter.java
+++ b/jetty-ee10/jetty-ee10-servlets/src/main/java/org/eclipse/jetty/ee10/servlets/CrossOriginFilter.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
+
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.FilterConfig;


### PR DESCRIPTION
Alternate fix for #13933. Replaces #13934