### PR TITLE
Issue #13328 - Add option to share Server thread pool in ProxyHandler

### DIFF
--- a/jetty-core/jetty-fcgi/jetty-fcgi-proxy/src/main/java/org/eclipse/jetty/fcgi/proxy/FastCGIProxyHandler.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-proxy/src/main/java/org/eclipse/jetty/fcgi/proxy/FastCGIProxyHandler.java
@@ -40,7 +40,6 @@ import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.handler.TryPathsHandler;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.URIUtil;
-import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -269,11 +268,7 @@ public class FastCGIProxyHandler extends ProxyHandler.Reverse
     @Override
     protected HttpClient newHttpClient()
     {
-        ClientConnector clientConnector = new ClientConnector();
-        QueuedThreadPool proxyClientThreads = new QueuedThreadPool();
-        proxyClientThreads.setName("proxy-client");
-        clientConnector.setExecutor(proxyClientThreads);
-        return new HttpClient(new ProxyHttpClientTransportOverFCGI(clientConnector, getScriptRoot()));
+        return new HttpClient(new ProxyHttpClientTransportOverFCGI(new ClientConnector(), getScriptRoot()));
     }
 
     @Override

--- a/jetty-core/jetty-fcgi/jetty-fcgi-proxy/src/main/java/org/eclipse/jetty/fcgi/proxy/FastCGIProxyHandler.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-proxy/src/main/java/org/eclipse/jetty/fcgi/proxy/FastCGIProxyHandler.java
@@ -49,7 +49,6 @@ import org.slf4j.LoggerFactory;
  * request that is sent to the FastCGI server, and viceversa for the response.</p>
  *
  * @see TryPathsHandler
- * @see ProxyHandler#setUseServerThreadPool(boolean)
  */
 public class FastCGIProxyHandler extends ProxyHandler.Reverse
 {

--- a/jetty-core/jetty-fcgi/jetty-fcgi-proxy/src/main/java/org/eclipse/jetty/fcgi/proxy/FastCGIProxyHandler.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-proxy/src/main/java/org/eclipse/jetty/fcgi/proxy/FastCGIProxyHandler.java
@@ -49,6 +49,7 @@ import org.slf4j.LoggerFactory;
  * request that is sent to the FastCGI server, and viceversa for the response.</p>
  *
  * @see TryPathsHandler
+ * @see ProxyHandler#setUseServerThreadPool(boolean)
  */
 public class FastCGIProxyHandler extends ProxyHandler.Reverse
 {

--- a/jetty-core/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/ProxyHandler.java
+++ b/jetty-core/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/ProxyHandler.java
@@ -198,7 +198,7 @@ public abstract class ProxyHandler extends Handler.Abstract
         {
             httpClient.setExecutor(getServer().getThreadPool());
         }
-        else if (httpClient.getExecutor() == null)
+        else
         {
             QueuedThreadPool proxyClientThreads = new QueuedThreadPool();
             proxyClientThreads.setName("proxy-client");

--- a/jetty-core/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/ProxyHandler.java
+++ b/jetty-core/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/ProxyHandler.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -51,6 +52,7 @@ import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.StringUtil;
+import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.slf4j.Logger;
@@ -146,6 +148,7 @@ public abstract class ProxyHandler extends Handler.Abstract
      * Get whether the proxy should use the server's thread pool.
      * @return true if using the server's thread pool
      */
+    @ManagedAttribute("whether the proxy uses the server's thread pool")
     public boolean isUseServerThreadPool()
     {
         return useServerThreadPool;
@@ -194,15 +197,19 @@ public abstract class ProxyHandler extends Handler.Abstract
     private HttpClient createHttpClient()
     {
         HttpClient httpClient = newHttpClient();
-        if (isUseServerThreadPool())
+        Executor executor = httpClient.getExecutor();
+        if (executor == null)
         {
-            httpClient.setExecutor(getServer().getThreadPool());
-        }
-        else
-        {
-            QueuedThreadPool proxyClientThreads = new QueuedThreadPool();
-            proxyClientThreads.setName("proxy-client");
-            httpClient.setExecutor(proxyClientThreads);
+            if (isUseServerThreadPool())
+            {
+                httpClient.setExecutor(getServer().getThreadPool());
+            }
+            else
+            {
+                QueuedThreadPool proxyClientThreads = new QueuedThreadPool();
+                proxyClientThreads.setName("proxy-client");
+                httpClient.setExecutor(proxyClientThreads);
+            }
         }
         configureHttpClient(httpClient);
         LifeCycle.start(httpClient);

--- a/jetty-core/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/ProxyHandler.java
+++ b/jetty-core/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/ProxyHandler.java
@@ -90,6 +90,7 @@ public abstract class ProxyHandler extends Handler.Abstract
     private HttpClient httpClient;
     private String proxyToServerHost;
     private String viaHost;
+    private boolean useServerThreadPool;
 
     public HttpClient getHttpClient()
     {
@@ -141,6 +142,30 @@ public abstract class ProxyHandler extends Handler.Abstract
         this.viaHost = viaHost;
     }
 
+    /**
+     * Get whether the proxy should use the server's thread pool.
+     * @return true if using the server's thread pool
+     */
+    public boolean isUseServerThreadPool()
+    {
+        return useServerThreadPool;
+    }
+
+    /**
+     * <p>Sets whether the proxy's HttpClient should share the Server's thread pool.</p>
+     * <p>If {@code true}, the HttpClient will use the Server's thread pool.
+     * If {@code false} (the default), a dedicated thread pool named "proxy-client" is created.</p>
+     * <p>Sharing the Server's thread pool simplifies memory management, but threads will
+     * retain the server pool's name in logs, making it harder to distinguish server-side
+     * processing from proxy client-side processing.</p>
+     *
+     * @param useServerThreadPool true to share the Server's thread pool
+     */
+    public void setUseServerThreadPool(boolean useServerThreadPool)
+    {
+        this.useServerThreadPool = useServerThreadPool;
+    }
+
     private static String viaHost()
     {
         try
@@ -185,15 +210,24 @@ public abstract class ProxyHandler extends Handler.Abstract
      * pool named {@code proxy-client} and with the
      * {@link HttpClientTransportDynamic dynamic transport} configured only
      * with HTTP/1.1.</p>
+     * <p>If {@link #isUseServerThreadPool()} returns {@code true}, the
+     * Server's thread pool is used instead of creating a dedicated one.</p>
      *
      * @return a new {@code HttpClient} instance
      */
     protected HttpClient newHttpClient()
     {
         ClientConnector clientConnector = new ClientConnector();
-        QueuedThreadPool proxyClientThreads = new QueuedThreadPool();
-        proxyClientThreads.setName("proxy-client");
-        clientConnector.setExecutor(proxyClientThreads);
+        if (isUseServerThreadPool())
+        {
+            clientConnector.setExecutor(getServer().getThreadPool());
+        }
+        else
+        {
+            QueuedThreadPool proxyClientThreads = new QueuedThreadPool();
+            proxyClientThreads.setName("proxy-client");
+            clientConnector.setExecutor(proxyClientThreads);
+        }
         return new HttpClient(new HttpClientTransportDynamic(clientConnector));
     }
 

--- a/jetty-core/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/ProxyHandler.java
+++ b/jetty-core/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/ProxyHandler.java
@@ -194,6 +194,16 @@ public abstract class ProxyHandler extends Handler.Abstract
     private HttpClient createHttpClient()
     {
         HttpClient httpClient = newHttpClient();
+        if (isUseServerThreadPool())
+        {
+            httpClient.setExecutor(getServer().getThreadPool());
+        }
+        else if (httpClient.getExecutor() == null)
+        {
+            QueuedThreadPool proxyClientThreads = new QueuedThreadPool();
+            proxyClientThreads.setName("proxy-client");
+            httpClient.setExecutor(proxyClientThreads);
+        }
         configureHttpClient(httpClient);
         LifeCycle.start(httpClient);
         httpClient.getContentDecoderFactories().clear();
@@ -206,29 +216,19 @@ public abstract class ProxyHandler extends Handler.Abstract
     }
 
     /**
-     * <p>Creates a new {@link HttpClient} instance, by default with a thread
-     * pool named {@code proxy-client} and with the
+     * <p>Creates a new {@link HttpClient} instance with the
      * {@link HttpClientTransportDynamic dynamic transport} configured only
      * with HTTP/1.1.</p>
-     * <p>If {@link #isUseServerThreadPool()} returns {@code true}, the
-     * Server's thread pool is used instead of creating a dedicated one.</p>
+     * <p>The executor is set after this method returns: if
+     * {@link #isUseServerThreadPool()} returns {@code true}, the Server's
+     * thread pool is used; otherwise, if no executor was set by this method,
+     * a dedicated thread pool named "proxy-client" is created.</p>
      *
      * @return a new {@code HttpClient} instance
      */
     protected HttpClient newHttpClient()
     {
-        ClientConnector clientConnector = new ClientConnector();
-        if (isUseServerThreadPool())
-        {
-            clientConnector.setExecutor(getServer().getThreadPool());
-        }
-        else
-        {
-            QueuedThreadPool proxyClientThreads = new QueuedThreadPool();
-            proxyClientThreads.setName("proxy-client");
-            clientConnector.setExecutor(proxyClientThreads);
-        }
-        return new HttpClient(new HttpClientTransportDynamic(clientConnector));
+        return new HttpClient(new HttpClientTransportDynamic(new ClientConnector()));
     }
 
     /**

--- a/jetty-core/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ReverseProxyTest.java
+++ b/jetty-core/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ReverseProxyTest.java
@@ -36,7 +36,6 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
-import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -471,9 +470,6 @@ public class ReverseProxyTest extends AbstractProxyTest
     private static HttpClient newProxyHttpClient()
     {
         ClientConnector proxyClientConnector = new ClientConnector();
-        QueuedThreadPool proxyClientThreads = new QueuedThreadPool();
-        proxyClientThreads.setName("proxy-client");
-        proxyClientConnector.setExecutor(proxyClientThreads);
         HTTP2Client proxyHTTP2Client = new HTTP2Client(proxyClientConnector);
         return new HttpClient(new HttpClientTransportDynamic(proxyClientConnector, HttpClientConnectionFactory.HTTP11, new ClientConnectionFactoryOverHTTP2.HTTP2(proxyHTTP2Client)));
     }

--- a/jetty-core/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ReverseProxyTest.java
+++ b/jetty-core/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ReverseProxyTest.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.proxy;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jetty.client.CompletableResponseListener;
@@ -42,6 +43,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -415,6 +417,67 @@ public class ReverseProxyTest extends AbstractProxyTest
             .send());
 
         assertTrue(responseFailureLatch.await(5, TimeUnit.SECONDS));
+    }
+
+    @ParameterizedTest
+    @MethodSource("httpVersions")
+    public void testUseServerThreadPool(HttpVersion httpVersion) throws Exception
+    {
+        String serverContent = "hello";
+        startServer(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                Content.Sink.write(response, true, serverContent, callback);
+                return true;
+            }
+        });
+
+        ProxyHandler.Reverse proxyHandler = new ProxyHandler.Reverse(clientToProxyRequest ->
+            HttpURI.build(clientToProxyRequest.getHttpURI()).port(serverConnector.getLocalPort()))
+        {
+            @Override
+            protected HttpClient newHttpClient()
+            {
+                ClientConnector proxyClientConnector = new ClientConnector();
+                if (isUseServerThreadPool())
+                {
+                    proxyClientConnector.setExecutor(getServer().getThreadPool());
+                }
+                else
+                {
+                    QueuedThreadPool proxyClientThreads = new QueuedThreadPool();
+                    proxyClientThreads.setName("proxy-client");
+                    proxyClientConnector.setExecutor(proxyClientThreads);
+                }
+                HTTP2Client proxyHTTP2Client = new HTTP2Client(proxyClientConnector);
+                return new HttpClient(new HttpClientTransportDynamic(proxyClientConnector, HttpClientConnectionFactory.HTTP11, new ClientConnectionFactoryOverHTTP2.HTTP2(proxyHTTP2Client)));
+            }
+
+            @Override
+            protected org.eclipse.jetty.client.Request newProxyToServerRequest(Request clientToProxyRequest, HttpURI newHttpURI)
+            {
+                return super.newProxyToServerRequest(clientToProxyRequest, newHttpURI)
+                    .version(httpVersion);
+            }
+        };
+        proxyHandler.setUseServerThreadPool(true);
+        startProxy(proxyHandler);
+
+        // Verify the HttpClient uses the server's thread pool.
+        HttpClient proxyHttpClient = proxyHandler.getHttpClient();
+        assertNotNull(proxyHttpClient);
+        Executor clientExecutor = proxyHttpClient.getExecutor();
+        assertSame(proxy.getThreadPool(), clientExecutor);
+
+        startClient();
+
+        ContentResponse response = client.newRequest("localhost", proxyConnector.getLocalPort())
+            .version(httpVersion)
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+        assertEquals(serverContent, response.getContentAsString());
     }
 
     private static HttpClient newProxyHttpClient()

--- a/jetty-core/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ReverseProxyTest.java
+++ b/jetty-core/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ReverseProxyTest.java
@@ -16,8 +16,8 @@ package org.eclipse.jetty.proxy;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import org.eclipse.jetty.client.CompletableResponseListener;
 import org.eclipse.jetty.client.ContentResponse;
@@ -37,20 +37,30 @@ import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ReverseProxyTest extends AbstractProxyTest
 {
+    public static Stream<Arguments> httpVersionsAndThreadPools()
+    {
+        return Stream.of(
+            Arguments.of(HttpVersion.HTTP_1_1, false),
+            Arguments.of(HttpVersion.HTTP_1_1, true),
+            Arguments.of(HttpVersion.HTTP_2, false),
+            Arguments.of(HttpVersion.HTTP_2, true)
+        );
+    }
+
     @ParameterizedTest
-    @MethodSource("httpVersions")
-    public void testSimple(HttpVersion httpVersion) throws Exception
+    @MethodSource("httpVersionsAndThreadPools")
+    public void testSimple(HttpVersion httpVersion, boolean useServerThreadPool) throws Exception
     {
         String clientContent = "hello";
         String serverContent = "world";
@@ -66,7 +76,7 @@ public class ReverseProxyTest extends AbstractProxyTest
             }
         });
 
-        startProxy(new ProxyHandler.Reverse(clientToProxyRequest ->
+        ProxyHandler.Reverse proxyHandler = new ProxyHandler.Reverse(clientToProxyRequest ->
             HttpURI.build(clientToProxyRequest.getHttpURI()).port(serverConnector.getLocalPort()))
         {
             @Override
@@ -82,7 +92,9 @@ public class ReverseProxyTest extends AbstractProxyTest
                 return super.newProxyToServerRequest(clientToProxyRequest, newHttpURI)
                     .version(httpVersion);
             }
-        });
+        };
+        proxyHandler.setUseServerThreadPool(useServerThreadPool);
+        startProxy(proxyHandler);
 
         startClient();
 
@@ -416,55 +428,6 @@ public class ReverseProxyTest extends AbstractProxyTest
             .send());
 
         assertTrue(responseFailureLatch.await(5, TimeUnit.SECONDS));
-    }
-
-    @ParameterizedTest
-    @MethodSource("httpVersions")
-    public void testUseServerThreadPool(HttpVersion httpVersion) throws Exception
-    {
-        String serverContent = "hello";
-        startServer(new Handler.Abstract()
-        {
-            @Override
-            public boolean handle(Request request, Response response, Callback callback)
-            {
-                Content.Sink.write(response, true, serverContent, callback);
-                return true;
-            }
-        });
-
-        ProxyHandler.Reverse proxyHandler = new ProxyHandler.Reverse(clientToProxyRequest ->
-            HttpURI.build(clientToProxyRequest.getHttpURI()).port(serverConnector.getLocalPort()))
-        {
-            @Override
-            protected HttpClient newHttpClient()
-            {
-                return newProxyHttpClient();
-            }
-
-            @Override
-            protected org.eclipse.jetty.client.Request newProxyToServerRequest(Request clientToProxyRequest, HttpURI newHttpURI)
-            {
-                return super.newProxyToServerRequest(clientToProxyRequest, newHttpURI)
-                    .version(httpVersion);
-            }
-        };
-        proxyHandler.setUseServerThreadPool(true);
-        startProxy(proxyHandler);
-
-        // Verify the HttpClient uses the server's thread pool.
-        HttpClient proxyHttpClient = proxyHandler.getHttpClient();
-        assertNotNull(proxyHttpClient);
-        Executor clientExecutor = proxyHttpClient.getExecutor();
-        assertSame(proxy.getThreadPool(), clientExecutor);
-
-        startClient();
-
-        ContentResponse response = client.newRequest("localhost", proxyConnector.getLocalPort())
-            .version(httpVersion)
-            .timeout(5, TimeUnit.SECONDS)
-            .send();
-        assertEquals(serverContent, response.getContentAsString());
     }
 
     private static HttpClient newProxyHttpClient()

--- a/jetty-core/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ReverseProxyTest.java
+++ b/jetty-core/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ReverseProxyTest.java
@@ -440,19 +440,7 @@ public class ReverseProxyTest extends AbstractProxyTest
             @Override
             protected HttpClient newHttpClient()
             {
-                ClientConnector proxyClientConnector = new ClientConnector();
-                if (isUseServerThreadPool())
-                {
-                    proxyClientConnector.setExecutor(getServer().getThreadPool());
-                }
-                else
-                {
-                    QueuedThreadPool proxyClientThreads = new QueuedThreadPool();
-                    proxyClientThreads.setName("proxy-client");
-                    proxyClientConnector.setExecutor(proxyClientThreads);
-                }
-                HTTP2Client proxyHTTP2Client = new HTTP2Client(proxyClientConnector);
-                return new HttpClient(new HttpClientTransportDynamic(proxyClientConnector, HttpClientConnectionFactory.HTTP11, new ClientConnectionFactoryOverHTTP2.HTTP2(proxyHTTP2Client)));
+                return newProxyHttpClient();
             }
 
             @Override


### PR DESCRIPTION
Fixes #13328

- Added `useServerThreadPool` property to `ProxyHandler` that allows the internal `HttpClient` to share the Server's thread pool instead of creating a dedicated "proxy-client" pool
- Moved executor logic to `createHttpClient()` so subclasses overriding `newHttpClient()` don't need to handle it
- Simplified `FastCGIProxyHandler.newHttpClient()` accordingly

This feature already exists in `ProxyServlet` via the `maxThreads` init parameter; this PR adds equivalent functionality to the core `ProxyHandler`.
