### PR TITLE
Improve buffer pools stats and dump

### DIFF
--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -272,11 +272,10 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
         {
             key = 0;
         }
-        Throwable acquireStack = new Throwable("Acquired by " + Thread.currentThread().getName());
         map.compute(key, (k, v) ->
         {
             if (v == null)
-                return new NoBucketData(1L, acquireStack);
+                return new NoBucketData(1L, isStatisticsEnabled() ? new Throwable("Acquired by " + Thread.currentThread().getName()) : null);
             // incrementing the volatile is fine as this lambda is only ever
             // called by a single thread at a time, as guaranteed by CHM.compute().
             v.counter++;
@@ -569,6 +568,8 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
         @Override
         public String toString()
         {
+            if (acquireStack == null)
+                return Long.toString(counter);
             StringWriter w = new StringWriter();
             PrintWriter pw = new PrintWriter(w);
             acquireStack.printStackTrace(pw);

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -664,7 +664,7 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
         @Override
         public String toString()
         {
-            return String.format("%s@%x[%s]", TypeUtil.toShortName(this.getClass()), hashCode(), getStatistics());
+            return String.format("%s@%x[stats=%s,pool=%s]", TypeUtil.toShortName(this.getClass()), hashCode(), getStatistics(), _pool);
         }
 
         private record Statistics(int capacity, int inUseEntries, int totalEntries, long pooled, long acquires,

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -275,9 +275,7 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
         {
             if (v == null)
                 return new NoBucketData(1L, isStatisticsEnabled() ? new Throwable("Acquired by " + Thread.currentThread().getName()) : null);
-            // incrementing the volatile is fine as this lambda is only ever
-            // called by a single thread at a time, as guaranteed by CHM.compute().
-            v.counter++;
+            v.counter.incrementAndGet();
             return v;
         });
     }
@@ -507,7 +505,7 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
     private Map<Integer, Long> getNoBucketAcquires(boolean direct)
     {
         ConcurrentMap<Integer, NoBucketData> map = direct ? _noBucketDirectAcquires : _noBucketIndirectAcquires;
-        return map.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().counter));
+        return map.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().counter.get()));
     }
 
     @ManagedOperation(value = "Clears this ByteBufferPool", impact = "ACTION")
@@ -555,12 +553,12 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
 
     private static class NoBucketData
     {
-        private volatile long counter;
+        private final AtomicLong counter;
         private final Throwable acquireStack;
 
         private NoBucketData(long counter, Throwable acquireStack)
         {
-            this.counter = counter;
+            this.counter = new AtomicLong(counter);
             this.acquireStack = acquireStack;
         }
 
@@ -568,7 +566,7 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
         public String toString()
         {
             if (acquireStack == null)
-                return Long.toString(counter);
+                return Long.toString(counter.get());
             StringWriter w = new StringWriter();
             PrintWriter pw = new PrintWriter(w);
             acquireStack.printStackTrace(pw);

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -260,18 +260,23 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
 
     private void recordNoBucketAcquire(int size, boolean direct)
     {
+        ConcurrentMap<Integer, Long> map = direct ? _noBucketDirectAcquires : _noBucketIndirectAcquires;
+        int key;
         if (isStatisticsEnabled())
         {
-            ConcurrentMap<Integer, Long> map = direct ? _noBucketDirectAcquires : _noBucketIndirectAcquires;
             int idx = _bucketIndexFor.applyAsInt(size);
-            int key = _bucketCapacityFor.applyAsInt(idx);
-            map.compute(key, (k, v) ->
-            {
-                if (v == null)
-                    return 1L;
-                return v + 1L;
-            });
+            key = _bucketCapacityFor.applyAsInt(idx);
         }
+        else
+        {
+            key = 0;
+        }
+        map.compute(key, (k, v) ->
+        {
+            if (v == null)
+                return 1L;
+            return v + 1L;
+        });
     }
 
     private void reserve(RetainedBucket bucket, ByteBuffer byteBuffer)

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -1005,6 +1005,21 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
                 .collect(Collectors.joining(System.lineSeparator()));
         }
 
+        @Override
+        public void dump(Appendable out, String indent) throws IOException
+        {
+            Dumpable.dumpObjects(
+                out,
+                indent,
+                this,
+                DumpableCollection.fromArray("direct", ((ArrayByteBufferPool)this)._direct),
+                new DumpableMap("direct non-pooled acquisitions", ((ArrayByteBufferPool)this)._noBucketDirectAcquires),
+                DumpableCollection.fromArray("indirect", ((ArrayByteBufferPool)this)._indirect),
+                new DumpableMap("heap non-pooled acquisitions", ((ArrayByteBufferPool)this)._noBucketIndirectAcquires),
+                DumpableCollection.from("leaks", getLeaks().stream().map(TrackedBuffer::dump).toList())
+            );
+        }
+
         public class TrackedBuffer extends RetainableByteBuffer.FixedCapacity
         {
             private final int size;

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Function;
 import java.util.function.IntUnaryOperator;
 import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
@@ -78,8 +79,8 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
     private final IntUnaryOperator _bucketCapacityFor;
     private final AtomicBoolean _evictor = new AtomicBoolean(false);
     private final AtomicLong _reserved = new AtomicLong();
-    private final ConcurrentMap<Integer, Long> _noBucketDirectAcquires = new ConcurrentHashMap<>();
-    private final ConcurrentMap<Integer, Long> _noBucketIndirectAcquires = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Integer, NoBucketData> _noBucketDirectAcquires = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Integer, NoBucketData> _noBucketIndirectAcquires = new ConcurrentHashMap<>();
     private boolean _statisticsEnabled;
 
     /**
@@ -260,7 +261,7 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
 
     private void recordNoBucketAcquire(int size, boolean direct)
     {
-        ConcurrentMap<Integer, Long> map = direct ? _noBucketDirectAcquires : _noBucketIndirectAcquires;
+        ConcurrentMap<Integer, NoBucketData> map = direct ? _noBucketDirectAcquires : _noBucketIndirectAcquires;
         int key;
         if (isStatisticsEnabled())
         {
@@ -271,11 +272,15 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
         {
             key = 0;
         }
+        Throwable acquireStack = new Throwable("Acquired by " + Thread.currentThread().getName());
         map.compute(key, (k, v) ->
         {
             if (v == null)
-                return 1L;
-            return v + 1L;
+                return new NoBucketData(1L, acquireStack);
+            // incrementing the volatile is fine as this lambda is only ever
+            // called by a single thread at a time, as guaranteed by CHM.compute().
+            v.counter++;
+            return v;
         });
     }
 
@@ -503,7 +508,8 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
 
     private Map<Integer, Long> getNoBucketAcquires(boolean direct)
     {
-        return new HashMap<>(direct ? _noBucketDirectAcquires : _noBucketIndirectAcquires);
+        ConcurrentMap<Integer, NoBucketData> map = direct ? _noBucketDirectAcquires : _noBucketIndirectAcquires;
+        return map.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().counter));
     }
 
     @ManagedOperation(value = "Clears this ByteBufferPool", impact = "ACTION")
@@ -547,6 +553,27 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
             _direct.length,
             getHeapMemory(), _maxHeapMemory,
             getDirectMemory(), _maxDirectMemory);
+    }
+
+    private static class NoBucketData
+    {
+        private volatile long counter;
+        private final Throwable acquireStack;
+
+        private NoBucketData(long counter, Throwable acquireStack)
+        {
+            this.counter = counter;
+            this.acquireStack = acquireStack;
+        }
+
+        @Override
+        public String toString()
+        {
+            StringWriter w = new StringWriter();
+            PrintWriter pw = new PrintWriter(w);
+            acquireStack.printStackTrace(pw);
+            return counter + " from " + w;
+        }
     }
 
     private class RetainedBucket

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java
@@ -33,7 +33,6 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
-import java.util.function.Function;
 import java.util.function.IntUnaryOperator;
 import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
@@ -577,7 +576,7 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
         }
     }
 
-    private class RetainedBucket
+    private class RetainedBucket implements Dumpable
     {
         private final LongAdder _acquires = new LongAdder();
         private final LongAdder _totalAcquired = new LongAdder();
@@ -690,9 +689,15 @@ public class ArrayByteBufferPool implements ByteBufferPool, Dumpable
         }
 
         @Override
+        public void dump(Appendable out, String indent) throws IOException
+        {
+            Dumpable.dumpObjects(out, indent, this, _pool);
+        }
+
+        @Override
         public String toString()
         {
-            return String.format("%s@%x[stats=%s,pool=%s]", TypeUtil.toShortName(this.getClass()), hashCode(), getStatistics(), _pool);
+            return String.format("%s@%x[%s]", TypeUtil.toShortName(this.getClass()), hashCode(), getStatistics());
         }
 
         private record Statistics(int capacity, int inUseEntries, int totalEntries, long pooled, long acquires,

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/CompoundPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/CompoundPool.java
@@ -18,6 +18,7 @@ import java.util.Collection;
 import java.util.stream.Stream;
 
 import org.eclipse.jetty.util.Pool;
+import org.eclipse.jetty.util.TypeUtil;
 
 /**
  * <p>A {@link Pool} implementation that uses a primary pool which overflows to a secondary pool.</p>
@@ -114,5 +115,15 @@ public class CompoundPool<P> implements Pool<P>
     public int getTerminatedCount()
     {
         return primaryPool.getTerminatedCount() + secondaryPool.getTerminatedCount();
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("%s@%x[primary=%s,secondary=%s]",
+            TypeUtil.toShortName(getClass()),
+            hashCode(),
+            primaryPool,
+            secondaryPool);
     }
 }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/CompoundPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/CompoundPool.java
@@ -13,19 +13,20 @@
 
 package org.eclipse.jetty.io.internal;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.stream.Stream;
 
 import org.eclipse.jetty.util.Pool;
-import org.eclipse.jetty.util.TypeUtil;
+import org.eclipse.jetty.util.component.Dumpable;
 
 /**
  * <p>A {@link Pool} implementation that uses a primary pool which overflows to a secondary pool.</p>
  *
  * @param <P> the type of the pooled objects
  */
-public class CompoundPool<P> implements Pool<P>
+public class CompoundPool<P> implements Pool<P>, Dumpable
 {
     private final Pool<P> primaryPool;
     private final Pool<P> secondaryPool;
@@ -118,12 +119,8 @@ public class CompoundPool<P> implements Pool<P>
     }
 
     @Override
-    public String toString()
+    public void dump(Appendable out, String indent) throws IOException
     {
-        return String.format("%s@%x[primary=%s,secondary=%s]",
-            TypeUtil.toShortName(getClass()),
-            hashCode(),
-            primaryPool,
-            secondaryPool);
+        Dumpable.dumpObjects(out, indent, this, primaryPool, secondaryPool);
     }
 }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/QueuedPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/QueuedPool.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.io.internal;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
@@ -26,6 +27,8 @@ import java.util.stream.Stream;
 
 import org.eclipse.jetty.util.Pool;
 import org.eclipse.jetty.util.TypeUtil;
+import org.eclipse.jetty.util.component.Dumpable;
+import org.eclipse.jetty.util.component.DumpableCollection;
 
 /**
  * <p>A {@link Queue} based implementation of {@link Pool}.</p>
@@ -38,7 +41,7 @@ import org.eclipse.jetty.util.TypeUtil;
  *
  * @param <P> the type of the pooled objects
  */
-public class QueuedPool<P> implements Pool<P>
+public class QueuedPool<P> implements Pool<P>, Dumpable
 {
     // All code that uses these three fields is fully thread-safe.
     private final int maxSize;
@@ -194,6 +197,12 @@ public class QueuedPool<P> implements Pool<P>
     public int getTerminatedCount()
     {
         return 0;
+    }
+
+    @Override
+    public void dump(Appendable out, String indent) throws IOException
+    {
+        Dumpable.dumpObjects(out, indent, this, new DumpableCollection("entries", queue));
     }
 
     @Override

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/QueuedPool.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/internal/QueuedPool.java
@@ -25,6 +25,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Stream;
 
 import org.eclipse.jetty.util.Pool;
+import org.eclipse.jetty.util.TypeUtil;
 
 /**
  * <p>A {@link Queue} based implementation of {@link Pool}.</p>
@@ -193,6 +194,17 @@ public class QueuedPool<P> implements Pool<P>
     public int getTerminatedCount()
     {
         return 0;
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("%s@%x[size=%d,max=%d,terminated=%b]",
+            TypeUtil.toShortName(getClass()),
+            hashCode(),
+            size(),
+            getMaxSize(),
+            isTerminated());
     }
 
     private static class QueuedEntry<P> implements Entry<P>

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
@@ -71,7 +71,7 @@ public class ArrayByteBufferPoolTest
         else
         {
             assertThat(dump, containsString("direct non-pooled acquisitions size=1\n"));
-            assertThat(dump, containsString("0: 50 from"));
+            assertThat(dump, containsString("0: 50\n"));
         }
         pool.clear();
         assertThat(pool.dump(), containsString("direct non-pooled acquisitions size=0\n"));

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
@@ -26,6 +26,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -43,11 +44,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ArrayByteBufferPoolTest
 {
-    @Test
-    public void testDump()
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testDump(boolean statsEnabled)
     {
         ArrayByteBufferPool pool = new ArrayByteBufferPool(0, 10, 100, Integer.MAX_VALUE, 200, 200);
-        pool.setStatisticsEnabled(true);
+        pool.setStatisticsEnabled(statsEnabled);
 
         List<RetainableByteBuffer> buffers = new ArrayList<>();
 
@@ -57,12 +59,20 @@ public class ArrayByteBufferPoolTest
         buffers.forEach(RetainableByteBuffer::release);
 
         String dump = pool.dump();
-        assertThat(dump, containsString("direct non-pooled acquisitions size=5\n"));
-        assertThat(dump, containsString("110: 10\n"));
-        assertThat(dump, containsString("120: 10\n"));
-        assertThat(dump, containsString("130: 10\n"));
-        assertThat(dump, containsString("140: 10\n"));
-        assertThat(dump, containsString("150: 10\n"));
+        if (statsEnabled)
+        {
+            assertThat(dump, containsString("direct non-pooled acquisitions size=5\n"));
+            assertThat(dump, containsString("110: 10\n"));
+            assertThat(dump, containsString("120: 10\n"));
+            assertThat(dump, containsString("130: 10\n"));
+            assertThat(dump, containsString("140: 10\n"));
+            assertThat(dump, containsString("150: 10\n"));
+        }
+        else
+        {
+            assertThat(dump, containsString("direct non-pooled acquisitions size=1\n"));
+            assertThat(dump, containsString("0: 50\n"));
+        }
         pool.clear();
         assertThat(pool.dump(), containsString("direct non-pooled acquisitions size=0\n"));
     }

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
@@ -62,16 +62,16 @@ public class ArrayByteBufferPoolTest
         if (statsEnabled)
         {
             assertThat(dump, containsString("direct non-pooled acquisitions size=5\n"));
-            assertThat(dump, containsString("110: 10\n"));
-            assertThat(dump, containsString("120: 10\n"));
-            assertThat(dump, containsString("130: 10\n"));
-            assertThat(dump, containsString("140: 10\n"));
-            assertThat(dump, containsString("150: 10\n"));
+            assertThat(dump, containsString("110: 10 from "));
+            assertThat(dump, containsString("120: 10 from "));
+            assertThat(dump, containsString("130: 10 from "));
+            assertThat(dump, containsString("140: 10 from "));
+            assertThat(dump, containsString("150: 10 from "));
         }
         else
         {
             assertThat(dump, containsString("direct non-pooled acquisitions size=1\n"));
-            assertThat(dump, containsString("0: 50\n"));
+            assertThat(dump, containsString("0: 50 from"));
         }
         pool.clear();
         assertThat(pool.dump(), containsString("direct non-pooled acquisitions size=0\n"));
@@ -529,9 +529,9 @@ public class ArrayByteBufferPoolTest
             pool.acquire(800, false).release();
             pool.acquire(150, false).release();
             String dump = pool.dump();
-            assertThat(dump, containsString("200: 2\n"));
-            assertThat(dump, containsString("300: 1\n"));
-            assertThat(dump, containsString("800: 1\n"));
+            assertThat(dump, containsString("200: 2 from "));
+            assertThat(dump, containsString("300: 1 from "));
+            assertThat(dump, containsString("800: 1 from "));
         }
         {
             ArrayByteBufferPool pool = new ArrayByteBufferPool.WithBucketCapacities(1, 7, 50, 100);
@@ -541,16 +541,16 @@ public class ArrayByteBufferPoolTest
             pool.acquire(800, false).release();
             pool.acquire(150, false).release();
             String dump = pool.dump();
-            assertThat(dump, containsString("200: 2\n"));
-            assertThat(dump, containsString("300: 1\n"));
-            assertThat(dump, containsString("800: 1\n"));
+            assertThat(dump, containsString("200: 2 from "));
+            assertThat(dump, containsString("300: 1 from "));
+            assertThat(dump, containsString("800: 1 from "));
         }
         {
             ArrayByteBufferPool pool = new ArrayByteBufferPool.WithBucketCapacities(128, 512, 2048);
             pool.setStatisticsEnabled(true);
             pool.acquire(8192, false).release();
             String dump = pool.dump();
-            assertThat(dump, containsString("8192: 1\n"));
+            assertThat(dump, containsString("8192: 1 from "));
         }
     }
 
@@ -574,8 +574,8 @@ public class ArrayByteBufferPoolTest
         String dump = pool.dump();
         assertThat(dump, containsString("[stats=capacity=1024,in-use=0/1,pooled/acquires/releases=4/5/5(80.000%),avgSize=1023,non-pooled/evicts/removes=0/0/0,pool"));
         assertThat(dump, containsString("[stats=capacity=65536,in-use=0/1,pooled/acquires/releases=3/4/4(75.000%),avgSize=4096,non-pooled/evicts/removes=0/0/0,pool"));
-        assertThat(dump, containsString("131072: 2\n"));
-        assertThat(dump, containsString("196608: 2\n"));
+        assertThat(dump, containsString("131072: 2 from "));
+        assertThat(dump, containsString("196608: 2 from "));
     }
 
     @Test

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
@@ -498,23 +498,23 @@ public class ArrayByteBufferPoolTest
             ArrayByteBufferPool pool = new ArrayByteBufferPool.WithBucketCapacities(1024, 65536);
             String dump = pool.dump();
             assertThat(dump, containsString("direct size=2\n"));
-            assertThat(dump, containsString("[capacity=1024,"));
-            assertThat(dump, containsString("[capacity=65536,"));
+            assertThat(dump, containsString("[stats=capacity=1024,"));
+            assertThat(dump, containsString("[stats=capacity=65536,"));
         }
         {
             ArrayByteBufferPool pool = new ArrayByteBufferPool.WithBucketCapacities(30, 24);
             String dump = pool.dump();
             assertThat(dump, containsString("direct size=2\n"));
-            assertThat(dump, containsString("[capacity=24,"));
-            assertThat(dump, containsString("[capacity=30,"));
+            assertThat(dump, containsString("[stats=capacity=24,"));
+            assertThat(dump, containsString("[stats=capacity=30,"));
         }
         {
             ArrayByteBufferPool pool = new ArrayByteBufferPool.WithBucketCapacities(3, 7, 100);
             String dump = pool.dump();
             assertThat(dump, containsString("direct size=3\n"));
-            assertThat(dump, containsString("[capacity=3,"));
-            assertThat(dump, containsString("[capacity=7,"));
-            assertThat(dump, containsString("[capacity=100,"));
+            assertThat(dump, containsString("[stats=capacity=3,"));
+            assertThat(dump, containsString("[stats=capacity=7,"));
+            assertThat(dump, containsString("[stats=capacity=100,"));
         }
     }
 
@@ -572,8 +572,8 @@ public class ArrayByteBufferPoolTest
         pool.acquire(65536 * 2 + 1, false).release();
         pool.acquire(65536 * 3 - 1, false).release();
         String dump = pool.dump();
-        assertThat(dump, containsString("[capacity=1024,in-use=0/1,pooled/acquires/releases=4/5/5(80.000%),avgSize=1023,non-pooled/evicts/removes=0/0/0]"));
-        assertThat(dump, containsString("[capacity=65536,in-use=0/1,pooled/acquires/releases=3/4/4(75.000%),avgSize=4096,non-pooled/evicts/removes=0/0/0]"));
+        assertThat(dump, containsString("[stats=capacity=1024,in-use=0/1,pooled/acquires/releases=4/5/5(80.000%),avgSize=1023,non-pooled/evicts/removes=0/0/0,pool"));
+        assertThat(dump, containsString("[stats=capacity=65536,in-use=0/1,pooled/acquires/releases=3/4/4(75.000%),avgSize=4096,non-pooled/evicts/removes=0/0/0,pool"));
         assertThat(dump, containsString("131072: 2\n"));
         assertThat(dump, containsString("196608: 2\n"));
     }

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java
@@ -498,23 +498,23 @@ public class ArrayByteBufferPoolTest
             ArrayByteBufferPool pool = new ArrayByteBufferPool.WithBucketCapacities(1024, 65536);
             String dump = pool.dump();
             assertThat(dump, containsString("direct size=2\n"));
-            assertThat(dump, containsString("[stats=capacity=1024,"));
-            assertThat(dump, containsString("[stats=capacity=65536,"));
+            assertThat(dump, containsString("[capacity=1024,"));
+            assertThat(dump, containsString("[capacity=65536,"));
         }
         {
             ArrayByteBufferPool pool = new ArrayByteBufferPool.WithBucketCapacities(30, 24);
             String dump = pool.dump();
             assertThat(dump, containsString("direct size=2\n"));
-            assertThat(dump, containsString("[stats=capacity=24,"));
-            assertThat(dump, containsString("[stats=capacity=30,"));
+            assertThat(dump, containsString("[capacity=24,"));
+            assertThat(dump, containsString("[capacity=30,"));
         }
         {
             ArrayByteBufferPool pool = new ArrayByteBufferPool.WithBucketCapacities(3, 7, 100);
             String dump = pool.dump();
             assertThat(dump, containsString("direct size=3\n"));
-            assertThat(dump, containsString("[stats=capacity=3,"));
-            assertThat(dump, containsString("[stats=capacity=7,"));
-            assertThat(dump, containsString("[stats=capacity=100,"));
+            assertThat(dump, containsString("[capacity=3,"));
+            assertThat(dump, containsString("[capacity=7,"));
+            assertThat(dump, containsString("[capacity=100,"));
         }
     }
 
@@ -572,8 +572,8 @@ public class ArrayByteBufferPoolTest
         pool.acquire(65536 * 2 + 1, false).release();
         pool.acquire(65536 * 3 - 1, false).release();
         String dump = pool.dump();
-        assertThat(dump, containsString("[stats=capacity=1024,in-use=0/1,pooled/acquires/releases=4/5/5(80.000%),avgSize=1023,non-pooled/evicts/removes=0/0/0,pool"));
-        assertThat(dump, containsString("[stats=capacity=65536,in-use=0/1,pooled/acquires/releases=3/4/4(75.000%),avgSize=4096,non-pooled/evicts/removes=0/0/0,pool"));
+        assertThat(dump, containsString("[capacity=1024,in-use=0/1,pooled/acquires/releases=4/5/5(80.000%),avgSize=1023,non-pooled/evicts/removes=0/0/0]"));
+        assertThat(dump, containsString("[capacity=65536,in-use=0/1,pooled/acquires/releases=3/4/4(75.000%),avgSize=4096,non-pooled/evicts/removes=0/0/0]"));
         assertThat(dump, containsString("131072: 2 from "));
         assertThat(dump, containsString("196608: 2 from "));
     }


### PR DESCRIPTION
- record non-pooled acquisitions as a single bucket when stats are disabled
- make buckets include the wrapped `oeju.Pool` instance when dumped
- make `ArrayRetainableByteBuffer.Tracking` dump leaks when dumped
- save the stack of non-pooled acquisitions to include them in the dump