### PR TITLE
Add missing locale to `String.toLowerCase()` calls in `MimeTypes`

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MimeTypes.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MimeTypes.java
@@ -46,9 +46,9 @@ public class MimeTypes
 {
     static final  Logger LOG = LoggerFactory.getLogger(MimeTypes.class);
     private static final Set<Locale> KNOWN_LOCALES = Set.copyOf(Arrays.stream(Locale.getAvailableLocales()).filter(l -> !StringUtil.isBlank(l.getLanguage())).toList());
-    public static final String ISO_8859_1 = StandardCharsets.ISO_8859_1.name().toLowerCase();
-    public static final String UTF8 = StandardCharsets.UTF_8.name().toLowerCase();
-    public static final String UTF16 = StandardCharsets.UTF_16.name().toLowerCase();
+    public static final String ISO_8859_1 = StandardCharsets.ISO_8859_1.name().toLowerCase(Locale.ENGLISH);
+    public static final String UTF8 = StandardCharsets.UTF_8.name().toLowerCase(Locale.ENGLISH);
+    public static final String UTF16 = StandardCharsets.UTF_16.name().toLowerCase(Locale.ENGLISH);
     private static final Index<String> CHARSETS = new Index.Builder<String>()
         .caseSensitive(false)
         .with("utf-8", UTF8)


### PR DESCRIPTION
This avoids any encoding when configuring the JVM with an obscure locale like `-Duser.language=az`.

Fixes #14097