### PR TITLE
Fix Request.isSecure() when proxy offloads TLS and then sends PROXY-V2 information to the backend

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/ProxyProtocolClientConnectionFactory.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/ProxyProtocolClientConnectionFactory.java
@@ -17,6 +17,7 @@ import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.net.UnixDomainSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -31,6 +32,7 @@ import org.eclipse.jetty.io.AbstractConnection;
 import org.eclipse.jetty.io.ClientConnectionFactory;
 import org.eclipse.jetty.io.Connection;
 import org.eclipse.jetty.io.EndPoint;
+import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.Promise;
 import org.slf4j.Logger;
@@ -207,23 +209,7 @@ public abstract class ProxyProtocolClientConnectionFactory extends ClientConnect
             Executor executor = destination.getHttpClient().getExecutor();
             Tag tag = (Tag)destination.getOrigin().getTag();
             if (tag == null)
-            {
-                SocketAddress local = endPoint.getLocalSocketAddress();
-                InetSocketAddress inetLocal = local instanceof InetSocketAddress ? (InetSocketAddress)local : null;
-                InetAddress localAddress = inetLocal == null ? null : inetLocal.getAddress();
-                SocketAddress remote = endPoint.getRemoteSocketAddress();
-                InetSocketAddress inetRemote = remote instanceof InetSocketAddress ? (InetSocketAddress)remote : null;
-                InetAddress remoteAddress = inetRemote == null ? null : inetRemote.getAddress();
-                Tag.Family family = local == null || inetLocal == null ? Tag.Family.UNSPEC : localAddress instanceof Inet4Address ? Tag.Family.INET4 : Tag.Family.INET6;
-                tag = new Tag(Tag.Command.PROXY,
-                    family,
-                    Tag.Protocol.STREAM,
-                    localAddress == null ? null : localAddress.getHostAddress(),
-                    inetLocal == null ? 0 : inetLocal.getPort(),
-                    remoteAddress == null ? null : remoteAddress.getHostAddress(),
-                    inetRemote == null ? 0 : inetRemote.getPort(),
-                    null);
-            }
+                tag = Tag.from(endPoint, true);
             return new ProxyProtocolConnectionV2(endPoint, executor, getWrapped(), context, tag);
         }
 
@@ -240,6 +226,72 @@ public abstract class ProxyProtocolClientConnectionFactory extends ClientConnect
              * The PROXY V2 Tag typically used to "ping" the server.
              */
             public static final Tag LOCAL = new Tag(Command.LOCAL, Family.UNSPEC, Protocol.UNSPEC, null, 0, null, 0, null);
+
+            /**
+             * <p>Creates a {@code Tag} from the given {@link EndPoint}.</p>
+             * <p>The {@code source} parameter indicates whether the {@code EndPoint}
+             * is the local {@code EndPoint} (typical for clients), or the
+             * remote {@code EndPoint} (typical for proxies).
+             * In the latter case, the proxy wants to forward to the server the
+             * information about the remote client so the {@code EndPoint} must
+             * be that connected to the remote client (not to the server).</p>
+             *
+             * @param endPoint the {@code EndPoint} to create the {@code Tag} from
+             * @param local whether the {@code EndPoint} is local or remote
+             * @return a new {@code Tag} from the given {@code EndPoint}
+             */
+            public static Tag from(EndPoint endPoint, boolean local)
+            {
+                SocketAddress src = local ? endPoint.getLocalSocketAddress() : endPoint.getRemoteSocketAddress();
+                UnixDomainSocketAddress unixSrc = src instanceof UnixDomainSocketAddress ? (UnixDomainSocketAddress)src : null;
+                InetSocketAddress inetSrc = src instanceof InetSocketAddress ? (InetSocketAddress)src : null;
+                InetAddress srcAddress = inetSrc == null ? null : inetSrc.getAddress();
+                String srcAddr = unixSrc != null ? unixSrc.getPath().toString() :
+                    srcAddress != null ? srcAddress.getHostAddress() : null;
+
+                int srcPort = inetSrc != null ? inetSrc.getPort() : 0;
+
+                Family family = Family.UNSPEC;
+                if (unixSrc != null)
+                    family = Family.UNIX;
+                else if (inetSrc != null)
+                    family = srcAddress instanceof Inet4Address ? V2.Tag.Family.INET4 : V2.Tag.Family.INET6;
+
+                Protocol protocol = src == null ? Protocol.UNSPEC : Protocol.STREAM;
+
+                SocketAddress dst = local ? endPoint.getRemoteSocketAddress() : endPoint.getLocalSocketAddress();
+                UnixDomainSocketAddress unixDst = dst instanceof UnixDomainSocketAddress ? (UnixDomainSocketAddress)dst : null;
+                InetSocketAddress inetDst = dst instanceof InetSocketAddress ? (InetSocketAddress)dst : null;
+                InetAddress dstAddress = inetDst == null ? null : inetDst.getAddress();
+                String dstAddr = unixDst != null ? unixDst.getPath().toString() :
+                    dstAddress != null ? dstAddress.getHostAddress() : null;
+
+                int dstPort = inetDst != null ? inetDst.getPort() : 0;
+
+                List<TLV> tlvs = null;
+                EndPoint.SslSessionData sslSessionData = endPoint.getSslSessionData();
+                int length;
+                if (sslSessionData != null)
+                {
+                    length = 5;
+                    String cipherSuite = sslSessionData.cipherSuite();
+                    byte[] cipherBytes = cipherSuite == null ? BufferUtil.EMPTY_BYTES : cipherSuite.getBytes(StandardCharsets.US_ASCII);
+                    length += 1 + 2 + cipherBytes.length;
+                    byte[] value = new byte[length];
+                    ByteBuffer byteBuffer = ByteBuffer.wrap(value);
+                    byteBuffer.put((byte)TLV.CLIENT_SSL);
+                    byteBuffer.putInt(1); // Verify.
+                    if (cipherSuite != null)
+                    {
+                        byteBuffer.put((byte)TLV.SUBTYPE_SSL_CIPHER);
+                        byteBuffer.putShort((short)cipherBytes.length);
+                        byteBuffer.put(cipherBytes);
+                    }
+                    tlvs = List.of(new TLV(TLV.TYPE_SSL, value));
+                }
+
+                return new Tag(Command.PROXY, family, protocol, srcAddr, srcPort, dstAddr, dstPort, tlvs);
+            }
 
             private final Command command;
             private final Family family;
@@ -285,6 +337,7 @@ public abstract class ProxyProtocolClientConnectionFactory extends ClientConnect
 
             /**
              * <p>Creates a Tag with the given metadata.</p>
+             * <p>Missing metadata will be derived from the underlying EndPoint.</p>
              *
              * @param command the LOCAL or PROXY command
              * @param family the protocol family
@@ -394,6 +447,11 @@ public abstract class ProxyProtocolClientConnectionFactory extends ClientConnect
 
             public static class TLV
             {
+                public static final int TYPE_SSL = 0x20;
+                public static final int CLIENT_SSL = 0x01;
+                public static final int SUBTYPE_SSL_VERSION = 0x21;
+                public static final int SUBTYPE_SSL_CIPHER = 0x23;
+
                 private final int type;
                 private final byte[] value;
 
@@ -571,6 +629,7 @@ public abstract class ProxyProtocolClientConnectionFactory extends ClientConnect
     private static class ProxyProtocolConnectionV2 extends ProxyProtocolConnection
     {
         private static final byte[] MAGIC = {0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A};
+        private static final int UNIX_ADDRESS_MAX_LENGTH = 108;
 
         private final V2.Tag tag;
 
@@ -589,87 +648,116 @@ public abstract class ProxyProtocolClientConnectionFactory extends ClientConnect
                 capacity += 1; // version and command
                 capacity += 1; // family and protocol
                 capacity += 2; // length
-                capacity += 216; // max address length
+                capacity += 2 * UNIX_ADDRESS_MAX_LENGTH; // max address length
                 List<V2.Tag.TLV> tlvs = tag.getTLVs();
                 int vectorsLength = tlvs == null ? 0 : tlvs.stream()
                     .mapToInt(tlv -> 1 + 2 + tlv.getValue().length)
                     .sum();
                 capacity += vectorsLength;
                 ByteBuffer buffer = ByteBuffer.allocateDirect(capacity);
+
                 buffer.put(MAGIC);
+
                 V2.Tag.Command command = tag.getCommand();
                 int versionAndCommand = (2 << 4) | (command.ordinal() & 0x0F);
                 buffer.put((byte)versionAndCommand);
-                V2.Tag.Family family = tag.getFamily();
+
                 String srcAddr = tag.getSourceAddress();
                 SocketAddress local = endPoint.getLocalSocketAddress();
+                UnixDomainSocketAddress unixLocal = local instanceof UnixDomainSocketAddress ? (UnixDomainSocketAddress)local : null;
                 InetSocketAddress inetLocal = local instanceof InetSocketAddress ? (InetSocketAddress)local : null;
                 InetAddress localAddress = inetLocal == null ? null : inetLocal.getAddress();
-                if (srcAddr == null && localAddress != null)
-                    srcAddr = localAddress.getHostAddress();
+                if (srcAddr == null)
+                {
+                    if (unixLocal != null)
+                        srcAddr = unixLocal.getPath().toString();
+                    else if (localAddress != null)
+                        srcAddr = localAddress.getHostAddress();
+                }
+
                 int srcPort = tag.getSourcePort();
                 if (srcPort <= 0 && inetLocal != null)
                     srcPort = inetLocal.getPort();
+
+                V2.Tag.Family family = tag.getFamily();
                 if (family == null)
-                    family = local == null || inetLocal == null ? V2.Tag.Family.UNSPEC : localAddress instanceof Inet4Address ? V2.Tag.Family.INET4 : V2.Tag.Family.INET6;
+                {
+                    if (unixLocal != null)
+                        family = V2.Tag.Family.UNIX;
+                    else if (inetLocal != null)
+                        family = localAddress instanceof Inet4Address ? V2.Tag.Family.INET4 : V2.Tag.Family.INET6;
+                    else
+                        family = V2.Tag.Family.UNSPEC;
+                }
+
                 V2.Tag.Protocol protocol = tag.getProtocol();
                 if (protocol == null)
                     protocol = local == null ? V2.Tag.Protocol.UNSPEC : V2.Tag.Protocol.STREAM;
+
                 int familyAndProtocol = (family.ordinal() << 4) | protocol.ordinal();
                 buffer.put((byte)familyAndProtocol);
-                int length = 0;
-                switch (family)
+
+                int length = switch (family)
                 {
-                    case UNSPEC:
-                        break;
-                    case INET4:
-                        length = 12;
-                        break;
-                    case INET6:
-                        length = 36;
-                        break;
-                    case UNIX:
-                        length = 216;
-                        break;
-                    default:
-                        throw new IllegalStateException();
-                }
+                    case UNSPEC -> 0;
+                    case INET4 -> 12;
+                    case INET6 -> 36;
+                    case UNIX -> 2 * UNIX_ADDRESS_MAX_LENGTH;
+                };
                 length += vectorsLength;
                 buffer.putShort((short)length);
+
                 String dstAddr = tag.getDestinationAddress();
                 SocketAddress remote = endPoint.getRemoteSocketAddress();
+                UnixDomainSocketAddress unixRemote = remote instanceof UnixDomainSocketAddress ? (UnixDomainSocketAddress)remote : null;
                 InetSocketAddress inetRemote = remote instanceof InetSocketAddress ? (InetSocketAddress)remote : null;
                 InetAddress remoteAddress = inetRemote == null ? null : inetRemote.getAddress();
-                if (dstAddr == null && remoteAddress != null)
-                    dstAddr = remoteAddress.getHostAddress();
+                if (dstAddr == null)
+                {
+                    if (unixRemote != null)
+                        dstAddr = unixRemote.getPath().toString();
+                    else if (remoteAddress != null)
+                        dstAddr = remoteAddress.getHostAddress();
+                }
+
                 int dstPort = tag.getDestinationPort();
                 if (dstPort <= 0 && inetRemote != null)
                     dstPort = inetRemote.getPort();
+
                 switch (family)
                 {
-                    case UNSPEC:
-                        break;
-                    case INET4:
-                    case INET6:
+                    case UNSPEC ->
+                    {
+                        // Nothing to do.
+                    }
+                    case INET4, INET6 ->
+                    {
                         buffer.put(InetAddress.getByName(srcAddr).getAddress());
                         buffer.put(InetAddress.getByName(dstAddr).getAddress());
                         buffer.putShort((short)srcPort);
                         buffer.putShort((short)dstPort);
-                        break;
-                    case UNIX:
+                    }
+                    case UNIX ->
+                    {
                         int position = buffer.position();
                         if (srcAddr != null)
-                            buffer.put(srcAddr.getBytes(StandardCharsets.US_ASCII));
-                        position = position + 108;
+                        {
+                            byte[] bytes = srcAddr.getBytes(StandardCharsets.US_ASCII);
+                            buffer.put(bytes, 0, Math.min(bytes.length, UNIX_ADDRESS_MAX_LENGTH));
+                        }
+                        position = position + UNIX_ADDRESS_MAX_LENGTH;
                         buffer.position(position);
                         if (dstAddr != null)
-                            buffer.put(dstAddr.getBytes(StandardCharsets.US_ASCII));
-                        position = position + 108;
+                        {
+                            byte[] bytes = dstAddr.getBytes(StandardCharsets.US_ASCII);
+                            buffer.put(bytes, 0, Math.min(bytes.length, UNIX_ADDRESS_MAX_LENGTH));
+                        }
+                        position = position + UNIX_ADDRESS_MAX_LENGTH;
                         buffer.position(position);
-                        break;
-                    default:
-                        throw new IllegalStateException();
+                    }
+                    default -> throw new IllegalStateException();
                 }
+
                 if (tlvs != null)
                 {
                     for (V2.Tag.TLV tlv : tlvs)
@@ -680,6 +768,7 @@ public abstract class ProxyProtocolClientConnectionFactory extends ClientConnect
                         buffer.put(data);
                     }
                 }
+
                 buffer.flip();
                 endPoint.write(callback, buffer);
             }

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/ProxyProtocolClientConnectionFactory.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/ProxyProtocolClientConnectionFactory.java
@@ -246,8 +246,8 @@ public abstract class ProxyProtocolClientConnectionFactory extends ClientConnect
                 UnixDomainSocketAddress unixSrc = src instanceof UnixDomainSocketAddress ? (UnixDomainSocketAddress)src : null;
                 InetSocketAddress inetSrc = src instanceof InetSocketAddress ? (InetSocketAddress)src : null;
                 InetAddress srcAddress = inetSrc == null ? null : inetSrc.getAddress();
-                String srcAddr = unixSrc != null ? unixSrc.getPath().toString() :
-                    srcAddress != null ? srcAddress.getHostAddress() : null;
+                String srcAddr = unixSrc != null ? unixSrc.getPath().toString()
+                    : srcAddress != null ? srcAddress.getHostAddress() : null;
 
                 int srcPort = inetSrc != null ? inetSrc.getPort() : 0;
 
@@ -263,8 +263,8 @@ public abstract class ProxyProtocolClientConnectionFactory extends ClientConnect
                 UnixDomainSocketAddress unixDst = dst instanceof UnixDomainSocketAddress ? (UnixDomainSocketAddress)dst : null;
                 InetSocketAddress inetDst = dst instanceof InetSocketAddress ? (InetSocketAddress)dst : null;
                 InetAddress dstAddress = inetDst == null ? null : inetDst.getAddress();
-                String dstAddr = unixDst != null ? unixDst.getPath().toString() :
-                    dstAddress != null ? dstAddress.getHostAddress() : null;
+                String dstAddr = unixDst != null ? unixDst.getPath().toString()
+                    : dstAddress != null ? dstAddress.getHostAddress() : null;
 
                 int dstPort = inetDst != null ? inetDst.getPort() : 0;
 
@@ -279,15 +279,15 @@ public abstract class ProxyProtocolClientConnectionFactory extends ClientConnect
                     length += 1 + 2 + cipherBytes.length;
                     byte[] value = new byte[length];
                     ByteBuffer byteBuffer = ByteBuffer.wrap(value);
-                    byteBuffer.put((byte)TLV.CLIENT_SSL);
+                    byteBuffer.put((byte)TLV.PP2_CLIENT_SSL);
                     byteBuffer.putInt(1); // Verify.
                     if (cipherSuite != null)
                     {
-                        byteBuffer.put((byte)TLV.SUBTYPE_SSL_CIPHER);
+                        byteBuffer.put((byte)TLV.PP2_SUBTYPE_SSL_CIPHER);
                         byteBuffer.putShort((short)cipherBytes.length);
                         byteBuffer.put(cipherBytes);
                     }
-                    tlvs = List.of(new TLV(TLV.TYPE_SSL, value));
+                    tlvs = List.of(new TLV(TLV.PP2_TYPE_SSL, value));
                 }
 
                 return new Tag(Command.PROXY, family, protocol, srcAddr, srcPort, dstAddr, dstPort, tlvs);
@@ -447,10 +447,10 @@ public abstract class ProxyProtocolClientConnectionFactory extends ClientConnect
 
             public static class TLV
             {
-                public static final int TYPE_SSL = 0x20;
-                public static final int CLIENT_SSL = 0x01;
-                public static final int SUBTYPE_SSL_VERSION = 0x21;
-                public static final int SUBTYPE_SSL_CIPHER = 0x23;
+                public static final int PP2_TYPE_SSL = 0x20;
+                public static final int PP2_CLIENT_SSL = 0x01;
+                public static final int PP2_SUBTYPE_SSL_VERSION = 0x21;
+                public static final int PP2_SUBTYPE_SSL_CIPHER = 0x23;
 
                 private final int type;
                 private final byte[] value;

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientProxyProtocolTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientProxyProtocolTest.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import static org.eclipse.jetty.client.ProxyProtocolClientConnectionFactory.V1;
 import static org.eclipse.jetty.client.ProxyProtocolClientConnectionFactory.V2;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -161,35 +162,32 @@ public class HttpClientProxyProtocolTest
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    public void testClientProxyProtocolV2RequestIsSecure(boolean connectedOverTls) throws Exception
+    public void testClientProxyProtocolV2RequestIsSecure(boolean secure) throws Exception
     {
+        int clientPort = ThreadLocalRandom.current().nextInt(1024, 65536);
+
         startServer(new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, Response response, Callback callback)
             {
-                response.getHeaders().put(HttpHeader.CONTENT_TYPE, MimeTypes.Type.TEXT_PLAIN.asString());
-                Content.Sink.write(response, true, Request.getRemotePort(request) + "\n" + request.isSecure(), callback);
+                assertEquals(secure, request.isSecure());
+                assertEquals(clientPort, Request.getRemotePort(request));
+                callback.succeeded();
                 return true;
             }
         });
         startClient();
 
-        int serverPort = connector.getLocalPort();
-
-        int clientPort = ThreadLocalRandom.current().nextInt(1024, 65536);
-        // See PROXY protocol specification chapter 2.2.6: The PP2_TYPE_SSL type and subtypes
-        List<V2.Tag.TLV> tlvs = List.of(new V2.Tag.TLV(
-            0x20,                                   // 0x20 == PP2_TYPE_SSL
-            new byte[]{(byte)(connectedOverTls ? 1 : 2)} // PP2_CLIENT_SSL (bit 0), i.e.: the flag indicates that the client connected over SSL/TLS
-        ));
+        List<V2.Tag.TLV> tlvs = List.of();
+        if (secure)
+            tlvs = List.of(new V2.Tag.TLV(V2.Tag.TLV.TYPE_SSL, new byte[]{V2.Tag.TLV.CLIENT_SSL}));
         V2.Tag tag = new V2.Tag("127.0.0.1", clientPort, tlvs);
 
-        ContentResponse response = client.newRequest("localhost", serverPort)
+        ContentResponse response = client.newRequest("localhost", connector.getLocalPort())
             .tag(tag)
             .send();
         assertEquals(HttpStatus.OK_200, response.getStatus());
-        assertEquals(clientPort + "\n" + connectedOverTls, response.getContentAsString());
     }
 
     @Test
@@ -207,7 +205,6 @@ public class HttpClientProxyProtocolTest
     @Test
     public void testClientProxyProtocolV2WithVectors() throws Exception
     {
-        int typeTLS = 0x20;
         String tlsVersion = "TLSv1.3";
         byte[] tlsVersionBytes = tlsVersion.getBytes(StandardCharsets.US_ASCII);
         startServer(new Handler.Abstract()
@@ -216,11 +213,11 @@ public class HttpClientProxyProtocolTest
             public boolean handle(Request request, Response response, Callback callback)
             {
                 EndPoint endPoint = request.getConnectionMetaData().getConnection().getEndPoint();
-                assertTrue(endPoint instanceof ProxyConnectionFactory.ProxyEndPoint);
+                assertInstanceOf(ProxyConnectionFactory.ProxyEndPoint.class, endPoint);
                 ProxyConnectionFactory.ProxyEndPoint proxyEndPoint = (ProxyConnectionFactory.ProxyEndPoint)endPoint;
                 if (Request.getPathInContext(request).equals("/tls_version"))
                 {
-                    assertNotNull(proxyEndPoint.getTLV(typeTLS));
+                    assertNotNull(proxyEndPoint.getTLV(V2.Tag.TLV.TYPE_SSL));
                     assertNotNull(proxyEndPoint.getSslSessionData());
                 }
                 response.getHeaders().put(HttpHeader.CONTENT_TYPE, MimeTypes.Type.TEXT_PLAIN.asString());
@@ -234,12 +231,12 @@ public class HttpClientProxyProtocolTest
 
         int clientPort = ThreadLocalRandom.current().nextInt(1024, 65536);
         byte[] dataTLS = new byte[1 + 4 + (1 + 2 + tlsVersionBytes.length)];
-        dataTLS[0] = 0x01; // CLIENT_SSL
-        dataTLS[5] = 0x21; // SUBTYPE_SSL_VERSION
-        dataTLS[6] = 0x00; // Length, hi byte
-        dataTLS[7] = (byte)tlsVersionBytes.length; // Length, lo byte
+        dataTLS[0] = V2.Tag.TLV.CLIENT_SSL;
+        dataTLS[5] = V2.Tag.TLV.SUBTYPE_SSL_VERSION;
+        dataTLS[6] = 0; // Length, hi byte.
+        dataTLS[7] = (byte)tlsVersionBytes.length; // Length, lo byte.
         System.arraycopy(tlsVersionBytes, 0, dataTLS, 8, tlsVersionBytes.length);
-        V2.Tag.TLV tlv = new V2.Tag.TLV(typeTLS, dataTLS);
+        V2.Tag.TLV tlv = new V2.Tag.TLV(V2.Tag.TLV.TYPE_SSL, dataTLS);
         V2.Tag tag = new V2.Tag("127.0.0.1", clientPort, Collections.singletonList(tlv));
 
         ContentResponse response = client.newRequest("localhost", serverPort)
@@ -250,7 +247,7 @@ public class HttpClientProxyProtocolTest
         assertEquals(String.valueOf(clientPort), response.getContentAsString());
 
         // Make another request with the same address information, but different TLV.
-        V2.Tag.TLV tlv2 = new V2.Tag.TLV(0x01, "http/1.1".getBytes(StandardCharsets.UTF_8));
+        V2.Tag.TLV tlv2 = new V2.Tag.TLV(V2.Tag.TLV.CLIENT_SSL, "http/1.1".getBytes(StandardCharsets.UTF_8));
         V2.Tag tag2 = new V2.Tag("127.0.0.1", clientPort, Collections.singletonList(tlv2));
         response = client.newRequest("localhost", serverPort)
             .tag(tag2)

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientProxyProtocolTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientProxyProtocolTest.java
@@ -39,6 +39,8 @@ import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.eclipse.jetty.client.ProxyProtocolClientConnectionFactory.V1;
 import static org.eclipse.jetty.client.ProxyProtocolClientConnectionFactory.V2;
@@ -139,7 +141,7 @@ public class HttpClientProxyProtocolTest
             public boolean handle(Request request, Response response, Callback callback)
             {
                 response.getHeaders().put(HttpHeader.CONTENT_TYPE, MimeTypes.Type.TEXT_PLAIN.asString());
-                Content.Sink.write(response, true, String.valueOf(Request.getRemotePort(request)), callback);
+                Content.Sink.write(response, true, Request.getRemotePort(request) + "\n" + request.isSecure(), callback);
                 return true;
             }
         });
@@ -154,7 +156,40 @@ public class HttpClientProxyProtocolTest
             .tag(tag)
             .send();
         assertEquals(HttpStatus.OK_200, response.getStatus());
-        assertEquals(String.valueOf(clientPort), response.getContentAsString());
+        assertEquals(clientPort + "\nfalse", response.getContentAsString());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testClientProxyProtocolV2RequestIsSecure(boolean connectedOverTls) throws Exception
+    {
+        startServer(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                response.getHeaders().put(HttpHeader.CONTENT_TYPE, MimeTypes.Type.TEXT_PLAIN.asString());
+                Content.Sink.write(response, true, Request.getRemotePort(request) + "\n" + request.isSecure(), callback);
+                return true;
+            }
+        });
+        startClient();
+
+        int serverPort = connector.getLocalPort();
+
+        int clientPort = ThreadLocalRandom.current().nextInt(1024, 65536);
+        // See PROXY protocol specification chapter 2.2.6: The PP2_TYPE_SSL type and subtypes
+        List<V2.Tag.TLV> tlvs = List.of(new V2.Tag.TLV(
+            0x20,                                   // 0x20 == PP2_TYPE_SSL
+            new byte[]{(byte)(connectedOverTls ? 1 : 2)} // PP2_CLIENT_SSL (bit 0), i.e.: the flag indicates that the client connected over SSL/TLS
+        ));
+        V2.Tag tag = new V2.Tag("127.0.0.1", clientPort, tlvs);
+
+        ContentResponse response = client.newRequest("localhost", serverPort)
+            .tag(tag)
+            .send();
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+        assertEquals(clientPort + "\n" + connectedOverTls, response.getContentAsString());
     }
 
     @Test

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientProxyProtocolTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientProxyProtocolTest.java
@@ -179,9 +179,8 @@ public class HttpClientProxyProtocolTest
         });
         startClient();
 
-        List<V2.Tag.TLV> tlvs = List.of();
-        if (secure)
-            tlvs = List.of(new V2.Tag.TLV(V2.Tag.TLV.TYPE_SSL, new byte[]{V2.Tag.TLV.CLIENT_SSL}));
+        byte pp2Client = (byte)(secure ? V2.Tag.TLV.PP2_CLIENT_SSL : 0);
+        List<V2.Tag.TLV> tlvs = List.of(new V2.Tag.TLV(V2.Tag.TLV.PP2_TYPE_SSL, new byte[]{pp2Client}));
         V2.Tag tag = new V2.Tag("127.0.0.1", clientPort, tlvs);
 
         ContentResponse response = client.newRequest("localhost", connector.getLocalPort())
@@ -217,7 +216,7 @@ public class HttpClientProxyProtocolTest
                 ProxyConnectionFactory.ProxyEndPoint proxyEndPoint = (ProxyConnectionFactory.ProxyEndPoint)endPoint;
                 if (Request.getPathInContext(request).equals("/tls_version"))
                 {
-                    assertNotNull(proxyEndPoint.getTLV(V2.Tag.TLV.TYPE_SSL));
+                    assertNotNull(proxyEndPoint.getTLV(V2.Tag.TLV.PP2_TYPE_SSL));
                     assertNotNull(proxyEndPoint.getSslSessionData());
                 }
                 response.getHeaders().put(HttpHeader.CONTENT_TYPE, MimeTypes.Type.TEXT_PLAIN.asString());
@@ -231,12 +230,12 @@ public class HttpClientProxyProtocolTest
 
         int clientPort = ThreadLocalRandom.current().nextInt(1024, 65536);
         byte[] dataTLS = new byte[1 + 4 + (1 + 2 + tlsVersionBytes.length)];
-        dataTLS[0] = V2.Tag.TLV.CLIENT_SSL;
-        dataTLS[5] = V2.Tag.TLV.SUBTYPE_SSL_VERSION;
+        dataTLS[0] = V2.Tag.TLV.PP2_CLIENT_SSL;
+        dataTLS[5] = V2.Tag.TLV.PP2_SUBTYPE_SSL_VERSION;
         dataTLS[6] = 0; // Length, hi byte.
         dataTLS[7] = (byte)tlsVersionBytes.length; // Length, lo byte.
         System.arraycopy(tlsVersionBytes, 0, dataTLS, 8, tlsVersionBytes.length);
-        V2.Tag.TLV tlv = new V2.Tag.TLV(V2.Tag.TLV.TYPE_SSL, dataTLS);
+        V2.Tag.TLV tlv = new V2.Tag.TLV(V2.Tag.TLV.PP2_TYPE_SSL, dataTLS);
         V2.Tag tag = new V2.Tag("127.0.0.1", clientPort, Collections.singletonList(tlv));
 
         ContentResponse response = client.newRequest("localhost", serverPort)
@@ -247,7 +246,7 @@ public class HttpClientProxyProtocolTest
         assertEquals(String.valueOf(clientPort), response.getContentAsString());
 
         // Make another request with the same address information, but different TLV.
-        V2.Tag.TLV tlv2 = new V2.Tag.TLV(V2.Tag.TLV.CLIENT_SSL, "http/1.1".getBytes(StandardCharsets.UTF_8));
+        V2.Tag.TLV tlv2 = new V2.Tag.TLV(V2.Tag.TLV.PP2_CLIENT_SSL, "http/1.1".getBytes(StandardCharsets.UTF_8));
         V2.Tag tag2 = new V2.Tag("127.0.0.1", clientPort, Collections.singletonList(tlv2));
         response = client.newRequest("localhost", serverPort)
             .tag(tag2)

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ProxyConnectionFactory.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ProxyConnectionFactory.java
@@ -689,7 +689,7 @@ public class ProxyConnectionFactory extends DetectorConnectionFactory
                         }
                     }
 
-                    proxyEndPoint = new ProxyEndPoint(endPoint, local, remote, tlvs, (client & PP2_CLIENT_SSL) == 0 ? null : EndPoint.SslSessionData.from(null, null, sslCipher, null));
+                    proxyEndPoint = new ProxyEndPoint(endPoint, local, remote, tlvs, client == 0 ? null : EndPoint.SslSessionData.from(null, null, sslCipher, null));
 
                     if (LOG.isDebugEnabled())
                         LOG.debug("Proxy v2 {} {}", endPoint, proxyEndPoint);

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ProxyConnectionFactory.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ProxyConnectionFactory.java
@@ -689,7 +689,7 @@ public class ProxyConnectionFactory extends DetectorConnectionFactory
                         }
                     }
 
-                    proxyEndPoint = new ProxyEndPoint(endPoint, local, remote, tlvs, client == 0 ? null : EndPoint.SslSessionData.from(null, null, sslCipher, null));
+                    proxyEndPoint = new ProxyEndPoint(endPoint, local, remote, tlvs, (client & PP2_CLIENT_SSL) == 0 ? null : EndPoint.SslSessionData.from(null, null, sslCipher, null));
 
                     if (LOG.isDebugEnabled())
                         LOG.debug("Proxy v2 {} {}", endPoint, proxyEndPoint);

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -53,7 +53,6 @@ import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.io.EofException;
 import org.eclipse.jetty.io.RetainableByteBuffer;
-import org.eclipse.jetty.io.ssl.SslConnection;
 import org.eclipse.jetty.server.AbstractMetaDataConnection;
 import org.eclipse.jetty.server.ConnectionFactory;
 import org.eclipse.jetty.server.ConnectionMetaData;
@@ -1363,7 +1362,7 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
 
             // Set the scheme in the URI
             if (!_uri.isAbsolute())
-                _uri.scheme(getEndPoint() instanceof SslConnection.SslEndPoint ? HttpScheme.HTTPS : HttpScheme.HTTP);
+                _uri.scheme(getEndPoint().getSslSessionData() != null ? HttpScheme.HTTPS : HttpScheme.HTTP);
 
             // Set the authority (if not already set) in the URI
             if (_uri.getAuthority() == null && !HttpMethod.CONNECT.is(_method))

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/ProxyWithProxyProtocolTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/ProxyWithProxyProtocolTest.java
@@ -1,0 +1,111 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.test.client.transport;
+
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.client.ContentResponse;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.ProxyProtocolClientConnectionFactory;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpURI;
+import org.eclipse.jetty.io.EndPoint;
+import org.eclipse.jetty.proxy.ProxyHandler;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.ProxyConnectionFactory;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.toolchain.test.MavenPaths;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ProxyWithProxyProtocolTest
+{
+    private Server server;
+    private ServerConnector serverConnector;
+    private Server proxy;
+    private ServerConnector proxyConnector;
+    private HttpClient client;
+
+    private void start(Handler handler) throws Exception
+    {
+        server = new Server();
+        serverConnector = new ServerConnector(server, 1, 1, new ProxyConnectionFactory(), new HttpConnectionFactory());
+        server.addConnector(serverConnector);
+        server.setHandler(handler);
+        server.start();
+
+        SslContextFactory.Server proxyTLS = new SslContextFactory.Server();
+        proxyTLS.setKeyStorePath(MavenPaths.findTestResourceFile("keystore.p12"));
+        proxyTLS.setKeyStorePassword("storepwd");
+        proxy = new Server();
+        proxyConnector = new ServerConnector(proxy, 1, 1, proxyTLS);
+        proxy.addConnector(proxyConnector);
+        proxy.setHandler(new ProxyHandler.Reverse(request -> HttpURI.from("http://localhost:" + serverConnector.getLocalPort()))
+        {
+            @Override
+            protected org.eclipse.jetty.client.Request newProxyToServerRequest(Request clientToProxyRequest, HttpURI newHttpURI)
+            {
+                var request = super.newProxyToServerRequest(clientToProxyRequest, newHttpURI);
+                EndPoint clientToProxyEndPoint = clientToProxyRequest.getConnectionMetaData().getConnection().getEndPoint();
+                // Forward the remote client information to the server.
+                return request.tag(ProxyProtocolClientConnectionFactory.V2.Tag.from(clientToProxyEndPoint, false));
+            }
+        });
+        proxy.start();
+
+        SslContextFactory.Client clientTLS = new SslContextFactory.Client(true);
+        client = new HttpClient();
+        client.setSslContextFactory(clientTLS);
+        client.start();
+    }
+
+    @AfterEach
+    public void dispose()
+    {
+        LifeCycle.stop(client);
+        LifeCycle.stop(proxy);
+        LifeCycle.stop(server);
+    }
+
+    @Test
+    public void testProxyWithProxyProtocol() throws Exception
+    {
+        start(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                assertTrue(request.isSecure());
+                callback.succeeded();
+                return true;
+            }
+        });
+
+        ContentResponse response = client.newRequest("https://localhost:" + proxyConnector.getLocalPort())
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/jetty/jetty.project/issues/14134