### PR TITLE
Introduced Jetty module `json.mod`.

### DIFF
--- a/jetty-core/jetty-util-ajax/src/main/config/modules/json.mod
+++ b/jetty-core/jetty-util-ajax/src/main/config/modules/json.mod
@@ -1,0 +1,9 @@
+[description]
+Provides the Jetty JSON library support.
+
+[tags]
+json
+
+[lib]
+lib/jetty-util-${jetty.version}.jar
+lib/jetty-util-ajax-${jetty.version}.jar

--- a/jetty-integrations/jetty-openid/src/main/config/modules/openid.mod
+++ b/jetty-integrations/jetty-openid/src/main/config/modules/openid.mod
@@ -4,11 +4,11 @@
 Adds OpenId Connect authentication to the server.
 
 [depend]
-security
 client
+json
+security
 
 [lib]
-lib/jetty-util-ajax-${jetty.version}.jar
 lib/jetty-openid-${jetty.version}.jar
 
 [files]


### PR DESCRIPTION
Called it "json" and not "ajax" despite the Maven artifact name.

This is because "json" is what this module provides, while "ajax" was a historical name for "async javascript and xml" more related to the web than JSON itself, and it is now obsolete at best, if not completed forgotten.