### PR TITLE
Issue #13941 - allow streamed WebSocket message types for demanding endpoints

### DIFF
--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/messages/DispatchedMessageSink.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/messages/DispatchedMessageSink.java
@@ -58,16 +58,12 @@ public abstract class DispatchedMessageSink extends AbstractMessageSink
     public DispatchedMessageSink(CoreSession session, MethodHolder methodHolder, boolean autoDemand)
     {
         super(session, methodHolder, autoDemand);
-        if (!autoDemand)
-            throw new IllegalArgumentException("%s must be auto-demanding".formatted(getClass().getSimpleName()));
         executor = session.getWebSocketComponents().getExecutor();
     }
 
     public DispatchedMessageSink(CoreSession session, MethodHolder methodHolder, boolean autoDemand, Consumer<Throwable> onError)
     {
         super(session, methodHolder, autoDemand);
-        if (!autoDemand)
-            throw new IllegalArgumentException("%s must be auto-demanding".formatted(getClass().getSimpleName()));
         this.executor = session.getWebSocketComponents().getExecutor();
         this.onError = onError;
     }

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/annotations/OnWebSocketMessage.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-api/src/main/java/org/eclipse/jetty/websocket/api/annotations/OnWebSocketMessage.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.websocket.api.annotations;
 
-import java.io.InputStream;
 import java.io.Reader;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -30,9 +29,6 @@ import java.lang.annotation.Target;
  * </ol>
  * <p>The {@code *} before the parameter type means that the parameter is mandatory.</p>
  * <p>NOTE</p>
- * <p>Method that takes a {@link Reader} must have
- * {@link WebSocket#autoDemand()} set to {@code true}.</p>
- * <p>NOTE</p>
  * <p>The {@link Reader} argument will always use the UTF-8 charset,
  * (as dictated by RFC 6455). If you need to use a different charset,
  * you must use BINARY messages.</p>
@@ -42,9 +38,6 @@ import java.lang.annotation.Target;
  * <li>{@code public void methodName(Session session, *InputStream stream)}</li>
  * </ol>
  * <p>The {@code *} before the parameter type means that the parameter is mandatory.</p>
- * <p>NOTE</p>
- * <p>Method that takes a {@link InputStream} must have
- * {@link WebSocket#autoDemand()} set to {@code true}.</p>
  * <p>Partial messages are used to receive individual frames (and therefore partial
  * messages) without aggregating the frames into a complete WebSocket message.
  * A {@code boolean} parameter is supplied to indicate whether the frame is

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandlerFactory.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/main/java/org/eclipse/jetty/websocket/common/JettyWebSocketFrameHandlerFactory.java
@@ -439,9 +439,6 @@ public class JettyWebSocketFrameHandlerFactory extends ContainerLifeCycle
                 methodHandle = InvokerUtils.optionalMutatedInvoker(lookup, endpointClass, onMsg, inputStreamCallingArgs);
                 if (methodHandle != null)
                 {
-                    if (!metadata.isAutoDemand())
-                        throw new InvalidWebSocketException("InputStream methods require auto-demanding WebSocket endpoints");
-
                     // InputStream Binary Message
                     assertSignatureValid(endpointClass, onMsg, OnWebSocketMessage.class);
                     metadata.setBinaryHandle(InputStreamMessageSink.class, MethodHolder.from(methodHandle), onMsg);
@@ -451,9 +448,6 @@ public class JettyWebSocketFrameHandlerFactory extends ContainerLifeCycle
                 methodHandle = InvokerUtils.optionalMutatedInvoker(lookup, endpointClass, onMsg, readerCallingArgs);
                 if (methodHandle != null)
                 {
-                    if (!metadata.isAutoDemand())
-                        throw new InvalidWebSocketException("Reader methods require auto-demanding WebSocket endpoints");
-
                     // Reader Text Message
                     assertSignatureValid(endpointClass, onMsg, OnWebSocketMessage.class);
                     metadata.setTextHandle(ReaderMessageSink.class, MethodHolder.from(methodHandle), onMsg);

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/StreamedMessageTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/StreamedMessageTest.java
@@ -1,0 +1,177 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.websocket.tests;
+
+import java.io.InputStream;
+import java.io.Reader;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.util.IO;
+import org.eclipse.jetty.websocket.api.Callback;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.StatusCode;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
+import org.eclipse.jetty.websocket.api.annotations.WebSocket;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.eclipse.jetty.websocket.server.WebSocketUpgradeHandler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class StreamedMessageTest
+{
+    private Server _server;
+    private WebSocketClient _client;
+    private ServerConnector _connector;
+    private Object _serverEndpoint;
+
+    public void start(Supplier<Object> serverEndpointSupplier) throws Exception
+    {
+        _server = new Server();
+        _connector = new ServerConnector(_server);
+        _server.addConnector(_connector);
+
+        _serverEndpoint = serverEndpointSupplier.get();
+        WebSocketUpgradeHandler wsHandler = WebSocketUpgradeHandler.from(_server, container ->
+            container.addMapping("/", (rq, rs, cb) -> _serverEndpoint
+            ));
+
+        _server.setHandler(wsHandler);
+        _server.start();
+
+        _client = new WebSocketClient();
+        _client.start();
+    }
+
+    @AfterEach
+    public void stop() throws Exception
+    {
+        _client.stop();
+        _server.stop();
+    }
+
+    @WebSocket(autoDemand = false)
+    public static class DemandingStreamSocket
+    {
+        @OnWebSocketMessage
+        public void onMessage(Session session, InputStream inputStream) throws Exception
+        {
+            session.sendBinary(BufferUtil.toBuffer(inputStream.readAllBytes()), Callback.NOOP);
+            session.demand();
+        }
+
+        @OnWebSocketMessage
+        public void onMessage(Session session, Reader reader) throws Exception
+        {
+            session.sendText(IO.toString(reader), Callback.NOOP);
+            session.demand();
+        }
+    }
+
+    @WebSocket()
+    public static class AutoDemandingStreamSocket
+    {
+        @OnWebSocketMessage
+        public void onMessage(Session session, InputStream inputStream) throws Exception
+        {
+            session.sendBinary(BufferUtil.toBuffer(inputStream.readAllBytes()), Callback.NOOP);
+        }
+
+        @OnWebSocketMessage
+        public void onMessage(Session session, Reader reader) throws Exception
+        {
+            session.sendText(IO.toString(reader), Callback.NOOP);
+        }
+    }
+
+    @Test
+    public void testAutoDemandingStreams() throws Exception
+    {
+        start(AutoDemandingStreamSocket::new);
+        URI uri = new URI("ws://localhost:" + _connector.getLocalPort());
+        EventSocket clientEndpoint = new EventSocket();
+        Session session = _client.connect(clientEndpoint, uri).get(5, TimeUnit.SECONDS);
+
+        testBinaryEcho(clientEndpoint);
+        testBinaryEcho(clientEndpoint);
+
+        testTextEcho(clientEndpoint);
+        testTextEcho(clientEndpoint);
+
+        session.close();
+        assertTrue(clientEndpoint.closeLatch.await(5, TimeUnit.SECONDS));
+        assertThat(clientEndpoint.closeCode, equalTo(StatusCode.NORMAL));
+    }
+
+    @Test
+    public void testDemandingStreams() throws Exception
+    {
+        start(DemandingStreamSocket::new);
+        URI uri = new URI("ws://localhost:" + _connector.getLocalPort());
+        EventSocket clientEndpoint = new EventSocket();
+        Session session = _client.connect(clientEndpoint, uri).get(5, TimeUnit.SECONDS);
+
+        testBinaryEcho(clientEndpoint);
+        testBinaryEcho(clientEndpoint);
+
+        testTextEcho(clientEndpoint);
+        testTextEcho(clientEndpoint);
+
+        session.close();
+        assertTrue(clientEndpoint.closeLatch.await(5, TimeUnit.SECONDS));
+        assertThat(clientEndpoint.closeCode, equalTo(StatusCode.NORMAL));
+    }
+
+    private void testBinaryEcho(EventSocket clientEndpoint) throws Exception
+    {
+        Session session = clientEndpoint.session;
+        session.sendPartialBinary(BufferUtil.toBuffer("hello"), false, Callback.NOOP);
+        session.sendPartialBinary(BufferUtil.toBuffer(" world"), false, Callback.NOOP);
+        session.sendPartialBinary(BufferUtil.toBuffer(" 123"), false, Callback.NOOP);
+        session.sendPartialBinary(BufferUtil.toBuffer("4"), false, Callback.NOOP);
+
+        // We will not see the message until the final frame is sent with fin=true.
+        assertNull(clientEndpoint.binaryMessages.poll(500, TimeUnit.MILLISECONDS));
+
+        session.sendPartialBinary(BufferUtil.EMPTY_BUFFER, true, Callback.NOOP);
+        ByteBuffer received = clientEndpoint.binaryMessages.poll(5, TimeUnit.SECONDS);
+        assertThat(BufferUtil.toString(received), equalTo("hello world 1234"));
+    }
+
+    private void testTextEcho(EventSocket clientEndpoint) throws Exception
+    {
+        Session session = clientEndpoint.session;
+        session.sendPartialText("hello", false, Callback.NOOP);
+        session.sendPartialText(" world", false, Callback.NOOP);
+        session.sendPartialText(" 123", false, Callback.NOOP);
+        session.sendPartialText("4", false, Callback.NOOP);
+
+        // We will not see the message until the final frame is sent with fin=true.
+        assertNull(clientEndpoint.textMessages.poll(500, TimeUnit.MILLISECONDS));
+
+        session.sendPartialText(null, true, Callback.NOOP);
+        String received = clientEndpoint.textMessages.poll(5, TimeUnit.SECONDS);
+        assertThat(received, equalTo("hello world 1234"));
+    }
+}


### PR DESCRIPTION
## Closes #13941

Remove the restriction that `InputStream`/`Reader` `@OnWebSocketMessage` types cannot be used with demanding WebSocket endpoints.