### PR TITLE
Issue #13670 - Returning ISE in all getParameter use cases outlined by Servlet 6.1 spec

### DIFF
--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/http/HttpReceiverOverHTTPTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/http/HttpReceiverOverHTTPTest.java
@@ -34,8 +34,8 @@ import org.eclipse.jetty.client.transport.HttpRequest;
 import org.eclipse.jetty.client.transport.internal.HttpChannelOverHTTP;
 import org.eclipse.jetty.client.transport.internal.HttpConnectionOverHTTP;
 import org.eclipse.jetty.client.transport.internal.HttpReceiverOverHTTP;
-import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HttpCompliance;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpVersion;
@@ -226,7 +226,7 @@ public class HttpReceiverOverHTTPTest
 
         ExecutionException e = assertThrows(ExecutionException.class, () -> completable.get(5, TimeUnit.SECONDS));
         assertThat(e.getCause(), instanceOf(HttpResponseException.class));
-        assertThat(e.getCause().getCause(), instanceOf(BadMessageException.class));
+        assertThat(e.getCause().getCause(), instanceOf(HttpException.class));
         assertThat(e.getCause().getCause().getCause(), instanceOf(NumberFormatException.class));
     }
 

--- a/jetty-core/jetty-compression/jetty-compression-server/src/main/java/org/eclipse/jetty/compression/server/CompressionHandler.java
+++ b/jetty-core/jetty-compression/jetty-compression-server/src/main/java/org/eclipse/jetty/compression/server/CompressionHandler.java
@@ -21,7 +21,6 @@ import java.util.TreeMap;
 import org.eclipse.jetty.compression.Compression;
 import org.eclipse.jetty.compression.server.internal.CompressionResponse;
 import org.eclipse.jetty.compression.server.internal.DecompressionRequest;
-import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.ComplianceViolation;
 import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpField;
@@ -280,7 +279,7 @@ public class CompressionHandler extends Handler.Wrapper
                                 if (httpConfiguration.getHttpCompliance().allows(violation))
                                     httpConfiguration.notifyViolation(violation, value);
                                 else
-                                    throw new BadMessageException(violation.toString());
+                                    throw new HttpException.IllegalStateException(HttpStatus.BAD_REQUEST_400, violation.toString());
                             }
                         };
                     }

--- a/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/ServerFCGIConnection.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/ServerFCGIConnection.java
@@ -21,8 +21,9 @@ import org.eclipse.jetty.fcgi.FCGI;
 import org.eclipse.jetty.fcgi.generator.Flusher;
 import org.eclipse.jetty.fcgi.generator.ServerGenerator;
 import org.eclipse.jetty.fcgi.parser.ServerParser;
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.Content;
@@ -401,7 +402,7 @@ public class ServerFCGIConnection extends AbstractMetaDataConnection implements 
             if (LOG.isDebugEnabled())
                 LOG.atDebug().setCause(failure).log("Request {} failure on {}", request, stream);
             if (stream != null)
-                ThreadPool.executeImmediately(getExecutor(), stream.getHttpChannel().onFailure(new BadMessageException(null, failure)));
+                ThreadPool.executeImmediately(getExecutor(), stream.getHttpChannel().onFailure(new HttpException.IllegalStateException(HttpStatus.BAD_REQUEST_400, null, failure)));
             stream = null;
         }
     }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/BadMessageException.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/BadMessageException.java
@@ -49,5 +49,6 @@ public class BadMessageException extends HttpException.RuntimeException
     public BadMessageException(int code, String reason, Throwable cause)
     {
         super(code, reason, cause);
+        assert HttpStatus.isClientError(code);
     }
 }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/BadMessageException.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/BadMessageException.java
@@ -15,10 +15,11 @@ package org.eclipse.jetty.http;
 
 /**
  * <p>Exception thrown to indicate a Bad HTTP Message has either been received
- * or attempted to be generated.  Typically, these are handled with either 400
+ * or attempted to be generated.  Typically, these are handled with {@code 4xx} or {@code 5xx}
  * responses.</p>
- * @see HttpException
+ * @deprecated use HttpException
  */
+@Deprecated(since = "12.1.6", forRemoval = true)
 public class BadMessageException extends HttpException.RuntimeException
 {
     public BadMessageException()

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/BadMessageException.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/BadMessageException.java
@@ -17,7 +17,7 @@ package org.eclipse.jetty.http;
  * <p>Exception thrown to indicate a Bad HTTP Message has either been received
  * or attempted to be generated.  Typically, these are handled with {@code 4xx} or {@code 5xx}
  * responses.</p>
- * @deprecated use HttpException
+ * @deprecated use {@link HttpException}
  */
 @Deprecated(since = "12.1.6", forRemoval = true)
 public class BadMessageException extends HttpException.RuntimeException

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/BadMessageException.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/BadMessageException.java
@@ -15,8 +15,9 @@ package org.eclipse.jetty.http;
 
 /**
  * <p>Exception thrown to indicate a Bad HTTP Message has either been received
- * or attempted to be generated.  Typically these are handled with either 400
+ * or attempted to be generated.  Typically, these are handled with either 400
  * responses.</p>
+ * @see HttpException
  */
 public class BadMessageException extends HttpException.RuntimeException
 {
@@ -48,6 +49,5 @@ public class BadMessageException extends HttpException.RuntimeException
     public BadMessageException(int code, String reason, Throwable cause)
     {
         super(code, reason, cause);
-        assert HttpStatus.isClientError(code);
     }
 }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CookieCache.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CookieCache.java
@@ -159,7 +159,7 @@ public class CookieCache implements CookieParser.Handler, ComplianceViolation.Li
             }
             catch (CookieParser.InvalidCookieException invalidCookieException)
             {
-                throw new BadMessageException(invalidCookieException.getMessage(), invalidCookieException);
+                throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, invalidCookieException.getMessage(), invalidCookieException);
             }
         }
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HostPortHttpField.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HostPortHttpField.java
@@ -38,7 +38,7 @@ public class HostPortHttpField extends HttpField
         }
         catch (Exception e)
         {
-            throw new BadMessageException("Bad HostPort", e);
+            throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Bad HostPort", e);
         }
     }
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCompliance.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCompliance.java
@@ -456,6 +456,6 @@ public final class HttpCompliance implements ComplianceViolation.Mode
                 mode, violation, violation.getDescription()
             ));
         else
-            throw new BadMessageException(violation.getDescription());
+            throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, violation.getDescription());
     }
 }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpException.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpException.java
@@ -17,8 +17,8 @@ import org.eclipse.jetty.io.QuietException;
 import org.eclipse.jetty.util.ExceptionUtil;
 
 /**
- * <p>A tagging interface for Exceptions that carry a HTTP response code and reason.</p>
- * <p>Exception sub-classes that implement this interface will be caught by the container
+ * <p>A tagging interface for Exceptions that carry an HTTP response code and reason.</p>
+ * <p>Exception subclasses that implement this interface will be caught by the container
  * and the {@link #getCode()} used to send a response.</p>
  */
 public interface HttpException extends QuietException
@@ -27,15 +27,58 @@ public interface HttpException extends QuietException
 
     String getReason();
 
-    static void throwAsUnchecked(HttpException httpException)
+    static HttpException asHttpException(Throwable throwable)
     {
-        ExceptionUtil.ifExceptionThrowUnchecked((Throwable)httpException);
+        if (throwable instanceof IllegalArgumentException iae)
+            return iae;
+        if (throwable instanceof IllegalStateException ise)
+            return ise;
+        if (throwable instanceof RuntimeException re)
+            return re;
+        if (throwable instanceof java.lang.IllegalArgumentException)
+            return new HttpException.IllegalArgumentException(HttpStatus.BAD_REQUEST_400, throwable.getMessage(), throwable);
+        if (throwable instanceof java.lang.IllegalStateException)
+            return new HttpException.IllegalStateException(HttpStatus.BAD_REQUEST_400, throwable.getMessage(), throwable);
+        if (throwable instanceof java.lang.RuntimeException)
+            return new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, throwable.getMessage(), throwable);
+        return new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, throwable.getMessage(), throwable);
     }
 
     /**
-     * <p>Exception thrown to indicate a Bad HTTP Message has either been received
-     * or attempted to be generated.  Typically these are handled with either 400
-     * or 500 responses.</p>
+     * Throw the given HttpException as an unchecked exception.
+     *
+     * @param httpException the HttpException to throw
+     */
+    static void throwAsUnchecked(HttpException httpException)
+    {
+        if (httpException instanceof Throwable throwable)
+            ExceptionUtil.ifExceptionThrowUnchecked(throwable);
+        throw new IllegalStateException(httpException.getCode(), httpException.getReason());
+    }
+
+    /**
+     * Convert the given Throwable to an HttpException and throw it as an unchecked exception.
+     *
+     * @param throwable the Throwable to convert and throw
+     */
+    static void throwAsUncheckedHttpException(Throwable throwable)
+    {
+        throwAsUnchecked(asHttpException(throwable));
+    }
+
+    /**
+     * If the given Throwable is an HttpException, throw it as an unchecked exception.
+     *
+     * @param th the Throwable to check and possibly throw
+     */
+    static void throwIfHttpException(Throwable th)
+    {
+        if (th instanceof HttpException he)
+            HttpException.throwAsUnchecked(he);
+    }
+
+    /**
+     * A RuntimeException version of HttpException.
      */
     class RuntimeException extends java.lang.RuntimeException implements HttpException
     {
@@ -60,6 +103,7 @@ public interface HttpException extends QuietException
         public RuntimeException(int code, String reason, Throwable cause)
         {
             super(code + ": " + reason, cause);
+            assert HttpStatus.isClientError(code);
             _code = code;
             _reason = reason;
         }
@@ -75,12 +119,15 @@ public interface HttpException extends QuietException
         {
             return _reason;
         }
+
+        public IllegalStateException asIllegalStateException()
+        {
+            return new IllegalStateException(_code, _reason, getCause());
+        }
     }
 
     /**
-     * <p>Exception thrown to indicate a Bad HTTP Message has either been received
-     * or attempted to be generated.  Typically these are handled with either 400
-     * or 500 responses.</p>
+     * An IllegalArgumentException version of HttpException.
      */
     class IllegalArgumentException extends java.lang.IllegalArgumentException implements HttpException
     {
@@ -100,6 +147,46 @@ public interface HttpException extends QuietException
         public IllegalArgumentException(int code, String reason, Throwable cause)
         {
             super(code + ": " + reason, cause);
+            assert HttpStatus.isClientError(code);
+            _code = code;
+            _reason = reason;
+        }
+
+        @Override
+        public int getCode()
+        {
+            return _code;
+        }
+
+        @Override
+        public String getReason()
+        {
+            return _reason;
+        }
+    }
+
+    /**
+     * An IllegalStateException version of HttpException.
+     */
+    class IllegalStateException extends java.lang.IllegalStateException implements HttpException
+    {
+        private final int _code;
+        private final String _reason;
+
+        public IllegalStateException(int code)
+        {
+            this(code, null, null);
+        }
+
+        public IllegalStateException(int code, String reason)
+        {
+            this(code, reason, null);
+        }
+
+        public IllegalStateException(int code, String reason, Throwable cause)
+        {
+            super(code + ": " + reason, cause);
+            assert HttpStatus.isClientError(code);
             _code = code;
             _reason = reason;
         }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpException.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpException.java
@@ -103,7 +103,7 @@ public interface HttpException extends QuietException
         public RuntimeException(int code, String reason, Throwable cause)
         {
             super(code + ": " + reason, cause);
-            assert HttpStatus.isClientError(code);
+            assert code == 0 || HttpStatus.isClientError(code) || HttpStatus.isServerError(code);
             _code = code;
             _reason = reason;
         }
@@ -147,7 +147,7 @@ public interface HttpException extends QuietException
         public IllegalArgumentException(int code, String reason, Throwable cause)
         {
             super(code + ": " + reason, cause);
-            assert HttpStatus.isClientError(code);
+            assert code == 0 || HttpStatus.isClientError(code) || HttpStatus.isServerError(code);
             _code = code;
             _reason = reason;
         }
@@ -186,7 +186,7 @@ public interface HttpException extends QuietException
         public IllegalStateException(int code, String reason, Throwable cause)
         {
             super(code + ": " + reason, cause);
-            assert HttpStatus.isClientError(code);
+            assert code == 0 || HttpStatus.isClientError(code) || HttpStatus.isServerError(code);
             _code = code;
             _reason = reason;
         }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -364,12 +364,12 @@ public class HttpParser
         _fieldCache.setCaseSensitive(headerCacheCaseSensitive);
     }
 
-    protected void checkViolation(Violation violation) throws BadMessageException
+    protected void checkViolation(Violation violation) throws HttpException.RuntimeException
     {
         if (violation.isAllowedBy(_complianceMode))
             reportComplianceViolation(violation, violation.getDescription());
         else
-            throw new BadMessageException(violation.getDescription());
+            throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, violation.getDescription());
     }
 
     protected void reportComplianceViolation(Violation violation)
@@ -503,7 +503,7 @@ public class HttpParser
 
             case CR:
                 if (_cr)
-                    throw new BadMessageException("Bad EOL");
+                    throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Bad EOL");
 
                 if (buffer.hasRemaining())
                 {
@@ -514,7 +514,7 @@ public class HttpParser
                     {
                         case CNTL -> throw new IllegalCharacterException(_state, t, buffer);
                         case LF -> EOL_CRLF;
-                        default -> throw new BadMessageException("Bad EOL");
+                        default -> throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Bad EOL");
                     };
                 }
                 _cr = true;
@@ -529,7 +529,7 @@ public class HttpParser
             case OTEXT:
             case COLON:
                 if (_cr)
-                    throw new BadMessageException("Bad EOL");
+                    throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Bad EOL");
                 break;
 
             default:
@@ -547,9 +547,9 @@ public class HttpParser
             if (_headerBytes > _maxHeaderBytes)
             {
                 if (_state == State.URI)
-                    throw new BadMessageException(HttpStatus.URI_TOO_LONG_414);
+                    throw new HttpException.RuntimeException(HttpStatus.URI_TOO_LONG_414);
                 if (_requestParser)
-                    throw new BadMessageException(HttpStatus.REQUEST_HEADER_FIELDS_TOO_LARGE_431);
+                    throw new HttpException.RuntimeException(HttpStatus.REQUEST_HEADER_FIELDS_TOO_LARGE_431);
                 throw new HttpException.RuntimeException(_responseStatus, "Response Header Bytes Too Large");
             }
         }
@@ -786,7 +786,7 @@ public class HttpParser
                             break;
 
                         case EOL:
-                            throw new BadMessageException("No URI");
+                            throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "No URI");
 
                         case ALPHA:
                         case DIGIT:
@@ -818,7 +818,7 @@ public class HttpParser
                             _string.append(t.getChar());
                             break;
                         case EOL:
-                            throw new BadMessageException("No Status");
+                            throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "No Status");
                         default:
                             throw new IllegalCharacterException(_state, t, buffer);
                     }
@@ -838,7 +838,7 @@ public class HttpParser
                             if (!_requestParser)
                             {
                                 if (t.getType() != HttpTokens.Type.DIGIT || t.getByte() == '0')
-                                    throw new BadMessageException("Bad status");
+                                    throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Bad status");
                                 setState(State.STATUS);
                                 setResponseStatus(t.getByte() - '0');
                             }
@@ -873,7 +873,7 @@ public class HttpParser
 
                         default:
                             if (_requestParser)
-                                throw new BadMessageException("No URI");
+                                throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "No URI");
                             else
                                 throw new HttpException.RuntimeException(_responseStatus, "No Status");
                     }
@@ -885,14 +885,14 @@ public class HttpParser
                     {
                         case SPACE:
                             if (_responseStatus < 100)
-                                throw new BadMessageException("Bad status");
+                                throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Bad status");
                             setState(State.SPACE2);
                             break;
 
                         case DIGIT:
                             _responseStatus = _responseStatus * 10 + (t.getByte() - '0');
                             if (_responseStatus >= 1000)
-                                throw new BadMessageException("Bad status");
+                                throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Bad status");
                             break;
 
                         case EOL:
@@ -902,7 +902,7 @@ public class HttpParser
                             break;
 
                         default:
-                            throw new BadMessageException("Bad status");
+                            throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Bad status");
                     }
                     break;
 
@@ -1154,7 +1154,7 @@ public class HttpParser
                         {
                             checkViolation(MULTIPLE_CONTENT_LENGTHS);
                             if (contentLength != _contentLength)
-                                throw new BadMessageException(MULTIPLE_CONTENT_LENGTHS.getDescription());
+                                throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, MULTIPLE_CONTENT_LENGTHS.getDescription());
                         }
                         _hasContentLength = true;
 
@@ -1173,7 +1173,7 @@ public class HttpParser
 
                         // we encountered another Transfer-Encoding header, but chunked was already set
                         if (_endOfContent == EndOfContent.CHUNKED_CONTENT)
-                            throw new BadMessageException("Bad Transfer-Encoding, chunked not last");
+                            throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Bad Transfer-Encoding, chunked not last");
 
                         if (HttpHeaderValue.CHUNKED.is(_valueString))
                         {
@@ -1190,7 +1190,7 @@ public class HttpParser
                                 if (HttpHeaderValue.CHUNKED.is(values.get(i)))
                                 {
                                     if (chunked != -1)
-                                        throw new BadMessageException("Bad Transfer-Encoding, multiple chunked tokens");
+                                        throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Bad Transfer-Encoding, multiple chunked tokens");
                                     chunked = i;
                                     // declared chunked
                                     _endOfContent = EndOfContent.CHUNKED_CONTENT;
@@ -1199,7 +1199,7 @@ public class HttpParser
                                 // we have a non-chunked token after a declared chunked token
                                 else if (_endOfContent == EndOfContent.CHUNKED_CONTENT)
                                 {
-                                    throw new BadMessageException("Bad Transfer-Encoding, chunked not last");
+                                    throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Bad Transfer-Encoding, chunked not last");
                                 }
                             }
                         }
@@ -1287,7 +1287,7 @@ public class HttpParser
     private long convertContentLength(String valueString)
     {
         if (valueString == null || valueString.isEmpty())
-            throw new BadMessageException("Invalid Content-Length Value", new NumberFormatException());
+            throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Invalid Content-Length Value", new NumberFormatException());
 
         long value = 0;
         int length = valueString.length();
@@ -1296,7 +1296,7 @@ public class HttpParser
         {
             char c = valueString.charAt(i);
             if (c < '0' || c > '9')
-                throw new BadMessageException("Invalid Content-Length Value", new NumberFormatException());
+                throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Invalid Content-Length Value", new NumberFormatException());
 
             value = Math.addExact(Math.multiplyExact(value, 10), c - '0');
         }
@@ -1370,14 +1370,14 @@ public class HttpParser
                                 {
                                     // Transfer-Encoding chunked not specified
                                     // https://tools.ietf.org/html/rfc7230#section-3.3.1
-                                    throw new BadMessageException("Bad Transfer-Encoding, chunked not last");
+                                    throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Bad Transfer-Encoding, chunked not last");
                                 }
                             }
 
                             // Was there a required host header?
                             if (_parsedHost == null && _version == HttpVersion.HTTP_1_1 && _requestParser)
                             {
-                                throw new BadMessageException("No Host");
+                                throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "No Host");
                             }
 
                             // is it a response that cannot have a body?
@@ -1803,7 +1803,7 @@ public class HttpParser
                             LOG.debug("{} EOF in {}", this, _state);
                         setState(State.CLOSED);
                         if (_requestParser)
-                            _handler.badMessage(new BadMessageException(HttpStatus.BAD_REQUEST_400, "Early EOF"));
+                            _handler.badMessage(new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Early EOF"));
                         else
                             _handler.badMessage(new HttpException.RuntimeException(_responseStatus, "Early EOF"));
                         break;
@@ -1821,7 +1821,7 @@ public class HttpParser
             else
             {
                 if (_requestParser)
-                    bad = new BadMessageException("Bad Request", x);
+                    bad = new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Bad Request", x);
                 else
                     bad = new HttpException.RuntimeException(_responseStatus, "Bad Response", x);
             }
@@ -1968,7 +1968,7 @@ public class HttpParser
                         if (t.isHexDigit())
                         {
                             if (_chunkLength > MAX_CHUNK_LENGTH)
-                                throw new BadMessageException(HttpStatus.PAYLOAD_TOO_LARGE_413);
+                                throw new HttpException.RuntimeException(HttpStatus.PAYLOAD_TOO_LARGE_413);
                             _chunkLength = _chunkLength * 16 + t.getHexDigit();
                         }
                         else if (t.getChar() == ';')
@@ -2256,11 +2256,11 @@ public class HttpParser
         void startResponse(HttpVersion version, int status, String reason);
     }
 
-    private static class IllegalCharacterException extends BadMessageException
+    private static class IllegalCharacterException extends HttpException.RuntimeException
     {
         private IllegalCharacterException(State state, HttpTokens.Token token, ByteBuffer buffer)
         {
-            super(String.format("Illegal character %s", token));
+            super(HttpStatus.BAD_REQUEST_400, String.format("Illegal character %s", token));
             if (LOG.isDebugEnabled())
                 LOG.debug(String.format("Illegal character %s in state=%s for buffer %s", token, state, BufferUtil.toDetailString(buffer)));
         }
@@ -2381,7 +2381,7 @@ public class HttpParser
                     if (_complianceMode.allows(violation))
                         _handler.onViolation(new ComplianceViolation.Event(_complianceMode, violation, value));
                     else
-                        throw new BadMessageException(violation.toString());
+                        throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, violation.toString());
                 }
             };
         }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -2367,13 +2367,9 @@ public class HttpParser
                         {
                             _handler.onViolation(new ComplianceViolation.Event(_complianceMode, v, r));
                         }
-                        catch (BadMessageException bme)
-                        {
-                            throw bme;
-                        }
                         catch (Throwable t)
                         {
-                            throw new BadMessageException(t.getMessage(), t);
+                            HttpException.throwAsUncheckedHttpException(t);
                         }
                     }, value);
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpTester.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpTester.java
@@ -491,7 +491,7 @@ public class HttpTester
 
                         case HEADER_OVERFLOW:
                             if (header.capacity() >= 32 * 1024)
-                                throw new BadMessageException(500, "Header too large");
+                                throw new HttpException.RuntimeException(HttpStatus.INTERNAL_SERVER_ERROR_500, "Header too large");
                             header = BufferUtil.allocate(32 * 1024);
                             continue;
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPart.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MultiPart.java
@@ -1259,14 +1259,14 @@ public class MultiPart
                             // SPEC: ignore linear whitespace after boundary.
                             else if (type != HttpTokens.Type.SPACE && type != HttpTokens.Type.HTAB)
                             {
-                                throw new BadMessageException("bad last boundary");
+                                throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "bad last boundary");
                             }
                         }
                         case BOUNDARY_CLOSE ->
                         {
                             HttpTokens.Token token = next(buffer);
                             if (token.getByte() != '-')
-                                throw new BadMessageException("bad last boundary");
+                                throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "bad last boundary");
                             notifyEndOfLineViolations();
                             state = State.EPILOGUE;
                         }
@@ -1338,7 +1338,7 @@ public class MultiPart
             {
                 case CNTL ->
                 {
-                    throw new BadMessageException("invalid byte " + Integer.toHexString(t.getChar()));
+                    throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "invalid byte " + Integer.toHexString(t.getChar()));
                 }
                 case LF ->
                 {
@@ -1347,7 +1347,7 @@ public class MultiPart
                         MultiPartCompliance.Violation violation = MultiPartCompliance.Violation.LF_LINE_TERMINATION;
                         addEndOfLineViolation(violation);
                         if (!compliance.allows(violation))
-                            throw new BadMessageException("invalid LF-only EOL");
+                            throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "invalid LF-only EOL");
                     }
                     crFlag = false;
                 }
@@ -1358,7 +1358,7 @@ public class MultiPart
                         MultiPartCompliance.Violation violation = MultiPartCompliance.Violation.CR_LINE_TERMINATION;
                         addEndOfLineViolation(violation);
                         if (!compliance.allows(violation))
-                            throw new BadMessageException("invalid CR-only EOL");
+                            throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "invalid CR-only EOL");
                     }
                     crFlag = true;
                 }
@@ -1369,7 +1369,7 @@ public class MultiPart
                         MultiPartCompliance.Violation violation = MultiPartCompliance.Violation.CR_LINE_TERMINATION;
                         addEndOfLineViolation(violation);
                         if (!compliance.allows(violation))
-                            throw new BadMessageException("invalid CR-only EOL");
+                            throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "invalid CR-only EOL");
                     }
                 }
             }
@@ -1441,14 +1441,14 @@ public class MultiPart
                     }
                     case COLON ->
                     {
-                        throw new BadMessageException("invalid empty header name");
+                        throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "invalid empty header name");
                     }
                     default ->
                     {
                         if (Character.isWhitespace(token.getByte()))
                         {
                             if (text.length() == 0)
-                                throw new BadMessageException("invalid leading whitespace before header");
+                                throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "invalid leading whitespace before header");
                         }
                         else
                         {
@@ -1482,7 +1482,7 @@ public class MultiPart
                     {
                         byte current = token.getByte();
                         if (trailingWhiteSpaces > 0)
-                            throw new BadMessageException("invalid header name");
+                            throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "invalid header name");
                         incrementAndCheckPartHeadersLength();
                         text.append(current);
                     }
@@ -1496,7 +1496,7 @@ public class MultiPart
                         }
                         else
                         {
-                            throw new BadMessageException("invalid header name");
+                            throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "invalid header name");
                         }
                     }
                 }
@@ -1572,7 +1572,7 @@ public class MultiPart
                             MultiPartCompliance.Violation violation = MultiPartCompliance.Violation.LF_LINE_TERMINATION;
                             addEndOfLineViolation(violation);
                             if (!compliance.allows(violation))
-                                throw new BadMessageException("invalid LF-only EOL");
+                                throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "invalid LF-only EOL");
                         }
                         partialBoundaryMatch = 0;
                         crContent = false;
@@ -1622,7 +1622,7 @@ public class MultiPart
                         MultiPartCompliance.Violation violation = MultiPartCompliance.Violation.LF_LINE_TERMINATION;
                         addEndOfLineViolation(violation);
                         if (!compliance.allows(violation))
-                            throw new BadMessageException("invalid LF-only EOL");
+                            throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "invalid LF-only EOL");
                     }
                     crContent = false;
                 }
@@ -1644,7 +1644,7 @@ public class MultiPart
                     MultiPartCompliance.Violation violation = MultiPartCompliance.Violation.LF_LINE_TERMINATION;
                     addEndOfLineViolation(violation);
                     if (!compliance.allows(violation))
-                        throw new BadMessageException("invalid LF-only EOL");
+                        throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "invalid LF-only EOL");
                 }
                 Content.Chunk content = asSlice(chunk, position, length, true);
                 buffer.position(position + boundaryOffset + boundaryFinder.getLength());

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpParserTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpParserTest.java
@@ -4018,7 +4018,7 @@ public class HttpParserTest
                 if (scenario.compliance.allows(WHITESPACE_IN_PARAMETER))
                     assertThat(field.getValueList(), hasItem("value;param=bad"));
                 else
-                    assertThrows(BadMessageException.class, field::getValueList);
+                    assertThrows(HttpException.RuntimeException.class, field::getValueList);
             }
         }
     }

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/MultiPartFormDataTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/MultiPartFormDataTest.java
@@ -116,7 +116,7 @@ public class MultiPartFormDataTest
         formData.parse(source).handle((parts, failure) ->
         {
             assertNull(parts);
-            assertInstanceOf(BadMessageException.class, failure);
+            assertInstanceOf(HttpException.class, failure);
             assertThat(failure.getMessage(), containsStringIgnoringCase("bad last boundary"));
             return null;
         }).get(5, TimeUnit.SECONDS);
@@ -422,9 +422,8 @@ public class MultiPartFormDataTest
         Content.Sink.write(source, true, str, Callback.NOOP);
 
         ExecutionException ee = assertThrows(ExecutionException.class, () -> formData.parse(source).get(5, TimeUnit.SECONDS));
-        assertThat(ee.getCause(), instanceOf(BadMessageException.class));
-        BadMessageException bme = (BadMessageException)ee.getCause();
-        assertThat(bme.getMessage(), containsString("invalid LF-only EOL"));
+        assertThat(ee.getCause(), instanceOf(HttpException.class));
+        assertThat(ee.getCause().getMessage(), containsString("invalid LF-only EOL"));
     }
 
     /**
@@ -485,9 +484,8 @@ public class MultiPartFormDataTest
         Content.Sink.write(source, true, str, Callback.NOOP);
 
         ExecutionException ee = assertThrows(ExecutionException.class, () -> formData.parse(source).get(5, TimeUnit.SECONDS));
-        assertThat(ee.getCause(), instanceOf(BadMessageException.class));
-        BadMessageException bme = (BadMessageException)ee.getCause();
-        assertThat(bme.getMessage(), containsString("invalid CR-only EOL"));
+        assertThat(ee.getCause(), instanceOf(HttpException.class));
+        assertThat(ee.getCause().getMessage(), containsString("invalid CR-only EOL"));
     }
 
     @Test
@@ -514,9 +512,8 @@ public class MultiPartFormDataTest
         Content.Sink.write(source, true, str, Callback.NOOP);
 
         ExecutionException ee = assertThrows(ExecutionException.class, () -> formData.parse(source).get());
-        assertThat(ee.getCause(), instanceOf(BadMessageException.class));
-        BadMessageException bme = (BadMessageException)ee.getCause();
-        assertThat(bme.getMessage(), containsString("invalid CR-only EOL"));
+        assertThat(ee.getCause(), instanceOf(HttpException.class));
+        assertThat(ee.getCause().getMessage(), containsString("invalid CR-only EOL"));
     }
 
     @Test

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/HTTP2CServerConnectionFactory.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/HTTP2CServerConnectionFactory.java
@@ -13,7 +13,7 @@
 
 package org.eclipse.jetty.http2.server;
 
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.MetaData.Request;
 import org.eclipse.jetty.http2.server.internal.HTTP2ServerConnection;
@@ -67,7 +67,7 @@ public class HTTP2CServerConnectionFactory extends HTTP2ServerConnectionFactory 
     }
 
     @Override
-    public Connection upgradeConnection(Connector connector, EndPoint endPoint, Request request, HttpFields.Mutable response101) throws BadMessageException
+    public Connection upgradeConnection(Connector connector, EndPoint endPoint, Request request, HttpFields.Mutable response101) throws HttpException.RuntimeException
     {
         if (LOG.isDebugEnabled())
             LOG.debug("{} upgrading {}{}{}", this, request, System.lineSeparator(), request.getHttpFields());

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HTTP2ServerConnection.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HTTP2ServerConnection.java
@@ -23,11 +23,12 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeoutException;
 
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.http.MetaData.Request;
@@ -291,7 +292,7 @@ public class HTTP2ServerConnection extends HTTP2Connection implements Connection
         {
             HttpField settingsField = request.getHttpFields().getField(HttpHeader.HTTP2_SETTINGS);
             if (settingsField == null)
-                throw new BadMessageException("Missing " + HttpHeader.HTTP2_SETTINGS + " header");
+                throw new HttpException.IllegalStateException(HttpStatus.BAD_REQUEST_400, "Missing " + HttpHeader.HTTP2_SETTINGS + " header");
             String value = settingsField.getValue();
             final byte[] settings = Base64.getUrlDecoder().decode(value == null ? "" : value);
 
@@ -302,7 +303,7 @@ public class HTTP2ServerConnection extends HTTP2Connection implements Connection
             if (settingsFrame == null)
             {
                 LOG.warn("Invalid {} header value: {}", HttpHeader.HTTP2_SETTINGS, value);
-                throw new BadMessageException();
+                throw new HttpException.IllegalStateException(HttpStatus.BAD_REQUEST_400);
             }
 
             responseFields.put(HttpHeader.UPGRADE, "h2c");

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HTTP2ServerSession.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HTTP2ServerSession.java
@@ -17,7 +17,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.http2.CloseState;
 import org.eclipse.jetty.http2.ErrorCode;
@@ -120,7 +121,7 @@ public class HTTP2ServerSession extends HTTP2Session implements ServerParser.Lis
                         {
                             // It's a bad request, request content will be dropped.
                             stream.updateClose(true, CloseState.Event.RECEIVED);
-                            notifyStreamFailure(stream, new BadMessageException(metaDataFailure.getMessage(), metaDataFailure), Callback.NOOP);
+                            notifyStreamFailure(stream, new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, metaDataFailure.getMessage(), metaDataFailure), Callback.NOOP);
                         }
                         else
                         {

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
@@ -20,7 +20,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
-import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.ComplianceViolation;
 import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.http.HttpException;
@@ -126,7 +125,7 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
 
             HttpField expectField = fields.getField(HttpHeader.EXPECT);
             if (expectField != null && !HttpHeaderValue.CONTINUE.is(expectField.getValue()))
-                throw new BadMessageException(HttpStatus.EXPECTATION_FAILED_417);
+                throw new HttpException.RuntimeException(HttpStatus.EXPECTATION_FAILED_417);
 
             InvocationType invocationType = Invocable.getInvocationType(handler);
             return new ReadyTask(invocationType, handler)

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/ConcurrentRequestsTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/ConcurrentRequestsTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.MetaData;
@@ -144,7 +144,7 @@ public class ConcurrentRequestsTest extends AbstractTest
                 int status = response.getStatus();
                 result.set(status == HttpStatus.OK_200 && frame.isEndStream());
                 if (status != HttpStatus.OK_200)
-                    failures.add(new BadMessageException("expected 200, got " + status + " id=" + id));
+                    failures.add(new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "expected 200, got " + status + " id=" + id));
                 if (!frame.isEndStream())
                     stream.demand();
                 else
@@ -228,7 +228,7 @@ public class ConcurrentRequestsTest extends AbstractTest
                 int status = response.getStatus();
                 result.set(status == HttpStatus.BAD_REQUEST_400);
                 if (status != HttpStatus.BAD_REQUEST_400)
-                    failures.add(new BadMessageException("expected 400, got " + status + " id=" + id));
+                    failures.add(new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "expected 400, got " + status + " id=" + id));
                 if (!frame.isEndStream())
                     stream.demand();
                 else

--- a/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HTTP3SessionServer.java
+++ b/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HTTP3SessionServer.java
@@ -13,7 +13,8 @@
 
 package org.eclipse.jetty.http3.server.internal;
 
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.http3.HTTP3ErrorCode;
 import org.eclipse.jetty.http3.HTTP3Session;
@@ -90,7 +91,7 @@ public class HTTP3SessionServer extends HTTP3Session implements Session.Server
             {
                 // It's a bad request, request content will be dropped.
                 stream.updateClose(true, false);
-                notifyStreamFailure(stream, new BadMessageException(metaDataFailure.getMessage(), metaDataFailure));
+                notifyStreamFailure(stream, new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, metaDataFailure.getMessage(), metaDataFailure));
             }
             else
             {

--- a/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HttpStreamOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HttpStreamOverHTTP3.java
@@ -19,7 +19,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
-import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.ComplianceViolation;
 import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.http.HttpException;
@@ -114,7 +113,7 @@ public class HttpStreamOverHTTP3 implements HttpStream
 
             HttpField expectField = fields.getField(HttpHeader.EXPECT);
             if (expectField != null && !HttpHeaderValue.CONTINUE.is(expectField.getValue()))
-                throw new BadMessageException(HttpStatus.EXPECTATION_FAILED_417);
+                throw new HttpException.RuntimeException(HttpStatus.EXPECTATION_FAILED_417);
 
             InvocationType invocationType = Invocable.getInvocationType(handler);
             return new ReadyTask(invocationType, handler)

--- a/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/ConcurrentRequestsTest.java
+++ b/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/ConcurrentRequestsTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
@@ -142,7 +142,7 @@ public class ConcurrentRequestsTest extends AbstractClientServerTest
                 int status = response.getStatus();
                 result.set(status == HttpStatus.OK_200 && frame.isLast());
                 if (status != HttpStatus.OK_200)
-                    failures.add(new BadMessageException("expected 200, got " + status + " id=" + id));
+                    failures.add(new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "expected 200, got " + status + " id=" + id));
                 if (!frame.isLast())
                     stream.demand();
                 else
@@ -217,7 +217,7 @@ public class ConcurrentRequestsTest extends AbstractClientServerTest
                 int status = response.getStatus();
                 result.set(status == HttpStatus.BAD_REQUEST_400);
                 if (status != HttpStatus.BAD_REQUEST_400)
-                    failures.add(new BadMessageException("expected 400, got " + status + " id=" + id));
+                    failures.add(new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "expected 400, got " + status + " id=" + id));
                 if (!frame.isLast())
                     stream.demand();
                 else

--- a/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/CompactPathRule.java
+++ b/jetty-core/jetty-rewrite/src/main/java/org/eclipse/jetty/rewrite/handler/CompactPathRule.java
@@ -17,7 +17,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.util.URIUtil;
 
@@ -146,7 +147,7 @@ public class CompactPathRule extends Rule
         }
         catch (IllegalArgumentException e)
         {
-            throw new BadMessageException("Bad Path");
+            throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Bad Path");
         }
     }
 

--- a/jetty-core/jetty-security/src/test/java/org/eclipse/jetty/security/jaas/TestHandler.java
+++ b/jetty-core/jetty-security/src/test/java/org/eclipse/jetty/security/jaas/TestHandler.java
@@ -16,7 +16,6 @@ package org.eclipse.jetty.security.jaas;
 
 import java.util.List;
 
-import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpStatus;
@@ -61,7 +60,7 @@ public class TestHandler extends Handler.Abstract
                 for (String role : _hasRoles)
                 {
                     if (!userAuthentication.isUserInRole(role))
-                        throw new BadMessageException(HttpStatus.FORBIDDEN_403, "! in role " + role);
+                        throw new HttpException.RuntimeException(HttpStatus.FORBIDDEN_403, "! in role " + role);
                 }
             }
         }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ConnectionFactory.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ConnectionFactory.java
@@ -21,7 +21,6 @@ import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.io.Connection;
 import org.eclipse.jetty.io.EndPoint;
-import org.eclipse.jetty.io.QuietException;
 
 /**
  * A Factory to create {@link Connection} instances for {@link Connector}s.
@@ -79,7 +78,7 @@ public interface ConnectionFactory
          * indicate that the upgrade should proceed.
          * @throws HttpException.RuntimeException Thrown to indicate the upgrade attempt was illegal and that a bad message response should be sent.
          */
-        Connection upgradeConnection(Connector connector, EndPoint endPoint, MetaData.Request upgradeRequest, HttpFields.Mutable responseFields) throws QuietException.RuntimeException;
+        Connection upgradeConnection(Connector connector, EndPoint endPoint, MetaData.Request upgradeRequest, HttpFields.Mutable responseFields) throws HttpException.RuntimeException;
     }
 
     /**

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ConnectionFactory.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ConnectionFactory.java
@@ -16,11 +16,12 @@ package org.eclipse.jetty.server;
 import java.nio.ByteBuffer;
 import java.util.List;
 
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.io.Connection;
 import org.eclipse.jetty.io.EndPoint;
+import org.eclipse.jetty.io.QuietException;
 
 /**
  * A Factory to create {@link Connection} instances for {@link Connector}s.
@@ -45,12 +46,12 @@ public interface ConnectionFactory
     /**
      * @return A string representing the primary protocol name.
      */
-    public String getProtocol();
+    String getProtocol();
 
     /**
      * @return A list of alternative protocol names/versions including the primary protocol.
      */
-    public List<String> getProtocols();
+    List<String> getProtocols();
 
     /**
      * <p>Creates a new {@link Connection} with the given parameters</p>
@@ -59,9 +60,9 @@ public interface ConnectionFactory
      * @param endPoint the {@link EndPoint} associated with the connection
      * @return a new {@link Connection}
      */
-    public Connection newConnection(Connector connector, EndPoint endPoint);
+    Connection newConnection(Connector connector, EndPoint endPoint);
 
-    public interface Upgrading extends ConnectionFactory
+    interface Upgrading extends ConnectionFactory
     {
 
         /**
@@ -76,9 +77,9 @@ public interface ConnectionFactory
          * @param responseFields The fields to be sent with the 101 response
          * @return Null to indicate that request processing should continue normally without upgrading. A new connection instance to
          * indicate that the upgrade should proceed.
-         * @throws BadMessageException Thrown to indicate the upgrade attempt was illegal and that a bad message response should be sent.
+         * @throws HttpException.RuntimeException Thrown to indicate the upgrade attempt was illegal and that a bad message response should be sent.
          */
-        public Connection upgradeConnection(Connector connector, EndPoint endPoint, MetaData.Request upgradeRequest, HttpFields.Mutable responseFields) throws BadMessageException;
+        Connection upgradeConnection(Connector connector, EndPoint endPoint, MetaData.Request upgradeRequest, HttpFields.Mutable responseFields) throws QuietException.RuntimeException;
     }
 
     /**

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/CookieCache.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/CookieCache.java
@@ -24,14 +24,15 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.function.Function;
 
-import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.ComplianceViolation;
 import org.eclipse.jetty.http.CookieCompliance;
 import org.eclipse.jetty.http.CookieParser;
 import org.eclipse.jetty.http.HttpCookie;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -245,7 +246,7 @@ public class CookieCache extends AbstractList<HttpCookie> implements CookieParse
             }
             catch (CookieParser.InvalidCookieException invalidCookieException)
             {
-                throw new BadMessageException(invalidCookieException.getMessage(), invalidCookieException);
+                throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, invalidCookieException.getMessage(), invalidCookieException);
             }
         }
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ForwardedRequestCustomizer.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ForwardedRequestCustomizer.java
@@ -20,12 +20,13 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Set;
 
-import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HostPortHttpField;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpScheme;
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.QuotedCSVParser;
 import org.eclipse.jetty.io.EndPoint;
@@ -663,7 +664,7 @@ public class ForwardedRequestCustomizer implements HttpConfiguration.Customizer
 
     protected void onError(HttpField field, Throwable t)
     {
-        throw new BadMessageException("Bad header value for " + field.getName(), t);
+        throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Bad header value for " + field.getName(), t);
     }
 
     protected static String getLeftMost(String headerValue)
@@ -978,7 +979,7 @@ public class ForwardedRequestCustomizer implements HttpConfiguration.Customizer
             }
             else
             {
-                throw new BadMessageException("Invalid value for " + field.getName());
+                throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Invalid value for " + field.getName());
             }
         }
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Request.java
@@ -36,13 +36,14 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.ComplianceViolation;
 import org.eclipse.jetty.http.HttpCookie;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpScheme;
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.http.MimeTypes;
@@ -609,7 +610,8 @@ public interface Request extends Attributes, Content.Source
         }
         catch (Throwable t)
         {
-            throw new BadMessageException("Bad query", t);
+            HttpException.throwIfHttpException(t);
+            throw new HttpException.IllegalStateException(HttpStatus.BAD_REQUEST_400, "Bad query", t);
         }
     }
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/SecureRequestCustomizer.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/SecureRequestCustomizer.java
@@ -24,10 +24,11 @@ import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSession;
 
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.PreEncodedHttpField;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.util.TypeUtil;
@@ -222,16 +223,16 @@ public class SecureRequestCustomizer implements HttpConfiguration.Customizer
 
             X509 x509 = getX509(session);
             if (x509 == null)
-                throw new BadMessageException(400, "Invalid SNI");
+                throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Invalid SNI");
             String serverName = Request.getServerName(request);
             if (LOG.isDebugEnabled())
                 LOG.debug("Host={}, SNI={}, SNI Certificate={}", serverName, sniHost, x509);
 
             if (isSniRequired() && (sniHost == null || !x509.matches(sniHost)))
-                throw new BadMessageException(400, "Invalid SNI");
+                throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Invalid SNI");
 
             if (isSniHostCheck() && !x509.matches(serverName))
-                throw new BadMessageException(400, "Invalid SNI");
+                throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Invalid SNI");
         }
     }
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/SizeLimitHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/SizeLimitHandler.java
@@ -15,7 +15,6 @@ package org.eclipse.jetty.server.handler;
 
 import java.nio.ByteBuffer;
 
-import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
@@ -35,7 +34,7 @@ import org.eclipse.jetty.util.Callback;
  * <p>Handler order is important; for example, if this handler is before the {@link GzipHandler},
  * then it will limit compressed sizes, if it as after the {@link GzipHandler} then it will limit
  * uncompressed sizes.</p>
- * <p>If a size limit is exceeded then {@link BadMessageException} is thrown with a
+ * <p>If a size limit is exceeded then {@link HttpException.RuntimeException} is thrown with a
  * {@link HttpStatus#PAYLOAD_TOO_LARGE_413} status.</p>
  */
 public class SizeLimitHandler extends Handler.Wrapper
@@ -98,7 +97,7 @@ public class SizeLimitHandler extends Handler.Wrapper
                 _read += content.remaining();
                 if (_requestLimit >= 0 && _read > _requestLimit)
                 {
-                    BadMessageException e = new BadMessageException(HttpStatus.PAYLOAD_TOO_LARGE_413, "Request body is too large: " + _read + ">" + _requestLimit);
+                    HttpException.RuntimeException e = new HttpException.RuntimeException(HttpStatus.PAYLOAD_TOO_LARGE_413, "Request body is too large: " + _read + ">" + _requestLimit);
                     getWrapped().fail(e);
                     return null;
                 }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -28,8 +28,8 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.ComplianceViolation;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
@@ -692,7 +692,7 @@ public class HttpChannelState implements HttpChannel, Components
                 {
                     String method = request.getMethod();
                     if (!HttpMethod.PRI.is(method) && !HttpMethod.CONNECT.is(method) && !HttpMethod.OPTIONS.is(method))
-                        throw new BadMessageException("Bad URI path");
+                        throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Bad URI path");
                 }
 
                 HttpURI uri = request.getHttpURI();
@@ -700,7 +700,7 @@ public class HttpChannelState implements HttpChannel, Components
                 {
                     String badMessage = UriCompliance.checkUriCompliance(getConnectionMetaData().getHttpConfiguration().getUriCompliance(), uri, HttpChannel.from(request).getComplianceViolationListener());
                     if (badMessage != null)
-                        throw new BadMessageException(badMessage);
+                        throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, badMessage);
                 }
 
                 // Customize before processing.

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -28,7 +28,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.ComplianceViolation;
 import org.eclipse.jetty.http.HostPortHttpField;
 import org.eclipse.jetty.http.HttpCompliance;
@@ -1337,7 +1336,7 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
                 compliance = getHttpConfiguration().getUriCompliance();
                 String badMessage = UriCompliance.checkUriCompliance(compliance, _uri, getHttpChannel().getComplianceViolationListener());
                 if (badMessage != null)
-                    throw new BadMessageException(badMessage);
+                    throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, badMessage);
             }
 
             // Check host field matches the authority in the absolute URI or is not blank
@@ -1351,13 +1350,13 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
                         if (httpCompliance.allows(MISMATCHED_AUTHORITY))
                             getHttpChannel().getComplianceViolationListener().onComplianceViolation(new ComplianceViolation.Event(httpCompliance, MISMATCHED_AUTHORITY, _uri.asString()));
                         else
-                            throw new BadMessageException("Authority!=Host");
+                            throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Authority!=Host");
                     }
                 }
                 else
                 {
                     if (StringUtil.isBlank(_hostField.getHostPort().getHost()))
-                        throw new BadMessageException("Blank Host");
+                        throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Blank Host");
                 }
             }
 
@@ -1424,7 +1423,7 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
                 case HTTP_1_1:
                 {
                     if (_unknownExpectation)
-                        throw new BadMessageException(HttpStatus.EXPECTATION_FAILED_417);
+                        throw new HttpException.RuntimeException(HttpStatus.EXPECTATION_FAILED_417);
 
                     persistent = getHttpConfiguration().isPersistentConnectionsEnabled() &&
                         !_connectionClose ||
@@ -1456,7 +1455,7 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
 
                     // TODO is this sufficient?
                     _parser.close();
-                    throw new BadMessageException(HttpStatus.UPGRADE_REQUIRED_426, "Upgrade Required");
+                    throw new HttpException.RuntimeException(HttpStatus.UPGRADE_REQUIRED_426, "Upgrade Required");
                 }
                 default:
                 {
@@ -1609,7 +1608,7 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
             @SuppressWarnings("ReferenceEquality")
             boolean isPriorKnowledgeH2C = _upgrade == PREAMBLE_UPGRADE_H2C;
             if (!isPriorKnowledgeH2C  && !_connectionUpgrade)
-                throw new BadMessageException(HttpStatus.BAD_REQUEST_400);
+                throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400);
 
             // Find the upgrade factory.
             ConnectionFactory.Upgrading factory = getConnector().getConnectionFactories().stream()

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ErrorHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ErrorHandlerTest.java
@@ -22,7 +22,7 @@ import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpTester;
@@ -79,7 +79,7 @@ public class ErrorHandlerTest
                 if (pathInContext.startsWith("/badmessage/"))
                 {
                     int code = Integer.parseInt(pathInContext.substring(pathInContext.lastIndexOf('/') + 1));
-                    throw new BadMessageException(code);
+                    throw new HttpException.RuntimeException(code);
                 }
 
                 // produce an exception with an JSON formatted cause message
@@ -554,7 +554,7 @@ public class ErrorHandlerTest
         assertThat("Response status code", response.getStatus(), is(444));
         assertThat("Response Content-Length", response.getField(HttpHeader.CONTENT_LENGTH).getIntValue(), greaterThan(0));
         assertThat(response.getContent(), containsString("<th>CAUSED BY:</th>"));
-        assertThat(response.getContent(), containsString("<td>org.eclipse.jetty.http.BadMessageException: 444: null</td>"));
+        assertThat(response.getContent(), containsString("<td>org.eclipse.jetty.http.HttpException$RuntimeException: 444: null</td>"));
     }
 
     @Test

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/LargeHeaderTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/LargeHeaderTest.java
@@ -29,7 +29,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.http.MimeTypes;
@@ -235,10 +235,17 @@ public class LargeHeaderTest
                             countOther.incrementAndGet();
                         }
                     }
-                    catch (BadMessageException bme)
+                    catch (Throwable throwable)
                     {
-                        System.err.printf("%n---[Response:%d]----%n%s%n----%n", rawResponse.length(), rawResponse);
-                        LOG.warn("Failed Response Parse", bme);
+                        if (throwable instanceof HttpException)
+                        {
+                            System.err.printf("%n---[Response:%d]----%n%s%n----%n", rawResponse.length(), rawResponse);
+                            LOG.warn("Failed Response Parse", throwable);
+                        }
+                        else
+                        {
+                            throw throwable;
+                        }
                     }
                 }
                 catch (Throwable t)

--- a/jetty-core/jetty-session/src/main/java/org/eclipse/jetty/session/AbstractSessionManager.java
+++ b/jetty-core/jetty-session/src/main/java/org/eclipse/jetty/session/AbstractSessionManager.java
@@ -28,9 +28,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HttpCookie;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpScheme;
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.http.Syntax;
@@ -1349,7 +1350,7 @@ public abstract class AbstractSessionManager extends ContainerLifeCycle implemen
                             LOG.debug("Error releasing duplicate valid session: {}", id);
                     }
 
-                    throw new BadMessageException(duplicateSession(
+                    throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, duplicateSession(
                         requestedSessionId, requestedSessionIdFromCookie,
                         id, true, i < cookieIds));
                 }

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/ExtensionStack.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/ExtensionStack.java
@@ -20,7 +20,8 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.stream.Collectors;
 
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.TypeUtil;
 import org.eclipse.jetty.util.annotation.ManagedAttribute;
@@ -152,7 +153,7 @@ public class ExtensionStack implements IncomingFrames, OutgoingFrames, Dumpable
                         for (ExtensionConfig offered : offeredConfigs)
                         {
                             if (offered.getParameterizedName().equals(parameterizedName))
-                                throw new BadMessageException("could not instantiate offered extension", t);
+                                throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "could not instantiate offered extension", t);
                         }
                         throw new WebSocketException("could not instantiate negotiated extension", t);
                     }
@@ -164,7 +165,7 @@ public class ExtensionStack implements IncomingFrames, OutgoingFrames, Dumpable
                             if (offered.getParameterizedName().equals(parameterizedName))
                                 throw new WebSocketException("could not instantiate offered extension", t);
                         }
-                        throw new BadMessageException("could not instantiate negotiated extension", t);
+                        throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "could not instantiate negotiated extension", t);
                     }
                     default:
                         throw new IllegalStateException();

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketExtensionRegistry.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketExtensionRegistry.java
@@ -19,7 +19,8 @@ import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
 
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.TypeUtil;
 
@@ -88,7 +89,7 @@ public class WebSocketExtensionRegistry implements Iterable<Class<? extends Exte
         }
         catch (Throwable t)
         {
-            throw new BadMessageException("Cannot instantiate extension: " + extClass, t);
+            throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Cannot instantiate extension: " + extClass, t);
         }
     }
 

--- a/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/RFC6455Handshaker.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/RFC6455Handshaker.java
@@ -13,7 +13,7 @@
 
 package org.eclipse.jetty.websocket.core.server.internal;
 
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
@@ -70,7 +70,7 @@ public final class RFC6455Handshaker extends AbstractHandshaker
         if (!result)
             return false;
         if (((RFC6455Negotiation)negotiation).getKey() == null)
-            throw new BadMessageException("Missing request header 'Sec-WebSocket-Key'");
+            throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Missing request header 'Sec-WebSocket-Key'");
         return true;
     }
 

--- a/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/RFC6455Negotiation.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/RFC6455Negotiation.java
@@ -13,7 +13,7 @@
 
 package org.eclipse.jetty.websocket.core.server.internal;
 
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.QuotedCSV;
@@ -27,7 +27,7 @@ public class RFC6455Negotiation extends WebSocketNegotiation
     private boolean successful;
     private String key;
 
-    public RFC6455Negotiation(Request request, Response response, Callback callback, WebSocketComponents components) throws BadMessageException
+    public RFC6455Negotiation(Request request, Response response, Callback callback, WebSocketComponents components) throws HttpException.RuntimeException
     {
         super(request, response, callback, components);
     }

--- a/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/RFC8441Negotiation.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/RFC8441Negotiation.java
@@ -13,7 +13,7 @@
 
 package org.eclipse.jetty.websocket.core.server.internal;
 
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.TunnelSupport;
@@ -22,7 +22,7 @@ import org.eclipse.jetty.websocket.core.WebSocketComponents;
 
 public class RFC8441Negotiation extends WebSocketNegotiation
 {
-    public RFC8441Negotiation(Request request, Response response, Callback callback, WebSocketComponents components) throws BadMessageException
+    public RFC8441Negotiation(Request request, Response response, Callback callback, WebSocketComponents components) throws HttpException.RuntimeException
     {
         super(request, response, callback, components);
     }

--- a/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/ServerUpgradeRequestImpl.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/ServerUpgradeRequestImpl.java
@@ -15,7 +15,7 @@ package org.eclipse.jetty.websocket.core.server.internal;
 
 import java.util.List;
 
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.websocket.core.ExtensionConfig;
@@ -32,7 +32,7 @@ public class ServerUpgradeRequestImpl extends Request.Wrapper implements ServerU
     private final Request request;
     private final WebSocketNegotiation negotiation;
 
-    public ServerUpgradeRequestImpl(WebSocketNegotiation negotiation, Request baseRequest) throws BadMessageException
+    public ServerUpgradeRequestImpl(WebSocketNegotiation negotiation, Request baseRequest) throws HttpException.RuntimeException
     {
         super(baseRequest);
         this.negotiation = negotiation;

--- a/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/WebSocketNegotiation.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/WebSocketNegotiation.java
@@ -19,9 +19,11 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.QuotedCSV;
+import org.eclipse.jetty.io.QuietException;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
@@ -71,7 +73,7 @@ public abstract class WebSocketNegotiation
         return components;
     }
 
-    public void negotiate() throws BadMessageException
+    public void negotiate() throws QuietException.RuntimeException
     {
         try
         {
@@ -79,7 +81,7 @@ public abstract class WebSocketNegotiation
         }
         catch (Throwable x)
         {
-            throw new BadMessageException("Invalid upgrade request", x);
+            throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Invalid upgrade request", x);
         }
     }
 

--- a/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/WebSocketNegotiation.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-server/src/main/java/org/eclipse/jetty/websocket/core/server/internal/WebSocketNegotiation.java
@@ -23,7 +23,6 @@ import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.QuotedCSV;
-import org.eclipse.jetty.io.QuietException;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
@@ -73,7 +72,7 @@ public abstract class WebSocketNegotiation
         return components;
     }
 
-    public void negotiate() throws QuietException.RuntimeException
+    public void negotiate() throws HttpException.RuntimeException
     {
         try
         {

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiRequest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiRequest.java
@@ -1103,8 +1103,8 @@ public class ServletApiRequest implements HttpServletRequest
                         catch (ServletException e)
                         {
                             Throwable cause = e.getCause();
-                            if (cause instanceof BadMessageException badMessageException)
-                                throw badMessageException;
+                            if (cause instanceof HttpException httpException)
+                                HttpException.throwAsUnchecked(httpException);
 
                             String msg = "Unable to extract content parameters";
                             if (LOG.isDebugEnabled())

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ErrorPageTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ErrorPageTest.java
@@ -1387,14 +1387,14 @@ public class ErrorPageTest
 
             String responseBody = response.getContent();
             assertThat(responseBody, Matchers.containsString("ERROR_PAGE: /BadMessageException"));
-            assertThat(responseBody, Matchers.containsString("ERROR_MESSAGE: Bad query"));
+            assertThat(responseBody, Matchers.containsString("ERROR_MESSAGE: Unable to parse URI query"));
             assertThat(responseBody, Matchers.containsString("ERROR_CODE: 400"));
-            assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION: org.eclipse.jetty.http.BadMessageException: 400: Bad query"));
+            assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION: org.eclipse.jetty.http.BadMessageException: 400: Unable to parse URI query"));
             assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION_TYPE: class org.eclipse.jetty.http.BadMessageException"));
             assertThat(responseBody, Matchers.containsString("ERROR_SERVLET: " + appServlet.getClass().getName()));
             assertThat(responseBody, Matchers.containsString("ERROR_REQUEST_URI: /app"));
             assertThat(responseBody, Matchers.containsString("getQueryString()=[baa=%88%A4]"));
-            assertThat(responseBody, Matchers.containsString("getParameterMap().size=org.eclipse.jetty.http.BadMessageException"));
+            assertThat(responseBody, Matchers.containsString("getParameterMap().size=0"));
         }
     }
 

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/AsyncContentProducer.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/AsyncContentProducer.java
@@ -16,7 +16,7 @@ package org.eclipse.jetty.ee11.servlet;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.Trailers;
 import org.eclipse.jetty.io.Content;
@@ -134,7 +134,8 @@ class AsyncContentProducer implements ContentProducer
                 {
                     if (LOG.isDebugEnabled())
                         LOG.debug("checkMinDataRate check failed {}", this);
-                    BadMessageException bad = new BadMessageException(HttpStatus.REQUEST_TIMEOUT_408,
+                    HttpException.IllegalStateException bad = new HttpException.IllegalStateException(
+                        HttpStatus.REQUEST_TIMEOUT_408,
                         String.format("Request content data rate < %d B/s", minRequestDataRate));
                     if (_servletChannel.getServletRequestState().isResponseCommitted())
                     {

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletApiRequest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletApiRequest.java
@@ -61,7 +61,6 @@ import jakarta.servlet.http.HttpUpgradeHandler;
 import jakarta.servlet.http.Part;
 import jakarta.servlet.http.PushBuilder;
 import org.eclipse.jetty.ee11.servlet.ServletContextHandler.ServletRequestInfo;
-import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.CookieCompliance;
 import org.eclipse.jetty.http.HttpCookie;
 import org.eclipse.jetty.http.HttpException;
@@ -117,7 +116,7 @@ public class ServletApiRequest implements HttpServletRequest
         }
 
         @Override
-        protected void extractQueryParameters() throws BadMessageException
+        protected void extractQueryParameters() throws HttpException.IllegalStateException
         {
             // Extract query string parameters; these may be replaced by a forward()
             // and may have already been extracted by mergeQueryParameters().
@@ -204,7 +203,7 @@ public class ServletApiRequest implements HttpServletRequest
         }
 
         @Override
-        protected void extractQueryParameters() throws BadMessageException
+        protected void extractQueryParameters() throws HttpException.IllegalStateException
         {
             // Extract query string parameters; these may be replaced by a forward()
             // and may have already been extracted by mergeQueryParameters().
@@ -735,7 +734,7 @@ public class ServletApiRequest implements HttpServletRequest
                 if (cause instanceof IOException ioException)
                     throw ioException;
 
-                throw new ServletException(new BadMessageException("bad multipart", cause));
+                throw new ServletException(new HttpException.IllegalStateException(HttpStatus.BAD_REQUEST_400, "bad multipart", cause));
             }
         }
 
@@ -1138,7 +1137,7 @@ public class ServletApiRequest implements HttpServletRequest
         }
     }
 
-    protected void extractQueryParameters() throws BadMessageException
+    protected void extractQueryParameters() throws HttpException.IllegalStateException
     {
         // Extract query string parameters; these may be replaced by a forward()
         // and may have already been extracted by mergeQueryParameters().

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletApiRequest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletApiRequest.java
@@ -1057,7 +1057,7 @@ public class ServletApiRequest implements HttpServletRequest
         return parameters == null ? ServletContextRequest.NO_PARAMS : parameters;
     }
 
-    private void extractContentParameters() throws BadMessageException
+    private void extractContentParameters() throws HttpException.IllegalStateException
     {
         // Extract content parameters; these cannot be replaced by a forward()
         // once extracted and may have already been extracted by getParts() or
@@ -1082,7 +1082,7 @@ public class ServletApiRequest implements HttpServletRequest
                         }
                         catch (IllegalStateException | IllegalArgumentException | CompletionException e)
                         {
-                            throw new BadMessageException("Unable to parse form content", e);
+                            throw new HttpException.IllegalStateException(HttpStatus.BAD_REQUEST_400, "Unable to parse form content", e);
                         }
                     }
                     else if (MimeTypes.Type.MULTIPART_FORM_DATA.is(baseType) &&
@@ -1097,20 +1097,19 @@ public class ServletApiRequest implements HttpServletRequest
                             String msg = "Unable to extract content parameters";
                             if (LOG.isDebugEnabled())
                                 LOG.debug(msg, e);
-                            throw new UncheckedIOException(msg, e);
+                            throw new HttpException.IllegalStateException(HttpStatus.BAD_REQUEST_400, msg, new IOException(msg, e));
                         }
                         catch (ServletException e)
                         {
                             Throwable cause = e.getCause();
-                            if (cause instanceof BadMessageException badMessageException)
-                                throw badMessageException;
+                            HttpException.throwIfHttpException(cause);
 
                             String msg = "Unable to extract content parameters";
                             if (LOG.isDebugEnabled())
                                 LOG.debug(msg, e);
                             if (cause instanceof IOException ioe)
                                 throw new UncheckedIOException(msg, ioe);
-                            throw new RuntimeException(msg, e);
+                            throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, msg, e);
                         }
                     }
                     else
@@ -1121,7 +1120,8 @@ public class ServletApiRequest implements HttpServletRequest
                         }
                         catch (IllegalStateException | IllegalArgumentException | CompletionException e)
                         {
-                            throw new BadMessageException("Unable to parse form content", e);
+                            HttpException.throwAsUncheckedHttpException(e);
+                            throw new HttpException.IllegalStateException(HttpStatus.BAD_REQUEST_400, "Unable to parse form content", e);
                         }
                     }
                 }
@@ -1131,7 +1131,9 @@ public class ServletApiRequest implements HttpServletRequest
             }
             catch (IllegalStateException | IllegalArgumentException e)
             {
-                throw new BadMessageException("Unable to parse form content", e);
+                _contentParameters = ServletContextRequest.BAD_PARAMS;
+                HttpException.throwIfHttpException(e);
+                throw new HttpException.IllegalStateException(HttpStatus.BAD_REQUEST_400, "Unable to parse form content", e);
             }
         }
     }
@@ -1154,7 +1156,8 @@ public class ServletApiRequest implements HttpServletRequest
                 catch (IllegalStateException | IllegalArgumentException e)
                 {
                     _queryParameters = ServletContextRequest.BAD_PARAMS;
-                    throw new BadMessageException("Unable to parse URI query", e);
+                    HttpException.throwIfHttpException(e);
+                    throw new HttpException.IllegalStateException(HttpStatus.BAD_REQUEST_400, "Unable to parse form content", e);
                 }
             }
         }

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletChannel.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletChannel.java
@@ -29,7 +29,7 @@ import org.eclipse.jetty.ee11.servlet.ServletChannelState.Action;
 import org.eclipse.jetty.ee11.servlet.internal.JettyWebConnection;
 import org.eclipse.jetty.ee11.servlet.internal.UpgradedServletInputStream;
 import org.eclipse.jetty.ee11.servlet.internal.UpgradedServletOutputStream;
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpURI;
@@ -687,7 +687,7 @@ public class ServletChannel
     {
         // Unwrap wrapping Jetty and Servlet exceptions.
         Throwable quiet = unwrap(failure, QuietException.class);
-        Throwable noStack = unwrap(failure, BadMessageException.class, IOException.class, TimeoutException.class);
+        Throwable noStack = unwrap(failure, HttpException.class, IOException.class, TimeoutException.class);
 
         if (quiet != null || !getServer().isRunning())
         {
@@ -968,7 +968,7 @@ public class ServletChannel
             //dispatch is to a specific path
             String encodedPathQuery = URIUtil.normalizePath(URIUtil.addEncodedPaths(targetContextHandler.getContextPath(), dispatchPathInContext));
             if (encodedPathQuery == null)
-                throw new BadMessageException(500, "Bad dispatch path");
+                throw new HttpException.IllegalStateException(500, "Bad dispatch path");
 
             //Add in any query params
             if (asyncContextEvent.getBaseURI() != null)

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/AsyncContextTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/AsyncContextTest.java
@@ -31,7 +31,7 @@ import jakarta.servlet.http.HttpServletMapping;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpServletResponseWrapper;
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.LocalConnector;
@@ -752,7 +752,7 @@ public class AsyncContextTest
                         AsyncContext asyncContext = request.startAsync();
                         try
                         {
-                            ((ServletApiResponse)response).getServletChannel().abort(new BadMessageException(488));
+                            ((ServletApiResponse)response).getServletChannel().abort(new HttpException.IllegalStateException(488));
                         }
                         finally
                         {

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/ErrorPageTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/ErrorPageTest.java
@@ -44,7 +44,7 @@ import jakarta.servlet.UnavailableException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpTester;
@@ -1369,7 +1369,9 @@ public class ErrorPageTest
         contextHandler.addServlet(ErrorDumpServlet.class, "/error/*");
 
         ErrorPageErrorHandler errorPageErrorHandler = new ErrorPageErrorHandler();
-        errorPageErrorHandler.addErrorPage(BadMessageException.class, "/error/BadMessageException");
+        errorPageErrorHandler.addErrorPage(HttpException.RuntimeException.class, "/error/BadMessageException");
+        errorPageErrorHandler.addErrorPage(HttpException.IllegalStateException.class, "/error/BadMessageException");
+        errorPageErrorHandler.addErrorPage(HttpException.IllegalArgumentException.class, "/error/BadMessageException");
         contextHandler.setErrorHandler(errorPageErrorHandler);
 
         startServer(contextHandler);
@@ -1392,12 +1394,12 @@ public class ErrorPageTest
             assertThat(responseBody, Matchers.containsString("ERROR_PAGE: /BadMessageException"));
             assertThat(responseBody, Matchers.containsString("ERROR_MESSAGE: Bad query"));
             assertThat(responseBody, Matchers.containsString("ERROR_CODE: 400"));
-            assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION: org.eclipse.jetty.http.BadMessageException: 400: Bad query"));
-            assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION_TYPE: class org.eclipse.jetty.http.BadMessageException"));
+            assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION: org.eclipse.jetty.http.HttpException$IllegalStateException: 400: Bad query"));
+            assertThat(responseBody, Matchers.containsString("ERROR_EXCEPTION_TYPE: class org.eclipse.jetty.http.HttpException$IllegalStateException"));
             assertThat(responseBody, Matchers.containsString("ERROR_SERVLET: " + appServlet.getClass().getName()));
             assertThat(responseBody, Matchers.containsString("ERROR_REQUEST_URI: /app"));
             assertThat(responseBody, Matchers.containsString("getQueryString()=[baa=%88%A4]"));
-            assertThat(responseBody, Matchers.containsString("getParameterMap().size=org.eclipse.jetty.http.BadMessageException"));
+            assertThat(responseBody, Matchers.containsString("getParameterMap().size=0"));
         }
     }
 

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/RequestTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/RequestTest.java
@@ -37,6 +37,7 @@ import java.util.stream.Stream;
 
 import jakarta.servlet.MultipartConfigElement;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -786,5 +787,70 @@ public class RequestTest
         {
             assertThat(response, startsWith("HTTP/1.1 200 OK"));
         }
+    }
+
+    public record ParameterCase(String purpose, Consumer<HttpServletRequest> requestAction)
+    {
+        @Override
+        public String toString()
+        {
+            return purpose;
+        }
+    }
+
+    public static Stream<Arguments> parameterISECases()
+    {
+        List<Arguments> cases = new ArrayList<>();
+
+        cases.add(Arguments.of(new ParameterCase("getParameter(String)",
+            (request) -> request.getParameter("x"))));
+        cases.add(Arguments.of(new ParameterCase("getParameterNames()",
+            ServletRequest::getParameterNames)));
+        cases.add(Arguments.of(new ParameterCase("getParameterValues(String)",
+            (request) -> request.getParameterValues("x"))));
+        cases.add(Arguments.of(new ParameterCase("getParameterMap()",
+            ServletRequest::getParameterMap)));
+
+        return cases.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameterISECases")
+    public void testGetParameterISE(ParameterCase parameterCase) throws Exception
+    {
+        startServer(new HttpServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest request, HttpServletResponse resp) throws IOException
+            {
+                try
+                {
+                    parameterCase.requestAction.accept(request);
+                    resp.setStatus(500);
+                    resp.getWriter().print("BAD: ISE Should have Occurred");
+                }
+                catch (IllegalStateException e)
+                {
+                    resp.setStatus(200);
+                    resp.getWriter().print("GOOD: ISE Occurred");
+                }
+                catch (Throwable t)
+                {
+                    t.printStackTrace();
+                    throw t;
+                }
+            }
+        });
+
+        String rawResponse = _connector.getResponse(
+            """
+                POST /test/parameters?x=%80 HTTP/1.1\r
+                Host: localhost\r
+                Connection: close\r
+                \r
+                """);
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        assertThat(response.getContent(), is("GOOD: ISE Occurred"));
     }
 }

--- a/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee11/websocket/jakarta/tests/JakartaClientClassLoaderTest.java
+++ b/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee11/websocket/jakarta/tests/JakartaClientClassLoaderTest.java
@@ -38,7 +38,7 @@ import org.eclipse.jetty.ee11.webapp.Configurations;
 import org.eclipse.jetty.ee11.websocket.jakarta.client.JakartaWebSocketClientContainerProvider;
 import org.eclipse.jetty.ee11.websocket.jakarta.common.JakartaWebSocketContainer;
 import org.eclipse.jetty.ee11.websocket.jakarta.server.config.JakartaWebSocketConfiguration;
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
@@ -155,7 +155,7 @@ public class JakartaClientClassLoaderTest
         app.copyLib(Compression.class, "jetty-compression-common.jar");
         app.copyLib(GzipCompression.class, "jetty-compression-gzip.jar");
         app.copyLib(EndPoint.class, "jetty-io.jar");
-        app.copyLib(BadMessageException.class, "jetty-http.jar");
+        app.copyLib(HttpException.class, "jetty-http.jar");
         app.copyLib(XmlConfiguration.class, "jetty-xml.jar");
 
         return app;

--- a/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee11/websocket/jakarta/tests/JakartaClientShutdownWithServerWebAppTest.java
+++ b/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee11/websocket/jakarta/tests/JakartaClientShutdownWithServerWebAppTest.java
@@ -32,10 +32,9 @@ import org.eclipse.jetty.ee11.websocket.jakarta.client.JakartaWebSocketClientCon
 import org.eclipse.jetty.ee11.websocket.jakarta.client.webapp.JakartaWebSocketShutdownContainer;
 import org.eclipse.jetty.ee11.websocket.jakarta.common.JakartaWebSocketContainer;
 import org.eclipse.jetty.ee11.websocket.jakarta.server.config.JakartaWebSocketConfiguration;
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.io.EndPoint;
-import org.eclipse.jetty.util.TypeUtil;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
 import org.eclipse.jetty.websocket.core.WebSocketComponents;
 import org.eclipse.jetty.websocket.core.client.CoreClientUpgradeRequest;
@@ -106,7 +105,7 @@ public class JakartaClientShutdownWithServerWebAppTest
         app.copyLib(Compression.class, "jetty-compression-common.jar");
         app.copyLib(GzipCompression.class, "jetty-compression-gzip.jar");
         app.copyLib(EndPoint.class, "jetty-io.jar");
-        app.copyLib(BadMessageException.class, "jetty-http.jar");
+        app.copyLib(HttpException.class, "jetty-http.jar");
 
         return app;
     }

--- a/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee11/websocket/server/internal/DelegatedServerUpgradeRequest.java
+++ b/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jetty-server/src/main/java/org/eclipse/jetty/ee11/websocket/server/internal/DelegatedServerUpgradeRequest.java
@@ -31,10 +31,11 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import org.eclipse.jetty.ee11.websocket.server.JettyServerUpgradeRequest;
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.websocket.api.ExtensionConfig;
 import org.eclipse.jetty.websocket.common.JettyExtensionConfig;
@@ -193,7 +194,7 @@ public class DelegatedServerUpgradeRequest implements JettyServerUpgradeRequest
             }
             catch (Throwable t)
             {
-                throw new BadMessageException("Bad WebSocket UpgradeRequest URI", t);
+                throw new HttpException.IllegalStateException(HttpStatus.BAD_REQUEST_400, "Bad WebSocket UpgradeRequest URI", t);
             }
         }
 

--- a/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee11/websocket/tests/JettyClientClassLoaderTest.java
+++ b/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee11/websocket/tests/JettyClientClassLoaderTest.java
@@ -32,7 +32,7 @@ import org.eclipse.jetty.ee11.websocket.client.config.JettyWebSocketClientConfig
 import org.eclipse.jetty.ee11.websocket.server.JettyWebSocketServlet;
 import org.eclipse.jetty.ee11.websocket.server.JettyWebSocketServletFactory;
 import org.eclipse.jetty.ee11.websocket.server.config.JettyWebSocketConfiguration;
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
@@ -175,7 +175,7 @@ public class JettyClientClassLoaderTest
         app.copyLib(Compression.class, "jetty-compression-common.jar");
         app.copyLib(GzipCompression.class, "jetty-compression-gzip.jar");
         app.copyLib(EndPoint.class, "jetty-io.jar");
-        app.copyLib(BadMessageException.class, "jetty-http.jar");
+        app.copyLib(HttpException.class, "jetty-http.jar");
         app.copyLib(XmlConfiguration.class, "jetty-xml.jar");
 
         return app;

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
@@ -66,6 +66,7 @@ import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.ComplianceViolation;
 import org.eclipse.jetty.http.CookieCompliance;
 import org.eclipse.jetty.http.HttpCookie;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
@@ -2079,13 +2080,10 @@ public class Request implements HttpServletRequest
             {
                 parts = _multiParts.getParts();
             }
-            catch (BadMessageException e)
-            {
-                throw e;
-            }
             // Catch RuntimeException to handle IllegalStateException, IllegalArgumentException, CharacterEncodingException, etc .. (long list)
             catch (RuntimeException | IOException e)
             {
+                HttpException.throwIfHttpException(e);
                 throw new BadMessageException("Unable to parse form content", e);
             }
             reportComplianceViolations();
@@ -2206,12 +2204,9 @@ public class Request implements HttpServletRequest
             {
                 UrlEncoded.decodeTo(newQuery, newQueryParams::add, UrlEncoded.ENCODING);
             }
-            catch (BadMessageException e)
-            {
-                throw e;
-            }
             catch (Throwable th)
             {
+                HttpException.throwIfHttpException(th);
                 throw new BadMessageException("Bad query encoding", th);
             }
         }
@@ -2224,13 +2219,10 @@ public class Request implements HttpServletRequest
             {
                 UrlEncoded.decodeTo(oldQuery, oldQueryParams::add, getQueryCharset());
             }
-            catch (BadMessageException e)
-            {
-                throw e;
-            }
             catch (Throwable th)
             {
                 _queryParameters = BAD_PARAMS;
+                HttpException.throwIfHttpException(th);
                 throw new BadMessageException("Bad query encoding", th);
             }
         }

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/NcsaRequestLogTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/NcsaRequestLogTest.java
@@ -28,6 +28,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.logging.StacklessLogging;
 import org.eclipse.jetty.server.CustomRequestLog;
 import org.eclipse.jetty.server.HttpChannel;
@@ -531,13 +532,12 @@ public class NcsaRequestLogTest
                                 if (!baseRequest.isHandled())
                                     response.sendError(404);
                             }
-                            catch (BadMessageException bad)
+                            catch (Throwable e)
                             {
-                                response.sendError(bad.getCode(), bad.getReason());
-                            }
-                            catch (Exception e)
-                            {
-                                response.sendError(500, e.toString());
+                                if (e instanceof HttpException httpEx)
+                                    response.sendError(httpEx.getCode(), httpEx.getReason());
+                                else
+                                    response.sendError(500, e.toString());
                             }
                         }
                         catch (IOException | IllegalStateException th)

--- a/jetty-integrations/jetty-ethereum/src/main/java/org/eclipse/jetty/security/siwe/EthereumAuthenticator.java
+++ b/jetty-integrations/jetty-ethereum/src/main/java/org/eclipse/jetty/security/siwe/EthereumAuthenticator.java
@@ -23,7 +23,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
@@ -447,7 +447,7 @@ public class EthereumAuthenticator extends LoginAuthenticator implements Dumpabl
 
             totalRead += len;
             if (_maxMessageSize >= 0 && totalRead > _maxMessageSize)
-                throw new BadMessageException("SIWE Message Too Large");
+                throw new HttpException.IllegalStateException(HttpStatus.BAD_REQUEST_400, "SIWE Message Too Large");
             out.append(buffer, 0, len);
         }
 

--- a/tests/jetty-test-common/src/main/java/org/eclipse/jetty/tests/OpenIdProvider.java
+++ b/tests/jetty-test-common/src/main/java/org/eclipse/jetty/tests/OpenIdProvider.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
@@ -203,7 +203,7 @@ public class OpenIdProvider extends ContainerLifeCycle
         {
             case "GET" -> doGetAuthEndpoint(request, response, callback);
             case "POST" -> doPostAuthEndpoint(request, response, callback);
-            default -> throw new BadMessageException("Unsupported HTTP method: " + method);
+            default -> throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Unsupported HTTP method: " + method);
         }
     }
 
@@ -332,7 +332,7 @@ public class OpenIdProvider extends ContainerLifeCycle
     protected void doTokenEndpoint(Request request, Response response, Callback callback) throws Exception
     {
         if (!HttpMethod.POST.is(request.getMethod()))
-            throw new BadMessageException("Unsupported HTTP method for token Endpoint: " + request.getMethod());
+            throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Unsupported HTTP method for token Endpoint: " + request.getMethod());
 
         response.getHeaders().put(HttpHeader.CONTENT_TYPE, "application/json");
 

--- a/tests/test-integration/src/test/java/org/eclipse/jetty/test/CoreMultiPartTest.java
+++ b/tests/test-integration/src/test/java/org/eclipse/jetty/test/CoreMultiPartTest.java
@@ -36,7 +36,7 @@ import org.eclipse.jetty.client.InputStreamResponseListener;
 import org.eclipse.jetty.client.MultiPartRequestContent;
 import org.eclipse.jetty.client.OutputStreamRequestContent;
 import org.eclipse.jetty.client.StringRequestContent;
-import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
@@ -144,7 +144,7 @@ public class CoreMultiPartTest
         }
         catch (Throwable t)
         {
-            throw new BadMessageException("bad multipart", t.getCause());
+            throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "bad multipart", t.getCause());
         }
     }
 


### PR DESCRIPTION
Fixes #13670 as an alternate to #13678

Use the existing HttpException mechanism. Perhaps BadMessageException could  be deprecated.
Prefer HttpException.IllegalStateException over BadMessageException, to not generate the wrong exception type in the first place.