### PR TITLE
Make sure `cancelSend()` can't complete `_writeCallback` a 2nd time

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
@@ -673,8 +673,12 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
                 }
             }
         }
-        _httpChannel.recycle();
-        _connection.offerHttpChannel(_httpChannel);
+
+        if (_connection.isRecycleHttpChannels())
+        {
+            _httpChannel.recycle();
+            _connection.offerHttpChannel(_httpChannel);
+        }
     }
 
     @Override

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -496,8 +496,12 @@ public class HttpChannelState implements HttpChannel, Components
                     }
                 };
 
-                // Serialize all the error actions.
-                task = Invocable.combine(_readInvoker.offer(invokeOnContentAvailable), _writeInvoker.offer(invokeWriteFailure), _readInvoker.offer(invokeOnFailureListeners));
+                // Serialize all the error actions, keep each call on a separate line to help with debugging.
+                task = Invocable.combine(
+                    _readInvoker.offer(invokeOnContentAvailable),
+                    _writeInvoker.offer(invokeWriteFailure),
+                    _readInvoker.offer(invokeOnFailureListeners)
+                );
             }
         }
 
@@ -1204,9 +1208,31 @@ public class HttpChannelState implements HttpChannel, Components
             Callback writeCallback = _writeCallback;
             if (writeCallback == null)
                 return null;
-            _writeCallback = null;
 
-            Runnable cancellation = _request.getHttpStream().cancelSend(x, writeCallback);
+            // Do not complete _writeCallback a 2nd time if it has already been completed and nulled.
+            Runnable cancellation = _request.getHttpStream().cancelSend(x, Callback.from(writeCallback.getInvocationType(),
+                () ->
+                {
+                    Callback wc;
+                    try (AutoLock ignore = _request._lock.lock())
+                    {
+                        wc = _writeCallback;
+                        _writeCallback = null;
+                    }
+                    if (wc != null)
+                        wc.succeeded();
+                },
+                failure ->
+                {
+                    Callback wc;
+                    try (AutoLock ignore = _request._lock.lock())
+                    {
+                        wc = _writeCallback;
+                        _writeCallback = null;
+                    }
+                    if (wc != null)
+                        wc.failed(failure);
+                }));
 
             _writeFailure = ExceptionUtil.combine(_writeFailure, x);
             return cancellation;


### PR DESCRIPTION
Prototype fix for https://github.com/jetty/jetty.project/issues/14135

Here are the relevant logs captured from a test failure:

```
2025-12-16 15:28:04.153:DEBUG:oejut.SerializedInvoker:server-97: Offered oejut.SerializedInvoker$Link@34ecb4e0{Queued by server-97 at org.eclipse.jetty.server.internal.HttpChannelState.onFailure(HttpChannelState.java:500)[NON_BLOCKING] -> null} on oejsi.HttpChannelState$HttpChannelSerializedInvoker@765284ee{name=HttpChannelState_writeInvoker,tail=oejut.SerializedInvoker$Link@34ecb4e0{Queued by server-97 at org.eclipse.jetty.server.internal.HttpChannelState.onFailure(HttpChannelState.java:500)[NON_BLOCKING] -> null},invoker=null}
2025-12-16 15:28:04.153:DEBUG:oejh2i.HTTP2Flusher:server-98: process oejh2si.HTTP2ServerSession@6666186e{local:/127.0.0.1:43937,remote:/127.0.0.1:59362,sendWindow=16777216,recvWindow=1048576,state=[streams=0,NOT_CLOSED,goAwayRecv=null,goAwaySent=null,failure=null]} oejh2i.HTTP2Flusher@11c6c7e6[:PROCESSING,aborted=false,failure=null][:windowQueue=0,frameQueue=0,processed/pending=0/0]
2025-12-16 15:28:04.153:DEBUG:oejsi.HttpChannelState:server-98: completeStream(org.eclipse.jetty.http2.server.internal.HttpStreamOverHTTP2@745ed20c, null)
2025-12-16 15:28:04.153:DEBUG:oejsi.HttpChannelState:server-98: recycling oejsi.HttpChannelState@47964147[:handling=null,handled=true,send=LAST_COMPLETE,completed=true,request=GET@3a5fe59b http://localhost:43937/1 HTTP/2.0]
2025-12-16 15:28:04.153:DEBUG:oejut.SerializedInvoker:server-97: Running oejut.SerializedInvoker$Link@34ecb4e0{Queued by server-97 at org.eclipse.jetty.server.internal.HttpChannelState.onFailure(HttpChannelState.java:500)[NON_BLOCKING] -> null} of oejsi.HttpChannelState$HttpChannelSerializedInvoker@765284ee{name=HttpChannelState_writeInvoker,tail=oejut.SerializedInvoker$Link@34ecb4e0{Queued by server-97 at org.eclipse.jetty.server.internal.HttpChannelState.onFailure(HttpChannelState.java:500)[NON_BLOCKING] -> null},invoker=null}
2025-12-16 15:28:04.156:DEBUG:oeju.IteratingCallback:server-97: failed oejh2i.HTTP2Flusher@11c6c7e6[:PROCESSING,aborted=false,failure=null][:windowQueue=0,frameQueue=0,processed/pending=1/0]
java.lang.AssertionError:
	at org.eclipse.jetty.server.internal.HttpChannelState$LastWriteCallback.completeLastWrite(HttpChannelState.java:793)
	at org.eclipse.jetty.server.internal.HttpChannelState$LastWriteCallback.failed(HttpChannelState.java:783)
```

Thread `server-97` enqueues the write failure job into the write invoker `_writeInvoker.offer(invokeWriteFailure)`, that job will eventually call `HttpStream.cancelSend()`.

Then thread `server-98` executes and tells the H2 flusher to iterate which makes it complete the stream and recycle the `HttpChannelState` instance.

Then `server-97` resumes to run `HttpStream.cancelSend()` which upon completion completes a 2nd time the `_writeCallback` that was captured during the creation of the Runnable that was enqueued in the invoker.

The fix is about passing a different callback to `HttpStream.cancelSend()` that checks if `_writeCallback` has already been nulled or not.