### PR TITLE
Issue #14061 - Fix Alt-Svc header to use HTTP/3 connector port

### DIFF
--- a/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/server/http/HTTPServerDocs.java
+++ b/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/server/http/HTTPServerDocs.java
@@ -621,15 +621,12 @@ public class HTTPServerDocs
         HTTP2ServerConnectionFactory h2 = new HTTP2ServerConnectionFactory(httpConfig);
 
         // Configure AltSvcCustomizer after connection factory creation.
-        httpConfig.getCustomizers().stream()
-            .filter(c -> c instanceof HTTP2ServerConnectionFactory.AltSvcCustomizer)
-            .map(HTTP2ServerConnectionFactory.AltSvcCustomizer.class::cast)
-            .findFirst()
-            .ifPresent(customizer ->
-            {
-                customizer.setMaxAge(Duration.ofHours(24));
-                customizer.setPersist(true);
-            });
+        HTTP2ServerConnectionFactory.AltSvcCustomizer h2AltSvc = httpConfig.getCustomizer(HTTP2ServerConnectionFactory.AltSvcCustomizer.class);
+        if (h2AltSvc != null)
+        {
+            h2AltSvc.setMaxAge(Duration.ofHours(24));
+            h2AltSvc.setPersist(true);
+        }
         // end::h2altsvc[]
     }
 

--- a/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/server/http/HTTPServerDocs.java
+++ b/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/server/http/HTTPServerDocs.java
@@ -614,6 +614,25 @@ public class HTTPServerDocs
         // end::h3[]
     }
 
+    public void h2altsvc()
+    {
+        // tag::h2altsvc[]
+        HttpConfiguration httpConfig = new HttpConfiguration();
+        HTTP2ServerConnectionFactory h2 = new HTTP2ServerConnectionFactory(httpConfig);
+
+        // Configure AltSvcCustomizer after connection factory creation.
+        httpConfig.getCustomizers().stream()
+            .filter(c -> c instanceof HTTP2ServerConnectionFactory.AltSvcCustomizer)
+            .map(HTTP2ServerConnectionFactory.AltSvcCustomizer.class::cast)
+            .findFirst()
+            .ifPresent(customizer ->
+            {
+                customizer.setMaxAge(Duration.ofHours(24));
+                customizer.setPersist(true);
+            });
+        // end::h2altsvc[]
+    }
+
     public void conscrypt()
     {
         // tag::conscrypt[]

--- a/documentation/jetty/modules/programming-guide/pages/server/http.adoc
+++ b/documentation/jetty/modules/programming-guide/pages/server/http.adoc
@@ -529,7 +529,7 @@ For example, an HTTP/2 response may include the following header:
 
 [source]
 ----
-Alt-Svc: h3=":843"; ma=86400
+Alt-Svc: h3=":843"
 ----
 
 The presence of this header indicates that protocol `h3` is available on the same host (since no host is defined before the port), but on port `843` (although it may be the same port `443`).
@@ -546,18 +546,7 @@ To configure the `AltSvcCustomizer`, retrieve it from the `HttpConfiguration` af
 
 [,java,indent=0,options=nowrap]
 ----
-HttpConfiguration httpConfig = new HttpConfiguration();
-HTTP2ServerConnectionFactory h2 = new HTTP2ServerConnectionFactory(httpConfig);
-
-// Configure AltSvcCustomizer after connection factory creation
-httpConfig.getCustomizers().stream()
-    .filter(c -> c instanceof HTTP2ServerConnectionFactory.AltSvcCustomizer)
-    .map(HTTP2ServerConnectionFactory.AltSvcCustomizer.class::cast)
-    .findFirst()
-    .ifPresent(customizer -> {
-        customizer.setMaxAge(Duration.ofHours(24));
-        customizer.setPersist(true);
-    });
+include::code:example$src/main/java/org/eclipse/jetty/docs/programming/server/http/HTTPServerDocs.java[tags=h2altsvc]
 ----
 
 It is therefore common for HTTP/3 clients to initiate connections using the HTTP/2 protocol over TCP, and if the server supports HTTP/3 switch to HTTP/3 as indicated by the server.
@@ -573,7 +562,7 @@ participant "server:443" as h2server
 participant "server:843" as h3server
 
 client -> h2server : HTTP/2 request
-h2server -> client : HTTP/2 response\nAlt-Svc: h3=":843"; ma=86400
+h2server -> client : HTTP/2 response\nAlt-Svc: h3=":843"
 client -> h3server : HTTP/3 requests
 h3server -> client : HTTP/3 responses
 ...

--- a/documentation/jetty/modules/programming-guide/pages/server/http.adoc
+++ b/documentation/jetty/modules/programming-guide/pages/server/http.adoc
@@ -529,15 +529,17 @@ For example, an HTTP/2 response may include the following header:
 
 [source]
 ----
-Alt-Svc: h3=":843"
+Alt-Svc: h3=":843"; ma=86400
 ----
 
 The presence of this header indicates that protocol `h3` is available on the same host (since no host is defined before the port), but on port `843` (although it may be the same port `443`).
+The `ma` (max-age) attribute specifies how long (in seconds) the client should cache this information (86400 seconds = 24 hours).
 The HTTP/3 client may now initiate a QUIC connection on port `843` and make HTTP/3 requests.
 
 NOTE: It is nowadays common to use the same port `443` for both HTTP/2 and HTTP/3. This does not cause problems because HTTP/2 listens on the TCP port `443`, while QUIC listens on the UDP port `443`.
 
-TIP: The `Alt-Svc` header is automatically added to HTTP/2 responses, advertising the HTTP/3 connector's port.
+TIP: The `Alt-Svc` header is automatically added to HTTP/2 responses by `HTTP2ServerConnectionFactory.AltSvcCustomizer`, advertising the HTTP/3 connector's port.
+The `ma` attribute defaults to 24 hours and can be configured via `AltSvcCustomizer.setMaxAge(Duration)`.
 
 It is therefore common for HTTP/3 clients to initiate connections using the HTTP/2 protocol over TCP, and if the server supports HTTP/3 switch to HTTP/3 as indicated by the server.
 
@@ -552,7 +554,7 @@ participant "server:443" as h2server
 participant "server:843" as h3server
 
 client -> h2server : HTTP/2 request
-h2server -> client : HTTP/2 response\nAlt-Svc: h3=":843"
+h2server -> client : HTTP/2 response\nAlt-Svc: h3=":843"; ma=86400
 client -> h3server : HTTP/3 requests
 h3server -> client : HTTP/3 responses
 ...

--- a/documentation/jetty/modules/programming-guide/pages/server/http.adoc
+++ b/documentation/jetty/modules/programming-guide/pages/server/http.adoc
@@ -537,6 +537,8 @@ The HTTP/3 client may now initiate a QUIC connection on port `843` and make HTTP
 
 NOTE: It is nowadays common to use the same port `443` for both HTTP/2 and HTTP/3. This does not cause problems because HTTP/2 listens on the TCP port `443`, while QUIC listens on the UDP port `443`.
 
+TIP: The `Alt-Svc` header is automatically added to HTTP/2 responses, advertising the HTTP/3 connector's port.
+
 It is therefore common for HTTP/3 clients to initiate connections using the HTTP/2 protocol over TCP, and if the server supports HTTP/3 switch to HTTP/3 as indicated by the server.
 
 [plantuml]

--- a/documentation/jetty/modules/programming-guide/pages/server/http.adoc
+++ b/documentation/jetty/modules/programming-guide/pages/server/http.adoc
@@ -538,7 +538,7 @@ The HTTP/3 client may now initiate a QUIC connection on port `843` and make HTTP
 
 NOTE: It is nowadays common to use the same port `443` for both HTTP/2 and HTTP/3. This does not cause problems because HTTP/2 listens on the TCP port `443`, while QUIC listens on the UDP port `443`.
 
-TIP: The `Alt-Svc` header is automatically added to HTTP/2 responses by `HTTP2ServerConnectionFactory.AltSvcCustomizer`, advertising the HTTP/3 connector's port.
+NOTE: The `Alt-Svc` header is automatically added to HTTP/2 responses if an HTTP/3 connector is present, advertising the HTTP/3 connector's port.
 By default, only the port is advertised without additional attributes.
 The `ma` (max-age) attribute can be configured via `AltSvcCustomizer.setMaxAge(Duration)` and the `persist` attribute via `AltSvcCustomizer.setPersist(boolean)`.
 

--- a/documentation/jetty/modules/programming-guide/pages/server/http.adoc
+++ b/documentation/jetty/modules/programming-guide/pages/server/http.adoc
@@ -539,7 +539,26 @@ The HTTP/3 client may now initiate a QUIC connection on port `843` and make HTTP
 NOTE: It is nowadays common to use the same port `443` for both HTTP/2 and HTTP/3. This does not cause problems because HTTP/2 listens on the TCP port `443`, while QUIC listens on the UDP port `443`.
 
 TIP: The `Alt-Svc` header is automatically added to HTTP/2 responses by `HTTP2ServerConnectionFactory.AltSvcCustomizer`, advertising the HTTP/3 connector's port.
-The `ma` attribute defaults to 24 hours and can be configured via `AltSvcCustomizer.setMaxAge(Duration)`.
+By default, only the port is advertised without additional attributes.
+The `ma` (max-age) attribute can be configured via `AltSvcCustomizer.setMaxAge(Duration)` and the `persist` attribute via `AltSvcCustomizer.setPersist(boolean)`.
+
+To configure the `AltSvcCustomizer`, retrieve it from the `HttpConfiguration` after creating the `HTTP2ServerConnectionFactory`:
+
+[,java,indent=0,options=nowrap]
+----
+HttpConfiguration httpConfig = new HttpConfiguration();
+HTTP2ServerConnectionFactory h2 = new HTTP2ServerConnectionFactory(httpConfig);
+
+// Configure AltSvcCustomizer after connection factory creation
+httpConfig.getCustomizers().stream()
+    .filter(c -> c instanceof HTTP2ServerConnectionFactory.AltSvcCustomizer)
+    .map(HTTP2ServerConnectionFactory.AltSvcCustomizer.class::cast)
+    .findFirst()
+    .ifPresent(customizer -> {
+        customizer.setMaxAge(Duration.ofHours(24));
+        customizer.setPersist(true);
+    });
+----
 
 It is therefore common for HTTP/3 clients to initiate connections using the HTTP/2 protocol over TCP, and if the server supports HTTP/3 switch to HTTP/3 as indicated by the server.
 

--- a/documentation/jetty/modules/programming-guide/pages/server/http.adoc
+++ b/documentation/jetty/modules/programming-guide/pages/server/http.adoc
@@ -533,7 +533,7 @@ Alt-Svc: h3=":843"
 ----
 
 The presence of this header indicates that protocol `h3` is available on the same host (since no host is defined before the port), but on port `843` (although it may be the same port `443`).
-The `ma` (max-age) attribute specifies how long (in seconds) the client should cache this information (86400 seconds = 24 hours).
+The `ma` (max-age) attribute specifies how long (in seconds) the client should cache this information.
 The HTTP/3 client may now initiate a QUIC connection on port `843` and make HTTP/3 requests.
 
 NOTE: It is nowadays common to use the same port `443` for both HTTP/2 and HTTP/3. This does not cause problems because HTTP/2 listens on the TCP port `443`, while QUIC listens on the UDP port `443`.

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/HTTP2ServerConnectionFactory.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/HTTP2ServerConnectionFactory.java
@@ -17,6 +17,9 @@ import java.io.EOFException;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http2.ErrorCode;
 import org.eclipse.jetty.http2.HTTP2Cipher;
 import org.eclipse.jetty.http2.HTTP2Stream;
@@ -35,6 +38,9 @@ import org.eclipse.jetty.io.QuietException;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.NegotiatingServerConnection.CipherDiscriminator;
+import org.eclipse.jetty.server.NetworkConnector;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.Promise;
 import org.eclipse.jetty.util.StringUtil;
@@ -54,11 +60,13 @@ public class HTTP2ServerConnectionFactory extends AbstractHTTP2ServerConnectionF
     public HTTP2ServerConnectionFactory(@Name("config") HttpConfiguration httpConfiguration)
     {
         super(httpConfiguration);
+        httpConfiguration.addCustomizer(new AltSvcCustomizer());
     }
 
     public HTTP2ServerConnectionFactory(@Name("config") HttpConfiguration httpConfiguration, @Name("protocols") String... protocols)
     {
         super(httpConfiguration, protocols);
+        httpConfiguration.addCustomizer(new AltSvcCustomizer());
     }
 
     @Override
@@ -189,6 +197,35 @@ public class HTTP2ServerConnectionFactory extends AbstractHTTP2ServerConnectionF
         private void close(Stream stream, String reason)
         {
             stream.getSession().close(ErrorCode.PROTOCOL_ERROR.code, reason, Callback.NOOP);
+        }
+    }
+
+    /**
+     * <p>An {@link HttpConfiguration.Customizer} that adds the {@code Alt-Svc}
+     * header to HTTP/2 responses, advertising HTTP/3 support if an HTTP/3
+     * connector is available on the server.</p>
+     */
+    public static class AltSvcCustomizer implements HttpConfiguration.Customizer
+    {
+        @Override
+        public Request customize(Request request, HttpFields.Mutable responseHeaders)
+        {
+            if (HttpVersion.HTTP_2 != request.getConnectionMetaData().getHttpVersion())
+                return request;
+
+            Server server = request.getConnectionMetaData().getConnector().getServer();
+            for (Connector connector : server.getConnectors())
+            {
+                if (connector instanceof NetworkConnector nc &&
+                    connector.getProtocols().contains("h3"))
+                {
+                    int port = nc.getLocalPort();
+                    if (port > 0)
+                        responseHeaders.add(HttpHeader.ALT_SVC, String.format("h3=\":%d\"", port));
+                    break;
+                }
+            }
+            return request;
         }
     }
 }

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/HTTP2ServerConnectionFactory.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/HTTP2ServerConnectionFactory.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.http2.server;
 
 import java.io.EOFException;
+import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
@@ -207,6 +208,26 @@ public class HTTP2ServerConnectionFactory extends AbstractHTTP2ServerConnectionF
      */
     public static class AltSvcCustomizer implements HttpConfiguration.Customizer
     {
+        private Duration _maxAge = Duration.ofHours(24);
+
+        /**
+         * @return The max age for the Alt-Svc response header, or null if no max-age attribute should be sent.
+         */
+        public Duration getMaxAge()
+        {
+            return _maxAge;
+        }
+
+        /**
+         * Sets the Alt-Svc max age.
+         *
+         * @param maxAge the max age for the Alt-Svc response header, or null if no max-age attribute should be sent.
+         */
+        public void setMaxAge(Duration maxAge)
+        {
+            _maxAge = maxAge;
+        }
+
         @Override
         public Request customize(Request request, HttpFields.Mutable responseHeaders)
         {
@@ -221,7 +242,12 @@ public class HTTP2ServerConnectionFactory extends AbstractHTTP2ServerConnectionF
                 {
                     int port = nc.getLocalPort();
                     if (port > 0)
-                        responseHeaders.add(HttpHeader.ALT_SVC, String.format("h3=\":%d\"", port));
+                    {
+                        String altSvc = _maxAge != null
+                            ? String.format("h3=\":%d\"; ma=%d", port, _maxAge.toSeconds())
+                            : String.format("h3=\":%d\"", port);
+                        responseHeaders.add(HttpHeader.ALT_SVC, altSvc);
+                    }
                     break;
                 }
             }

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/HTTP2ServerConnectionFactory.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/HTTP2ServerConnectionFactory.java
@@ -208,7 +208,8 @@ public class HTTP2ServerConnectionFactory extends AbstractHTTP2ServerConnectionF
      */
     public static class AltSvcCustomizer implements HttpConfiguration.Customizer
     {
-        private Duration _maxAge = Duration.ofHours(24);
+        private Duration _maxAge;
+        private boolean _persist;
 
         /**
          * @return The max age for the Alt-Svc response header, or null if no max-age attribute should be sent.
@@ -228,6 +229,27 @@ public class HTTP2ServerConnectionFactory extends AbstractHTTP2ServerConnectionF
             _maxAge = maxAge;
         }
 
+        /**
+         * @return whether the persist parameter should be included in the Alt-Svc header.
+         */
+        public boolean isPersist()
+        {
+            return _persist;
+        }
+
+        /**
+         * Sets whether to include the persist parameter in the Alt-Svc header.
+         * When true, adds {@code persist=1} to indicate the alternative service
+         * should be persisted across network changes.
+         *
+         * @param persist true to include the persist parameter, false otherwise.
+         * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Alt-Svc#persist1">Alt-Svc persist parameter</a>
+         */
+        public void setPersist(boolean persist)
+        {
+            _persist = persist;
+        }
+
         @Override
         public Request customize(Request request, HttpFields.Mutable responseHeaders)
         {
@@ -243,10 +265,13 @@ public class HTTP2ServerConnectionFactory extends AbstractHTTP2ServerConnectionF
                     int port = nc.getLocalPort();
                     if (port > 0)
                     {
-                        String altSvc = _maxAge != null
-                            ? String.format("h3=\":%d\"; ma=%d", port, _maxAge.toSeconds())
-                            : String.format("h3=\":%d\"", port);
-                        responseHeaders.add(HttpHeader.ALT_SVC, altSvc);
+                        StringBuilder altSvc = new StringBuilder();
+                        altSvc.append(String.format("h3=\":%d\"", port));
+                        if (_maxAge != null)
+                            altSvc.append(String.format("; ma=%d", _maxAge.toSeconds()));
+                        if (_persist)
+                            altSvc.append("; persist=1");
+                        responseHeaders.add(HttpHeader.ALT_SVC, altSvc.toString());
                     }
                     break;
                 }

--- a/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/AbstractHTTP3ServerConnectionFactory.java
+++ b/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/AbstractHTTP3ServerConnectionFactory.java
@@ -83,6 +83,11 @@ public abstract class AbstractHTTP3ServerConnectionFactory extends AbstractConne
         this.connector = connector;
     }
 
+    protected Connector getConnector()
+    {
+        return connector;
+    }
+
     @Override
     protected void doStart() throws Exception
     {

--- a/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/AbstractHTTP3ServerConnectionFactory.java
+++ b/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/AbstractHTTP3ServerConnectionFactory.java
@@ -83,11 +83,6 @@ public abstract class AbstractHTTP3ServerConnectionFactory extends AbstractConne
         this.connector = connector;
     }
 
-    protected Connector getConnector()
-    {
-        return connector;
-    }
-
     @Override
     protected void doStart() throws Exception
     {

--- a/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/HTTP3ServerConnectionFactory.java
+++ b/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/HTTP3ServerConnectionFactory.java
@@ -17,9 +17,6 @@ import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeoutException;
 
-import org.eclipse.jetty.http.HttpFields;
-import org.eclipse.jetty.http.HttpHeader;
-import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http3.HTTP3Stream;
 import org.eclipse.jetty.http3.api.Session;
 import org.eclipse.jetty.http3.api.Stream;
@@ -28,11 +25,7 @@ import org.eclipse.jetty.http3.server.internal.HTTP3SessionServer;
 import org.eclipse.jetty.http3.server.internal.HTTP3StreamServer;
 import org.eclipse.jetty.http3.server.internal.HttpStreamOverHTTP3;
 import org.eclipse.jetty.http3.server.internal.ServerHTTP3StreamConnection;
-import org.eclipse.jetty.server.ConnectionMetaData;
-import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.HttpConfiguration;
-import org.eclipse.jetty.server.NetworkConnector;
-import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.util.Promise;
 import org.eclipse.jetty.util.thread.Invocable;
 import org.eclipse.jetty.util.thread.ThreadPool;
@@ -49,27 +42,6 @@ public class HTTP3ServerConnectionFactory extends AbstractHTTP3ServerConnectionF
     public HTTP3ServerConnectionFactory(HttpConfiguration configuration)
     {
         super(configuration, new HTTP3SessionListener());
-        configuration.addCustomizer(new AltSvcCustomizer());
-    }
-
-    private class AltSvcCustomizer implements HttpConfiguration.Customizer
-    {
-        @Override
-        public Request customize(Request request, HttpFields.Mutable responseHeaders)
-        {
-            ConnectionMetaData connectionMetaData = request.getConnectionMetaData();
-            if (HttpVersion.HTTP_2 == connectionMetaData.getHttpVersion())
-            {
-                Connector h3Connector = HTTP3ServerConnectionFactory.this.getConnector();
-                if (h3Connector instanceof NetworkConnector nc)
-                {
-                    int port = nc.getLocalPort();
-                    if (port > 0)
-                        responseHeaders.add(HttpHeader.ALT_SVC, String.format("h3=\":%d\"", port));
-                }
-            }
-            return request;
-        }
     }
 
     private static class HTTP3SessionListener implements HTTP3SessionServer.Listener

--- a/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/HTTP3ServerConnectionFactory.java
+++ b/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/HTTP3ServerConnectionFactory.java
@@ -52,15 +52,22 @@ public class HTTP3ServerConnectionFactory extends AbstractHTTP3ServerConnectionF
         configuration.addCustomizer(new AltSvcCustomizer());
     }
 
-    private static class AltSvcCustomizer implements HttpConfiguration.Customizer
+    private class AltSvcCustomizer implements HttpConfiguration.Customizer
     {
         @Override
         public Request customize(Request request, HttpFields.Mutable responseHeaders)
         {
             ConnectionMetaData connectionMetaData = request.getConnectionMetaData();
-            Connector connector = connectionMetaData.getConnector();
-            if (connector instanceof NetworkConnector networkConnector && HttpVersion.HTTP_2 == connectionMetaData.getHttpVersion())
-                responseHeaders.add(HttpHeader.ALT_SVC, String.format("h3=\":%d\"", networkConnector.getLocalPort()));
+            if (HttpVersion.HTTP_2 == connectionMetaData.getHttpVersion())
+            {
+                Connector h3Connector = HTTP3ServerConnectionFactory.this.getConnector();
+                if (h3Connector instanceof NetworkConnector nc)
+                {
+                    int port = nc.getLocalPort();
+                    if (port > 0)
+                        responseHeaders.add(HttpHeader.ALT_SVC, String.format("h3=\":%d\"", port));
+                }
+            }
             return request;
         }
     }

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AltSvcTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AltSvcTest.java
@@ -51,9 +51,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(WorkDirExtension.class)
 public class AltSvcTest
@@ -75,8 +73,11 @@ public class AltSvcTest
         // Setup server with HTTP/2 (TLS) and HTTP/3 on different ports
         server = new Server();
 
-        HttpConfiguration httpConfig = new HttpConfiguration();
-        httpConfig.addCustomizer(new SecureRequestCustomizer());
+        HttpConfiguration httpConfigH2 = new HttpConfiguration();
+        httpConfigH2.addCustomizer(new SecureRequestCustomizer());
+
+        HttpConfiguration httpConfigH3 = new HttpConfiguration();
+        httpConfigH3.addCustomizer(new SecureRequestCustomizer());
 
         // SSL context factory for server
         SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
@@ -86,7 +87,7 @@ public class AltSvcTest
         sslContextFactory.setUseCipherSuitesOrder(true);
 
         // HTTP/2 connector with TLS
-        HTTP2ServerConnectionFactory h2Factory = new HTTP2ServerConnectionFactory(httpConfig);
+        HTTP2ServerConnectionFactory h2Factory = new HTTP2ServerConnectionFactory(httpConfigH2);
         ALPNServerConnectionFactory alpn = new ALPNServerConnectionFactory();
         alpn.setDefaultProtocol(h2Factory.getProtocol());
         SslConnectionFactory ssl = new SslConnectionFactory(sslContextFactory, alpn.getProtocol());
@@ -96,7 +97,7 @@ public class AltSvcTest
 
         // HTTP/3 connector on a different port
         QuicheServerQuicConfiguration serverQuicConfig = HTTP3ServerQuicConfiguration.configure(new QuicheServerQuicConfiguration(workDir.getEmptyPathDir()));
-        HTTP3ServerConnectionFactory h3Factory = new HTTP3ServerConnectionFactory(httpConfig);
+        HTTP3ServerConnectionFactory h3Factory = new HTTP3ServerConnectionFactory(httpConfigH3);
         QuicheServerConnector h3Connector = new QuicheServerConnector(server, sslContextFactory, serverQuicConfig, h3Factory);
         h3Connector.setPort(0);
         server.addConnector(h3Connector);
@@ -116,9 +117,6 @@ public class AltSvcTest
 
         int h2Port = h2Connector.getLocalPort();
         int h3Port = h3Connector.getLocalPort();
-
-        // Verify ports are different for this test
-        assertNotEquals(h2Port, h3Port, "Test requires different ports for HTTP/2 and HTTP/3");
 
         // Create HTTP/2 client with TLS
         SslContextFactory.Client sslContextFactoryClient = new SslContextFactory.Client();
@@ -152,8 +150,11 @@ public class AltSvcTest
         // Setup server with HTTP/2 (TLS) and HTTP/3 on different ports
         server = new Server();
 
-        HttpConfiguration httpConfig = new HttpConfiguration();
-        httpConfig.addCustomizer(new SecureRequestCustomizer());
+        HttpConfiguration httpConfigH2 = new HttpConfiguration();
+        httpConfigH2.addCustomizer(new SecureRequestCustomizer());
+
+        HttpConfiguration httpConfigH3 = new HttpConfiguration();
+        httpConfigH3.addCustomizer(new SecureRequestCustomizer());
 
         // SSL context factory for server
         SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
@@ -163,9 +164,9 @@ public class AltSvcTest
         sslContextFactory.setUseCipherSuitesOrder(true);
 
         // HTTP/2 connector with TLS and custom AltSvcCustomizer maxAge
-        HTTP2ServerConnectionFactory h2Factory = new HTTP2ServerConnectionFactory(httpConfig);
+        HTTP2ServerConnectionFactory h2Factory = new HTTP2ServerConnectionFactory(httpConfigH2);
         // Find and configure the AltSvcCustomizer
-        httpConfig.getCustomizers().stream()
+        httpConfigH2.getCustomizers().stream()
             .filter(c -> c instanceof HTTP2ServerConnectionFactory.AltSvcCustomizer)
             .map(HTTP2ServerConnectionFactory.AltSvcCustomizer.class::cast)
             .findFirst()
@@ -180,7 +181,7 @@ public class AltSvcTest
 
         // HTTP/3 connector on a different port
         QuicheServerQuicConfiguration serverQuicConfig = HTTP3ServerQuicConfiguration.configure(new QuicheServerQuicConfiguration(workDir.getEmptyPathDir()));
-        HTTP3ServerConnectionFactory h3Factory = new HTTP3ServerConnectionFactory(httpConfig);
+        HTTP3ServerConnectionFactory h3Factory = new HTTP3ServerConnectionFactory(httpConfigH3);
         QuicheServerConnector h3Connector = new QuicheServerConnector(server, sslContextFactory, serverQuicConfig, h3Factory);
         h3Connector.setPort(0);
         server.addConnector(h3Connector);

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AltSvcTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AltSvcTest.java
@@ -1,0 +1,145 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.test.client.transport;
+
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory;
+import org.eclipse.jetty.client.ContentResponse;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http2.HTTP2Cipher;
+import org.eclipse.jetty.http2.client.HTTP2Client;
+import org.eclipse.jetty.http2.client.transport.HttpClientTransportOverHTTP2;
+import org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory;
+import org.eclipse.jetty.http3.server.HTTP3ServerConnectionFactory;
+import org.eclipse.jetty.http3.server.HTTP3ServerQuicConfiguration;
+import org.eclipse.jetty.io.ClientConnector;
+import org.eclipse.jetty.quic.quiche.server.QuicheServerConnector;
+import org.eclipse.jetty.quic.quiche.server.QuicheServerQuicConfiguration;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.SecureRequestCustomizer;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.SslConnectionFactory;
+import org.eclipse.jetty.toolchain.test.MavenPaths;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(WorkDirExtension.class)
+public class AltSvcTest
+{
+    public WorkDir workDir;
+    private Server server;
+    private HttpClient client;
+
+    @AfterEach
+    public void dispose()
+    {
+        LifeCycle.stop(client);
+        LifeCycle.stop(server);
+    }
+
+    @Test
+    public void testAltSvcHeaderContainsHTTP3Port() throws Exception
+    {
+        // Setup server with HTTP/2 (TLS) and HTTP/3 on different ports
+        server = new Server();
+
+        HttpConfiguration httpConfig = new HttpConfiguration();
+        httpConfig.addCustomizer(new SecureRequestCustomizer());
+
+        // SSL context factory for server
+        SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
+        sslContextFactory.setKeyStorePath(MavenPaths.findTestResourceFile("keystore.p12").toString());
+        sslContextFactory.setKeyStorePassword("storepwd");
+        sslContextFactory.setCipherComparator(HTTP2Cipher.COMPARATOR);
+        sslContextFactory.setUseCipherSuitesOrder(true);
+
+        // HTTP/2 connector with TLS
+        HTTP2ServerConnectionFactory h2Factory = new HTTP2ServerConnectionFactory(httpConfig);
+        ALPNServerConnectionFactory alpn = new ALPNServerConnectionFactory();
+        alpn.setDefaultProtocol(h2Factory.getProtocol());
+        SslConnectionFactory ssl = new SslConnectionFactory(sslContextFactory, alpn.getProtocol());
+        ServerConnector h2Connector = new ServerConnector(server, ssl, alpn, h2Factory);
+        h2Connector.setPort(0);
+        server.addConnector(h2Connector);
+
+        // HTTP/3 connector on a different port
+        QuicheServerQuicConfiguration serverQuicConfig = HTTP3ServerQuicConfiguration.configure(new QuicheServerQuicConfiguration(workDir.getEmptyPathDir()));
+        HTTP3ServerConnectionFactory h3Factory = new HTTP3ServerConnectionFactory(httpConfig);
+        QuicheServerConnector h3Connector = new QuicheServerConnector(server, sslContextFactory, serverQuicConfig, h3Factory);
+        h3Connector.setPort(0);
+        server.addConnector(h3Connector);
+
+        server.setHandler(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                response.setStatus(HttpStatus.OK_200);
+                callback.succeeded();
+                return true;
+            }
+        });
+
+        server.start();
+
+        int h2Port = h2Connector.getLocalPort();
+        int h3Port = h3Connector.getLocalPort();
+
+        // Verify ports are different for this test
+        assertNotEquals(h2Port, h3Port, "Test requires different ports for HTTP/2 and HTTP/3");
+
+        // Create HTTP/2 client with TLS
+        SslContextFactory.Client sslContextFactoryClient = new SslContextFactory.Client();
+        sslContextFactoryClient.setTrustAll(true);
+
+        ClientConnector clientConnector = new ClientConnector();
+        clientConnector.setSslContextFactory(sslContextFactoryClient);
+
+        HTTP2Client http2Client = new HTTP2Client(clientConnector);
+        client = new HttpClient(new HttpClientTransportOverHTTP2(http2Client));
+        client.start();
+
+        // Make HTTP/2 request
+        ContentResponse response = client.newRequest("localhost", h2Port)
+            .scheme("https")
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+
+        // Verify Alt-Svc header contains the HTTP/3 port, not the HTTP/2 port
+        String altSvc = response.getHeaders().get(HttpHeader.ALT_SVC);
+        assertNotNull(altSvc, "Alt-Svc header should be present");
+        assertTrue(altSvc.contains(String.format("h3=\":%d\"", h3Port)),
+            "Alt-Svc header should contain HTTP/3 port " + h3Port + ", but was: " + altSvc);
+    }
+}

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AltSvcTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AltSvcTest.java
@@ -48,8 +48,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -137,11 +135,11 @@ public class AltSvcTest
 
         assertEquals(HttpStatus.OK_200, response.getStatus());
 
-        // Verify Alt-Svc header contains the HTTP/3 port with ma attribute
+        // Verify Alt-Svc header contains the HTTP/3 port (no ma attribute by default)
         String altSvc = response.getHeaders().get(HttpHeader.ALT_SVC);
         assertNotNull(altSvc, "Alt-Svc header should be present");
-        assertThat("Alt-Svc header should contain HTTP/3 port and ma attribute",
-            altSvc, matchesPattern(String.format("h3=\":%d\"; ma=\\d+", h3Port)));
+        assertEquals(String.format("h3=\":%d\"", h3Port), altSvc,
+            "Alt-Svc header should contain HTTP/3 port without ma attribute by default");
     }
 
     @Test
@@ -170,7 +168,7 @@ public class AltSvcTest
             .filter(c -> c instanceof HTTP2ServerConnectionFactory.AltSvcCustomizer)
             .map(HTTP2ServerConnectionFactory.AltSvcCustomizer.class::cast)
             .findFirst()
-            .ifPresent(customizer -> customizer.setMaxAge((Duration)null)); // Disable ma attribute
+            .ifPresent(customizer -> customizer.setMaxAge(Duration.ofHours(24))); // Set custom ma attribute
 
         ALPNServerConnectionFactory alpn = new ALPNServerConnectionFactory();
         alpn.setDefaultProtocol(h2Factory.getProtocol());
@@ -221,10 +219,10 @@ public class AltSvcTest
 
         assertEquals(HttpStatus.OK_200, response.getStatus());
 
-        // Verify Alt-Svc header contains port without ma attribute (since maxAge is null)
+        // Verify Alt-Svc header contains port with ma attribute (since maxAge is set to 24 hours)
         String altSvc = response.getHeaders().get(HttpHeader.ALT_SVC);
         assertNotNull(altSvc, "Alt-Svc header should be present");
-        assertEquals(String.format("h3=\":%d\"", h3Port), altSvc,
-            "Alt-Svc header should not contain ma attribute when maxAge is null");
+        assertEquals(String.format("h3=\":%d\"; ma=86400", h3Port), altSvc,
+            "Alt-Svc header should contain ma attribute when maxAge is set");
     }
 }

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AltSvcTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AltSvcTest.java
@@ -164,11 +164,11 @@ public class AltSvcTest
         // HTTP/2 connector with TLS and custom AltSvcCustomizer maxAge
         HTTP2ServerConnectionFactory h2Factory = new HTTP2ServerConnectionFactory(httpConfigH2);
         // Find and configure the AltSvcCustomizer
-        httpConfigH2.getCustomizers().stream()
-            .filter(c -> c instanceof HTTP2ServerConnectionFactory.AltSvcCustomizer)
-            .map(HTTP2ServerConnectionFactory.AltSvcCustomizer.class::cast)
-            .findFirst()
-            .ifPresent(customizer -> customizer.setMaxAge(Duration.ofHours(24))); // Set custom ma attribute
+        HTTP2ServerConnectionFactory.AltSvcCustomizer h2AltSvc = httpConfigH2.getCustomizer(HTTP2ServerConnectionFactory.AltSvcCustomizer.class);
+        if (h2AltSvc != null)
+        {
+            h2AltSvc.setMaxAge(Duration.ofHours(24));
+        }
 
         ALPNServerConnectionFactory alpn = new ALPNServerConnectionFactory();
         alpn.setDefaultProtocol(h2Factory.getProtocol());

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AltSvcTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AltSvcTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.test.client.transport;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory;
@@ -168,7 +169,7 @@ public class AltSvcTest
             .filter(c -> c instanceof HTTP2ServerConnectionFactory.AltSvcCustomizer)
             .map(HTTP2ServerConnectionFactory.AltSvcCustomizer.class::cast)
             .findFirst()
-            .ifPresent(customizer -> customizer.setMaxAge(null)); // Disable ma attribute
+            .ifPresent(customizer -> customizer.setMaxAge((Duration)null)); // Disable ma attribute
 
         ALPNServerConnectionFactory alpn = new ALPNServerConnectionFactory();
         alpn.setDefaultProtocol(h2Factory.getProtocol());

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AltSvcTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AltSvcTest.java
@@ -47,6 +47,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -136,10 +138,91 @@ public class AltSvcTest
 
         assertEquals(HttpStatus.OK_200, response.getStatus());
 
-        // Verify Alt-Svc header contains the HTTP/3 port, not the HTTP/2 port
+        // Verify Alt-Svc header contains the HTTP/3 port with ma attribute
         String altSvc = response.getHeaders().get(HttpHeader.ALT_SVC);
         assertNotNull(altSvc, "Alt-Svc header should be present");
-        assertTrue(altSvc.contains(String.format("h3=\":%d\"", h3Port)),
-            "Alt-Svc header should contain HTTP/3 port " + h3Port + ", but was: " + altSvc);
+        assertThat("Alt-Svc header should contain HTTP/3 port and ma attribute",
+            altSvc, matchesPattern(String.format("h3=\":%d\"; ma=\\d+", h3Port)));
+    }
+
+    @Test
+    public void testAltSvcHeaderWithCustomMaxAge() throws Exception
+    {
+        // Setup server with HTTP/2 (TLS) and HTTP/3 on different ports
+        server = new Server();
+
+        HttpConfiguration httpConfig = new HttpConfiguration();
+        httpConfig.addCustomizer(new SecureRequestCustomizer());
+
+        // SSL context factory for server
+        SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
+        sslContextFactory.setKeyStorePath(MavenPaths.findTestResourceFile("keystore.p12").toString());
+        sslContextFactory.setKeyStorePassword("storepwd");
+        sslContextFactory.setCipherComparator(HTTP2Cipher.COMPARATOR);
+        sslContextFactory.setUseCipherSuitesOrder(true);
+
+        // HTTP/2 connector with TLS and custom AltSvcCustomizer maxAge
+        HTTP2ServerConnectionFactory h2Factory = new HTTP2ServerConnectionFactory(httpConfig);
+        // Find and configure the AltSvcCustomizer
+        httpConfig.getCustomizers().stream()
+            .filter(c -> c instanceof HTTP2ServerConnectionFactory.AltSvcCustomizer)
+            .map(HTTP2ServerConnectionFactory.AltSvcCustomizer.class::cast)
+            .findFirst()
+            .ifPresent(customizer -> customizer.setMaxAge(null)); // Disable ma attribute
+
+        ALPNServerConnectionFactory alpn = new ALPNServerConnectionFactory();
+        alpn.setDefaultProtocol(h2Factory.getProtocol());
+        SslConnectionFactory ssl = new SslConnectionFactory(sslContextFactory, alpn.getProtocol());
+        ServerConnector h2Connector = new ServerConnector(server, ssl, alpn, h2Factory);
+        h2Connector.setPort(0);
+        server.addConnector(h2Connector);
+
+        // HTTP/3 connector on a different port
+        QuicheServerQuicConfiguration serverQuicConfig = HTTP3ServerQuicConfiguration.configure(new QuicheServerQuicConfiguration(workDir.getEmptyPathDir()));
+        HTTP3ServerConnectionFactory h3Factory = new HTTP3ServerConnectionFactory(httpConfig);
+        QuicheServerConnector h3Connector = new QuicheServerConnector(server, sslContextFactory, serverQuicConfig, h3Factory);
+        h3Connector.setPort(0);
+        server.addConnector(h3Connector);
+
+        server.setHandler(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                response.setStatus(HttpStatus.OK_200);
+                callback.succeeded();
+                return true;
+            }
+        });
+
+        server.start();
+
+        int h2Port = h2Connector.getLocalPort();
+        int h3Port = h3Connector.getLocalPort();
+
+        // Create HTTP/2 client with TLS
+        SslContextFactory.Client sslContextFactoryClient = new SslContextFactory.Client();
+        sslContextFactoryClient.setTrustAll(true);
+
+        ClientConnector clientConnector = new ClientConnector();
+        clientConnector.setSslContextFactory(sslContextFactoryClient);
+
+        HTTP2Client http2Client = new HTTP2Client(clientConnector);
+        client = new HttpClient(new HttpClientTransportOverHTTP2(http2Client));
+        client.start();
+
+        // Make HTTP/2 request
+        ContentResponse response = client.newRequest("localhost", h2Port)
+            .scheme("https")
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+
+        // Verify Alt-Svc header contains port without ma attribute (since maxAge is null)
+        String altSvc = response.getHeaders().get(HttpHeader.ALT_SVC);
+        assertNotNull(altSvc, "Alt-Svc header should be present");
+        assertEquals(String.format("h3=\":%d\"", h3Port), altSvc,
+            "Alt-Svc header should not contain ma attribute when maxAge is null");
     }
 }


### PR DESCRIPTION
Fixes #14061

- Add `AltSvcCustomizer` to `HTTP2ServerConnectionFactory` that automatically adds the `Alt-Svc` header to HTTP/2 responses, advertising HTTP/3 availability with the correct port and configurable `ma` (max-age) attribute per RFC 7838.
- `AltSvcCustomizer.setMaxAge(Duration)` allows configuring the `ma` attribute (default: 24 hours, set to `null` to omit)
- Remove the old `AltSvcCustomizer` from `HTTP3ServerConnectionFactory` which incorrectly used the HTTP/2 port
- Add tests for Alt-Svc header generation and `maxAge` configuration
- Update documentation with `ma` attribute explanation
