### PR TITLE
Remove `jetty-ee11-servlets` dependency on `jetty-client`

### DIFF
--- a/jetty-ee11/jetty-ee11-servlets/pom.xml
+++ b/jetty-ee11/jetty-ee11-servlets/pom.xml
@@ -19,10 +19,6 @@
   <dependencies>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-client</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-http</artifactId>
     </dependency>
     <dependency>
@@ -46,6 +42,11 @@
       <groupId>org.eclipse.jetty.ee11</groupId>
       <artifactId>jetty-ee11-webapp</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-client</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
Fixes https://github.com/jetty/jetty.project/issues/14280