### PR TITLE
Issue #14068 - Cleanup IO.asFile on Windows

### DIFF
--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/IOTest.java
@@ -47,12 +47,14 @@ import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -644,4 +646,43 @@ public class IOTest
         assertFalse(Files.isSymbolicLink(linkPath));
     }
 
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    public void testAsFileTempDirWindowsStringLinuxSlashes(WorkDir workDir) throws IOException
+    {
+        Path testDir = workDir.getEmptyPathDir().resolve("test");
+        FS.ensureDirExists(testDir);
+
+        String testDirStr = testDir.toString().replaceAll("\\\\", "/");
+        File file = IO.asFile(testDirStr);
+
+        assertTrue(Files.isSameFile(file.toPath(), testDir));
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    public void testAsFileTempDirWindowsStringWindowsSlashes(WorkDir workDir) throws IOException
+    {
+        Path testDir = workDir.getEmptyPathDir().resolve("test");
+        FS.ensureDirExists(testDir);
+
+        String testDirStr = testDir.toString();
+        File file = IO.asFile(testDirStr);
+
+        assertTrue(Files.isSameFile(file.toPath(), testDir));
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    public void testAsFileTempDirWindowsStringFileUri(WorkDir workDir) throws IOException
+    {
+        Path testDir = workDir.getEmptyPathDir().resolve("test");
+        FS.ensureDirExists(testDir);
+
+        String testDirStr = testDir.toUri().toASCIIString();
+        assertThat(testDirStr, startsWith("file:"));
+        File file = IO.asFile(testDirStr);
+
+        assertTrue(Files.isSameFile(file.toPath(), testDir));
+    }
 }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/IO.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/IO.java
@@ -735,22 +735,22 @@ public class IO
 
     /**
      * <p>
-     *     Convert an object to a {@link File} if possible.
+     * Convert an object to a {@link File} if possible.
      * </p>
      *
-     * @param fileObject A {@link File}, {@link Path}, {@link String} (supporting absolute, relative, partial, and other URI syntaxes), to be converted into a {@link File}.
-     *  {@code null} will result in a {@code null} return.
-     * @return A {@link File} representation of the passed argument or {@code null}.
+     * @param pathObject A {@link File}, {@link Path}, {@link String} (supporting absolute, relative, partial, and other URI syntaxes), to be converted into a {@link File}.
+     * {@code null} will result in a {@code null} return.
+     * @return A {@link Path} representation of the passed argument or {@code null}.
      */
-    public static File asFile(Object fileObject)
+    public static Path asPath(Object pathObject)
     {
-        if (fileObject == null)
+        if (pathObject == null)
             return null;
-        if (fileObject instanceof File file)
-            return file;
-        if (fileObject instanceof Path path)
-            return path.toFile();
-        if (fileObject instanceof String str)
+        if (pathObject instanceof File file)
+            return file.toPath();
+        if (pathObject instanceof Path path)
+            return path;
+        if (pathObject instanceof String str)
         {
             // attempt to support absolute, relative, partial, and URI syntaxes.
             if (URIUtil.hasScheme(str))
@@ -758,13 +758,10 @@ public class IO
                 try
                 {
                     URI uri = new URI(str);
-                    if (uri.isAbsolute() && !uri.getScheme().equalsIgnoreCase("file"))
+                    if (uri.isAbsolute() && uri.getScheme().equalsIgnoreCase("file"))
                     {
-                        if (LOG.isDebugEnabled())
-                            LOG.debug("Not a local file system: {}", str);
-                        return null;
+                        return Path.of(uri);
                     }
-                    return Path.of(uri).toFile();
                 }
                 catch (URISyntaxException e)
                 {
@@ -780,8 +777,7 @@ public class IO
 
             try
             {
-                Path path = Path.of(str);
-                return path.toFile();
+                return Path.of(str);
             }
             catch (InvalidPathException x)
             {
@@ -792,8 +788,27 @@ public class IO
         }
 
         if (LOG.isDebugEnabled())
-            LOG.debug("Not able to be converted to a File object: ({}) {}", fileObject.getClass().getName(), fileObject);
+            LOG.debug("Not able to be converted to a Path object: ({}) {}", pathObject.getClass().getName(), pathObject);
         return null;
+    }
+
+    /**
+     * <p>
+     *     Convert an object to a {@link File} if possible.
+     * </p>
+     *
+     * @param fileObject A {@link File}, {@link Path}, {@link String} (supporting absolute, relative, partial, and other URI syntaxes), to be converted into a {@link File}.
+     *  {@code null} will result in a {@code null} return.
+     * @return A {@link File} representation of the passed argument or {@code null}.
+     * @deprecated use {@link #asPath(Object)} instead to have proper conversion of various path syntaxes across JVMs, Architectures, and OSs.
+     */
+    @Deprecated(since = "12.1.6", forRemoval = true)
+    public static File asFile(Object fileObject)
+    {
+        Path path = asPath(fileObject);
+        if (path == null)
+            return null;
+        return path.toFile();
     }
 
     private IO()


### PR DESCRIPTION
Using Path to cleanup user input strings for File / Path resolution.

The Java `File` object cannot operate successfully with the variety of JVMs, Architectures, File Systems, and OSs out there.
Only the `Path` object has proper support for all combinations.

* Deprecate `IO.asFile(Object)`
* Introduce replacement of `IO.asPath(Object)` with proper usage.
* Introduce test cases for Windows path resolution options when using `IO.asPath(Object)`

Closes #14068