### PR TITLE
12.0.x: #13849 ignore last writes done by the `ResourceService` used in `ResourceServlet`

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ResourceServlet.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ResourceServlet.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.ee10.servlet;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.file.InvalidPathException;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -537,9 +538,18 @@ public class ResourceServlet extends HttpServlet
                 // otherwise we can use the core response directly.
                 boolean writingOrStreaming = servletContextResponse.isWritingOrStreaming();
                 boolean useServletResponse = !(httpServletResponse instanceof ServletApiResponse) || writingOrStreaming;
-                Response coreResponse = useServletResponse
+                Response r = useServletResponse
                     ? new ServletCoreResponse(coreRequest, httpServletResponse, included)
                     : servletChannel.getResponse();
+                // Ignore last writes done via the Core API as the ServletChannel will perform the last write upon completion.
+                Response coreResponse = new Response.Wrapper(coreRequest, r)
+                {
+                    @Override
+                    public void write(boolean last, ByteBuffer byteBuffer, Callback callback)
+                    {
+                        super.write(false, byteBuffer, callback);
+                    }
+                };
 
                 // If the core response is already committed then do nothing more
                 if (coreResponse.isCommitted())

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ResourceServletTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ResourceServletTest.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
@@ -64,10 +65,13 @@ import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.IOResources;
 import org.eclipse.jetty.logging.StacklessLogging;
 import org.eclipse.jetty.server.AllowedResourceAliasChecker;
+import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.LocalConnector;
+import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.ResourceService;
+import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.SymlinkAllowedResourceAliasChecker;
 import org.eclipse.jetty.toolchain.test.FS;
@@ -76,6 +80,7 @@ import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.resource.Resource;
@@ -3806,6 +3811,48 @@ public class ResourceServletTest
         assertThat(response.get(HttpHeader.CONTENT_LENGTH), is("18"));
         assertThat(response.getContent(), is("Test 2 to too two\n"));
         assertThat(filterCalled.get(), is(true));
+    }
+
+    @Test
+    public void testSingleLastWrite() throws Exception
+    {
+        server.stop();
+        var rootHandler = new Handler.Wrapper(context)
+        {
+            final AtomicInteger lastWriteCounter = new AtomicInteger();
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            {
+                response = new Response.Wrapper(request, response)
+                {
+                    @Override
+                    public void write(boolean last, ByteBuffer byteBuffer, Callback callback)
+                    {
+                        if (last)
+                            lastWriteCounter.incrementAndGet();
+                        super.write(last, byteBuffer, callback);
+                    }
+                };
+                return super.handle(request, response, callback);
+            }
+        };
+        server.setHandler(rootHandler);
+        server.start();
+
+        context.addServlet(DefaultServlet.class, "/");
+
+        Files.writeString(docRoot.resolve("file.txt"), "How now brown cow", UTF_8);
+
+        String rawResponse = connector.getResponse("""
+            GET /context/file.txt HTTP/1.1\r
+            Host: local\r
+            Connection: close\r
+            \r
+            """);
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.toString(), response.getStatus(), is(HttpStatus.OK_200));
+        assertThat(response.toString(), response.getContent(), is("How now brown cow"));
+        assertThat(rootHandler.lastWriteCounter.get(), is(1));
     }
 
     public static class WriterFilter implements Filter

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/AsyncIOServletTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/AsyncIOServletTest.java
@@ -19,6 +19,8 @@ import java.io.InterruptedIOException;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Deque;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
@@ -54,6 +56,7 @@ import org.eclipse.jetty.client.Result;
 import org.eclipse.jetty.client.StringRequestContent;
 import org.eclipse.jetty.client.transport.internal.HttpConnectionOverHTTP;
 import org.eclipse.jetty.ee10.servlet.HttpOutput;
+import org.eclipse.jetty.ee10.servlet.ResourceServlet;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpHeaderValue;
 import org.eclipse.jetty.http.HttpMethod;
@@ -64,9 +67,11 @@ import org.eclipse.jetty.http2.client.transport.internal.HttpConnectionOverHTTP2
 import org.eclipse.jetty.io.Connection;
 import org.eclipse.jetty.io.EofException;
 import org.eclipse.jetty.logging.StacklessLogging;
+import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.internal.HttpChannelState;
+import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.FuturePromise;
@@ -77,6 +82,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -1530,6 +1536,49 @@ public class AsyncIOServletTest extends AbstractTest
 
         ContentResponse response = completable.get(5, TimeUnit.SECONDS);
         assertEquals(HttpStatus.NO_CONTENT_204, response.getStatus());
+    }
+
+    @ParameterizedTest
+    @MethodSource("transportsNoFCGI")
+    public void testResourceServletLastWrite(TransportType transportType) throws Exception
+    {
+        prepareServer(transportType, new ResourceServlet());
+        Path docRoot = workDir.getPathFile("docroot");
+        FS.ensureDirExists(docRoot);
+        Files.writeString(docRoot.resolve("file.txt"), "How now brown cow", UTF_8);
+        servletContextHandler.setBaseResourceAsPath(docRoot);
+
+        AtomicInteger lastWriteCounter = new AtomicInteger();
+        server.setHandler(new Handler.Wrapper(servletContextHandler)
+        {
+            @Override
+            public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback) throws Exception
+            {
+                response = new org.eclipse.jetty.server.Response.Wrapper(request, response)
+                {
+                    @Override
+                    public void write(boolean last, ByteBuffer byteBuffer, Callback callback)
+                    {
+                        if (last)
+                            lastWriteCounter.incrementAndGet();
+                        super.write(last, byteBuffer, callback);
+                    }
+                };
+                return super.handle(request, response, callback);
+            }
+        });
+        server.start();
+        startClient(transportType);
+
+        var request = client.newRequest(newURI(transportType))
+            .path("/file.txt")
+            .method(HttpMethod.GET)
+            .timeout(15, TimeUnit.SECONDS);
+        CompletableFuture<ContentResponse> completable = new CompletableResponseListener(request).send();
+        ContentResponse response = completable.get(5, TimeUnit.SECONDS);
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+        assertEquals("How now brown cow", response.getContentAsString());
+        assertEquals(1, lastWriteCounter.get());
     }
 
     private static class Listener implements ReadListener, WriteListener

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/AsyncIOServletTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/AsyncIOServletTest.java
@@ -1540,9 +1540,9 @@ public class AsyncIOServletTest extends AbstractTest
 
     @ParameterizedTest
     @MethodSource("transportsNoFCGI")
-    public void testResourceServletLastWrite(TransportType transportType) throws Exception
+    public void testResourceServletLastWrite(Transport transport) throws Exception
     {
-        prepareServer(transportType, new ResourceServlet());
+        prepareServer(transport, new ResourceServlet());
         Path docRoot = workDir.getPathFile("docroot");
         FS.ensureDirExists(docRoot);
         Files.writeString(docRoot.resolve("file.txt"), "How now brown cow", UTF_8);
@@ -1568,9 +1568,9 @@ public class AsyncIOServletTest extends AbstractTest
             }
         });
         server.start();
-        startClient(transportType);
+        startClient(transport);
 
-        var request = client.newRequest(newURI(transportType))
+        var request = client.newRequest(newURI(transport))
             .path("/file.txt")
             .method(HttpMethod.GET)
             .timeout(15, TimeUnit.SECONDS);


### PR DESCRIPTION
12.0.x version of https://github.com/jetty/jetty.project/pull/13914

Fixes #13849