### PR TITLE
Issue #13513 - Refactor MemoryEndPointPipe to use RetainableByteBuffer.DynamicCapacity

### DIFF
--- a/documentation/jetty/modules/programming-guide/pages/migration/12.0-to-12.1.adoc
+++ b/documentation/jetty/modules/programming-guide/pages/migration/12.0-to-12.1.adoc
@@ -120,6 +120,15 @@ In Jetty 12.1.x, `RetainableByteBuffer` has broader usage within the xref:migrat
 This class is useful to retain or copy other buffers such as ``Content.Chunk``s.
 Dynamic capacity buffers are particularly effective to read and accumulate data efficiently (for example for later processing), when processing server-side request content, client-side response content, or WebSocket binary messages.
 
+[[api-changes-memoryendpointpipe]]
+=== `MemoryEndPointPipe`
+
+`MemoryEndPointPipe` is an internal class that provides an in-memory implementation of `EndPoint.Pipe` for testing and internal use.
+
+In Jetty 12.0.x, `MemoryEndPointPipe` allocated `ByteBuffer` instances directly for buffering data between endpoints.
+
+In Jetty 12.1.x, `MemoryEndPointPipe` uses `RetainableByteBuffer.DynamicCapacity` for more efficient buffer management and integration with buffer pooling.
+
 [[api-changes-httpconfig-maxresponseheadersize]]
 === `HttpConfiguration.maxResponseHeaderSize`
 

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/MemoryEndPointPipe.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/MemoryEndPointPipe.java
@@ -325,10 +325,10 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
         private RetainableByteBuffer lockedCopy(ByteBuffer buffer)
         {
             int length = buffer.remaining();
-            long maxCap = getMaxCapacity();
-            if (maxCap > 0)
+            long maxCapacity = getMaxCapacity();
+            if (maxCapacity > 0)
             {
-                long space = maxCap - capacity;
+                long space = maxCapacity - capacity;
                 if (space == 0)
                     return null;
                 length = (int)Math.min(length, space);

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/MemoryEndPointPipe.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/MemoryEndPointPipe.java
@@ -88,7 +88,7 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
         private static final RetainableByteBuffer EOF = RetainableByteBuffer.EMPTY;
 
         private final AutoLock lock = new AutoLock();
-        private final Deque<RetainableByteBuffer> buffers = new ArrayDeque<>();
+        private final Deque<RetainableByteBuffer> byteBuffers = new ArrayDeque<>();
         private final SocketAddress localAddress;
         private MemoryEndPoint peerEndPoint;
         private Invocable.Task fillableTask;
@@ -183,7 +183,7 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
                 {
                     while (true)
                     {
-                        RetainableByteBuffer data = buffers.peek();
+                        RetainableByteBuffer data = byteBuffers.peek();
                         if (data == null)
                             return filled;
                         if (data == EOF)
@@ -201,7 +201,7 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
                             // Copy all and consume
                             data.putTo(dest);
                             data.release();
-                            buffers.poll();
+                            byteBuffers.poll();
                         }
                         else
                         {
@@ -237,7 +237,7 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
             {
                 // Checking for data and setting the callback must be atomic,
                 // otherwise the notification issued by a write() may be lost.
-                if (peerEndPoint.buffers.isEmpty())
+                if (peerEndPoint.byteBuffers.isEmpty())
                 {
                     super.fillInterested(callback);
                     return;
@@ -255,7 +255,7 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
             {
                 // Checking for data and setting the callback must be atomic,
                 // otherwise the notification issued by a write() may be lost.
-                if (peerEndPoint.buffers.isEmpty())
+                if (peerEndPoint.byteBuffers.isEmpty())
                     return super.tryFillInterested(callback);
             }
             if (LOG.isDebugEnabled())
@@ -291,7 +291,7 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
                         result = false;
                         break;
                     }
-                    this.buffers.offer(copy);
+                    this.byteBuffers.offer(copy);
                     int length = (int)copy.size();
                     capacity += length;
                     flushed += length;
@@ -358,7 +358,7 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
             super.doShutdownOutput();
             try (AutoLock ignored = lock.lock())
             {
-                buffers.offer(EOF);
+                byteBuffers.offer(EOF);
             }
             onFlushed();
         }
@@ -369,9 +369,9 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
             super.doClose();
             try (AutoLock ignored = lock.lock())
             {
-                RetainableByteBuffer last = buffers.peekLast();
+                RetainableByteBuffer last = byteBuffers.peekLast();
                 if (last != EOF)
-                    buffers.offer(EOF);
+                    byteBuffers.offer(EOF);
             }
             onFlushed();
         }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/MemoryEndPointPipe.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/MemoryEndPointPipe.java
@@ -173,10 +173,10 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
             return filled;
         }
 
-        private int fillInto(ByteBuffer dest)
+        private int fillInto(ByteBuffer buffer)
         {
             int filled = 0;
-            int pos = BufferUtil.flipToFill(dest);
+            int pos = BufferUtil.flipToFill(buffer);
             try
             {
                 try (AutoLock ignored = lock.lock())
@@ -189,7 +189,7 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
                         if (data == EOF)
                             return filled > 0 ? filled : -1;
 
-                        int space = dest.remaining();
+                        int space = buffer.remaining();
                         if (space == 0)
                             return filled;
 
@@ -199,7 +199,7 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
                         if (toCopy == available)
                         {
                             // Copy all and consume
-                            data.putTo(dest);
+                            data.putTo(buffer);
                             data.release();
                             byteBuffers.poll();
                         }
@@ -207,7 +207,7 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
                         {
                             // Partial copy using slice
                             RetainableByteBuffer slice = data.slice(toCopy);
-                            slice.putTo(dest);
+                            slice.putTo(buffer);
                             slice.release();
                             data.skip(toCopy);
                         }
@@ -219,7 +219,7 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
             }
             finally
             {
-                BufferUtil.flipToFlush(dest, pos);
+                BufferUtil.flipToFlush(buffer, pos);
             }
         }
 
@@ -291,7 +291,7 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
                         result = false;
                         break;
                     }
-                    this.byteBuffers.offer(copy);
+                    byteBuffers.offer(copy);
                     int length = (int)copy.size();
                     capacity += length;
                     flushed += length;

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/MemoryEndPointPipe.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/MemoryEndPointPipe.java
@@ -16,8 +16,6 @@ package org.eclipse.jetty.io;
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
-import java.util.ArrayDeque;
-import java.util.Deque;
 import java.util.HexFormat;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
@@ -71,19 +69,22 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
         remoteEndPoint.setMaxCapacity(maxCapacity);
     }
 
+    /**
+     * <p>Memory-based {@link EndPoint} that uses {@link RetainableByteBuffer.DynamicCapacity}
+     * for efficient buffer management.</p>
+     */
     private class MemoryEndPoint extends AbstractEndPoint
     {
         private static final Logger LOG = LoggerFactory.getLogger(MemoryEndPoint.class);
-        private static final ByteBuffer EOF = ByteBuffer.allocate(0);
 
         private final AutoLock lock = new AutoLock();
-        private final Deque<ByteBuffer> byteBuffers = new ArrayDeque<>();
+        private final RetainableByteBuffer.DynamicCapacity buffer = new RetainableByteBuffer.DynamicCapacity();
         private final SocketAddress localAddress;
         private MemoryEndPoint peerEndPoint;
         private Invocable.Task fillableTask;
         private Invocable.Task completeWriteTask;
         private long maxCapacity;
-        private long capacity;
+        private boolean eof;
 
         private MemoryEndPoint(Scheduler scheduler, SocketAddress localAddress)
         {
@@ -162,25 +163,49 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
             return filled;
         }
 
-        private int fillInto(ByteBuffer buffer)
+        private int fillInto(ByteBuffer dest)
         {
-            int filled = 0;
-            try (AutoLock ignored = lock.lock())
+            try (AutoLock l = lock.lock())
             {
-                while (true)
+                // Check for data or EOF
+                if (buffer.isEmpty())
                 {
-                    ByteBuffer data = byteBuffers.peek();
-                    if (data == null)
-                        return filled;
-                    if (data == EOF)
+                    return eof ? -1 : 0;
+                }
+
+                // Use flipToFill/flipToFlush to properly handle the destination buffer state.
+                // This allows the buffer to be reused across multiple fill calls.
+                int pos = BufferUtil.flipToFill(dest);
+                try
+                {
+                    int filled = 0;
+                    while (!buffer.isEmpty())
+                    {
+                        int space = dest.remaining();
+                        if (space == 0)
+                        {
+                            break;
+                        }
+
+                        int available = (int)Math.min(space, buffer.size());
+                        byte[] temp = new byte[available];
+                        int read = buffer.get(temp, 0, available);
+                        dest.put(temp, 0, read);
+                        filled += read;
+                    }
+
+                    // If we filled some data and buffer is now empty with EOF pending,
+                    // return what we got; next call will return -1
+                    if (buffer.isEmpty() && eof)
+                    {
                         return filled > 0 ? filled : -1;
-                    int length = data.remaining();
-                    int copied = BufferUtil.append(buffer, data);
-                    capacity -= copied;
-                    filled += copied;
-                    if (copied < length)
-                        return filled;
-                    byteBuffers.poll();
+                    }
+
+                    return filled;
+                }
+                finally
+                {
+                    BufferUtil.flipToFlush(dest, pos);
                 }
             }
         }
@@ -195,33 +220,41 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
         @Override
         public void fillInterested(Callback callback)
         {
-            try (AutoLock ignored = lock.lock())
+            // Must hold peer's lock to safely check peer's buffer state.
+            try (AutoLock peerLock = peerEndPoint.lock.lock())
             {
                 // Checking for data and setting the callback must be atomic,
                 // otherwise the notification issued by a write() may be lost.
-                if (peerEndPoint.byteBuffers.isEmpty())
+                if (peerEndPoint.buffer.isEmpty() && !peerEndPoint.eof)
                 {
                     super.fillInterested(callback);
                     return;
                 }
             }
             if (LOG.isDebugEnabled())
+            {
                 LOG.debug("fill interested, data available {}", this);
+            }
             callback.succeeded();
         }
 
         @Override
         public boolean tryFillInterested(Callback callback)
         {
-            try (AutoLock ignored = lock.lock())
+            // Must hold peer's lock to safely check peer's buffer state.
+            try (AutoLock peerLock = peerEndPoint.lock.lock())
             {
                 // Checking for data and setting the callback must be atomic,
                 // otherwise the notification issued by a write() may be lost.
-                if (peerEndPoint.byteBuffers.isEmpty())
+                if (peerEndPoint.buffer.isEmpty() && !peerEndPoint.eof)
+                {
                     return super.tryFillInterested(callback);
+                }
             }
             if (LOG.isDebugEnabled())
+            {
                 LOG.debug("try fill interested, data available {}", this);
+            }
             callback.succeeded();
             return false;
         }
@@ -238,24 +271,23 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
             boolean result = true;
             try (AutoLock ignored = lock.lock())
             {
-                for (ByteBuffer buffer : buffers)
+                for (ByteBuffer buf : buffers)
                 {
-                    int remaining = buffer.remaining();
+                    int remaining = buf.remaining();
                     if (remaining == 0)
                         continue;
 
-                    // The buffer must be copied, otherwise a write() would complete
-                    // and return it to the buffer pool where its backing store would
-                    // be overwritten before it is read by the peer EndPoint.
-                    ByteBuffer copy = lockedCopy(buffer);
-                    if (copy == null)
+                    // The buffer content is copied into the DynamicCapacity buffer,
+                    // otherwise a write() would complete and return it to the buffer
+                    // pool where its backing store would be overwritten before it is
+                    // read by the peer EndPoint.
+                    int before = buf.remaining();
+                    if (!lockedAppend(buf))
                     {
                         result = false;
                         break;
                     }
-                    byteBuffers.offer(copy);
-                    int length = copy.remaining();
-                    capacity += length;
+                    int length = before - buf.remaining();
                     flushed += length;
                     if (length < remaining)
                     {
@@ -277,22 +309,40 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
             return result;
         }
 
-        private ByteBuffer lockedCopy(ByteBuffer buffer)
+        /**
+         * Appends data from src to the internal buffer, respecting maxCapacity.
+         * When maxCapacity limits how much can be appended, only a portion of src
+         * is copied: the limit is temporarily reduced to expose only the allowed
+         * bytes, then restored so the caller sees the remaining unconsumed data.
+         *
+         * @param src the source buffer to append from
+         * @return true if any bytes were appended, false if buffer is at capacity
+         */
+        private boolean lockedAppend(ByteBuffer src)
         {
-            int length = buffer.remaining();
-            long maxCapacity = getMaxCapacity();
-            if (maxCapacity > 0)
+            int length = src.remaining();
+            long maxCap = getMaxCapacity();
+            if (maxCap > 0)
             {
-                long space = maxCapacity - capacity;
+                long space = maxCap - buffer.size();
                 if (space == 0)
-                    return null;
+                    return false;
                 length = (int)Math.min(length, space);
             }
-            // TODO: Use RetainableByteBuffer.DynamicCapacity in Jetty 12.1.x.
-            ByteBuffer copy = buffer.isDirect() ? ByteBuffer.allocateDirect(length) : ByteBuffer.allocate(length);
-            copy.put(0, buffer, buffer.position(), length);
-            buffer.position(buffer.position() + length);
-            return copy;
+            if (length < src.remaining())
+            {
+                // Partial append: temporarily reduce limit to copy only 'length' bytes,
+                // then restore the original limit so caller sees remaining data.
+                int limit = src.limit();
+                src.limit(src.position() + length);
+                buffer.append(src);
+                src.limit(limit);
+            }
+            else
+            {
+                buffer.append(src);
+            }
+            return true;
         }
 
         @Override
@@ -301,7 +351,7 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
             super.doShutdownOutput();
             try (AutoLock ignored = lock.lock())
             {
-                byteBuffers.offer(EOF);
+                eof = true;
             }
             onFlushed();
         }
@@ -312,9 +362,9 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
             super.doClose();
             try (AutoLock ignored = lock.lock())
             {
-                ByteBuffer last = byteBuffers.peekLast();
-                if (last != EOF)
-                    byteBuffers.offer(EOF);
+                // Set EOF but don't clear the buffer - data should remain
+                // readable until EOF is encountered.
+                eof = true;
             }
             onFlushed();
         }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/MemoryEndPointPipe.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/MemoryEndPointPipe.java
@@ -16,9 +16,10 @@ package org.eclipse.jetty.io;
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.HexFormat;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
@@ -32,6 +33,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * <p>Memory-based implementation of {@link EndPoint.Pipe}.</p>
+ * <p>This implementation uses {@link RetainableByteBuffer.DynamicCapacity} for efficient
+ * buffer management in {@link #flush(ByteBuffer...)}, avoiding per-write ByteBuffer allocations.</p>
  */
 public class MemoryEndPointPipe implements EndPoint.Pipe
 {
@@ -64,7 +67,7 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
     {
         localEndPoint.setMaxCapacity(maxCapacity);
     }
-    
+
     public void setRemoteEndPointMaxCapacity(int maxCapacity)
     {
         remoteEndPoint.setMaxCapacity(maxCapacity);
@@ -73,37 +76,30 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
     /**
      * <p>Memory-based {@link EndPoint} that uses {@link RetainableByteBuffer.DynamicCapacity}
      * for efficient buffer management.</p>
+     * <p>Data written via {@link #flush(ByteBuffer...)} is stored in RetainableByteBuffers in a queue,
+     * and read via {@link #fill(ByteBuffer)} from the peer's queue. EOF is tracked using a sentinel
+     * in the queue to ensure proper ordering of data and EOF signals.</p>
      */
     private class MemoryEndPoint extends AbstractEndPoint
     {
         private static final Logger LOG = LoggerFactory.getLogger(MemoryEndPoint.class);
-        // Sequence counter for tracing events across threads
-        private static final AtomicInteger SEQ = new AtomicInteger();
+
+        // Sentinel to mark EOF in the queue - ensures EOF is delivered after all data
+        private static final RetainableByteBuffer EOF = RetainableByteBuffer.wrap(BufferUtil.EMPTY_BUFFER);
 
         private final AutoLock lock = new AutoLock();
-        private final RetainableByteBuffer.DynamicCapacity buffer = new RetainableByteBuffer.DynamicCapacity();
+        private final Deque<RetainableByteBuffer> buffers = new ArrayDeque<>();
         private final SocketAddress localAddress;
-        private final String name;
         private MemoryEndPoint peerEndPoint;
         private Invocable.Task fillableTask;
         private Invocable.Task completeWriteTask;
         private long maxCapacity;
-        private boolean eof;
+        private long capacity;
 
-        private MemoryEndPoint(Scheduler scheduler, SocketAddress localAddress, String name)
+        private MemoryEndPoint(Scheduler scheduler, SocketAddress localAddress)
         {
             super(scheduler);
             this.localAddress = localAddress;
-            this.name = name;
-        }
-
-        private void trace(String format, Object... args)
-        {
-            if (LOG.isDebugEnabled())
-            {
-                String msg = "[%03d] [%s] %s: ".formatted(SEQ.incrementAndGet(), Thread.currentThread().getName(), name) + format.formatted(args);
-                LOG.debug(msg);
-            }
         }
 
         void setPeerEndPoint(MemoryEndPoint peerEndPoint)
@@ -154,20 +150,15 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
         @Override
         public int fill(ByteBuffer buffer) throws IOException
         {
-            trace("fill() called, destRemaining=%d, destPos=%d, destLimit=%d",
-                buffer.remaining(), buffer.position(), buffer.limit());
-
             if (!isOpen())
                 throw new IOException("closed");
             if (isInputShutdown())
-            {
-                trace("fill() -> -1 (input shutdown)");
                 return -1;
-            }
 
             int filled = peerEndPoint.fillInto(buffer);
 
-            trace("fill() -> %d, destRemaining=%d", filled, buffer.remaining());
+            if (LOG.isDebugEnabled())
+                LOG.debug("filled {} from {}", filled, this);
 
             if (filled > 0)
             {
@@ -182,117 +173,110 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
             return filled;
         }
 
-        private int fillInto(ByteBuffer dest)
+        private int fillInto(ByteBuffer buffer)
         {
-            try (AutoLock l = lock.lock())
+            int filled = 0;
+            try (AutoLock ignored = lock.lock())
             {
-                trace("fillInto() called, bufferSize=%d, eof=%b, destRemaining=%d",
-                    buffer.size(), eof, dest.remaining());
-
-                // Check for data or EOF
-                if (buffer.isEmpty())
+                while (true)
                 {
-                    int result = eof ? -1 : 0;
-                    trace("fillInto() -> %d (buffer empty, eof=%b)", result, eof);
-                    return result;
-                }
+                    RetainableByteBuffer data = buffers.peek();
+                    if (data == null)
+                        return filled;
+                    if (data == EOF)
+                        return filled > 0 ? filled : -1;
 
-                // Use flipToFill/flipToFlush to properly handle the destination buffer state.
-                // This allows the buffer to be reused across multiple fill calls.
-                int pos = BufferUtil.flipToFill(dest);
-                trace("fillInto() after flipToFill: destPos=%d, destLimit=%d, destRemaining=%d",
-                    dest.position(), dest.limit(), dest.remaining());
-                try
-                {
-                    int filled = 0;
-                    while (!buffer.isEmpty())
+                    int sizeBefore = (int)data.size();
+                    int copied = copyTo(data, buffer);
+                    capacity -= copied;
+                    filled += copied;
+
+                    if (copied < sizeBefore)
                     {
-                        int space = dest.remaining();
-                        if (space == 0)
-                        {
-                            trace("fillInto() breaking - no space in dest");
-                            break;
-                        }
-
-                        int available = (int)Math.min(space, buffer.size());
-                        byte[] temp = new byte[available];
-                        int read = buffer.get(temp, 0, available);
-                        dest.put(temp, 0, read);
-                        filled += read;
-                        trace("fillInto() copied %d bytes, filled=%d, bufferSize=%d",
-                            read, filled, buffer.size());
+                        // Destination buffer is full, can't copy more
+                        return filled;
                     }
 
-                    // If we filled some data and buffer is now empty with EOF pending,
-                    // return what we got; next call will return -1
-                    if (buffer.isEmpty() && eof)
-                    {
-                        int result = filled > 0 ? filled : -1;
-                        trace("fillInto() -> %d (buffer now empty, eof=%b)", result, eof);
-                        return result;
-                    }
+                    // Fully consumed this buffer, release and remove
+                    data.release();
+                    buffers.poll();
+                }
+            }
+        }
 
-                    trace("fillInto() -> %d, bufferSize=%d, eof=%b", filled, buffer.size(), eof);
-                    return filled;
-                }
-                finally
-                {
-                    BufferUtil.flipToFlush(dest, pos);
-                }
+        /**
+         * Copy data from source RetainableByteBuffer to destination ByteBuffer.
+         * Uses flipToFill/flipToFlush to handle buffer state properly, allowing
+         * the buffer to be reused across multiple fill calls.
+         *
+         * @param src the source buffer to copy from
+         * @param dest the destination buffer to copy to
+         * @return the number of bytes copied
+         */
+        private int copyTo(RetainableByteBuffer src, ByteBuffer dest)
+        {
+            // flipToFill must be called first to properly prepare the buffer,
+            // especially when position == limit (buffer fully consumed)
+            int pos = BufferUtil.flipToFill(dest);
+            try
+            {
+                int space = dest.remaining();
+                if (space == 0)
+                    return 0;
+
+                int toCopy = (int)Math.min(space, src.size());
+                if (toCopy == 0)
+                    return 0;
+
+                byte[] temp = new byte[toCopy];
+                int read = src.get(temp, 0, toCopy);
+                dest.put(temp, 0, read);
+
+                return read;
+            }
+            finally
+            {
+                BufferUtil.flipToFlush(dest, pos);
             }
         }
 
         private void onFilled()
         {
-            trace("onFilled() -> queuing completeWriteTask for peer's WriteFlusher");
+            if (LOG.isDebugEnabled())
+                LOG.debug("filled, notifying completeWrite {}", this);
             taskConsumer.accept(completeWriteTask);
         }
 
         @Override
         public void fillInterested(Callback callback)
         {
-            // Must hold peer's lock to safely check peer's buffer state.
-            try (AutoLock peerLock = peerEndPoint.lock.lock())
+            try (AutoLock ignored = lock.lock())
             {
-                boolean peerEmpty = peerEndPoint.buffer.isEmpty();
-                boolean peerEof = peerEndPoint.eof;
-                trace("fillInterested() checking peer: peerBufferEmpty=%b, peerEof=%b",
-                    peerEmpty, peerEof);
-
                 // Checking for data and setting the callback must be atomic,
                 // otherwise the notification issued by a write() may be lost.
-                if (peerEmpty && !peerEof)
+                if (peerEndPoint.buffers.isEmpty())
                 {
-                    trace("fillInterested() -> registering callback (no data, no eof)");
                     super.fillInterested(callback);
                     return;
                 }
             }
-            trace("fillInterested() -> callback.succeeded() immediately (data or eof available)");
+            if (LOG.isDebugEnabled())
+                LOG.debug("fill interested, data available {}", this);
             callback.succeeded();
         }
 
         @Override
         public boolean tryFillInterested(Callback callback)
         {
-            // Must hold peer's lock to safely check peer's buffer state.
-            try (AutoLock peerLock = peerEndPoint.lock.lock())
+            try (AutoLock ignored = lock.lock())
             {
-                boolean peerEmpty = peerEndPoint.buffer.isEmpty();
-                boolean peerEof = peerEndPoint.eof;
-                trace("tryFillInterested() checking peer: peerBufferEmpty=%b, peerEof=%b",
-                    peerEmpty, peerEof);
-
                 // Checking for data and setting the callback must be atomic,
                 // otherwise the notification issued by a write() may be lost.
-                if (peerEmpty && !peerEof)
-                {
-                    boolean result = super.tryFillInterested(callback);
-                    trace("tryFillInterested() -> %b (registered callback)", result);
-                    return result;
-                }
+                if (peerEndPoint.buffers.isEmpty())
+                    return super.tryFillInterested(callback);
             }
-            trace("tryFillInterested() -> false (data or eof available, callback.succeeded())");
+            if (LOG.isDebugEnabled())
+                LOG.debug("try fill interested, data available {}", this);
             callback.succeeded();
             return false;
         }
@@ -300,12 +284,6 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
         @Override
         public boolean flush(ByteBuffer... buffers) throws IOException
         {
-            int totalRemaining = 0;
-            for (ByteBuffer b : buffers)
-                totalRemaining += b.remaining();
-            trace("flush() called with %d buffers, totalRemaining=%d, currentBufferSize=%d, maxCapacity=%d",
-                buffers.length, totalRemaining, buffer.size(), maxCapacity);
-
             if (!isOpen())
                 throw new IOException("closed");
             if (isOutputShutdown())
@@ -315,37 +293,35 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
             boolean result = true;
             try (AutoLock ignored = lock.lock())
             {
-                for (ByteBuffer buf : buffers)
+                for (ByteBuffer buffer : buffers)
                 {
-                    int remaining = buf.remaining();
+                    int remaining = buffer.remaining();
                     if (remaining == 0)
                         continue;
 
-                    // The buffer content is copied into the DynamicCapacity buffer,
-                    // otherwise a write() would complete and return it to the buffer
-                    // pool where its backing store would be overwritten before it is
-                    // read by the peer EndPoint.
-                    int before = buf.remaining();
-                    if (!lockedAppend(buf))
+                    // The buffer must be copied, otherwise a write() would complete
+                    // and return it to the buffer pool where its backing store would
+                    // be overwritten before it is read by the peer EndPoint.
+                    RetainableByteBuffer copy = lockedCopy(buffer);
+                    if (copy == null)
                     {
-                        trace("flush() lockedAppend returned false (at capacity)");
                         result = false;
                         break;
                     }
-                    int length = before - buf.remaining();
+                    this.buffers.offer(copy);
+                    int length = (int)copy.size();
+                    capacity += length;
                     flushed += length;
-                    trace("flush() appended %d bytes, flushed=%d, bufferSize=%d",
-                        length, flushed, buffer.size());
                     if (length < remaining)
                     {
-                        trace("flush() partial write: length=%d < remaining=%d", length, remaining);
                         result = false;
                         break;
                     }
                 }
             }
 
-            trace("flush() -> result=%b, flushed=%d, bufferSize=%d", result, flushed, buffer.size());
+            if (LOG.isDebugEnabled())
+                LOG.debug("flushed {} to {}", flushed, this);
 
             if (flushed > 0)
             {
@@ -357,58 +333,49 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
         }
 
         /**
-         * Appends data from src to the internal buffer, respecting maxCapacity.
-         * When maxCapacity limits how much can be appended, only a portion of src
-         * is copied: the limit is temporarily reduced to expose only the allowed
-         * bytes, then restored so the caller sees the remaining unconsumed data.
+         * Creates a copy of data from the source buffer, respecting maxCapacity.
+         * Uses {@link RetainableByteBuffer.DynamicCapacity} for efficient buffer management.
          *
-         * @param src the source buffer to append from
-         * @return true if any bytes were appended, false if buffer is at capacity
+         * @param buffer the source buffer to copy from
+         * @return a RetainableByteBuffer containing the copied data, or null if at capacity
          */
-        private boolean lockedAppend(ByteBuffer src)
+        private RetainableByteBuffer lockedCopy(ByteBuffer buffer)
         {
-            int length = src.remaining();
+            int length = buffer.remaining();
             long maxCap = getMaxCapacity();
-            trace("lockedAppend() srcRemaining=%d, maxCap=%d, bufferSize=%d",
-                length, maxCap, buffer.size());
             if (maxCap > 0)
             {
-                long space = maxCap - buffer.size();
-                trace("lockedAppend() space=%d", space);
+                long space = maxCap - capacity;
                 if (space == 0)
-                {
-                    trace("lockedAppend() -> false (no space)");
-                    return false;
-                }
+                    return null;
                 length = (int)Math.min(length, space);
             }
-            if (length < src.remaining())
+
+            // Use DynamicCapacity to efficiently copy the data
+            RetainableByteBuffer.DynamicCapacity copy = new RetainableByteBuffer.DynamicCapacity();
+            if (length < buffer.remaining())
             {
-                // Partial append: temporarily reduce limit to copy only 'length' bytes,
+                // Partial copy: temporarily reduce limit to copy only 'length' bytes,
                 // then restore the original limit so caller sees remaining data.
-                int limit = src.limit();
-                src.limit(src.position() + length);
-                buffer.append(src);
-                src.limit(limit);
-                trace("lockedAppend() partial append: %d bytes, srcRemaining=%d", length, src.remaining());
+                int limit = buffer.limit();
+                buffer.limit(buffer.position() + length);
+                copy.append(buffer);
+                buffer.limit(limit);
             }
             else
             {
-                buffer.append(src);
-                trace("lockedAppend() full append: %d bytes", length);
+                copy.append(buffer);
             }
-            return true;
+            return copy;
         }
 
         @Override
         protected void doShutdownOutput()
         {
-            trace("doShutdownOutput() called, bufferSize=%d", buffer.size());
             super.doShutdownOutput();
             try (AutoLock ignored = lock.lock())
             {
-                eof = true;
-                trace("doShutdownOutput() set eof=true, bufferSize=%d", buffer.size());
+                buffers.offer(EOF);
             }
             onFlushed();
         }
@@ -416,21 +383,20 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
         @Override
         protected void doClose()
         {
-            trace("doClose() called, bufferSize=%d, eof=%b", buffer.size(), eof);
             super.doClose();
             try (AutoLock ignored = lock.lock())
             {
-                // Set EOF but don't clear the buffer - data should remain
-                // readable until EOF is encountered.
-                eof = true;
-                trace("doClose() set eof=true, bufferSize=%d", buffer.size());
+                RetainableByteBuffer last = buffers.peekLast();
+                if (last != EOF)
+                    buffers.offer(EOF);
             }
             onFlushed();
         }
 
         private void onFlushed()
         {
-            trace("onFlushed() -> queuing fillableTask for peer's FillInterest");
+            if (LOG.isDebugEnabled())
+                LOG.debug("flushed, notifying fillable {}", this);
             taskConsumer.accept(fillableTask);
         }
     }
@@ -439,7 +405,7 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
     {
         private LocalEndPoint(Scheduler scheduler, SocketAddress socketAddress)
         {
-            super(scheduler, socketAddress, "LOCAL");
+            super(scheduler, socketAddress);
         }
     }
 
@@ -447,26 +413,16 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
     {
         private RemoteEndPoint(Scheduler scheduler, SocketAddress socketAddress)
         {
-            super(scheduler, socketAddress, "REMOTE");
+            super(scheduler, socketAddress);
         }
     }
 
     private record FillableTask(FillInterest fillInterest) implements Invocable.Task
     {
-        private static final Logger LOG = LoggerFactory.getLogger(FillableTask.class);
-        private static final AtomicInteger SEQ = new AtomicInteger();
-
         @Override
         public void run()
         {
-            int seq = SEQ.incrementAndGet();
-            if (LOG.isDebugEnabled())
-                LOG.debug("[{}] [{}] FillableTask.run() -> fillInterest.fillable()",
-                    seq, Thread.currentThread().getName());
             fillInterest.fillable();
-            if (LOG.isDebugEnabled())
-                LOG.debug("[{}] [{}] FillableTask.run() completed",
-                    seq, Thread.currentThread().getName());
         }
 
         @Override
@@ -478,20 +434,10 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
 
     private record CompleteWriteTask(WriteFlusher writeFlusher) implements Invocable.Task
     {
-        private static final Logger LOG = LoggerFactory.getLogger(CompleteWriteTask.class);
-        private static final AtomicInteger SEQ = new AtomicInteger();
-
         @Override
         public void run()
         {
-            int seq = SEQ.incrementAndGet();
-            if (LOG.isDebugEnabled())
-                LOG.debug("[{}] [{}] CompleteWriteTask.run() -> writeFlusher.completeWrite(), isPending={}",
-                    seq, Thread.currentThread().getName(), writeFlusher.isPending());
             writeFlusher.completeWrite();
-            if (LOG.isDebugEnabled())
-                LOG.debug("[{}] [{}] CompleteWriteTask.run() completed, isPending={}",
-                    seq, Thread.currentThread().getName(), writeFlusher.isPending());
         }
 
         @Override

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/MemoryEndPointPipe.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/MemoryEndPointPipe.java
@@ -173,66 +173,49 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
             return filled;
         }
 
-        private int fillInto(ByteBuffer buffer)
+        private int fillInto(ByteBuffer dest)
         {
             int filled = 0;
-            try (AutoLock ignored = lock.lock())
-            {
-                while (true)
-                {
-                    RetainableByteBuffer data = buffers.peek();
-                    if (data == null)
-                        return filled;
-                    if (data == EOF)
-                        return filled > 0 ? filled : -1;
-
-                    int sizeBefore = (int)data.size();
-                    int copied = copyTo(data, buffer);
-                    capacity -= copied;
-                    filled += copied;
-
-                    if (copied < sizeBefore)
-                    {
-                        // Destination buffer is full, can't copy more
-                        return filled;
-                    }
-
-                    // Fully consumed this buffer, release and remove
-                    data.release();
-                    buffers.poll();
-                }
-            }
-        }
-
-        /**
-         * Copy data from source RetainableByteBuffer to destination ByteBuffer.
-         * Uses flipToFill/flipToFlush to handle buffer state, allowing
-         * the buffer to be reused across multiple fill calls.
-         *
-         * @param src the source buffer to copy from
-         * @param dest the destination buffer to copy to
-         * @return the number of bytes copied
-         */
-        private int copyTo(RetainableByteBuffer src, ByteBuffer dest)
-        {
-            // flipToFill must be called first to prepare the buffer,
-            // especially when position == limit (buffer fully consumed)
             int pos = BufferUtil.flipToFill(dest);
             try
             {
-                int space = dest.remaining();
-                if (space == 0)
-                    return 0;
+                try (AutoLock ignored = lock.lock())
+                {
+                    while (true)
+                    {
+                        RetainableByteBuffer data = buffers.peek();
+                        if (data == null)
+                            return filled;
+                        if (data == EOF)
+                            return filled > 0 ? filled : -1;
 
-                int toCopy = (int)Math.min(space, src.size());
-                if (toCopy == 0)
-                    return 0;
+                        int space = dest.remaining();
+                        if (space == 0)
+                            return filled;
 
-                byte[] temp = new byte[toCopy];
-                int read = src.get(temp, 0, toCopy);
-                dest.put(temp, 0, read);
+                        int available = (int)data.size();
+                        int toCopy = Math.min(space, available);
 
-                return read;
+                        if (toCopy == available)
+                        {
+                            // Copy all and consume
+                            data.putTo(dest);
+                            data.release();
+                            buffers.poll();
+                        }
+                        else
+                        {
+                            // Partial copy using slice
+                            RetainableByteBuffer slice = data.slice(toCopy);
+                            slice.putTo(dest);
+                            slice.release();
+                            data.skip(toCopy);
+                        }
+
+                        capacity -= toCopy;
+                        filled += toCopy;
+                    }
+                }
             }
             finally
             {

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/MemoryEndPointPipe.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/MemoryEndPointPipe.java
@@ -193,7 +193,7 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
                         if (space == 0)
                             return filled;
 
-                        int available = (int)data.size();
+                        int available = data.remaining();
                         int toCopy = Math.min(space, available);
 
                         if (toCopy == available)
@@ -292,7 +292,7 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
                         break;
                     }
                     byteBuffers.offer(copy);
-                    int length = (int)copy.size();
+                    int length = copy.remaining();
                     capacity += length;
                     flushed += length;
                     if (length < remaining)

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/MemoryEndPointPipe.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/MemoryEndPointPipe.java
@@ -85,7 +85,7 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
         private static final Logger LOG = LoggerFactory.getLogger(MemoryEndPoint.class);
 
         // Sentinel to mark EOF in the queue - ensures EOF is delivered after all data
-        private static final RetainableByteBuffer EOF = RetainableByteBuffer.wrap(BufferUtil.EMPTY_BUFFER);
+        private static final RetainableByteBuffer EOF = RetainableByteBuffer.EMPTY;
 
         private final AutoLock lock = new AutoLock();
         private final Deque<RetainableByteBuffer> buffers = new ArrayDeque<>();
@@ -206,7 +206,7 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
 
         /**
          * Copy data from source RetainableByteBuffer to destination ByteBuffer.
-         * Uses flipToFill/flipToFlush to handle buffer state properly, allowing
+         * Uses flipToFill/flipToFlush to handle buffer state, allowing
          * the buffer to be reused across multiple fill calls.
          *
          * @param src the source buffer to copy from
@@ -215,7 +215,7 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
          */
         private int copyTo(RetainableByteBuffer src, ByteBuffer dest)
         {
-            // flipToFill must be called first to properly prepare the buffer,
+            // flipToFill must be called first to prepare the buffer,
             // especially when position == limit (buffer fully consumed)
             int pos = BufferUtil.flipToFill(dest);
             try

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/MemoryEndPointPipe.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/MemoryEndPointPipe.java
@@ -18,6 +18,7 @@ import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.util.HexFormat;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
@@ -76,20 +77,33 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
     private class MemoryEndPoint extends AbstractEndPoint
     {
         private static final Logger LOG = LoggerFactory.getLogger(MemoryEndPoint.class);
+        // Sequence counter for tracing events across threads
+        private static final AtomicInteger SEQ = new AtomicInteger();
 
         private final AutoLock lock = new AutoLock();
         private final RetainableByteBuffer.DynamicCapacity buffer = new RetainableByteBuffer.DynamicCapacity();
         private final SocketAddress localAddress;
+        private final String name;
         private MemoryEndPoint peerEndPoint;
         private Invocable.Task fillableTask;
         private Invocable.Task completeWriteTask;
         private long maxCapacity;
         private boolean eof;
 
-        private MemoryEndPoint(Scheduler scheduler, SocketAddress localAddress)
+        private MemoryEndPoint(Scheduler scheduler, SocketAddress localAddress, String name)
         {
             super(scheduler);
             this.localAddress = localAddress;
+            this.name = name;
+        }
+
+        private void trace(String format, Object... args)
+        {
+            if (LOG.isDebugEnabled())
+            {
+                String msg = "[%03d] [%s] %s: ".formatted(SEQ.incrementAndGet(), Thread.currentThread().getName(), name) + format.formatted(args);
+                LOG.debug(msg);
+            }
         }
 
         void setPeerEndPoint(MemoryEndPoint peerEndPoint)
@@ -140,15 +154,20 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
         @Override
         public int fill(ByteBuffer buffer) throws IOException
         {
+            trace("fill() called, destRemaining=%d, destPos=%d, destLimit=%d",
+                buffer.remaining(), buffer.position(), buffer.limit());
+
             if (!isOpen())
                 throw new IOException("closed");
             if (isInputShutdown())
+            {
+                trace("fill() -> -1 (input shutdown)");
                 return -1;
+            }
 
             int filled = peerEndPoint.fillInto(buffer);
 
-            if (LOG.isDebugEnabled())
-                LOG.debug("filled {} from {}", filled, this);
+            trace("fill() -> %d, destRemaining=%d", filled, buffer.remaining());
 
             if (filled > 0)
             {
@@ -167,15 +186,22 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
         {
             try (AutoLock l = lock.lock())
             {
+                trace("fillInto() called, bufferSize=%d, eof=%b, destRemaining=%d",
+                    buffer.size(), eof, dest.remaining());
+
                 // Check for data or EOF
                 if (buffer.isEmpty())
                 {
-                    return eof ? -1 : 0;
+                    int result = eof ? -1 : 0;
+                    trace("fillInto() -> %d (buffer empty, eof=%b)", result, eof);
+                    return result;
                 }
 
                 // Use flipToFill/flipToFlush to properly handle the destination buffer state.
                 // This allows the buffer to be reused across multiple fill calls.
                 int pos = BufferUtil.flipToFill(dest);
+                trace("fillInto() after flipToFill: destPos=%d, destLimit=%d, destRemaining=%d",
+                    dest.position(), dest.limit(), dest.remaining());
                 try
                 {
                     int filled = 0;
@@ -184,6 +210,7 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
                         int space = dest.remaining();
                         if (space == 0)
                         {
+                            trace("fillInto() breaking - no space in dest");
                             break;
                         }
 
@@ -192,15 +219,20 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
                         int read = buffer.get(temp, 0, available);
                         dest.put(temp, 0, read);
                         filled += read;
+                        trace("fillInto() copied %d bytes, filled=%d, bufferSize=%d",
+                            read, filled, buffer.size());
                     }
 
                     // If we filled some data and buffer is now empty with EOF pending,
                     // return what we got; next call will return -1
                     if (buffer.isEmpty() && eof)
                     {
-                        return filled > 0 ? filled : -1;
+                        int result = filled > 0 ? filled : -1;
+                        trace("fillInto() -> %d (buffer now empty, eof=%b)", result, eof);
+                        return result;
                     }
 
+                    trace("fillInto() -> %d, bufferSize=%d, eof=%b", filled, buffer.size(), eof);
                     return filled;
                 }
                 finally
@@ -212,8 +244,7 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
 
         private void onFilled()
         {
-            if (LOG.isDebugEnabled())
-                LOG.debug("filled, notifying completeWrite {}", this);
+            trace("onFilled() -> queuing completeWriteTask for peer's WriteFlusher");
             taskConsumer.accept(completeWriteTask);
         }
 
@@ -223,18 +254,21 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
             // Must hold peer's lock to safely check peer's buffer state.
             try (AutoLock peerLock = peerEndPoint.lock.lock())
             {
+                boolean peerEmpty = peerEndPoint.buffer.isEmpty();
+                boolean peerEof = peerEndPoint.eof;
+                trace("fillInterested() checking peer: peerBufferEmpty=%b, peerEof=%b",
+                    peerEmpty, peerEof);
+
                 // Checking for data and setting the callback must be atomic,
                 // otherwise the notification issued by a write() may be lost.
-                if (peerEndPoint.buffer.isEmpty() && !peerEndPoint.eof)
+                if (peerEmpty && !peerEof)
                 {
+                    trace("fillInterested() -> registering callback (no data, no eof)");
                     super.fillInterested(callback);
                     return;
                 }
             }
-            if (LOG.isDebugEnabled())
-            {
-                LOG.debug("fill interested, data available {}", this);
-            }
+            trace("fillInterested() -> callback.succeeded() immediately (data or eof available)");
             callback.succeeded();
         }
 
@@ -244,17 +278,21 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
             // Must hold peer's lock to safely check peer's buffer state.
             try (AutoLock peerLock = peerEndPoint.lock.lock())
             {
+                boolean peerEmpty = peerEndPoint.buffer.isEmpty();
+                boolean peerEof = peerEndPoint.eof;
+                trace("tryFillInterested() checking peer: peerBufferEmpty=%b, peerEof=%b",
+                    peerEmpty, peerEof);
+
                 // Checking for data and setting the callback must be atomic,
                 // otherwise the notification issued by a write() may be lost.
-                if (peerEndPoint.buffer.isEmpty() && !peerEndPoint.eof)
+                if (peerEmpty && !peerEof)
                 {
-                    return super.tryFillInterested(callback);
+                    boolean result = super.tryFillInterested(callback);
+                    trace("tryFillInterested() -> %b (registered callback)", result);
+                    return result;
                 }
             }
-            if (LOG.isDebugEnabled())
-            {
-                LOG.debug("try fill interested, data available {}", this);
-            }
+            trace("tryFillInterested() -> false (data or eof available, callback.succeeded())");
             callback.succeeded();
             return false;
         }
@@ -262,6 +300,12 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
         @Override
         public boolean flush(ByteBuffer... buffers) throws IOException
         {
+            int totalRemaining = 0;
+            for (ByteBuffer b : buffers)
+                totalRemaining += b.remaining();
+            trace("flush() called with %d buffers, totalRemaining=%d, currentBufferSize=%d, maxCapacity=%d",
+                buffers.length, totalRemaining, buffer.size(), maxCapacity);
+
             if (!isOpen())
                 throw new IOException("closed");
             if (isOutputShutdown())
@@ -284,21 +328,24 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
                     int before = buf.remaining();
                     if (!lockedAppend(buf))
                     {
+                        trace("flush() lockedAppend returned false (at capacity)");
                         result = false;
                         break;
                     }
                     int length = before - buf.remaining();
                     flushed += length;
+                    trace("flush() appended %d bytes, flushed=%d, bufferSize=%d",
+                        length, flushed, buffer.size());
                     if (length < remaining)
                     {
+                        trace("flush() partial write: length=%d < remaining=%d", length, remaining);
                         result = false;
                         break;
                     }
                 }
             }
 
-            if (LOG.isDebugEnabled())
-                LOG.debug("flushed {} to {}", flushed, this);
+            trace("flush() -> result=%b, flushed=%d, bufferSize=%d", result, flushed, buffer.size());
 
             if (flushed > 0)
             {
@@ -322,11 +369,17 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
         {
             int length = src.remaining();
             long maxCap = getMaxCapacity();
+            trace("lockedAppend() srcRemaining=%d, maxCap=%d, bufferSize=%d",
+                length, maxCap, buffer.size());
             if (maxCap > 0)
             {
                 long space = maxCap - buffer.size();
+                trace("lockedAppend() space=%d", space);
                 if (space == 0)
+                {
+                    trace("lockedAppend() -> false (no space)");
                     return false;
+                }
                 length = (int)Math.min(length, space);
             }
             if (length < src.remaining())
@@ -337,10 +390,12 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
                 src.limit(src.position() + length);
                 buffer.append(src);
                 src.limit(limit);
+                trace("lockedAppend() partial append: %d bytes, srcRemaining=%d", length, src.remaining());
             }
             else
             {
                 buffer.append(src);
+                trace("lockedAppend() full append: %d bytes", length);
             }
             return true;
         }
@@ -348,10 +403,12 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
         @Override
         protected void doShutdownOutput()
         {
+            trace("doShutdownOutput() called, bufferSize=%d", buffer.size());
             super.doShutdownOutput();
             try (AutoLock ignored = lock.lock())
             {
                 eof = true;
+                trace("doShutdownOutput() set eof=true, bufferSize=%d", buffer.size());
             }
             onFlushed();
         }
@@ -359,20 +416,21 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
         @Override
         protected void doClose()
         {
+            trace("doClose() called, bufferSize=%d, eof=%b", buffer.size(), eof);
             super.doClose();
             try (AutoLock ignored = lock.lock())
             {
                 // Set EOF but don't clear the buffer - data should remain
                 // readable until EOF is encountered.
                 eof = true;
+                trace("doClose() set eof=true, bufferSize=%d", buffer.size());
             }
             onFlushed();
         }
 
         private void onFlushed()
         {
-            if (LOG.isDebugEnabled())
-                LOG.debug("flushed, notifying fillable {}", this);
+            trace("onFlushed() -> queuing fillableTask for peer's FillInterest");
             taskConsumer.accept(fillableTask);
         }
     }
@@ -381,7 +439,7 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
     {
         private LocalEndPoint(Scheduler scheduler, SocketAddress socketAddress)
         {
-            super(scheduler, socketAddress);
+            super(scheduler, socketAddress, "LOCAL");
         }
     }
 
@@ -389,16 +447,26 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
     {
         private RemoteEndPoint(Scheduler scheduler, SocketAddress socketAddress)
         {
-            super(scheduler, socketAddress);
+            super(scheduler, socketAddress, "REMOTE");
         }
     }
 
     private record FillableTask(FillInterest fillInterest) implements Invocable.Task
     {
+        private static final Logger LOG = LoggerFactory.getLogger(FillableTask.class);
+        private static final AtomicInteger SEQ = new AtomicInteger();
+
         @Override
         public void run()
         {
+            int seq = SEQ.incrementAndGet();
+            if (LOG.isDebugEnabled())
+                LOG.debug("[{}] [{}] FillableTask.run() -> fillInterest.fillable()",
+                    seq, Thread.currentThread().getName());
             fillInterest.fillable();
+            if (LOG.isDebugEnabled())
+                LOG.debug("[{}] [{}] FillableTask.run() completed",
+                    seq, Thread.currentThread().getName());
         }
 
         @Override
@@ -410,10 +478,20 @@ public class MemoryEndPointPipe implements EndPoint.Pipe
 
     private record CompleteWriteTask(WriteFlusher writeFlusher) implements Invocable.Task
     {
+        private static final Logger LOG = LoggerFactory.getLogger(CompleteWriteTask.class);
+        private static final AtomicInteger SEQ = new AtomicInteger();
+
         @Override
         public void run()
         {
+            int seq = SEQ.incrementAndGet();
+            if (LOG.isDebugEnabled())
+                LOG.debug("[{}] [{}] CompleteWriteTask.run() -> writeFlusher.completeWrite(), isPending={}",
+                    seq, Thread.currentThread().getName(), writeFlusher.isPending());
             writeFlusher.completeWrite();
+            if (LOG.isDebugEnabled())
+                LOG.debug("[{}] [{}] CompleteWriteTask.run() completed, isPending={}",
+                    seq, Thread.currentThread().getName(), writeFlusher.isPending());
         }
 
         @Override

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/MemoryEndPointPipeTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/MemoryEndPointPipeTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.io;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
@@ -27,6 +28,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MemoryEndPointPipeTest
@@ -146,5 +149,190 @@ public class MemoryEndPointPipeTest
         }
 
         assertThat(totalFilled, equalTo(totalWritten));
+    }
+
+    @Test
+    public void testEofAfterAllDataConsumed() throws Exception
+    {
+        MemoryEndPointPipe pipe = new MemoryEndPointPipe(scheduler, executor::execute, null);
+
+        EndPoint localEndPoint = pipe.getLocalEndPoint();
+        EndPoint remoteEndPoint = pipe.getRemoteEndPoint();
+
+        // Register fill interest before writing
+        Callback.Completable remoteFillCallback = new Callback.Completable();
+        remoteEndPoint.fillInterested(remoteFillCallback);
+
+        // Write some data
+        byte[] data = new byte[100];
+        Arrays.fill(data, (byte)42);
+        Blocker.Shared blocker = new Blocker.Shared();
+        try (Blocker.Callback callback = blocker.callback())
+        {
+            localEndPoint.write(callback, ByteBuffer.wrap(data));
+            callback.block();
+        }
+
+        // Shutdown output to signal EOF
+        localEndPoint.shutdownOutput();
+
+        // Wait for data to be available
+        remoteFillCallback.get(5, TimeUnit.SECONDS);
+
+        // Read all data first
+        RetainableByteBuffer buffer = buffers.acquire(200, false);
+        ByteBuffer readBuffer = buffer.getByteBuffer();
+        int totalFilled = 0;
+        int filled = remoteEndPoint.fill(readBuffer);
+        while (filled > 0)
+        {
+            readBuffer.position(readBuffer.position() + filled);
+            totalFilled += filled;
+            filled = remoteEndPoint.fill(readBuffer);
+        }
+
+        // Verify all data was read
+        assertThat(totalFilled, equalTo(data.length));
+
+        // Verify EOF is returned after all data consumed
+        assertThat(filled, equalTo(-1));
+    }
+
+    @Test
+    public void testShutdownOutput() throws Exception
+    {
+        MemoryEndPointPipe pipe = new MemoryEndPointPipe(scheduler, executor::execute, null);
+
+        EndPoint localEndPoint = pipe.getLocalEndPoint();
+        EndPoint remoteEndPoint = pipe.getRemoteEndPoint();
+
+        // Shutdown output without writing any data
+        localEndPoint.shutdownOutput();
+
+        // Remote endpoint should get EOF immediately
+        ByteBuffer readBuffer = ByteBuffer.allocate(100);
+        int filled = remoteEndPoint.fill(readBuffer);
+        assertThat(filled, equalTo(-1));
+
+        // Verify local endpoint is output shutdown
+        assertTrue(localEndPoint.isOutputShutdown());
+    }
+
+    @Test
+    public void testCloseEndpoint() throws Exception
+    {
+        MemoryEndPointPipe pipe = new MemoryEndPointPipe(scheduler, executor::execute, null);
+
+        EndPoint localEndPoint = pipe.getLocalEndPoint();
+        EndPoint remoteEndPoint = pipe.getRemoteEndPoint();
+
+        // Register fill interest before writing
+        Callback.Completable remoteFillCallback = new Callback.Completable();
+        remoteEndPoint.fillInterested(remoteFillCallback);
+
+        // Write some data
+        byte[] data = new byte[50];
+        Blocker.Shared blocker = new Blocker.Shared();
+        try (Blocker.Callback callback = blocker.callback())
+        {
+            localEndPoint.write(callback, ByteBuffer.wrap(data));
+            callback.block();
+        }
+
+        // Close local endpoint
+        localEndPoint.close();
+
+        // Verify local endpoint is closed
+        assertFalse(localEndPoint.isOpen());
+
+        // Wait for data to be available
+        remoteFillCallback.get(5, TimeUnit.SECONDS);
+
+        // Remote endpoint should still be able to read existing data
+        RetainableByteBuffer buffer = buffers.acquire(100, false);
+        ByteBuffer readBuffer = buffer.getByteBuffer();
+        int filled = remoteEndPoint.fill(readBuffer);
+        assertThat(filled, equalTo(data.length));
+
+        // Advance buffer position after reading
+        readBuffer.position(readBuffer.position() + filled);
+
+        // After reading all data, should get EOF
+        filled = remoteEndPoint.fill(readBuffer);
+        assertThat(filled, equalTo(-1));
+    }
+
+    @Test
+    public void testFillOnClosedEndpoint() throws Exception
+    {
+        MemoryEndPointPipe pipe = new MemoryEndPointPipe(scheduler, executor::execute, null);
+
+        EndPoint localEndPoint = pipe.getLocalEndPoint();
+        EndPoint remoteEndPoint = pipe.getRemoteEndPoint();
+
+        // Close remote endpoint
+        remoteEndPoint.close();
+
+        // fill() on closed endpoint should throw IOException
+        ByteBuffer readBuffer = ByteBuffer.allocate(100);
+        assertThrows(IOException.class, () -> remoteEndPoint.fill(readBuffer));
+    }
+
+    @Test
+    public void testFlushOnClosedEndpoint() throws Exception
+    {
+        MemoryEndPointPipe pipe = new MemoryEndPointPipe(scheduler, executor::execute, null);
+
+        EndPoint localEndPoint = pipe.getLocalEndPoint();
+
+        // Close local endpoint
+        localEndPoint.close();
+
+        // flush() on closed endpoint should throw IOException
+        ByteBuffer writeBuffer = ByteBuffer.wrap(new byte[50]);
+        assertThrows(IOException.class, () -> localEndPoint.flush(writeBuffer));
+    }
+
+    @Test
+    public void testSmallCapacityPartialFlush() throws Exception
+    {
+        MemoryEndPointPipe pipe = new MemoryEndPointPipe(scheduler, executor::execute, null);
+        // Set a small capacity that is less than the data we want to write
+        pipe.setLocalEndPointMaxCapacity(20);
+
+        EndPoint localEndPoint = pipe.getLocalEndPoint();
+
+        // Try to flush more data than capacity allows
+        ByteBuffer writeBuffer = ByteBuffer.wrap(new byte[50]);
+        boolean flushed = localEndPoint.flush(writeBuffer);
+        assertFalse(flushed);
+
+        // Only 20 bytes should have been flushed, 30 remaining
+        assertThat(writeBuffer.remaining(), equalTo(30));
+    }
+
+    @Test
+    public void testEmptyBufferFlush() throws Exception
+    {
+        MemoryEndPointPipe pipe = new MemoryEndPointPipe(scheduler, executor::execute, null);
+
+        EndPoint localEndPoint = pipe.getLocalEndPoint();
+        EndPoint remoteEndPoint = pipe.getRemoteEndPoint();
+
+        // Flush empty buffers
+        ByteBuffer emptyBuffer = ByteBuffer.allocate(0);
+        boolean flushed = localEndPoint.flush(emptyBuffer);
+        assertTrue(flushed);
+
+        // Flush with position == limit (consumed buffer)
+        ByteBuffer consumedBuffer = ByteBuffer.allocate(50);
+        consumedBuffer.position(consumedBuffer.limit());
+        flushed = localEndPoint.flush(consumedBuffer);
+        assertTrue(flushed);
+
+        // Remote should have no data to read
+        ByteBuffer readBuffer = ByteBuffer.allocate(100);
+        int filled = remoteEndPoint.fill(readBuffer);
+        assertThat(filled, equalTo(0));
     }
 }


### PR DESCRIPTION
Fixes #13513

Refactored `MemoryEndPointPipe` to use `RetainableByteBuffer.DynamicCapacity` instead of allocating ByteBuffers directly.

Changes:

- Replace `Deque<ByteBuffer>` with `Deque<RetainableByteBuffer>`
- Each `flush()` creates a DynamicCapacity buffer via `append()` and adds it to the deque
- `fillInto()` reads from the deque using `get()`, releasing buffers when fully consumed
- Preserve existing EOF sentinel pattern for proper data/EOF ordering
- Add edge case tests for EOF handling, close behavior, and capacity limits
- Add notes to migration docs
