### PR TITLE
Issue #10905 - Support cookie name prefixes

### DIFF
--- a/documentation/jetty/modules/programming-guide/pages/client/http.adoc
+++ b/documentation/jetty/modules/programming-guide/pages/client/http.adoc
@@ -797,6 +797,25 @@ include::code:example$src/main/java/org/eclipse/jetty/docs/programming/client/ht
 
 The example above will retain only cookies that come from the `google.com` domain or sub-domains.
 
+=== Cookie Name Prefixes
+
+Jetty's `HttpClient` validates cookie name prefixes as defined in https://datatracker.ietf.org/doc/draft-ietf-httpbis-rfc6265bis/[RFC 6265bis].
+
+Cookies with the `+__Secure-+` prefix are only accepted if:
+
+* The cookie has the `Secure` attribute set.
+* The cookie was received over a secure (HTTPS) connection.
+
+Cookies with the `+__Host-+` prefix are only accepted if:
+
+* The cookie has the `Secure` attribute set.
+* The cookie was received over a secure (HTTPS) connection.
+* The cookie does not have a `Domain` attribute (making it a host-only cookie).
+* The cookie has `Path=/` explicitly set.
+
+These prefixes allow servers to "lock down" cookies with additional security guarantees.
+Cookies that violate these requirements are silently discarded by the `HttpCookieStore`.
+
 // TODO: move this section to server-side
 === Special Characters in Cookies
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookieStore.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookieStore.java
@@ -250,8 +250,8 @@ public interface HttpCookieStore
 
             boolean secure = HttpScheme.isSecure(uri.getScheme());
 
-            // __Host- prefix validation (case-insensitive).
-            if (name.regionMatches(true, 0, "__Host-", 0, 7))
+            // __Host- prefix validation (case-sensitive per RFC 6265bis).
+            if (name.startsWith("__Host-"))
             {
                 // Must be secure connection.
                 if (!secure)
@@ -266,8 +266,8 @@ public interface HttpCookieStore
                 if (!"/".equals(cookie.getPath()))
                     return false;
             }
-            // __Secure- prefix validation (case-insensitive).
-            else if (name.regionMatches(true, 0, "__Secure-", 0, 9))
+            // __Secure- prefix validation (case-sensitive per RFC 6265bis).
+            else if (name.startsWith("__Secure-"))
             {
                 // Must be secure connection.
                 if (!secure)

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookieStore.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookieStore.java
@@ -131,6 +131,10 @@ public interface HttpCookieStore
         {
             // TODO: reject if cookie size is too big?
 
+            // Validate cookie name prefixes (RFC 6265bis).
+            if (!validateCookiePrefix(uri, cookie))
+                return false;
+
             String resolvedDomain = resolveDomain(uri, cookie);
             if (resolvedDomain == null)
                 return false;
@@ -223,6 +227,57 @@ public interface HttpCookieStore
                 }
             }
             return resolvedPath;
+        }
+
+        /**
+         * <p>Validates cookie name prefixes as defined in RFC 6265bis.</p>
+         * <p>Cookies with the {@code __Secure-} prefix must have the
+         * {@code Secure} attribute and be received over a secure connection.</p>
+         * <p>Cookies with the {@code __Host-} prefix must have the
+         * {@code Secure} attribute, be received over a secure connection,
+         * must not have a {@code Domain} attribute, and must have
+         * {@code Path=/} explicitly set.</p>
+         *
+         * @param uri the URI associated with the cookie
+         * @param cookie the cookie to validate
+         * @return whether the cookie passes prefix validation
+         */
+        private boolean validateCookiePrefix(URI uri, HttpCookie cookie)
+        {
+            String name = cookie.getName();
+            if (name == null)
+                return true;
+
+            boolean secure = HttpScheme.isSecure(uri.getScheme());
+
+            // __Host- prefix validation (case-insensitive).
+            if (name.regionMatches(true, 0, "__Host-", 0, 7))
+            {
+                // Must be secure connection.
+                if (!secure)
+                    return false;
+                // Must have Secure attribute.
+                if (!cookie.isSecure())
+                    return false;
+                // Must NOT have Domain attribute (host-only).
+                if (cookie.getDomain() != null)
+                    return false;
+                // Must have Path=/ explicitly.
+                if (!"/".equals(cookie.getPath()))
+                    return false;
+            }
+            // __Secure- prefix validation (case-insensitive).
+            else if (name.regionMatches(true, 0, "__Secure-", 0, 9))
+            {
+                // Must be secure connection.
+                if (!secure)
+                    return false;
+                // Must have Secure attribute.
+                if (!cookie.isSecure())
+                    return false;
+            }
+
+            return true;
         }
 
         /**

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpCookieStoreTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpCookieStoreTest.java
@@ -453,4 +453,120 @@ public class HttpCookieStoreTest
         List<HttpCookie> matches = store.match(cookieURI);
         assertEquals(0, matches.size());
     }
+
+    @Test
+    public void testSecurePrefixAccepted()
+    {
+        HttpCookieStore store = new HttpCookieStore.Default();
+        // __Secure- cookie with Secure attribute over HTTPS should be accepted.
+        URI uri = URI.create("https://example.com");
+        assertTrue(store.add(uri, HttpCookie.build("__Secure-SID", "12345").secure(true).build()));
+        assertEquals(1, store.all().size());
+    }
+
+    @Test
+    public void testSecurePrefixRejectedNoSecureAttribute()
+    {
+        HttpCookieStore store = new HttpCookieStore.Default();
+        // __Secure- cookie without Secure attribute should be rejected.
+        URI uri = URI.create("https://example.com");
+        assertFalse(store.add(uri, HttpCookie.from("__Secure-SID", "12345")));
+        assertEquals(0, store.all().size());
+    }
+
+    @Test
+    public void testSecurePrefixRejectedNotSecureConnection()
+    {
+        HttpCookieStore store = new HttpCookieStore.Default();
+        // __Secure- cookie over HTTP should be rejected.
+        URI uri = URI.create("http://example.com");
+        assertFalse(store.add(uri, HttpCookie.build("__Secure-SID", "12345").secure(true).build()));
+        assertEquals(0, store.all().size());
+    }
+
+    @Test
+    public void testHostPrefixAccepted()
+    {
+        HttpCookieStore store = new HttpCookieStore.Default();
+        // __Host- cookie with Secure, no Domain, Path=/ over HTTPS should be accepted.
+        URI uri = URI.create("https://example.com");
+        assertTrue(store.add(uri, HttpCookie.build("__Host-SID", "12345").secure(true).path("/").build()));
+        assertEquals(1, store.all().size());
+    }
+
+    @Test
+    public void testHostPrefixRejectedWithDomain()
+    {
+        HttpCookieStore store = new HttpCookieStore.Default();
+        // __Host- cookie with Domain attribute should be rejected.
+        URI uri = URI.create("https://example.com");
+        assertFalse(store.add(uri, HttpCookie.build("__Host-SID", "12345").secure(true).path("/").domain("example.com").build()));
+        assertEquals(0, store.all().size());
+    }
+
+    @Test
+    public void testHostPrefixRejectedWrongPath()
+    {
+        HttpCookieStore store = new HttpCookieStore.Default();
+        // __Host- cookie with Path=/foo should be rejected.
+        URI uri = URI.create("https://example.com");
+        assertFalse(store.add(uri, HttpCookie.build("__Host-SID", "12345").secure(true).path("/foo").build()));
+        assertEquals(0, store.all().size());
+    }
+
+    @Test
+    public void testHostPrefixRejectedNoPath()
+    {
+        HttpCookieStore store = new HttpCookieStore.Default();
+        // __Host- cookie without explicit Path=/ should be rejected.
+        URI uri = URI.create("https://example.com");
+        assertFalse(store.add(uri, HttpCookie.build("__Host-SID", "12345").secure(true).build()));
+        assertEquals(0, store.all().size());
+    }
+
+    @Test
+    public void testHostPrefixRejectedNotSecureConnection()
+    {
+        HttpCookieStore store = new HttpCookieStore.Default();
+        // __Host- cookie over HTTP should be rejected.
+        URI uri = URI.create("http://example.com");
+        assertFalse(store.add(uri, HttpCookie.build("__Host-SID", "12345").secure(true).path("/").build()));
+        assertEquals(0, store.all().size());
+    }
+
+    @Test
+    public void testHostPrefixRejectedNoSecureAttribute()
+    {
+        HttpCookieStore store = new HttpCookieStore.Default();
+        // __Host- cookie without Secure attribute should be rejected.
+        URI uri = URI.create("https://example.com");
+        assertFalse(store.add(uri, HttpCookie.build("__Host-SID", "12345").path("/").build()));
+        assertEquals(0, store.all().size());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"__Secure-", "__SECURE-", "__secure-", "__SeCuRe-"})
+    public void testSecurePrefixCaseInsensitive(String prefix)
+    {
+        HttpCookieStore store = new HttpCookieStore.Default();
+        URI uri = URI.create("https://example.com");
+        // Valid __Secure- cookie should be accepted regardless of case.
+        assertTrue(store.add(uri, HttpCookie.build(prefix + "SID", "12345").secure(true).build()));
+        store.clear();
+        // Invalid __Secure- cookie (no Secure attribute) should be rejected regardless of case.
+        assertFalse(store.add(uri, HttpCookie.from(prefix + "SID", "12345")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"__Host-", "__HOST-", "__host-", "__HoSt-"})
+    public void testHostPrefixCaseInsensitive(String prefix)
+    {
+        HttpCookieStore store = new HttpCookieStore.Default();
+        URI uri = URI.create("https://example.com");
+        // Valid __Host- cookie should be accepted regardless of case.
+        assertTrue(store.add(uri, HttpCookie.build(prefix + "SID", "12345").secure(true).path("/").build()));
+        store.clear();
+        // Invalid __Host- cookie (has Domain attribute) should be rejected regardless of case.
+        assertFalse(store.add(uri, HttpCookie.build(prefix + "SID", "12345").secure(true).path("/").domain("example.com").build()));
+    }
 }

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpCookieStoreTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpCookieStoreTest.java
@@ -543,30 +543,4 @@ public class HttpCookieStoreTest
         assertFalse(store.add(uri, HttpCookie.build("__Host-SID", "12345").path("/").build()));
         assertEquals(0, store.all().size());
     }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"__Secure-", "__SECURE-", "__secure-", "__SeCuRe-"})
-    public void testSecurePrefixCaseInsensitive(String prefix)
-    {
-        HttpCookieStore store = new HttpCookieStore.Default();
-        URI uri = URI.create("https://example.com");
-        // Valid __Secure- cookie should be accepted regardless of case.
-        assertTrue(store.add(uri, HttpCookie.build(prefix + "SID", "12345").secure(true).build()));
-        store.clear();
-        // Invalid __Secure- cookie (no Secure attribute) should be rejected regardless of case.
-        assertFalse(store.add(uri, HttpCookie.from(prefix + "SID", "12345")));
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"__Host-", "__HOST-", "__host-", "__HoSt-"})
-    public void testHostPrefixCaseInsensitive(String prefix)
-    {
-        HttpCookieStore store = new HttpCookieStore.Default();
-        URI uri = URI.create("https://example.com");
-        // Valid __Host- cookie should be accepted regardless of case.
-        assertTrue(store.add(uri, HttpCookie.build(prefix + "SID", "12345").secure(true).path("/").build()));
-        store.clear();
-        // Invalid __Host- cookie (has Domain attribute) should be rejected regardless of case.
-        assertFalse(store.add(uri, HttpCookie.build(prefix + "SID", "12345").secure(true).path("/").domain("example.com").build()));
-    }
 }


### PR DESCRIPTION
Fixes #10905 

Add client-side validation for `__Secure-` and `__Host-` cookie prefixes as per RFC 6265bis.

The `HttpCookieStore` now rejects cookies that use these prefixes but don't meet the requirements (e.g., `__Secure-` without the Secure attribute, or `__Host-` with a Domain attribute).