### PR TITLE
Fix loop caused by `NegotiatingClientConnection` talking to broken server

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/BrokenServerNegotiationTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/BrokenServerNegotiationTest.java
@@ -17,8 +17,6 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import javax.net.ssl.SSLHandshakeException;
 
 import org.eclipse.jetty.client.HttpClient;
@@ -26,30 +24,32 @@ import org.eclipse.jetty.client.transport.HttpClientConnectionFactory;
 import org.eclipse.jetty.client.transport.HttpClientTransportDynamic;
 import org.eclipse.jetty.http2.client.HTTP2Client;
 import org.eclipse.jetty.http2.client.transport.ClientConnectionFactoryOverHTTP2;
+import org.eclipse.jetty.http2.client.transport.HttpClientTransportOverHTTP2;
 import org.eclipse.jetty.io.ClientConnectionFactory;
 import org.eclipse.jetty.io.ClientConnector;
 import org.eclipse.jetty.util.component.LifeCycle;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.awaitility.Awaitility.await;
-import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BrokenServerNegotiationTest
 {
-    @Test
-    public void testAlpnNegociationWithBrokenServer() throws Exception
+    private volatile ServerSocket serverSocket;
+
+    public int startServer() throws Exception
     {
-        AtomicReference<ServerSocket> serverSocketRef = new AtomicReference<>();
-        AtomicInteger port = new AtomicInteger();
+        if (serverSocket != null)
+            return serverSocket.getLocalPort();
         Thread server = new Thread(() ->
         {
             try
             {
-                ServerSocket serverSocket = new ServerSocket(0);
-                serverSocketRef.set(serverSocket);
-                port.set(serverSocket.getLocalPort());
+                serverSocket = new ServerSocket(0);
                 while (true)
                 {
                     Socket accept = serverSocket.accept();
@@ -62,20 +62,51 @@ public class BrokenServerNegotiationTest
             }
         });
         server.start();
-        await().atMost(5, TimeUnit.SECONDS).until(port::get, greaterThan(0));
+        await().atMost(5, TimeUnit.SECONDS).until(() -> serverSocket, notNullValue());
+        return serverSocket.getLocalPort();
+    }
 
+    @AfterEach
+    public void stopServer() throws Exception
+    {
+        if (serverSocket != null)
+            serverSocket.close();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testAlpnNegotiation(boolean useAlpn) throws Exception
+    {
+        int port = startServer();
         ClientConnector clientConnector = new ClientConnector();
         HTTP2Client h2Client = new HTTP2Client();
+        h2Client.setUseALPN(useAlpn);
         ClientConnectionFactoryOverHTTP2.HTTP2 http2 = new ClientConnectionFactoryOverHTTP2.HTTP2(h2Client);
         ClientConnectionFactory.Info http1 = HttpClientConnectionFactory.HTTP11;
         HttpClientTransportDynamic transportDynamic = new HttpClientTransportDynamic(clientConnector, http1,  http2);
         HttpClient client = new HttpClient(transportDynamic);
         client.start();
 
-        ExecutionException ee = assertThrows(ExecutionException.class, () -> client.GET("https://localhost:" + port.get() + "/hello"));
+        ExecutionException ee = assertThrows(ExecutionException.class, () -> client.GET("https://localhost:" + port + "/hello"));
         assertInstanceOf(SSLHandshakeException.class, ee.getCause());
 
         LifeCycle.stop(client);
-        serverSocketRef.get().close();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testH2Only(boolean useAlpn) throws Exception
+    {
+        int port = startServer();
+        HTTP2Client h2Client = new HTTP2Client();
+        h2Client.setUseALPN(useAlpn);
+        HttpClientTransportOverHTTP2 httpClientTransportOverHTTP2 = new HttpClientTransportOverHTTP2(h2Client);
+        HttpClient client = new HttpClient(httpClientTransportOverHTTP2);
+        client.start();
+
+        ExecutionException ee = assertThrows(ExecutionException.class, () -> client.GET("https://localhost:" + port + "/hello"));
+        assertInstanceOf(SSLHandshakeException.class, ee.getCause());
+
+        LifeCycle.stop(client);
     }
 }

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/BrokenServerNegotiationTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/BrokenServerNegotiationTest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.jetty.http2.tests;
 
+import javax.net.ssl.SSLHandshakeException;
+
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.concurrent.ExecutionException;
@@ -73,7 +75,7 @@ public class BrokenServerNegotiationTest
         client.start();
 
         ExecutionException ee = assertThrows(ExecutionException.class, () -> client.GET("https://localhost:" + port.get() + "/hello"));
-        assertInstanceOf(EofException.class, ee.getCause());
+        assertInstanceOf(SSLHandshakeException.class, ee.getCause());
 
         LifeCycle.stop(client);
         serverSocketRef.get().close();

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/BrokenServerNegotiationTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/BrokenServerNegotiationTest.java
@@ -19,6 +19,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.transport.HttpClientConnectionFactory;
 import org.eclipse.jetty.client.transport.HttpClientTransportDynamic;

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/BrokenServerNegotiationTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/BrokenServerNegotiationTest.java
@@ -1,0 +1,80 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.http2.tests;
+
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.transport.HttpClientConnectionFactory;
+import org.eclipse.jetty.client.transport.HttpClientTransportDynamic;
+import org.eclipse.jetty.http2.client.HTTP2Client;
+import org.eclipse.jetty.http2.client.transport.ClientConnectionFactoryOverHTTP2;
+import org.eclipse.jetty.io.ClientConnectionFactory;
+import org.eclipse.jetty.io.ClientConnector;
+import org.eclipse.jetty.io.EofException;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.junit.jupiter.api.Test;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class BrokenServerNegotiationTest
+{
+    @Test
+    public void testAlpnNegociationWithBrokenServer() throws Exception
+    {
+        AtomicReference<ServerSocket> serverSocketRef = new AtomicReference<>();
+        AtomicInteger port = new AtomicInteger();
+        Thread server = new Thread(() ->
+        {
+            try
+            {
+                ServerSocket serverSocket = new ServerSocket(0);
+                serverSocketRef.set(serverSocket);
+                port.set(serverSocket.getLocalPort());
+                while (true)
+                {
+                    Socket accept = serverSocket.accept();
+                    accept.close();
+                }
+            }
+            catch (Exception e)
+            {
+                // ignore, time to shut down
+            }
+        });
+        server.start();
+        await().atMost(5, TimeUnit.SECONDS).until(port::get, greaterThan(0));
+
+        ClientConnector clientConnector = new ClientConnector();
+        HTTP2Client h2Client = new HTTP2Client();
+        ClientConnectionFactoryOverHTTP2.HTTP2 http2 = new ClientConnectionFactoryOverHTTP2.HTTP2(h2Client);
+        ClientConnectionFactory.Info http1 = HttpClientConnectionFactory.HTTP11;
+        HttpClientTransportDynamic transportDynamic = new HttpClientTransportDynamic(clientConnector, http1,  http2);
+        HttpClient client = new HttpClient(transportDynamic);
+        client.start();
+
+        ExecutionException ee = assertThrows(ExecutionException.class, () -> client.GET("https://localhost:" + port.get() + "/hello"));
+        assertInstanceOf(EofException.class, ee.getCause());
+
+        LifeCycle.stop(client);
+        serverSocketRef.get().close();
+    }
+}

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/BrokenServerNegotiationTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/BrokenServerNegotiationTest.java
@@ -13,14 +13,13 @@
 
 package org.eclipse.jetty.http2.tests;
 
-import javax.net.ssl.SSLHandshakeException;
-
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.net.ssl.SSLHandshakeException;
 
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.transport.HttpClientConnectionFactory;
@@ -29,7 +28,6 @@ import org.eclipse.jetty.http2.client.HTTP2Client;
 import org.eclipse.jetty.http2.client.transport.ClientConnectionFactoryOverHTTP2;
 import org.eclipse.jetty.io.ClientConnectionFactory;
 import org.eclipse.jetty.io.ClientConnector;
-import org.eclipse.jetty.io.EofException;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.junit.jupiter.api.Test;
 

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/NegotiatingClientConnection.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/NegotiatingClientConnection.java
@@ -99,8 +99,7 @@ public abstract class NegotiatingClientConnection extends AbstractConnection.Non
                 }
                 else if (filled < 0)
                 {
-                    failure = new SSLHandshakeException("Abruptly closed by peer");
-                    break;
+                    throw new SSLHandshakeException("Abruptly closed by peer");
                 }
                 else if (filled == 0)
                 {

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/NegotiatingClientConnection.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/NegotiatingClientConnection.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.io;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeoutException;
@@ -20,7 +21,6 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLHandshakeException;
 
 import org.eclipse.jetty.util.BufferUtil;
-import org.eclipse.jetty.util.ExceptionUtil;
 import org.eclipse.jetty.util.Promise;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,7 +61,7 @@ public abstract class NegotiatingClientConnection extends AbstractConnection.Non
     protected void completed(String protocol)
     {
         this.protocol = protocol;
-        completed = true;
+        this.completed = true;
     }
 
     @Override
@@ -79,8 +79,7 @@ public abstract class NegotiatingClientConnection extends AbstractConnection.Non
         catch (Throwable x)
         {
             close();
-            // TODO: should we not fail the promise in the context here?
-            throw ExceptionUtil.asRuntimeException(x);
+            failConnectionPromise(x);
         }
     }
 
@@ -98,7 +97,7 @@ public abstract class NegotiatingClientConnection extends AbstractConnection.Non
                     replaceConnection();
                     break;
                 }
-                if (filled < 0)
+                else if (filled < 0)
                 {
                     failure = new SSLHandshakeException("Abruptly closed by peer");
                     break;
@@ -119,23 +118,7 @@ public abstract class NegotiatingClientConnection extends AbstractConnection.Non
         {
             LOG.atDebug().setCause(failure).log("Unable to fill from endpoint");
             close();
-            @SuppressWarnings("unchecked")
-            Promise<Connection> promise = (Promise<Connection>)context.get(ClientConnector.CONNECTION_PROMISE_CONTEXT_KEY);
-            promise.failed(failure);
-        }
-    }
-
-    private void replaceConnection()
-    {
-        EndPoint endPoint = getEndPoint();
-        try
-        {
-            endPoint.upgrade(connectionFactory.newConnection(endPoint, context));
-        }
-        catch (Throwable x)
-        {
-            LOG.atDebug().setCause(x).log("Unable to replace connection");
-            close();
+            failConnectionPromise(failure);
         }
     }
 
@@ -143,11 +126,7 @@ public abstract class NegotiatingClientConnection extends AbstractConnection.Non
     public boolean onIdleExpired(TimeoutException timeout)
     {
         getEndPoint().close(timeout);
-
-        @SuppressWarnings("unchecked")
-        Promise<Connection> promise = (Promise<Connection>)context.get(ClientConnector.CONNECTION_PROMISE_CONTEXT_KEY);
-        promise.failed(timeout);
-
+        failConnectionPromise(timeout);
         return false;
     }
 
@@ -157,5 +136,17 @@ public abstract class NegotiatingClientConnection extends AbstractConnection.Non
         // Gentler close for SSL.
         getEndPoint().shutdownOutput();
         super.close();
+    }
+
+    private void replaceConnection() throws IOException
+    {
+        getEndPoint().upgrade(connectionFactory.newConnection(getEndPoint(), context));
+    }
+
+    private void failConnectionPromise(Throwable failure)
+    {
+        @SuppressWarnings("unchecked")
+        Promise<Connection> promise = (Promise<Connection>)context.get(ClientConnector.CONNECTION_PROMISE_CONTEXT_KEY);
+        promise.failed(failure);
     }
 }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/NegotiatingClientConnection.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/NegotiatingClientConnection.java
@@ -140,7 +140,8 @@ public abstract class NegotiatingClientConnection extends AbstractConnection.Non
 
     private void replaceConnection() throws IOException
     {
-        getEndPoint().upgrade(connectionFactory.newConnection(getEndPoint(), context));
+        EndPoint endPoint = getEndPoint();
+        endPoint.upgrade(connectionFactory.newConnection(endPoint, context));
     }
 
     private void failConnectionPromise(Throwable failure)

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/NegotiatingClientConnection.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/NegotiatingClientConnection.java
@@ -13,11 +13,11 @@
 
 package org.eclipse.jetty.io;
 
-import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeoutException;
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLHandshakeException;
 
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.ExceptionUtil;
@@ -87,40 +87,41 @@ public abstract class NegotiatingClientConnection extends AbstractConnection.Non
     @Override
     public void onFillable()
     {
-        while (true)
-        {
-            int filled = fill();
-            if (completed)
-            {
-                replaceConnection();
-                break;
-            }
-            if (filled < 0)
-            {
-                @SuppressWarnings("unchecked")
-                Promise<Connection> promise = (Promise<Connection>)context.get(ClientConnector.CONNECTION_PROMISE_CONTEXT_KEY);
-                promise.failed(new EofException());
-                break;
-            }
-            else if (filled == 0)
-            {
-                fillInterested();
-                break;
-            }
-        }
-    }
-
-    private int fill()
-    {
+        Throwable failure = null;
         try
         {
-            return getEndPoint().fill(BufferUtil.EMPTY_BUFFER);
+            while (true)
+            {
+                int filled = getEndPoint().fill(BufferUtil.EMPTY_BUFFER);
+                if (completed)
+                {
+                    replaceConnection();
+                    break;
+                }
+                if (filled < 0)
+                {
+                    failure = new SSLHandshakeException("Abruptly closed by peer");
+                    break;
+                }
+                else if (filled == 0)
+                {
+                    fillInterested();
+                    break;
+                }
+            }
         }
-        catch (IOException x)
+        catch (Throwable x)
         {
-            LOG.atDebug().setCause(x).log("Unable to fill from endpoint");
+            failure = x;
+        }
+
+        if (failure != null)
+        {
+            LOG.atDebug().setCause(failure).log("Unable to fill from endpoint");
             close();
-            return -1;
+            @SuppressWarnings("unchecked")
+            Promise<Connection> promise = (Promise<Connection>)context.get(ClientConnector.CONNECTION_PROMISE_CONTEXT_KEY);
+            promise.failed(failure);
         }
     }
 

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/NegotiatingClientConnection.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/NegotiatingClientConnection.java
@@ -90,12 +90,19 @@ public abstract class NegotiatingClientConnection extends AbstractConnection.Non
         while (true)
         {
             int filled = fill();
-            if (completed || filled < 0)
+            if (completed)
             {
                 replaceConnection();
                 break;
             }
-            if (filled == 0)
+            if (filled < 0)
+            {
+                @SuppressWarnings("unchecked")
+                Promise<Connection> promise = (Promise<Connection>)context.get(ClientConnector.CONNECTION_PROMISE_CONTEXT_KEY);
+                promise.failed(new EofException());
+                break;
+            }
+            else if (filled == 0)
             {
                 fillInterested();
                 break;


### PR DESCRIPTION
Currently, when the client is configured to negotiate via ALPN which protocol to use but the server immediately closes the connection, the client mistakenly retries connecting to the server.

Immediately fail the promise instead to notify the client that the connection failed.

Fixes #13964