### PR TITLE
make sure `HttpStreamOverHTTP2.onFailure()` cannot work on recycled channels

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
@@ -17,7 +17,7 @@ import java.io.EOFException;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
@@ -67,7 +67,7 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
     private final AutoLock _lock = new AutoLock();
     private final HTTP2ServerConnection _connection;
     private final HttpChannel _httpChannel;
-    private final AtomicReference<RecycleState> _recycle = new AtomicReference<>(RecycleState.CAN_RECYCLE);
+    private final AtomicBoolean _recycle = new AtomicBoolean(); // Set to true when _httpChannel has been recycled or cannot be recycled anymore.
     private final HTTP2Stream _stream;
     private MetaData.Request _requestMetaData;
     private MetaData.Response _responseMetaData;
@@ -76,49 +76,6 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
     private Content.Chunk _trailer;
     private boolean _committed;
     private boolean _demand;
-
-    /**
-     * This state machine tracks if the {@link #_httpChannel} can be recycled or not.
-     * The on*() methods race against succeeded() and they need to figure out if they
-     * can use the _httpChannel or if it has been recycled, while succeeded() needs to
-     * know if it can safely recycle the _httpChannel because no on*() method was
-     * called, or if it cannot.
-     */
-    private enum RecycleState
-    {
-        CAN_RECYCLE(false),
-        RECYCLED(true),
-        CANNOT_RECYCLE(true);
-
-        private final boolean terminal;
-
-        RecycleState(boolean terminal)
-        {
-            this.terminal = terminal;
-        }
-
-        public boolean isTerminal()
-        {
-            return terminal;
-        }
-
-        /**
-         * Changes the current state if it isn't a terminal state.
-         * @param reference the {@code AtomicReference} containing the state.
-         * @param newStateIfNotTerminal the state to change to if the current state is not already a terminal one.
-         * @return the previous state.
-         */
-        private static RecycleState tryUpdate(AtomicReference<RecycleState> reference, RecycleState newStateIfNotTerminal)
-        {
-            assert newStateIfNotTerminal.isTerminal();
-            return reference.getAndUpdate(currentState -> switch (currentState)
-            {
-                case CAN_RECYCLE -> newStateIfNotTerminal;
-                case RECYCLED -> RECYCLED;
-                case CANNOT_RECYCLE -> CANNOT_RECYCLE;
-            });
-        }
-    }
 
     public HttpStreamOverHTTP2(HTTP2ServerConnection connection, HttpChannel httpChannel, HTTP2Stream stream)
     {
@@ -660,8 +617,8 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
     @Override
     public void onTimeout(TimeoutException timeout, BiConsumer<Runnable, Boolean> consumer)
     {
-        RecycleState previousState = RecycleState.tryUpdate(_recycle, RecycleState.CANNOT_RECYCLE);
-        if (previousState.isTerminal())
+        boolean wasRecycled = !_recycle.compareAndSet(false, true);
+        if (wasRecycled)
             return;
         HttpChannel.IdleTimeoutTask task = _httpChannel.onIdleTimeout(timeout);
         consumer.accept(task.action(), !task.handlingRequest());
@@ -670,8 +627,8 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
     @Override
     public Runnable onFailure(Throwable failure, Callback callback)
     {
-        RecycleState previousState = RecycleState.tryUpdate(_recycle, RecycleState.CANNOT_RECYCLE);
-        if (previousState.isTerminal())
+        boolean wasRecycled = !_recycle.compareAndSet(false, true);
+        if (wasRecycled)
             return new FailureTask(null, callback);
         boolean remote = failure instanceof EOFException;
         Runnable task = remote ? _httpChannel.onRemoteFailure(new EofException(failure)) : _httpChannel.onFailure(failure);
@@ -725,8 +682,8 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
             }
         }
 
-        RecycleState previousState = RecycleState.tryUpdate(_recycle, RecycleState.RECYCLED);
-        if (!previousState.isTerminal())
+        boolean canRecycle = _recycle.compareAndSet(false, true);
+        if (canRecycle)
         {
             _httpChannel.recycle();
             _connection.offerHttpChannel(_httpChannel);
@@ -756,7 +713,7 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
                 LOG.atDebug().setCause(x).log("HTTP2 response #{}/{}: failed {}", _stream.getId(), Integer.toHexString(_stream.getSession().hashCode()), errorCode);
             _stream.reset(new ResetFrame(_stream.getId(), errorCode.code), Callback.NOOP);
         }
-        _recycle.set(RecycleState.CANNOT_RECYCLE);
+        _recycle.set(true);
     }
 
     private class SendTrailers extends Callback.Nested

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
@@ -627,11 +627,13 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
         Runnable task;
         if (_channelInUse.compareAndSet(false, true))
         {
+            // This branch prevents the recycling of channels going through on[Remote]Failure().
             boolean remote = failure instanceof EOFException;
             task = remote ? _httpChannel.onRemoteFailure(new EofException(failure)) : _httpChannel.onFailure(failure);
         }
         else
         {
+            // This branch prevents going through on[Remote]Failure() for recycled channels.
             task = null;
         }
         return new FailureTask(task, callback);

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
@@ -688,15 +688,12 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
 
         // Do not recycle when we are racing against the execution of onFailure()'s Runnable.
         if (_channelInUse.compareAndSet(false, true))
-            recycleChannel();
-    }
-
-    private void recycleChannel()
-    {
-        if (_connection.isRecycleHttpChannels())
         {
-            _httpChannel.recycle();
-            _connection.offerHttpChannel(_httpChannel);
+            if (_connection.isRecycleHttpChannels())
+            {
+                _httpChannel.recycle();
+                _connection.offerHttpChannel(_httpChannel);
+            }
         }
     }
 

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
@@ -66,8 +66,7 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
     private final AutoLock lock = new AutoLock();
     private final HTTP2ServerConnection _connection;
     private final HttpChannel _httpChannel;
-    private boolean _channelCaptured;
-    private boolean _recycleChannel;
+    private boolean _channelInUse;
     private final HTTP2Stream _stream;
     private MetaData.Request _requestMetaData;
     private MetaData.Response _responseMetaData;
@@ -626,37 +625,31 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
     {
         boolean remote = failure instanceof EOFException;
 
-        boolean captured;
+        boolean canUseChannel;
         try (AutoLock ignored = lock.lock())
         {
-            if (!_channelCaptured)
+            if (!_channelInUse)
             {
-                _channelCaptured = true;
-                captured = true;
+                _channelInUse = true;
+                canUseChannel = true;
             }
             else
             {
-                captured = false;
+                canUseChannel = false;
             }
         }
 
         Runnable task;
-        if (!captured)
+        if (canUseChannel)
         {
             Runnable failureTask = remote ? _httpChannel.onRemoteFailure(new EofException(failure)) : _httpChannel.onFailure(failure);
             task = new ReadyTask(Invocable.getInvocationType(failureTask), () ->
             {
                 failureTask.run();
-                boolean recycle;
                 try (AutoLock ignored = lock.lock())
                 {
-                    // There is a slight race here: another thread may be about to set the _recycleChannel flag to true but
-                    // hasn't yet. In such case, the channel isn't recycled and becomes garbage, which is still correct.
-                    recycle = _recycleChannel;
-                    _channelCaptured = false;
+                    _channelInUse = false;
                 }
-                if (recycle)
-                    recycleChannel();
             });
         }
         else
@@ -714,22 +707,22 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
             }
         }
 
-        boolean recycleNow;
+        // Do not recycle when we are racing against the execution of onFailure()'s Runnable.
+        boolean recycle;
         try (AutoLock ignored = lock.lock())
         {
-            if (_channelCaptured)
+            if (_channelInUse)
             {
-                _recycleChannel = true;
-                recycleNow = false;
+                recycle = false;
             }
             else
             {
-                _channelCaptured = true;
-                recycleNow = true;
+                _channelInUse = true;
+                recycle = true;
             }
         }
 
-        if (recycleNow)
+        if (recycle)
             recycleChannel();
     }
 

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
@@ -17,6 +17,7 @@ import java.io.EOFException;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
@@ -66,7 +67,7 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
     private final AutoLock lock = new AutoLock();
     private final HTTP2ServerConnection _connection;
     private final HttpChannel _httpChannel;
-    private boolean _channelInUse;
+    private final AtomicBoolean _channelInUse = new AtomicBoolean();
     private final HTTP2Stream _stream;
     private MetaData.Request _requestMetaData;
     private MetaData.Response _responseMetaData;
@@ -623,40 +624,21 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
     @Override
     public Runnable onFailure(Throwable failure, Callback callback)
     {
-        boolean remote = failure instanceof EOFException;
-
-        boolean canUseChannel;
-        try (AutoLock ignored = lock.lock())
-        {
-            if (!_channelInUse)
-            {
-                _channelInUse = true;
-                canUseChannel = true;
-            }
-            else
-            {
-                canUseChannel = false;
-            }
-        }
-
         Runnable task;
-        if (canUseChannel)
+        if (_channelInUse.compareAndSet(false, true))
         {
+            boolean remote = failure instanceof EOFException;
             Runnable failureTask = remote ? _httpChannel.onRemoteFailure(new EofException(failure)) : _httpChannel.onFailure(failure);
             task = new ReadyTask(Invocable.getInvocationType(failureTask), () ->
             {
                 failureTask.run();
-                try (AutoLock ignored = lock.lock())
-                {
-                    _channelInUse = false;
-                }
+                _channelInUse.set(false);
             });
         }
         else
         {
             task = null;
         }
-
         return new FailureTask(task, callback);
     }
 
@@ -708,21 +690,7 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
         }
 
         // Do not recycle when we are racing against the execution of onFailure()'s Runnable.
-        boolean recycle;
-        try (AutoLock ignored = lock.lock())
-        {
-            if (_channelInUse)
-            {
-                recycle = false;
-            }
-            else
-            {
-                _channelInUse = true;
-                recycle = true;
-            }
-        }
-
-        if (recycle)
+        if (_channelInUse.compareAndSet(false, true))
             recycleChannel();
     }
 

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
@@ -628,12 +628,7 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
         if (_channelInUse.compareAndSet(false, true))
         {
             boolean remote = failure instanceof EOFException;
-            Runnable failureTask = remote ? _httpChannel.onRemoteFailure(new EofException(failure)) : _httpChannel.onFailure(failure);
-            task = new ReadyTask(Invocable.getInvocationType(failureTask), () ->
-            {
-                failureTask.run();
-                _channelInUse.set(false);
-            });
+            task = remote ? _httpChannel.onRemoteFailure(new EofException(failure)) : _httpChannel.onFailure(failure);
         }
         else
         {

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
@@ -17,7 +17,7 @@ import java.io.EOFException;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
@@ -67,7 +67,7 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
     private final AutoLock lock = new AutoLock();
     private final HTTP2ServerConnection _connection;
     private final HttpChannel _httpChannel;
-    private final AtomicBoolean _channelInUse = new AtomicBoolean();
+    private final AtomicReference<RecycleState> _recycle = new AtomicReference<>(RecycleState.CAN_RECYCLE);
     private final HTTP2Stream _stream;
     private MetaData.Request _requestMetaData;
     private MetaData.Response _responseMetaData;
@@ -76,6 +76,48 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
     private Content.Chunk _trailer;
     private boolean committed;
     private boolean _demand;
+
+    /**
+     * This state machine tracks if the {@link #_httpChannel} can be recycled or not.
+     * The on*() methods race against succeeded() and they need to figure out if they
+     * can use the _httpChannel or if it has been recycled, while succeeded() needs to
+     * know if it can safely recycle the _httpChannel because no on*() method was
+     * called, or if it cannot.
+     */
+    private enum RecycleState
+    {
+        /**
+         * start state
+         */
+        CAN_RECYCLE,
+
+        /**
+         * terminal state
+         */
+        RECYCLED,
+
+        /**
+         * terminal state
+         */
+        CANNOT_RECYCLE;
+
+        /**
+         * Change the current state if it isn't a terminal state.
+         * @param reference the {@code AtomicReference} containing the state.
+         * @param newStateIfCanRecycle the state to change to if the current state is {@link #CAN_RECYCLE}.
+         * @return the previous state.
+         */
+        private static RecycleState changeState(AtomicReference<RecycleState> reference, RecycleState newStateIfCanRecycle)
+        {
+            assert newStateIfCanRecycle != CAN_RECYCLE;
+            return reference.getAndUpdate(currentState -> switch (currentState)
+            {
+                case CAN_RECYCLE -> newStateIfCanRecycle;
+                case RECYCLED -> RECYCLED;
+                case CANNOT_RECYCLE -> CANNOT_RECYCLE;
+            });
+        }
+    }
 
     public HttpStreamOverHTTP2(HTTP2ServerConnection connection, HttpChannel httpChannel, HTTP2Stream stream)
     {
@@ -162,6 +204,9 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
         if (LOG.isDebugEnabled())
             LOG.debug("badMessage {} {}", this, x);
 
+        RecycleState previousState = RecycleState.changeState(_recycle, RecycleState.CANNOT_RECYCLE);
+        if (previousState == RecycleState.RECYCLED)
+            return null;
         Throwable failure = (Throwable)x;
         return _httpChannel.onFailure(failure);
     }
@@ -617,6 +662,9 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
     @Override
     public void onTimeout(TimeoutException timeout, BiConsumer<Runnable, Boolean> consumer)
     {
+        RecycleState previousState = RecycleState.changeState(_recycle, RecycleState.CANNOT_RECYCLE);
+        if (previousState == RecycleState.RECYCLED)
+            return;
         HttpChannel.IdleTimeoutTask task = _httpChannel.onIdleTimeout(timeout);
         consumer.accept(task.action(), !task.handlingRequest());
     }
@@ -624,18 +672,11 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
     @Override
     public Runnable onFailure(Throwable failure, Callback callback)
     {
-        Runnable task;
-        if (_channelInUse.compareAndSet(false, true))
-        {
-            // This branch prevents the recycling of channels going through on[Remote]Failure().
-            boolean remote = failure instanceof EOFException;
-            task = remote ? _httpChannel.onRemoteFailure(new EofException(failure)) : _httpChannel.onFailure(failure);
-        }
-        else
-        {
-            // This branch prevents going through on[Remote]Failure() for recycled channels.
-            task = null;
-        }
+        RecycleState previousState = RecycleState.changeState(_recycle, RecycleState.CANNOT_RECYCLE);
+        if (previousState == RecycleState.RECYCLED)
+            return new FailureTask(null, callback);
+        boolean remote = failure instanceof EOFException;
+        Runnable task = remote ? _httpChannel.onRemoteFailure(new EofException(failure)) : _httpChannel.onFailure(failure);
         return new FailureTask(task, callback);
     }
 
@@ -686,8 +727,8 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
             }
         }
 
-        // Do not recycle when we are racing against the execution of onFailure()'s Runnable.
-        if (_channelInUse.compareAndSet(false, true))
+        RecycleState previousState = RecycleState.changeState(_recycle, RecycleState.RECYCLED);
+        if (previousState == RecycleState.CAN_RECYCLE)
         {
             if (_connection.isRecycleHttpChannels())
             {
@@ -720,6 +761,8 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
                 LOG.atDebug().setCause(x).log("HTTP2 response #{}/{}: failed {}", _stream.getId(), Integer.toHexString(_stream.getSession().hashCode()), errorCode);
             _stream.reset(new ResetFrame(_stream.getId(), errorCode.code), Callback.NOOP);
         }
+        // Change the state just to make the content of _recycle less surprising when debugging.
+        _recycle.set(RecycleState.CANNOT_RECYCLE);
     }
 
     private class SendTrailers extends Callback.Nested

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
@@ -66,6 +66,8 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
     private final AutoLock lock = new AutoLock();
     private final HTTP2ServerConnection _connection;
     private final HttpChannel _httpChannel;
+    private boolean _channelCaptured;
+    private boolean _recycleChannel;
     private final HTTP2Stream _stream;
     private MetaData.Request _requestMetaData;
     private MetaData.Response _responseMetaData;
@@ -623,7 +625,45 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
     public Runnable onFailure(Throwable failure, Callback callback)
     {
         boolean remote = failure instanceof EOFException;
-        Runnable task = remote ? _httpChannel.onRemoteFailure(new EofException(failure)) : _httpChannel.onFailure(failure);
+
+        boolean captured;
+        try (AutoLock ignored = lock.lock())
+        {
+            if (!_channelCaptured)
+            {
+                _channelCaptured = true;
+                captured = true;
+            }
+            else
+            {
+                captured = false;
+            }
+        }
+
+        Runnable task;
+        if (!captured)
+        {
+            Runnable failureTask = remote ? _httpChannel.onRemoteFailure(new EofException(failure)) : _httpChannel.onFailure(failure);
+            task = new ReadyTask(Invocable.getInvocationType(failureTask), () ->
+            {
+                failureTask.run();
+                boolean recycle;
+                try (AutoLock ignored = lock.lock())
+                {
+                    // There is a slight race here: another thread may be about to set the _recycleChannel flag to true but
+                    // hasn't yet. In such case, the channel isn't recycled and becomes garbage, which is still correct.
+                    recycle = _recycleChannel;
+                    _channelCaptured = false;
+                }
+                if (recycle)
+                    recycleChannel();
+            });
+        }
+        else
+        {
+            task = null;
+        }
+
         return new FailureTask(task, callback);
     }
 
@@ -673,8 +713,33 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
                 }
             }
         }
-        _httpChannel.recycle();
-        _connection.offerHttpChannel(_httpChannel);
+
+        boolean recycleNow;
+        try (AutoLock ignored = lock.lock())
+        {
+            if (_channelCaptured)
+            {
+                _recycleChannel = true;
+                recycleNow = false;
+            }
+            else
+            {
+                _channelCaptured = true;
+                recycleNow = true;
+            }
+        }
+
+        if (recycleNow)
+            recycleChannel();
+    }
+
+    private void recycleChannel()
+    {
+        if (_connection.isRecycleHttpChannels())
+        {
+            _httpChannel.recycle();
+            _connection.offerHttpChannel(_httpChannel);
+        }
     }
 
     @Override

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
@@ -620,7 +620,7 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
         boolean wasRecycled = !_recycle.compareAndSet(false, true);
         if (wasRecycled)
         {
-            consumer.accept(null, false);
+            consumer.accept(null, true);
             return;
         }
         HttpChannel.IdleTimeoutTask task = _httpChannel.onIdleTimeout(timeout);

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
@@ -619,7 +619,10 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
     {
         boolean wasRecycled = !_recycle.compareAndSet(false, true);
         if (wasRecycled)
+        {
+            consumer.accept(null, false);
             return;
+        }
         HttpChannel.IdleTimeoutTask task = _httpChannel.onIdleTimeout(timeout);
         consumer.accept(task.action(), !task.handlingRequest());
     }

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
@@ -64,17 +64,17 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
 {
     private static final Logger LOG = LoggerFactory.getLogger(HttpStreamOverHTTP2.class);
 
-    private final AutoLock lock = new AutoLock();
+    private final AutoLock _lock = new AutoLock();
     private final HTTP2ServerConnection _connection;
     private final HttpChannel _httpChannel;
     private final AtomicReference<RecycleState> _recycle = new AtomicReference<>(RecycleState.CAN_RECYCLE);
     private final HTTP2Stream _stream;
     private MetaData.Request _requestMetaData;
     private MetaData.Response _responseMetaData;
-    private TunnelSupport tunnelSupport;
+    private TunnelSupport _tunnelSupport;
     private Content.Chunk _chunk;
     private Content.Chunk _trailer;
-    private boolean committed;
+    private boolean _committed;
     private boolean _demand;
 
     /**
@@ -86,33 +86,34 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
      */
     private enum RecycleState
     {
-        /**
-         * start state
-         */
-        CAN_RECYCLE,
+        CAN_RECYCLE(false),
+        RECYCLED(true),
+        CANNOT_RECYCLE(true);
+
+        private final boolean terminal;
+
+        RecycleState(boolean terminal)
+        {
+            this.terminal = terminal;
+        }
+
+        public boolean isTerminal()
+        {
+            return terminal;
+        }
 
         /**
-         * terminal state
-         */
-        RECYCLED,
-
-        /**
-         * terminal state
-         */
-        CANNOT_RECYCLE;
-
-        /**
-         * Change the current state if it isn't a terminal state.
+         * Changes the current state if it isn't a terminal state.
          * @param reference the {@code AtomicReference} containing the state.
-         * @param newStateIfCanRecycle the state to change to if the current state is {@link #CAN_RECYCLE}.
+         * @param newStateIfNotTerminal the state to change to if the current state is not already a terminal one.
          * @return the previous state.
          */
-        private static RecycleState changeState(AtomicReference<RecycleState> reference, RecycleState newStateIfCanRecycle)
+        private static RecycleState tryUpdate(AtomicReference<RecycleState> reference, RecycleState newStateIfNotTerminal)
         {
-            assert newStateIfCanRecycle != CAN_RECYCLE;
+            assert newStateIfNotTerminal.isTerminal();
             return reference.getAndUpdate(currentState -> switch (currentState)
             {
-                case CAN_RECYCLE -> newStateIfCanRecycle;
+                case CAN_RECYCLE -> newStateIfNotTerminal;
                 case RECYCLED -> RECYCLED;
                 case CANNOT_RECYCLE -> CANNOT_RECYCLE;
             });
@@ -149,7 +150,7 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
 
             if (frame.isEndStream())
             {
-                try (AutoLock ignored = lock.lock())
+                try (AutoLock ignored = _lock.lock())
                 {
                     _chunk = Content.Chunk.EOF;
                 }
@@ -158,7 +159,7 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
             HttpFields fields = _requestMetaData.getHttpFields();
 
             if (_requestMetaData instanceof MetaData.ConnectRequest)
-                tunnelSupport = new TunnelSupportOverHTTP2(_requestMetaData.getProtocol());
+                _tunnelSupport = new TunnelSupportOverHTTP2(_requestMetaData.getProtocol());
 
             if (LOG.isDebugEnabled())
             {
@@ -204,11 +205,8 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
         if (LOG.isDebugEnabled())
             LOG.debug("badMessage {} {}", this, x);
 
-        RecycleState previousState = RecycleState.changeState(_recycle, RecycleState.CANNOT_RECYCLE);
-        if (previousState == RecycleState.RECYCLED)
-            return null;
         Throwable failure = (Throwable)x;
-        return _httpChannel.onFailure(failure);
+        return onFailure(failure, Callback.NOOP);
     }
 
     @Override
@@ -216,12 +214,12 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
     {
         // Tunnel requests do not have HTTP content, avoid
         // returning chunks meant for a different protocol.
-        if (tunnelSupport != null)
+        if (_tunnelSupport != null)
             return null;
 
         // Check if there already is a chunk, e.g. EOF.
         Content.Chunk chunk;
-        try (AutoLock ignored = lock.lock())
+        try (AutoLock ignored = _lock.lock())
         {
             chunk = _chunk;
             _chunk = Content.Chunk.next(chunk);
@@ -237,7 +235,7 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
         if (data.frame().isEndStream())
         {
             Content.Chunk trailer;
-            try (AutoLock ignored = lock.lock())
+            try (AutoLock ignored = _lock.lock())
             {
                 trailer = _trailer;
                 if (trailer != null)
@@ -254,7 +252,7 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
         // the two actions cancel each other, no need to further retain or release.
         chunk = createChunk(data);
 
-        try (AutoLock ignored = lock.lock())
+        try (AutoLock ignored = _lock.lock())
         {
             _chunk = Content.Chunk.next(chunk);
         }
@@ -266,7 +264,7 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
     {
         boolean notify = false;
         boolean demand = false;
-        try (AutoLock ignored = lock.lock())
+        try (AutoLock ignored = _lock.lock())
         {
             if (_chunk != null || _trailer != null)
                 notify = true;
@@ -292,7 +290,7 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
     @Override
     public Runnable onDataAvailable()
     {
-        try (AutoLock ignored = lock.lock())
+        try (AutoLock ignored = _lock.lock())
         {
             _demand = false;
         }
@@ -311,7 +309,7 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
     public Runnable onTrailer(HeadersFrame frame)
     {
         HttpFields trailers = frame.getMetaData().getHttpFields().asImmutable();
-        try (AutoLock ignored = lock.lock())
+        try (AutoLock ignored = _lock.lock())
         {
             _trailer = new Trailers(trailers);
         }
@@ -378,7 +376,7 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
         }
         else
         {
-            committed = true;
+            _committed = true;
             if (last)
             {
                 long realContentLength = BufferUtil.length(content);
@@ -627,7 +625,7 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
     @Override
     public boolean isCommitted()
     {
-        return committed;
+        return _committed;
     }
 
     @Override
@@ -640,13 +638,13 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
     @Override
     public TunnelSupport getTunnelSupport()
     {
-        return tunnelSupport;
+        return _tunnelSupport;
     }
 
     @Override
     public Throwable consumeAvailable()
     {
-        if (tunnelSupport != null)
+        if (_tunnelSupport != null)
             return null;
         Throwable result = HttpStream.consumeAvailable(this, _httpChannel.getConnectionMetaData().getHttpConfiguration());
         if (result != null)
@@ -662,8 +660,8 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
     @Override
     public void onTimeout(TimeoutException timeout, BiConsumer<Runnable, Boolean> consumer)
     {
-        RecycleState previousState = RecycleState.changeState(_recycle, RecycleState.CANNOT_RECYCLE);
-        if (previousState == RecycleState.RECYCLED)
+        RecycleState previousState = RecycleState.tryUpdate(_recycle, RecycleState.CANNOT_RECYCLE);
+        if (previousState.isTerminal())
             return;
         HttpChannel.IdleTimeoutTask task = _httpChannel.onIdleTimeout(timeout);
         consumer.accept(task.action(), !task.handlingRequest());
@@ -672,8 +670,8 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
     @Override
     public Runnable onFailure(Throwable failure, Callback callback)
     {
-        RecycleState previousState = RecycleState.changeState(_recycle, RecycleState.CANNOT_RECYCLE);
-        if (previousState == RecycleState.RECYCLED)
+        RecycleState previousState = RecycleState.tryUpdate(_recycle, RecycleState.CANNOT_RECYCLE);
+        if (previousState.isTerminal())
             return new FailureTask(null, callback);
         boolean remote = failure instanceof EOFException;
         Runnable task = remote ? _httpChannel.onRemoteFailure(new EofException(failure)) : _httpChannel.onFailure(failure);
@@ -696,7 +694,7 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
                 }
                 else
                 {
-                    EndPoint endPoint = tunnelSupport.getEndPoint();
+                    EndPoint endPoint = _tunnelSupport.getEndPoint();
                     _stream.setAttachment(endPoint);
                     endPoint.upgrade(connection);
                 }
@@ -727,14 +725,11 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
             }
         }
 
-        RecycleState previousState = RecycleState.changeState(_recycle, RecycleState.RECYCLED);
-        if (previousState == RecycleState.CAN_RECYCLE)
+        RecycleState previousState = RecycleState.tryUpdate(_recycle, RecycleState.RECYCLED);
+        if (!previousState.isTerminal())
         {
-            if (_connection.isRecycleHttpChannels())
-            {
-                _httpChannel.recycle();
-                _connection.offerHttpChannel(_httpChannel);
-            }
+            _httpChannel.recycle();
+            _connection.offerHttpChannel(_httpChannel);
         }
     }
 
@@ -761,7 +756,6 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
                 LOG.atDebug().setCause(x).log("HTTP2 response #{}/{}: failed {}", _stream.getId(), Integer.toHexString(_stream.getSession().hashCode()), errorCode);
             _stream.reset(new ResetFrame(_stream.getId(), errorCode.code), Callback.NOOP);
         }
-        // Change the state just to make the content of _recycle less surprising when debugging.
         _recycle.set(RecycleState.CANNOT_RECYCLE);
     }
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -433,7 +433,7 @@ public class HttpChannelState implements HttpChannel, Components
         try (AutoLock ignored = _lock.lock())
         {
             if (LOG.isDebugEnabled())
-                LOG.atDebug().setCause(x).log("onFailure {}", this);
+                LOG.atDebug().setCause(x).log("onFailure remote={} {}", remote, this);
 
             // If the channel doesn't have a stream, then the error is ignored.
             stream = _stream;


### PR DESCRIPTION
Fixes https://github.com/jetty/jetty.project/issues/14135