### PR TITLE
Fixes #13962 - HTTP/2 Client connection timeout does not work.

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/ProxyProtocolClientConnectionFactory.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/ProxyProtocolClientConnectionFactory.java
@@ -496,7 +496,7 @@ public abstract class ProxyProtocolClientConnectionFactory extends ClientConnect
         @Override
         public void failed(Throwable x)
         {
-            close();
+            getEndPoint().close(x);
             Promise<?> promise = (Promise<?>)context.get(org.eclipse.jetty.client.Connection.PROMISE_CONTEXT_KEY);
             promise.failed(x);
         }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/NegotiatingClientConnection.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/NegotiatingClientConnection.java
@@ -16,10 +16,12 @@ package org.eclipse.jetty.io;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeoutException;
 import javax.net.ssl.SSLEngine;
 
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.ExceptionUtil;
+import org.eclipse.jetty.util.Promise;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -127,6 +129,18 @@ public abstract class NegotiatingClientConnection extends AbstractConnection.Non
             LOG.atDebug().setCause(x).log("Unable to replace connection");
             close();
         }
+    }
+
+    @Override
+    public boolean onIdleExpired(TimeoutException timeout)
+    {
+        getEndPoint().close(timeout);
+
+        @SuppressWarnings("unchecked")
+        Promise<Connection> promise = (Promise<Connection>)context.get(ClientConnector.CONNECTION_PROMISE_CONTEXT_KEY);
+        promise.failed(timeout);
+
+        return false;
     }
 
     @Override

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTransportDynamicTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTransportDynamicTest.java
@@ -13,12 +13,16 @@
 
 package org.eclipse.jetty.test.client.transport;
 
+import java.net.InetSocketAddress;
+import java.nio.channels.ServerSocketChannel;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
 import org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory;
@@ -62,6 +66,7 @@ import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.eclipse.jetty.client.ProxyProtocolClientConnectionFactory.V1;
@@ -779,5 +784,42 @@ public class HttpClientTransportDynamicTest
             .send());
 
         assertThat(failure.getCause(), instanceOf(HttpRequestException.class));
+    }
+
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+        http,  h1
+        http,  h2
+        http,  h1;h2
+        https, h1
+        https, h2
+        https, h1;h2
+        """)
+    public void testServerDoesNotAcceptConnections(String scheme, String protocols) throws Exception
+    {
+        try (ServerSocketChannel server = ServerSocketChannel.open())
+        {
+            // Bind but do not call accept().
+            server.bind(new InetSocketAddress("0.0.0.0", 0));
+            int port = ((InetSocketAddress)server.getLocalAddress()).getPort();
+
+            ClientConnector clientConnector = new ClientConnector();
+            List<ClientConnectionFactory.Info> infos = new ArrayList<>();
+            for (String protocol : protocols.split(";"))
+            {
+                if ("h1".equals(protocol))
+                    infos.add(HttpClientConnectionFactory.HTTP11);
+                if ("h2".equals(protocol))
+                {
+                    HTTP2Client http2Client = new HTTP2Client(clientConnector);
+                    ClientConnectionFactory.Info http2 = new ClientConnectionFactoryOverHTTP2.HTTP2(http2Client);
+                    infos.add(http2);
+                }
+            }
+            startClient(clientConnector, infos.toArray(ClientConnectionFactory.Info[]::new));
+            client.setIdleTimeout(1000);
+
+            assertThrows(TimeoutException.class, () -> client.GET(scheme + "://localhost:" + port));
+        }
     }
 }


### PR DESCRIPTION
The problem was that ALPNClientConnection, which is set up when using a HttpClientTransportDynamic with h1 and h2, does not properly override onIdleExpired().

Fixed by overriding onIdleExpired() and failing the connection promise, so that the error is reported to the application.