### PR TITLE
Issue #14209 - Allow custom XmlParser in Descriptor handling

### DIFF
--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaData.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaData.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.Resources;
 import org.eclipse.jetty.util.thread.AutoLock;
+import org.eclipse.jetty.xml.XmlParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +40,7 @@ public class MetaData
 
     private final AutoLock _lock = new AutoLock();
     protected Map<String, OriginInfo> _origins = new HashMap<>();
+    protected XmlParser _xmlParser;
     protected WebDescriptor _webDefaultsRoot;
     protected WebDescriptor _webXmlRoot;
     protected final List<WebDescriptor> _webOverrideRoots = new ArrayList<>();
@@ -185,7 +187,7 @@ public class MetaData
         throws Exception
     {
         _webDefaultsRoot = descriptor;
-        _webDefaultsRoot.parse(WebDescriptor.getParser(isValidateXml()));
+        _webDefaultsRoot.parse(getXmlParser());
         if (_webDefaultsRoot.isOrdered())
         {
             Ordering ordering = getOrdering();
@@ -214,7 +216,7 @@ public class MetaData
         throws Exception
     {
         _webXmlRoot = descriptor;
-        _webXmlRoot.parse(WebDescriptor.getParser(isValidateXml()));
+        _webXmlRoot.parse(getXmlParser());
         _metaDataComplete = WebDescriptor.isMetaDataComplete(_webXmlRoot);
 
         if (_webXmlRoot.isOrdered())
@@ -245,7 +247,7 @@ public class MetaData
     public void addOverrideDescriptor(OverrideDescriptor descriptor)
         throws Exception
     {
-        descriptor.parse(WebDescriptor.getParser(isValidateXml()));
+        descriptor.parse(getXmlParser());
 
         Boolean metaDataComplete = descriptor.getMetaDataComplete();
         if (metaDataComplete != null)
@@ -292,7 +294,7 @@ public class MetaData
         //Metadata-complete is not set, or there is no web.xml
         _webFragmentResourceMap.put(jarResource, descriptor);
         _webFragmentRoots.add(descriptor);
-        descriptor.parse(WebDescriptor.getParser(isValidateXml()));
+        descriptor.parse(getXmlParser());
 
         if (descriptor.getName() != null)
         {
@@ -638,7 +640,38 @@ public class MetaData
      */
     public void setValidateXml(boolean validateXml)
     {
+        if (_xmlParser != null && _xmlParser.isValidating() != _validateXml)
+            throw new IllegalStateException("XmlParser previously set");
+
         _validateXml = validateXml;
+    }
+
+    /**
+     * Set the XmlParser to use for handling metadata, this will
+     * also add an environment specific catalog to the XmlParser.
+     *
+     * <p>This is useful when you want to configure a custom XML Parser
+     * with a variety of custom attributes and configurations.</p>
+     *
+     * @param xmlParser the XML parser to use.
+     */
+    public void setXmlParser(XmlParser xmlParser)
+    {
+        _xmlParser = Objects.requireNonNull(xmlParser);
+
+        WebDescriptor.addDescriptorCatalog(_xmlParser);
+    }
+
+    /**
+     * The XmlParser in use for this metadata.
+     *
+     * @return the in use XML Parser
+     */
+    public XmlParser getXmlParser()
+    {
+        if (_xmlParser == null)
+            setXmlParser(new XmlParser(isValidateXml()));
+        return _xmlParser;
     }
 
     public Map<String, OriginInfo> getOrigins()

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
@@ -515,7 +515,9 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
         {
             _metadata.setAllowDuplicateFragmentNames(isAllowDuplicateFragmentNames());
             Boolean validate = (Boolean)getAttribute(MetaData.VALIDATE_XML);
-            _metadata.setValidateXml((validate != null && validate));
+            // Don't set validate unless it is declared.
+            if (validate != null)
+                _metadata.setValidateXml(validate);
             preConfigure();
             super.doStart();
             postConfigure();
@@ -602,7 +604,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
      *
      * @return Returns the defaultsDescriptor.
      */
-    @ManagedAttribute(value = "default web.xml deascriptor applied before standard web.xml", readonly = true)
+    @ManagedAttribute(value = "default web.xml descriptor applied before standard web.xml", readonly = true)
     public String getDefaultsDescriptor()
     {
         return _defaultsDescriptor;
@@ -625,7 +627,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
      *
      * @return Returns the Override Descriptor list
      */
-    @ManagedAttribute(value = "web.xml deascriptors applied after standard web.xml", readonly = true)
+    @ManagedAttribute(value = "web.xml descriptors applied after standard web.xml", readonly = true)
     public List<String> getOverrideDescriptors()
     {
         return Collections.unmodifiableList(_overrideDescriptors);
@@ -1400,8 +1402,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
                 _configurations.get(i).deconfigure(this);
             }
 
-            if (_metadata != null)
-                _metadata.clear();
+            _metadata.clear();
             _metadata = new MetaData();
         }
         finally

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebDescriptor.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebDescriptor.java
@@ -34,6 +34,10 @@ public class WebDescriptor extends Descriptor
 {
     private static final Logger LOG = LoggerFactory.getLogger(WebDescriptor.class);
 
+    /**
+     * @deprecated no direct replacement, use of {@link MetaData#getXmlParser()} is encouraged.
+     */
+    @Deprecated(since = "12.1.6", forRemoval = true)
     public static XmlParser __nonValidatingStaticParser = newParser(false);
     protected Boolean _metaDataComplete;
     protected int _majorVersion = 4; //default to container version
@@ -61,13 +65,12 @@ public class WebDescriptor extends Descriptor
      *
      * @param validating true if the parser should validate syntax, false otherwise
      * @return an XmlParser for web descriptors
+     * @deprecated use {@link MetaData#getXmlParser()} to control parser behavior.
      */
+    @Deprecated(since = "12.1.6", forRemoval = true)
     public static XmlParser getParser(boolean validating)
     {
-        if (!validating)
-            return __nonValidatingStaticParser;
-        else
-            return newParser(true);
+        return newParser(validating);
     }
 
     /**
@@ -75,29 +78,29 @@ public class WebDescriptor extends Descriptor
      *
      * @param validating if true, the parser will validate syntax
      * @return an XmlParser
+     * @deprecated use {@link MetaData#getXmlParser()} to control parser behavior.
      */
+    @Deprecated(since = "12.1.6", forRemoval = true)
     public static XmlParser newParser(boolean validating)
     {
+        XmlParser xmlParser = new XmlParser(validating);
+        addDescriptorCatalog(xmlParser);
+        return xmlParser;
+    }
+
+    protected static void addDescriptorCatalog(XmlParser xmlParser) throws IllegalStateException
+    {
+        String catalogName = "catalog-%s.xml".formatted(ServletContextHandler.ENVIRONMENT.getName());
+        URL url = WebDescriptor.class.getResource(catalogName);
+        if (url == null)
+            throw new IllegalStateException("Catalog not found: %s/%s".formatted(WebDescriptor.class.getPackageName(), catalogName));
         try
         {
-            return new WebDescriptorParser(validating);
+            xmlParser.addCatalog(URI.create(url.toExternalForm()), Servlet.class);
         }
         catch (IOException e)
         {
-            throw new IllegalStateException("Unable to instantiate WebDescriptorParser", e);
-        }
-    }
-
-    private static class WebDescriptorParser extends XmlParser
-    {
-        public WebDescriptorParser(boolean validating) throws IOException
-        {
-            super(validating);
-            String catalogName = "catalog-%s.xml".formatted(ServletContextHandler.ENVIRONMENT.getName());
-            URL url = WebDescriptor.class.getResource(catalogName);
-            if (url == null)
-                throw new IllegalStateException("Catalog not found: %s/%s".formatted(WebDescriptor.class.getPackageName(), catalogName));
-            addCatalog(URI.create(url.toExternalForm()), Servlet.class);
+            throw new IllegalStateException("Unable to add catalog: " + url, e);
         }
     }
 

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppContextTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppContextTest.java
@@ -78,6 +78,7 @@ import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.resource.FileSystemPool;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
+import org.eclipse.jetty.xml.XmlParser;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -110,6 +111,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Isolated()
@@ -1293,6 +1295,29 @@ public class WebAppContextTest
 
         assertThat("context API", protectedClasses, hasItem("org.context.specific."));
         assertThat("deprecated API", protectedClasses, hasItem("org.deprecated.api."));
+    }
+
+    @Test
+    public void testCustomXmlParser(WorkDir workDir) throws Exception
+    {
+        Server server = newServer();
+
+        MyXmlParser xmlParser = new MyXmlParser();
+        WebAppContext context = new WebAppContext();
+        context.getMetaData().setXmlParser(xmlParser);
+        context.setBaseResourceAsPath(workDir.getEmptyPathDir());
+
+        server.setHandler(context);
+        server.start();
+
+        assertTrue(context.isStarted());
+        assertTrue(context.isAvailable());
+        XmlParser startedXmlParser = context.getMetaData().getXmlParser();
+        assertSame(startedXmlParser, xmlParser);
+    }
+
+    public static class MyXmlParser extends XmlParser
+    {
     }
 
     public static class OkServlet extends HttpServlet

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebDescriptorTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebDescriptorTest.java
@@ -47,7 +47,7 @@ public class WebDescriptorTest
             """, StandardCharsets.UTF_8);
 
         WebDescriptor webDescriptor = new WebDescriptor(ResourceFactory.root().newResource(xml));
-        XmlParser xmlParser = WebDescriptor.newParser(true);
+        XmlParser xmlParser = new XmlParser(true);
         // This should not throw an exception, if it does then you have a bad state.
         // Such as missing required XML resource entities.
         webDescriptor.parse(xmlParser);

--- a/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/MetaData.java
+++ b/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/MetaData.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.Resources;
 import org.eclipse.jetty.util.thread.AutoLock;
+import org.eclipse.jetty.xml.XmlParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +40,7 @@ public class MetaData
 
     private final AutoLock _lock = new AutoLock();
     protected Map<String, OriginInfo> _origins = new HashMap<>();
+    protected XmlParser _xmlParser;
     protected WebDescriptor _webDefaultsRoot;
     protected WebDescriptor _webXmlRoot;
     protected final List<WebDescriptor> _webOverrideRoots = new ArrayList<>();
@@ -185,7 +187,7 @@ public class MetaData
         throws Exception
     {
         _webDefaultsRoot = descriptor;
-        _webDefaultsRoot.parse(WebDescriptor.getParser(isValidateXml()));
+        _webDefaultsRoot.parse(getXmlParser());
         if (_webDefaultsRoot.isOrdered())
         {
             Ordering ordering = getOrdering();
@@ -214,7 +216,7 @@ public class MetaData
         throws Exception
     {
         _webXmlRoot = descriptor;
-        _webXmlRoot.parse(WebDescriptor.getParser(isValidateXml()));
+        _webXmlRoot.parse(getXmlParser());
         _metaDataComplete = WebDescriptor.isMetaDataComplete(_webXmlRoot);
 
         if (_webXmlRoot.isOrdered())
@@ -245,7 +247,7 @@ public class MetaData
     public void addOverrideDescriptor(OverrideDescriptor descriptor)
         throws Exception
     {
-        descriptor.parse(WebDescriptor.getParser(isValidateXml()));
+        descriptor.parse(getXmlParser());
 
         Boolean metaDataComplete = descriptor.getMetaDataComplete();
         if (metaDataComplete != null)
@@ -292,7 +294,7 @@ public class MetaData
         //Metadata-complete is not set, or there is no web.xml
         _webFragmentResourceMap.put(jarResource, descriptor);
         _webFragmentRoots.add(descriptor);
-        descriptor.parse(WebDescriptor.getParser(isValidateXml()));
+        descriptor.parse(getXmlParser());
 
         if (descriptor.getName() != null)
         {
@@ -638,7 +640,38 @@ public class MetaData
      */
     public void setValidateXml(boolean validateXml)
     {
+        if (_xmlParser != null && _xmlParser.isValidating() != _validateXml)
+            throw new IllegalStateException("XmlParser previously set");
+
         _validateXml = validateXml;
+    }
+
+    /**
+     * Set the XmlParser to use for handling metadata, this will
+     * also add an environment specific catalog to the XmlParser.
+     *
+     * <p>This is useful when you want to configure a custom XML Parser
+     * with a variety of custom attributes and configurations.</p>
+     *
+     * @param xmlParser the XML parser to use.
+     */
+    public void setXmlParser(XmlParser xmlParser)
+    {
+        _xmlParser = Objects.requireNonNull(xmlParser);
+
+        WebDescriptor.addDescriptorCatalog(_xmlParser);
+    }
+
+    /**
+     * The XmlParser in use for this metadata.
+     *
+     * @return the in use XML Parser
+     */
+    public XmlParser getXmlParser()
+    {
+        if (_xmlParser == null)
+            setXmlParser(new XmlParser(isValidateXml()));
+        return _xmlParser;
     }
 
     public Map<String, OriginInfo> getOrigins()

--- a/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/WebAppContext.java
+++ b/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/WebAppContext.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.ee11.webapp;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -494,7 +493,9 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
         {
             _metadata.setAllowDuplicateFragmentNames(isAllowDuplicateFragmentNames());
             Boolean validate = (Boolean)getAttribute(MetaData.VALIDATE_XML);
-            _metadata.setValidateXml((validate != null && validate));
+            // Don't set validate unless it is declared.
+            if (validate != null)
+                _metadata.setValidateXml(validate);
             preConfigure();
             super.doStart();
             postConfigure();
@@ -581,7 +582,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
      *
      * @return Returns the defaultsDescriptor.
      */
-    @ManagedAttribute(value = "default web.xml deascriptor applied before standard web.xml", readonly = true)
+    @ManagedAttribute(value = "default web.xml descriptor applied before standard web.xml", readonly = true)
     public String getDefaultsDescriptor()
     {
         return _defaultsDescriptor;
@@ -604,7 +605,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
      *
      * @return Returns the Override Descriptor list
      */
-    @ManagedAttribute(value = "web.xml deascriptors applied after standard web.xml", readonly = true)
+    @ManagedAttribute(value = "web.xml descriptors applied after standard web.xml", readonly = true)
     public List<String> getOverrideDescriptors()
     {
         return Collections.unmodifiableList(_overrideDescriptors);
@@ -1286,8 +1287,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
                 _configurations.get(i).deconfigure(this);
             }
 
-            if (_metadata != null)
-                _metadata.clear();
+            _metadata.clear();
             _metadata = new MetaData();
         }
         finally

--- a/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/WebDescriptor.java
+++ b/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/WebDescriptor.java
@@ -41,6 +41,10 @@ public class WebDescriptor extends Descriptor
         """;
     private static final Logger LOG = LoggerFactory.getLogger(WebDescriptor.class);
 
+    /**
+     * @deprecated no direct replacement, use of {@link MetaData#getXmlParser()} is encouraged.
+     */
+    @Deprecated(since = "12.1.6", forRemoval = true)
     public static XmlParser __nonValidatingStaticParser = newParser(false);
     protected Boolean _metaDataComplete;
     protected int _majorVersion = 4; //default to container version
@@ -68,13 +72,12 @@ public class WebDescriptor extends Descriptor
      *
      * @param validating true if the parser should validate syntax, false otherwise
      * @return an XmlParser for web descriptors
+     * @deprecated use {@link MetaData#getXmlParser()} to control parser behavior.
      */
+    @Deprecated(since = "12.1.6", forRemoval = true)
     public static XmlParser getParser(boolean validating)
     {
-        if (!validating)
-            return __nonValidatingStaticParser;
-        else
-            return newParser(true);
+        return newParser(validating);
     }
 
     /**
@@ -82,29 +85,29 @@ public class WebDescriptor extends Descriptor
      *
      * @param validating if true, the parser will validate syntax
      * @return an XmlParser
+     * @deprecated use {@link MetaData#getXmlParser()} to control parser behavior.
      */
+    @Deprecated(since = "12.1.6", forRemoval = true)
     public static XmlParser newParser(boolean validating)
     {
+        XmlParser xmlParser = new XmlParser(validating);
+        addDescriptorCatalog(xmlParser);
+        return xmlParser;
+    }
+
+    protected static void addDescriptorCatalog(XmlParser xmlParser) throws IllegalStateException
+    {
+        String catalogName = "catalog-%s.xml".formatted(ServletContextHandler.ENVIRONMENT.getName());
+        URL url = WebDescriptor.class.getResource(catalogName);
+        if (url == null)
+            throw new IllegalStateException("Catalog not found: %s/%s".formatted(WebDescriptor.class.getPackageName(), catalogName));
         try
         {
-            return new WebDescriptorParser(validating);
+            xmlParser.addCatalog(URI.create(url.toExternalForm()), Servlet.class);
         }
         catch (IOException e)
         {
-            throw new IllegalStateException("Unable to instantiate WebDescriptorParser", e);
-        }
-    }
-
-    private static class WebDescriptorParser extends XmlParser
-    {
-        public WebDescriptorParser(boolean validating) throws IOException
-        {
-            super(validating);
-            String catalogName = "catalog-%s.xml".formatted(ServletContextHandler.ENVIRONMENT.getName());
-            URL url = WebDescriptor.class.getResource(catalogName);
-            if (url == null)
-                throw new IllegalStateException("Catalog not found: %s/%s".formatted(WebDescriptor.class.getPackageName(), catalogName));
-            addCatalog(URI.create(url.toExternalForm()), Servlet.class);
+            throw new IllegalStateException("Unable to add catalog: " + url, e);
         }
     }
 

--- a/jetty-ee11/jetty-ee11-webapp/src/test/java/org/eclipse/jetty/ee11/webapp/WebAppContextTest.java
+++ b/jetty-ee11/jetty-ee11-webapp/src/test/java/org/eclipse/jetty/ee11/webapp/WebAppContextTest.java
@@ -78,6 +78,7 @@ import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.resource.FileSystemPool;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
+import org.eclipse.jetty.xml.XmlParser;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -110,6 +111,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Isolated()
@@ -1287,6 +1289,29 @@ public class WebAppContextTest
             assertThat("Should have default patterns", protectedClasses, hasItem(defaultSystemClass));
 
         assertThat("context API", protectedClasses, hasItem("org.context.specific."));
+    }
+
+    @Test
+    public void testCustomXmlParser(WorkDir workDir) throws Exception
+    {
+        Server server = newServer();
+
+        MyXmlParser xmlParser = new MyXmlParser();
+        WebAppContext context = new WebAppContext();
+        context.getMetaData().setXmlParser(xmlParser);
+        context.setBaseResourceAsPath(workDir.getEmptyPathDir());
+
+        server.setHandler(context);
+        server.start();
+
+        assertTrue(context.isStarted());
+        assertTrue(context.isAvailable());
+        XmlParser startedXmlParser = context.getMetaData().getXmlParser();
+        assertSame(startedXmlParser, xmlParser);
+    }
+
+    public static class MyXmlParser extends XmlParser
+    {
     }
 
     public static class OkServlet extends HttpServlet

--- a/jetty-ee11/jetty-ee11-webapp/src/test/java/org/eclipse/jetty/ee11/webapp/WebDescriptorTest.java
+++ b/jetty-ee11/jetty-ee11-webapp/src/test/java/org/eclipse/jetty/ee11/webapp/WebDescriptorTest.java
@@ -47,7 +47,7 @@ public class WebDescriptorTest
             """, StandardCharsets.UTF_8);
 
         WebDescriptor webDescriptor = new WebDescriptor(ResourceFactory.root().newResource(xml));
-        XmlParser xmlParser = WebDescriptor.newParser(true);
+        XmlParser xmlParser = new XmlParser(true);
         // This should not throw an exception, if it does then you have a bad state.
         // Such as missing required XML resource entities.
         webDescriptor.parse(xmlParser);

--- a/jetty-ee8/pom.xml
+++ b/jetty-ee8/pom.xml
@@ -48,7 +48,7 @@
 
     <ee8.javax.security.auth.message>1.0.0.v201108011116</ee8.javax.security.auth.message>
     <ee8.javax.servlet.jsp.jstl.impl.version>1.2.5</ee8.javax.servlet.jsp.jstl.impl.version>
-    <ee8.jetty.servlet.api.version>4.0.6</ee8.jetty.servlet.api.version>
+    <ee8.jetty.servlet.api.version>4.0.7</ee8.jetty.servlet.api.version>
     <ee8.jsp.impl.version>9.0.111</ee8.jsp.impl.version>
     <ee8.weld.version>3.1.9.Final</ee8.weld.version>
     <ee9.module/>

--- a/jetty-ee8/pom.xml
+++ b/jetty-ee8/pom.xml
@@ -48,7 +48,7 @@
 
     <ee8.javax.security.auth.message>1.0.0.v201108011116</ee8.javax.security.auth.message>
     <ee8.javax.servlet.jsp.jstl.impl.version>1.2.5</ee8.javax.servlet.jsp.jstl.impl.version>
-    <ee8.jetty.servlet.api.version>4.0.7</ee8.jetty.servlet.api.version>
+    <ee8.jetty.servlet.api.version>4.0.8</ee8.jetty.servlet.api.version>
     <ee8.jsp.impl.version>9.0.111</ee8.jsp.impl.version>
     <ee8.weld.version>3.1.9.Final</ee8.weld.version>
     <ee9.module/>

--- a/jetty-ee8/pom.xml
+++ b/jetty-ee8/pom.xml
@@ -48,7 +48,7 @@
 
     <ee8.javax.security.auth.message>1.0.0.v201108011116</ee8.javax.security.auth.message>
     <ee8.javax.servlet.jsp.jstl.impl.version>1.2.5</ee8.javax.servlet.jsp.jstl.impl.version>
-    <ee8.jetty.servlet.api.version>4.0.8</ee8.jetty.servlet.api.version>
+    <ee8.jetty.servlet.api.version>4.0.9</ee8.jetty.servlet.api.version>
     <ee8.jsp.impl.version>9.0.111</ee8.jsp.impl.version>
     <ee8.weld.version>3.1.9.Final</ee8.weld.version>
     <ee9.module/>

--- a/jetty-ee9/jetty-ee9-plus/src/test/java/org/eclipse/jetty/ee9/plus/webapp/PlusDescriptorProcessorTest.java
+++ b/jetty-ee9/jetty-ee9-plus/src/test/java/org/eclipse/jetty/ee9/plus/webapp/PlusDescriptorProcessorTest.java
@@ -34,6 +34,7 @@ import org.eclipse.jetty.plus.jndi.NamingEntryUtil;
 import org.eclipse.jetty.plus.jndi.Resource;
 import org.eclipse.jetty.util.IntrospectionUtil;
 import org.eclipse.jetty.util.jndi.NamingUtil;
+import org.eclipse.jetty.xml.XmlParser;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -167,21 +168,23 @@ public class PlusDescriptorProcessorTest
         Resource res2 = new Resource(ServletContextHandler.ENVIRONMENT.getName(), "eeObject2", eeObject2);
 
         URL webXml = Thread.currentThread().getContextClassLoader().getResource("web.xml");
+        XmlParser xmlParser = new XmlParser(false);
+
         webDescriptor = new WebDescriptor(context.getResourceFactory().newResource(webXml));
-        webDescriptor.parse(WebDescriptor.getParser(false));
+        webDescriptor.parse(xmlParser);
 
         URL frag1Xml = Thread.currentThread().getContextClassLoader().getResource("web-fragment-1.xml");
         fragDescriptor1 = new FragmentDescriptor(context.getResourceFactory().newResource(frag1Xml));
-        fragDescriptor1.parse(WebDescriptor.getParser(false));
+        fragDescriptor1.parse(xmlParser);
         URL frag2Xml = Thread.currentThread().getContextClassLoader().getResource("web-fragment-2.xml");
         fragDescriptor2 = new FragmentDescriptor(context.getResourceFactory().newResource(frag2Xml));
-        fragDescriptor2.parse(WebDescriptor.getParser(false));
+        fragDescriptor2.parse(xmlParser);
         URL frag3Xml = Thread.currentThread().getContextClassLoader().getResource("web-fragment-3.xml");
         fragDescriptor3 = new FragmentDescriptor(context.getResourceFactory().newResource(frag3Xml));
-        fragDescriptor3.parse(WebDescriptor.getParser(false));
+        fragDescriptor3.parse(xmlParser);
         URL frag4Xml = Thread.currentThread().getContextClassLoader().getResource("web-fragment-4.xml");
         fragDescriptor4 = new FragmentDescriptor(context.getResourceFactory().newResource(frag4Xml));
-        fragDescriptor4.parse(WebDescriptor.getParser(false));
+        fragDescriptor4.parse(xmlParser);
         Thread.currentThread().setContextClassLoader(oldLoader);
     }
 

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-quickstart/src/test/java/org/eclipse/jetty/ee9/quickstart/QuickStartTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-quickstart/src/test/java/org/eclipse/jetty/ee9/quickstart/QuickStartTest.java
@@ -31,6 +31,7 @@ import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.xml.XmlConfiguration;
+import org.eclipse.jetty.xml.XmlParser;
 import org.eclipse.jetty.xml.XmlParser.Node;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -99,7 +100,7 @@ public class QuickStartTest
 
         Path webXmlPath = targetDir.resolve("WEB-INF/quickstart-web.xml");
         WebDescriptor descriptor = new WebDescriptor(webapp.getResourceFactory().newResource(webXmlPath));
-        descriptor.parse(WebDescriptor.getParser(!QuickStartGeneratorConfiguration.LOG.isDebugEnabled()));
+        descriptor.parse(new XmlParser(!QuickStartGeneratorConfiguration.LOG.isDebugEnabled()));
         Node node = descriptor.getRoot();
         assertNotNull(node);
 
@@ -153,7 +154,7 @@ public class QuickStartTest
         assertTrue(Files.exists(webXmlPath), "Path should exist:" + webXmlPath);
 
         WebDescriptor descriptor = new WebDescriptor(webapp.getResourceFactory().newResource(webXmlPath));
-        descriptor.parse(WebDescriptor.getParser(!QuickStartGeneratorConfiguration.LOG.isDebugEnabled()));
+        descriptor.parse(new XmlParser(!QuickStartGeneratorConfiguration.LOG.isDebugEnabled()));
         Node node = descriptor.getRoot();
         assertNotNull(node);
 
@@ -217,7 +218,7 @@ public class QuickStartTest
         Path webXmlPath = targetDir.resolve("WEB-INF/quickstart-web.xml");
         assertTrue(Files.exists(webXmlPath), "Exists: " + webXmlPath);
         WebDescriptor descriptor = new WebDescriptor(webapp.getResourceFactory().newResource(webXmlPath));
-        descriptor.parse(WebDescriptor.getParser(!QuickStartGeneratorConfiguration.LOG.isDebugEnabled()));
+        descriptor.parse(new XmlParser(!QuickStartGeneratorConfiguration.LOG.isDebugEnabled()));
         Node node = descriptor.getRoot();
         assertNotNull(node);
 

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaData.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaData.java
@@ -763,8 +763,6 @@ public class MetaData
             throw new IllegalStateException("XmlParser previously set");
 
         _validateXml = validateXml;
-
-        setXmlParser(new XmlParser(_validateXml));
     }
 
     /**

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaData.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaData.java
@@ -762,14 +762,15 @@ public class MetaData
      */
     public void setValidateXml(boolean validateXml)
     {
-        if (_xmlParser.isValidating() != validateXml)
-        {
-            _xmlParser = new XmlParser(validateXml);
-        }
+        if (_xmlParser != null)
+            throw new IllegalStateException("XmlParser previously set");
+
+        setXmlParser(new XmlParser(validateXml));
     }
 
     /**
-     * Set the XmlParser to use for handling metadata.
+     * Set the XmlParser to use for handling metadata, this will
+     * also add an environment specific catalog to the XmlParser.
      *
      * <p>This is useful when you want to configure a custom XML Parser
      * with a variety of custom attributes and configurations.</p>
@@ -778,7 +779,7 @@ public class MetaData
      */
     public void setXmlParser(XmlParser xmlParser)
     {
-        _xmlParser = xmlParser;
+        _xmlParser = WebDescriptor.addDescriptorCatalog(Objects.requireNonNull(xmlParser));
     }
 
     /**

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaData.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaData.java
@@ -38,11 +38,7 @@ public class MetaData
 {
     private static final Logger LOG = LoggerFactory.getLogger(MetaData.class);
 
-    /**
-     * @deprecated use {@link WebAppContext#VALIDATE_XML} instead
-     */
-    @Deprecated(since = "12.1.6", forRemoval = true)
-    public static final String VALIDATE_XML = WebAppContext.VALIDATE_XML;
+    public static final String VALIDATE_XML = "org.eclipse.jetty.ee9.webapp.validateXml";
     public static final String ORDERED_LIBS = "jakarta.servlet.context.orderedLibs";
 
     private final AutoLock _lock = new AutoLock();
@@ -63,6 +59,7 @@ public class MetaData
     protected final List<Resource> _orderedWebInfResources = new ArrayList<>();
     protected Ordering _ordering; //can be set to RelativeOrdering by web-default.xml, web.xml, web-override.xml
     protected boolean _allowDuplicateFragmentNames = false;
+    protected boolean _validateXml = false;
 
     public enum Complete
     {
@@ -753,7 +750,7 @@ public class MetaData
      */
     public boolean isValidateXml()
     {
-        return getXmlParser().isValidating();
+        return _validateXml;
     }
 
     /**
@@ -762,10 +759,12 @@ public class MetaData
      */
     public void setValidateXml(boolean validateXml)
     {
-        if (_xmlParser != null)
+        if (_xmlParser != null && _xmlParser.isValidating() != _validateXml)
             throw new IllegalStateException("XmlParser previously set");
 
-        setXmlParser(new XmlParser(validateXml));
+        _validateXml = validateXml;
+
+        setXmlParser(new XmlParser(_validateXml));
     }
 
     /**
@@ -779,7 +778,9 @@ public class MetaData
      */
     public void setXmlParser(XmlParser xmlParser)
     {
-        _xmlParser = WebDescriptor.addDescriptorCatalog(Objects.requireNonNull(xmlParser));
+        _xmlParser = Objects.requireNonNull(xmlParser);
+
+        WebDescriptor.addDescriptorCatalog(_xmlParser);
     }
 
     /**
@@ -790,7 +791,7 @@ public class MetaData
     public XmlParser getXmlParser()
     {
         if (_xmlParser == null)
-            setXmlParser(new XmlParser(false)); // defaults to false
+            setXmlParser(new XmlParser(isValidateXml()));
         return _xmlParser;
     }
 

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaData.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaData.java
@@ -47,7 +47,7 @@ public class MetaData
 
     private final AutoLock _lock = new AutoLock();
     protected Map<String, OriginInfo> _origins = new HashMap<>();
-    protected XmlParser _xmlParser = new XmlParser(false);
+    protected XmlParser _xmlParser;
     protected WebDescriptor _webDefaultsRoot;
     protected WebDescriptor _webXmlRoot;
     protected final List<WebDescriptor> _webOverrideRoots = new ArrayList<>();
@@ -198,7 +198,7 @@ public class MetaData
         throws Exception
     {
         _webDefaultsRoot = descriptor;
-        _webDefaultsRoot.parse(_xmlParser);
+        _webDefaultsRoot.parse(getXmlParser());
         if (_webDefaultsRoot.isOrdered())
         {
             Ordering ordering = getOrdering();
@@ -227,7 +227,7 @@ public class MetaData
         throws Exception
     {
         _webXmlRoot = descriptor;
-        _webXmlRoot.parse(_xmlParser);
+        _webXmlRoot.parse(getXmlParser());
         _metaDataComplete = WebDescriptor.isMetaDataComplete(_webXmlRoot);
 
         if (_webXmlRoot.isOrdered())
@@ -258,7 +258,7 @@ public class MetaData
     public void addOverrideDescriptor(OverrideDescriptor descriptor)
         throws Exception
     {
-        descriptor.parse(_xmlParser);
+        descriptor.parse(getXmlParser());
 
         switch (descriptor.getMetaDataComplete())
         {
@@ -313,7 +313,7 @@ public class MetaData
         //Metadata-complete is not set, or there is no web.xml
         _webFragmentResourceMap.put(jarResource, descriptor);
         _webFragmentRoots.add(descriptor);
-        descriptor.parse(_xmlParser);
+        descriptor.parse(getXmlParser());
 
         if (descriptor.getName() != null)
         {
@@ -753,7 +753,7 @@ public class MetaData
      */
     public boolean isValidateXml()
     {
-        return _xmlParser.isValidating();
+        return getXmlParser().isValidating();
     }
 
     /**
@@ -789,6 +789,8 @@ public class MetaData
      */
     public XmlParser getXmlParser()
     {
+        if (_xmlParser == null)
+            setXmlParser(new XmlParser(false)); // defaults to false
         return _xmlParser;
     }
 

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaData.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaData.java
@@ -27,6 +27,7 @@ import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.Resources;
 import org.eclipse.jetty.util.thread.AutoLock;
+import org.eclipse.jetty.xml.XmlParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,11 +38,16 @@ public class MetaData
 {
     private static final Logger LOG = LoggerFactory.getLogger(MetaData.class);
 
-    public static final String VALIDATE_XML = "org.eclipse.jetty.ee9.webapp.validateXml";
+    /**
+     * @deprecated use {@link WebAppContext#VALIDATE_XML} instead
+     */
+    @Deprecated(since = "12.1.6", forRemoval = true)
+    public static final String VALIDATE_XML = WebAppContext.VALIDATE_XML;
     public static final String ORDERED_LIBS = "jakarta.servlet.context.orderedLibs";
 
     private final AutoLock _lock = new AutoLock();
     protected Map<String, OriginInfo> _origins = new HashMap<>();
+    protected XmlParser _xmlParser = new XmlParser(false);
     protected WebDescriptor _webDefaultsRoot;
     protected WebDescriptor _webXmlRoot;
     protected final List<WebDescriptor> _webOverrideRoots = new ArrayList<>();
@@ -57,7 +63,6 @@ public class MetaData
     protected final List<Resource> _orderedWebInfResources = new ArrayList<>();
     protected Ordering _ordering; //can be set to RelativeOrdering by web-default.xml, web.xml, web-override.xml
     protected boolean _allowDuplicateFragmentNames = false;
-    protected boolean _validateXml = false;
 
     public enum Complete
     {
@@ -193,7 +198,7 @@ public class MetaData
         throws Exception
     {
         _webDefaultsRoot = descriptor;
-        _webDefaultsRoot.parse(WebDescriptor.getParser(isValidateXml()));
+        _webDefaultsRoot.parse(_xmlParser);
         if (_webDefaultsRoot.isOrdered())
         {
             Ordering ordering = getOrdering();
@@ -222,7 +227,7 @@ public class MetaData
         throws Exception
     {
         _webXmlRoot = descriptor;
-        _webXmlRoot.parse(WebDescriptor.getParser(isValidateXml()));
+        _webXmlRoot.parse(_xmlParser);
         _metaDataComplete = WebDescriptor.isMetaDataComplete(_webXmlRoot);
 
         if (_webXmlRoot.isOrdered())
@@ -253,7 +258,7 @@ public class MetaData
     public void addOverrideDescriptor(OverrideDescriptor descriptor)
         throws Exception
     {
-        descriptor.parse(WebDescriptor.getParser(isValidateXml()));
+        descriptor.parse(_xmlParser);
 
         switch (descriptor.getMetaDataComplete())
         {
@@ -308,7 +313,7 @@ public class MetaData
         //Metadata-complete is not set, or there is no web.xml
         _webFragmentResourceMap.put(jarResource, descriptor);
         _webFragmentRoots.add(descriptor);
-        descriptor.parse(WebDescriptor.getParser(isValidateXml()));
+        descriptor.parse(_xmlParser);
 
         if (descriptor.getName() != null)
         {
@@ -748,7 +753,7 @@ public class MetaData
      */
     public boolean isValidateXml()
     {
-        return _validateXml;
+        return _xmlParser.isValidating();
     }
 
     /**
@@ -757,7 +762,33 @@ public class MetaData
      */
     public void setValidateXml(boolean validateXml)
     {
-        _validateXml = validateXml;
+        if (_xmlParser.isValidating() != validateXml)
+        {
+            _xmlParser = new XmlParser(validateXml);
+        }
+    }
+
+    /**
+     * Set the XmlParser to use for handling metadata.
+     *
+     * <p>This is useful when you want to configure a custom XML Parser
+     * with a variety of custom attributes and configurations.</p>
+     *
+     * @param xmlParser the XML parser to use.
+     */
+    public void setXmlParser(XmlParser xmlParser)
+    {
+        _xmlParser = xmlParser;
+    }
+
+    /**
+     * The XmlParser in use for this metadata.
+     *
+     * @return the in use XML Parser
+     */
+    public XmlParser getXmlParser()
+    {
+        return _xmlParser;
     }
 
     public Map<String, OriginInfo> getOrigins()

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
@@ -91,6 +91,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
 
     public static final String WEB_DEFAULTS_XML = "org/eclipse/jetty/ee9/webapp/webdefault-ee9.xml";
     public static final String ERROR_PAGE = "org.eclipse.jetty.server.error_page";
+    public static final String VALIDATE_XML = "org.eclipse.jetty.ee9.webapp.validateXml";
     /**
      * @deprecated use {@link WebAppClassLoading#PROTECTED_CLASSES_ATTRIBUTE} instead.
      */
@@ -576,8 +577,11 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
         try
         {
             _metadata.setAllowDuplicateFragmentNames(isAllowDuplicateFragmentNames());
-            Boolean validate = (Boolean)getAttribute(MetaData.VALIDATE_XML);
-            _metadata.setValidateXml((validate != null && validate));
+            Boolean validate = (Boolean)getAttribute(WebAppContext.VALIDATE_XML);
+            // don't set validate unless it is declared.
+            // user might be using a custom XmlParser will not want that XmlParser replaced.
+            if (validate != null)
+                _metadata.setValidateXml(validate);
             wrapConfigurations();
             preConfigure();
             Thread.currentThread().setContextClassLoader(getClassLoader());
@@ -686,7 +690,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
      *
      * @return Returns the defaultsDescriptor.
      */
-    @ManagedAttribute(value = "default web.xml deascriptor applied before standard web.xml", readonly = true)
+    @ManagedAttribute(value = "default web.xml descriptor applied before standard web.xml", readonly = true)
     public String getDefaultsDescriptor()
     {
         return _defaultsDescriptor;
@@ -709,7 +713,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
      *
      * @return Returns the Override Descriptor list
      */
-    @ManagedAttribute(value = "web.xml deascriptors applied after standard web.xml", readonly = true)
+    @ManagedAttribute(value = "web.xml descriptors applied after standard web.xml", readonly = true)
     public List<String> getOverrideDescriptors()
     {
         return Collections.unmodifiableList(_overrideDescriptors);
@@ -1389,8 +1393,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
                 _configurations.get(i).deconfigure(this);
             }
 
-            if (_metadata != null)
-                _metadata.clear();
+            _metadata.clear();
             _metadata = new MetaData();
         }
         finally

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
@@ -91,7 +91,6 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
 
     public static final String WEB_DEFAULTS_XML = "org/eclipse/jetty/ee9/webapp/webdefault-ee9.xml";
     public static final String ERROR_PAGE = "org.eclipse.jetty.server.error_page";
-    public static final String VALIDATE_XML = "org.eclipse.jetty.ee9.webapp.validateXml";
     /**
      * @deprecated use {@link WebAppClassLoading#PROTECTED_CLASSES_ATTRIBUTE} instead.
      */
@@ -577,7 +576,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
         try
         {
             _metadata.setAllowDuplicateFragmentNames(isAllowDuplicateFragmentNames());
-            Boolean validate = (Boolean)getAttribute(WebAppContext.VALIDATE_XML);
+            Boolean validate = (Boolean)getAttribute(MetaData.VALIDATE_XML);
             // don't set validate unless it is declared.
             // user might be using a custom XmlParser will not want that XmlParser replaced.
             if (validate != null)

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
@@ -577,8 +577,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
         {
             _metadata.setAllowDuplicateFragmentNames(isAllowDuplicateFragmentNames());
             Boolean validate = (Boolean)getAttribute(MetaData.VALIDATE_XML);
-            // don't set validate unless it is declared.
-            // user might be using a custom XmlParser will not want that XmlParser replaced.
+            // Don't set validate unless it is declared.
             if (validate != null)
                 _metadata.setValidateXml(validate);
             wrapConfigurations();

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebDescriptor.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebDescriptor.java
@@ -34,6 +34,10 @@ public class WebDescriptor extends Descriptor
 {
     private static final Logger LOG = LoggerFactory.getLogger(WebDescriptor.class);
 
+    /**
+     * @deprecated no direct replacement, use of {@link MetaData#getXmlParser()} is encouraged.
+     */
+    @Deprecated(since = "12.1.6", forRemoval = true)
     public static XmlParser __nonValidatingStaticParser = newParser(false);
     protected MetaData.Complete _metaDataComplete;
     protected int _majorVersion = 4; //default to container version
@@ -61,13 +65,12 @@ public class WebDescriptor extends Descriptor
      *
      * @param validating true if the parser should validate syntax, false otherwise
      * @return an XmlParser for web descriptors
+     * @deprecated use {@link MetaData#getXmlParser()} to control parser behavior.
      */
+    @Deprecated(since = "12.1.6", forRemoval = true)
     public static XmlParser getParser(boolean validating)
     {
-        if (!validating)
-            return __nonValidatingStaticParser;
-        else
-            return newParser(true);
+        return newParser(validating);
     }
 
     /**
@@ -75,7 +78,9 @@ public class WebDescriptor extends Descriptor
      *
      * @param validating if true, the parser will validate syntax
      * @return an XmlParser
+     * @deprecated use {@link MetaData#getXmlParser()} to control parser behavior.
      */
+    @Deprecated(since = "12.1.6", forRemoval = true)
     public static XmlParser newParser(boolean validating)
     {
         try

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebDescriptor.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebDescriptor.java
@@ -83,27 +83,24 @@ public class WebDescriptor extends Descriptor
     @Deprecated(since = "12.1.6", forRemoval = true)
     public static XmlParser newParser(boolean validating)
     {
+        return addDescriptorCatalog(new XmlParser(validating));
+    }
+
+    protected static XmlParser addDescriptorCatalog(XmlParser xmlParser) throws IllegalStateException
+    {
+        String catalogName = "catalog-%s.xml".formatted(ContextHandler.ENVIRONMENT.getName());
+        URL url = WebDescriptor.class.getResource(catalogName);
+        if (url == null)
+            throw new IllegalStateException("Catalog not found: %s/%s".formatted(WebDescriptor.class.getPackageName(), catalogName));
         try
         {
-            return new WebDescriptorParser(validating);
+            xmlParser.addCatalog(URI.create(url.toExternalForm()), Servlet.class);
         }
         catch (IOException e)
         {
-            throw new IllegalStateException("Unable to instantiate WebDescriptorParser", e);
+            throw new IllegalStateException("Unable to add catalog: " + url, e);
         }
-    }
-
-    private static class WebDescriptorParser extends XmlParser
-    {
-        public WebDescriptorParser(boolean validating) throws IOException
-        {
-            super(validating);
-            String catalogName = "catalog-%s.xml".formatted(ContextHandler.ENVIRONMENT.getName());
-            URL url = WebDescriptor.class.getResource(catalogName);
-            if (url == null)
-                throw new IllegalStateException("Catalog not found: %s/%s".formatted(WebDescriptor.class.getPackageName(), catalogName));
-            addCatalog(URI.create(url.toExternalForm()), Servlet.class);
-        }
+        return xmlParser;
     }
 
     public WebDescriptor(Resource xml)

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebDescriptor.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebDescriptor.java
@@ -83,10 +83,12 @@ public class WebDescriptor extends Descriptor
     @Deprecated(since = "12.1.6", forRemoval = true)
     public static XmlParser newParser(boolean validating)
     {
-        return addDescriptorCatalog(new XmlParser(validating));
+        XmlParser xmlParser = new XmlParser(validating);
+        addDescriptorCatalog(xmlParser);
+        return xmlParser;
     }
 
-    protected static XmlParser addDescriptorCatalog(XmlParser xmlParser) throws IllegalStateException
+    protected static void addDescriptorCatalog(XmlParser xmlParser) throws IllegalStateException
     {
         String catalogName = "catalog-%s.xml".formatted(ContextHandler.ENVIRONMENT.getName());
         URL url = WebDescriptor.class.getResource(catalogName);
@@ -100,7 +102,6 @@ public class WebDescriptor extends Descriptor
         {
             throw new IllegalStateException("Unable to add catalog: " + url, e);
         }
-        return xmlParser;
     }
 
     public WebDescriptor(Resource xml)

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppContextTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppContextTest.java
@@ -72,6 +72,7 @@ import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.resource.FileSystemPool;
 import org.eclipse.jetty.util.resource.ResourceFactory;
+import org.eclipse.jetty.xml.XmlParser;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -100,6 +101,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Isolated
@@ -1077,6 +1079,29 @@ public class WebAppContextTest
             assertThat("Should have default patterns", systemClasses, hasItem(defaultSystemClass));
         }
         assertThat("deprecated API", systemClasses, hasItem("org.deprecated.api."));
+    }
+
+    @Test
+    public void testCustomXmlParser(WorkDir workDir) throws Exception
+    {
+        Server server = newServer();
+
+        MyXmlParser xmlParser = new MyXmlParser();
+        WebAppContext context = new WebAppContext();
+        context.getMetaData().setXmlParser(xmlParser);
+        context.setBaseResourceAsPath(workDir.getEmptyPathDir());
+
+        server.setHandler(context);
+        server.start();
+
+        assertTrue(context.isStarted());
+        assertTrue(context.isAvailable());
+        XmlParser startedXmlParser = context.getMetaData().getXmlParser();
+        assertSame(startedXmlParser, xmlParser);
+    }
+
+    public static class MyXmlParser extends XmlParser
+    {
     }
 
     private static URI toURI(URL url)

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppContextTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppContextTest.java
@@ -1104,7 +1104,7 @@ public class WebAppContextTest
     {
         public MyXmlParser()
         {
-            super(false);
+            super(true);
         }
     }
 

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppContextTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebAppContextTest.java
@@ -1102,6 +1102,10 @@ public class WebAppContextTest
 
     public static class MyXmlParser extends XmlParser
     {
+        public MyXmlParser()
+        {
+            super(false);
+        }
     }
 
     private static URI toURI(URL url)

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebDescriptorTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/WebDescriptorTest.java
@@ -48,7 +48,7 @@ public class WebDescriptorTest
 
         Resource xmlRes = ResourceFactory.root().newResource(xml);
         WebDescriptor webDescriptor = new WebDescriptor(xmlRes);
-        XmlParser xmlParser = WebDescriptor.newParser(true);
+        XmlParser xmlParser = new XmlParser(true);
         // This should not throw an exception, if it does then you have a bad state.
         // Such as missing required XML resource entities.
         webDescriptor.parse(xmlParser);


### PR DESCRIPTION
Reworking `WebDescriptor` and `MetaData` to allow for custom `XmlParser` usage.