### PR TITLE
Fix Multipart cleanup in HttpChannelState

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -640,7 +640,8 @@ public class HttpChannelState implements HttpChannel, Components
             }
 
             // Clean up any multipart tmp files and release any associated resources.
-            if (_request.getAttribute(MultiPartFormData.Parts.class.getName()) instanceof MultiPartFormData.Parts parts)
+            MultiPartFormData.Parts parts = MultiPartFormData.getParts(_request);
+            if (parts != null)
                 parts.close();
 
             long idleTO = getHttpConfiguration().getIdleTimeout();


### PR DESCRIPTION
These changes were already made in https://github.com/jetty/jetty.project/pull/13481.

However it looks like this was recently reverted by a bad merge from 12.0.x -> 12.1.x of PR https://github.com/jetty/jetty.project/pull/13814 which now causes the tests to fail for `12.1.x`.