### PR TITLE
12.1 Downgrade Maven build cache version as 1.2.1 is failing some builds 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
     <mariadb.docker.version>10.3.6</mariadb.docker.version>
     <mariadb.version>3.5.6</mariadb.version>
     <maven-artifact-transfer.version>0.13.1</maven-artifact-transfer.version>
-    <maven-build-cache.version>1.2.1</maven-build-cache.version>
+    <maven-build-cache.version>1.2.0</maven-build-cache.version>
     <maven-plugin.plugin.version>3.15.2</maven-plugin.plugin.version>
     <maven.antrun.plugin.version>3.2.0</maven.antrun.plugin.version>
     <maven.assembly.plugin.version>3.7.1</maven.assembly.plugin.version>


### PR DESCRIPTION
Error 
```
Caused by: org.apache.maven.project.DependencyResolutionException: Could not resolve dependencies for project org.eclipse.jetty:jetty-home:pom:12.1.5-SNAPSHOT
dependency: org.eclipse.jetty.ee11:jetty-ee11-home:zip:12.1.5-SNAPSHOT (compile)
	Could not find artifact org.eclipse.jetty.ee11:jetty-ee11-home:zip:12.1.5-SNAPSHOT in private-nexus (http://10.0.0.15:8081/repository/maven-public/)
dependency: org.eclipse.jetty.ee10:jetty-ee10-home:zip:12.1.5-SNAPSHOT (compile)
	Could not find artifact org.eclipse.jetty.ee10:jetty-ee10-home:zip:12.1.5-SNAPSHOT in private-nexus (http://10.0.0.15:8081/repository/maven-public/)
dependency: org.eclipse.jetty.ee9:jetty-ee9-home:zip:12.1.5-SNAPSHOT (compile)
	Could not find artifact org.eclipse.jetty.ee9:jetty-ee9-home:zip:12.1.5-SNAPSHOT in private-nexus (http://10.0.0.15:8081/repository/maven-public/)
```
for some reason version 1.2.1 of the Maven build cache extension is trying to download some artifacts which are produced by the reactor.

Possible culprit: https://github.com/apache/maven-build-cache-extension/pull/379


Signed-off-by: Olivier Lamy <olamy@apache.org>
