### PR TITLE
12.0.x: allow configuring the default max local streams on the H2 client

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-client/src/main/java/org/eclipse/jetty/http2/client/HTTP2Client.java
+++ b/jetty-core/jetty-http2/jetty-http2-client/src/main/java/org/eclipse/jetty/http2/client/HTTP2Client.java
@@ -322,6 +322,10 @@ public class HTTP2Client extends ContainerLifeCycle implements AutoCloseable
         return maxLocalStreams;
     }
 
+    /**
+     * @param maxLocalStreams the max number of local streams that can be opened,
+     * if the server does not send the max concurrent stream setting.
+     */
     public void setMaxLocalStreams(int maxLocalStreams)
     {
         this.maxLocalStreams = maxLocalStreams;

--- a/jetty-core/jetty-http2/jetty-http2-client/src/main/java/org/eclipse/jetty/http2/client/HTTP2Client.java
+++ b/jetty-core/jetty-http2/jetty-http2-client/src/main/java/org/eclipse/jetty/http2/client/HTTP2Client.java
@@ -110,6 +110,7 @@ public class HTTP2Client extends ContainerLifeCycle implements AutoCloseable
     private int initialStreamRecvWindow = 8 * 1024 * 1024;
     private int maxFrameSize = Frame.DEFAULT_MAX_SIZE;
     private int maxConcurrentPushedStreams = 32;
+    private int maxLocalStreams = -1;
     private int maxSettingsKeys = SettingsFrame.DEFAULT_MAX_KEYS;
     private int maxDecoderTableCapacity = HpackContext.DEFAULT_MAX_TABLE_CAPACITY;
     private int maxEncoderTableCapacity = HpackContext.DEFAULT_MAX_TABLE_CAPACITY;
@@ -313,6 +314,17 @@ public class HTTP2Client extends ContainerLifeCycle implements AutoCloseable
     public void setMaxConcurrentPushedStreams(int maxConcurrentPushedStreams)
     {
         this.maxConcurrentPushedStreams = maxConcurrentPushedStreams;
+    }
+
+    @ManagedAttribute("The maximum number of concurrent local streams")
+    public int getMaxLocalStreams()
+    {
+        return maxLocalStreams;
+    }
+
+    public void setMaxLocalStreams(int maxLocalStreams)
+    {
+        this.maxLocalStreams = maxLocalStreams;
     }
 
     @ManagedAttribute("The max number of keys in all SETTINGS frames")

--- a/jetty-core/jetty-http2/jetty-http2-client/src/main/java/org/eclipse/jetty/http2/client/HTTP2ClientConnectionFactory.java
+++ b/jetty-core/jetty-http2/jetty-http2-client/src/main/java/org/eclipse/jetty/http2/client/HTTP2ClientConnectionFactory.java
@@ -60,6 +60,7 @@ public class HTTP2ClientConnectionFactory implements ClientConnectionFactory
         parser.setMaxSettingsKeys(client.getMaxSettingsKeys());
 
         HTTP2ClientSession session = new HTTP2ClientSession(client.getScheduler(), endPoint, parser, generator, listener, flowControl);
+        session.setMaxLocalStreams(client.getMaxLocalStreams());
         session.setMaxRemoteStreams(client.getMaxConcurrentPushedStreams());
         session.setMaxEncoderTableCapacity(client.getMaxEncoderTableCapacity());
         long streamIdleTimeout = client.getStreamIdleTimeout();

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
@@ -17,6 +17,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.SocketAddress;
 import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -55,6 +56,7 @@ import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.http2.ErrorCode;
+import org.eclipse.jetty.http2.FlowControlStrategy;
 import org.eclipse.jetty.http2.HTTP2Connection;
 import org.eclipse.jetty.http2.HTTP2Session;
 import org.eclipse.jetty.http2.RateControl;
@@ -74,9 +76,11 @@ import org.eclipse.jetty.http2.frames.SettingsFrame;
 import org.eclipse.jetty.http2.generator.Generator;
 import org.eclipse.jetty.http2.hpack.HpackException;
 import org.eclipse.jetty.http2.parser.ServerParser;
+import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
 import org.eclipse.jetty.http2.server.RawHTTP2ServerConnectionFactory;
 import org.eclipse.jetty.io.ArrayByteBufferPool;
 import org.eclipse.jetty.io.ByteBufferPool;
+import org.eclipse.jetty.io.ClientConnectionFactory;
 import org.eclipse.jetty.io.ClientConnector;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.server.Handler;
@@ -84,6 +88,7 @@ import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.Promise;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.jupiter.api.Tag;
@@ -415,6 +420,52 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
         Stream stream = streamRef.get();
         assertNotNull(stream);
         assertEquals(lastStream.get(), stream.getId());
+    }
+
+    @Test
+    public void testSetMaxLocalStreams() throws Exception
+    {
+        HTTP2CServerConnectionFactory connectionFactory = new HTTP2CServerConnectionFactory();
+        connectionFactory.setInitialSessionRecvWindow(FlowControlStrategy.DEFAULT_WINDOW_SIZE);
+        connectionFactory.setInitialStreamRecvWindow(FlowControlStrategy.DEFAULT_WINDOW_SIZE);
+        prepareServer(connectionFactory);
+        server.setHandler(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
+            {
+                callback.succeeded();
+                return true;
+            }
+        });
+        server.start();
+
+        prepareClient();
+        http2Client.setMaxLocalStreams(777);
+        AtomicInteger configuredMaxLocalStreams = new AtomicInteger();
+        httpClient = new HttpClient(new HttpClientTransportOverHTTP2(http2Client)
+        {
+            @Override
+            protected void connect(SocketAddress address, ClientConnectionFactory factory, Session.Listener listener, Promise<Session> promise, Map<String, Object> context)
+            {
+                Promise<Session> p = new Promise.Wrapper<>(promise)
+                {
+                    @Override
+                    public void succeeded(Session result)
+                    {
+                        configuredMaxLocalStreams.set(((HTTP2Session)result).getMaxLocalStreams());
+                        super.succeeded(result);
+                    }
+                };
+                super.connect(address, factory, listener, p, context);
+            }
+        });
+        httpClient.start();
+
+        ContentResponse response = httpClient.newRequest("localhost", connector.getLocalPort())
+            .send();
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+        assertThat(configuredMaxLocalStreams.get(), is(777));
     }
 
     @Test


### PR DESCRIPTION
12.0.x backport of https://github.com/jetty/jetty.project/pull/13977

Closes https://github.com/jetty/jetty.project/issues/13976