### PR TITLE
Fix cookie-config web.xml attributes when used with quickstart

### DIFF
--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Response.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Response.java
@@ -1494,7 +1494,7 @@ public class Response implements HttpServletResponse
         }
     }
 
-    protected static class HttpCookieFacade implements HttpCookie
+    public static class HttpCookieFacade implements HttpCookie
     {
         private final Cookie _cookie;
         private final String _comment;
@@ -1617,17 +1617,17 @@ public class Response implements HttpServletResponse
             return HttpCookie.toString(this);
         }
 
-        private static boolean isHttpOnlyInComment(String comment)
+        public static boolean isHttpOnlyInComment(String comment)
         {
             return comment != null && comment.contains(HTTP_ONLY_COMMENT);
         }
 
-        protected static boolean isPartitionedInComment(String comment)
+        public static boolean isPartitionedInComment(String comment)
         {
             return comment != null && comment.contains(PARTITIONED_COMMENT);
         }
 
-        protected static SameSite getSameSiteFromComment(String comment)
+        public static SameSite getSameSiteFromComment(String comment)
         {
             if (comment == null)
                 return null;
@@ -1640,7 +1640,7 @@ public class Response implements HttpServletResponse
             return null;
         }
 
-        protected static String getCommentWithoutAttributes(String comment)
+        public static String getCommentWithoutAttributes(String comment)
         {
             if (comment == null)
                 return null;
@@ -1654,6 +1654,44 @@ public class Response implements HttpServletResponse
             strippedComment = StringUtil.strip(strippedComment, SAME_SITE_STRICT_COMMENT);
 
             return strippedComment.isEmpty() ? null : strippedComment;
+        }
+
+        public static String getCommentWithAttributes(String comment, boolean isPartitioned, HttpCookie.SameSite sameSite)
+        {
+            if (comment == null && sameSite == null)
+                return null;
+
+            StringBuilder builder = new StringBuilder();
+            if (StringUtil.isNotBlank(comment))
+            {
+                comment = getCommentWithoutAttributes(comment);
+                if (StringUtil.isNotBlank(comment))
+                    builder.append(comment);
+            }
+            if (isPartitioned)
+                builder.append(PARTITIONED_COMMENT);
+
+            if (sameSite != null)
+            {
+                switch (sameSite)
+                {
+                    case NONE:
+                        builder.append(SAME_SITE_NONE_COMMENT);
+                        break;
+                    case STRICT:
+                        builder.append(SAME_SITE_STRICT_COMMENT);
+                        break;
+                    case LAX:
+                        builder.append(SAME_SITE_LAX_COMMENT);
+                        break;
+                    default:
+                        throw new IllegalArgumentException(sameSite.toString());
+                }
+            }
+
+            if (builder.isEmpty())
+                return null;
+            return builder.toString();
         }
     }
 }

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/SessionHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/SessionHandler.java
@@ -684,9 +684,13 @@ public class SessionHandler extends ScopedHandler implements SessionConfig.Mutab
 
                 boolean partitioned = Response.HttpCookieFacade.isPartitionedInComment(comment);
                 if (partitioned)
-                    _sessionManager.setPartitioned(partitioned);
+                    _sessionManager.setPartitioned(true);
 
-                _sessionManager.setSessionComment(comment);
+                boolean httpOnly = Response.HttpCookieFacade.isHttpOnlyInComment(comment);
+                if (httpOnly)
+                    _sessionManager.setHttpOnly(true);
+
+                _sessionManager.setSessionComment(Response.HttpCookieFacade.getCommentWithoutAttributes(comment));
             }
         }
 

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/SessionHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/SessionHandler.java
@@ -686,7 +686,7 @@ public class SessionHandler extends ScopedHandler implements SessionConfig.Mutab
                 if (partitioned)
                     _sessionManager.setPartitioned(partitioned);
 
-                _sessionManager.setSessionComment(Response.HttpCookieFacade.getCommentWithoutAttributes(comment));
+                _sessionManager.setSessionComment(comment);
             }
         }
 

--- a/jetty-ee9/jetty-ee9-quickstart/src/main/java/org/eclipse/jetty/ee9/quickstart/QuickStartGeneratorConfiguration.java
+++ b/jetty-ee9/jetty-ee9-quickstart/src/main/java/org/eclipse/jetty/ee9/quickstart/QuickStartGeneratorConfiguration.java
@@ -33,6 +33,7 @@ import jakarta.servlet.descriptor.JspPropertyGroupDescriptor;
 import jakarta.servlet.descriptor.TaglibDescriptor;
 import org.eclipse.jetty.ee9.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.ee9.nested.ServletConstraint;
+import org.eclipse.jetty.ee9.nested.SessionHandler;
 import org.eclipse.jetty.ee9.security.Authenticator;
 import org.eclipse.jetty.ee9.security.ConstraintAware;
 import org.eclipse.jetty.ee9.security.ConstraintMapping;
@@ -64,6 +65,8 @@ import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.xml.XmlAppendable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.eclipse.jetty.ee9.nested.Response.HttpCookieFacade.getCommentWithAttributes;
 
 /**
  * QuickStartGeneratorConfiguration
@@ -424,14 +427,15 @@ public class QuickStartGeneratorConfiguration extends AbstractConfiguration
         }
 
         //session-config
-        if (context.getSessionHandler() != null)
+        SessionHandler sessionHandler = context.getSessionHandler();
+        if (sessionHandler != null)
         {
             out.openTag("session-config");
-            int maxInactiveSec = context.getSessionHandler().getMaxInactiveInterval();
+            int maxInactiveSec = sessionHandler.getMaxInactiveInterval();
             out.tag("session-timeout", (maxInactiveSec == 0 ? "0" : Integer.toString(maxInactiveSec / 60)));
 
             //cookie-config
-            SessionCookieConfig cookieConfig = context.getSessionHandler().getSessionCookieConfig();
+            SessionCookieConfig cookieConfig = sessionHandler.getSessionCookieConfig();
             if (cookieConfig != null)
             {
                 out.openTag("cookie-config");
@@ -445,8 +449,9 @@ public class QuickStartGeneratorConfiguration extends AbstractConfiguration
                 if (cookieConfig.getPath() != null)
                     out.tag("path", origin(md, "cookie-config.path"), cookieConfig.getPath());
 
-                if (cookieConfig.getComment() != null)
-                    out.tag("comment", origin(md, "cookie-config.comment"), cookieConfig.getComment());
+                String comment = getCommentWithAttributes(cookieConfig.getComment(), sessionHandler.isPartitioned(), sessionHandler.getSameSite());
+                if (comment != null)
+                    out.tag("comment", origin(md, "cookie-config.comment"), comment);
 
                 out.tag("http-only", origin(md, "cookie-config.http-only"), Boolean.toString(cookieConfig.isHttpOnly()));
                 out.tag("secure", origin(md, "cookie-config.secure"), Boolean.toString(cookieConfig.isSecure()));
@@ -455,7 +460,7 @@ public class QuickStartGeneratorConfiguration extends AbstractConfiguration
             }
 
             // tracking-modes
-            Set<SessionTrackingMode> modes = context.getSessionHandler().getEffectiveSessionTrackingModes();
+            Set<SessionTrackingMode> modes = sessionHandler.getEffectiveSessionTrackingModes();
             if (modes != null)
             {
                 for (SessionTrackingMode mode : modes)

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-quickstart/src/test/java/org/eclipse/jetty/ee9/quickstart/QuickStartTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-quickstart/src/test/java/org/eclipse/jetty/ee9/quickstart/QuickStartTest.java
@@ -309,12 +309,9 @@ public class QuickStartTest
 
         Path quickStartXml = target.resolve("WEB-INF/quickstart-web.xml");
         String quickStartContents = Files.readString(quickStartXml);
-        System.err.println(quickStartContents);
         assertThat(quickStartContents, containsString("""
                 <cookie-config>
-                    <name>JSESSIONID</name>
-                    <comment>__SAME_SITE_NONE__foo</comment>
+                  <comment>__SAME_SITE_NONE__foo</comment>
             """));
     }
-
 }

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-quickstart/src/test/java/org/eclipse/jetty/ee9/quickstart/QuickStartTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-quickstart/src/test/java/org/eclipse/jetty/ee9/quickstart/QuickStartTest.java
@@ -311,7 +311,7 @@ public class QuickStartTest
         String quickStartContents = Files.readString(quickStartXml);
         assertThat(quickStartContents, containsString("""
                 <cookie-config>
-                  <comment>__SAME_SITE_NONE__foo</comment>
+                  <comment>foo__SAME_SITE_NONE__</comment>
             """));
     }
 }

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-quickstart/src/test/java/org/eclipse/jetty/ee9/quickstart/QuickStartTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-quickstart/src/test/java/org/eclipse/jetty/ee9/quickstart/QuickStartTest.java
@@ -291,4 +291,30 @@ public class QuickStartTest
               </filter-mapping>
             """));
     }
+
+    @Test
+    public void testSameSiteCookie() throws Exception
+    {
+        Path workdir = MavenPaths.targetTestDir(PreconfigureSpecWar.class.getSimpleName());
+        FS.ensureEmpty(workdir);
+        Path target = workdir.resolve("test-cookie_samesite");
+        FS.ensureEmpty(target);
+        FS.ensureDirExists(target.resolve("WEB-INF"));
+
+        Path sourceWebXml = MavenPaths.findTestResourceFile("cookie-web.xml");
+        Files.copy(sourceWebXml, target.resolve("WEB-INF/web.xml"));
+        System.setProperty("jetty.home", target.toString());
+
+        PreconfigureQuickStartWar.main(target.toString());
+
+        Path quickStartXml = target.resolve("WEB-INF/quickstart-web.xml");
+        String quickStartContents = Files.readString(quickStartXml);
+        System.err.println(quickStartContents);
+        assertThat(quickStartContents, containsString("""
+                <cookie-config>
+                    <name>JSESSIONID</name>
+                    <comment>__SAME_SITE_NONE__foo</comment>
+            """));
+    }
+
 }

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-quickstart/src/test/resources/cookie-web.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-quickstart/src/test/resources/cookie-web.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app
+  xmlns="https://jakarta.ee/xml/ns/jakartaee"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
+  version="5.0">
+
+  <session-config>
+    <cookie-config>
+      <http-only>true</http-only>
+      <comment>__SAME_SITE_NONE__foo</comment>
+    </cookie-config>
+  </session-config>
+
+</web-app>


### PR DESCRIPTION
## Issue #14016

In PR https://github.com/jetty/jetty.project/pull/12263 the method `Response.HttpCookieFacade.getCommentWithoutAttributes(comment)` was used to filter out any `CookieConfig` attributes when setting the comment.

However this breaks its usage with quickstart because the comment attributes are lost in the `quickstart-web.xml`.