### PR TITLE
Issue #14137 - `ETag` response header not properly set on "304 Not Modified" from `CompressionHandler`.

### DIFF
--- a/jetty-core/jetty-compression/jetty-compression-server/src/main/java/org/eclipse/jetty/compression/server/CompressionHandler.java
+++ b/jetty-core/jetty-compression/jetty-compression-server/src/main/java/org/eclipse/jetty/compression/server/CompressionHandler.java
@@ -324,9 +324,13 @@ public class CompressionHandler extends Handler.Wrapper
                 request, requestContentEncoding, requestAcceptEncoding, decompressEncoding, compressEncoding);
         }
 
+        String originalEtag = null;
         // wrap request if etags need to be adjusted
         if (ifMatch != null || ifNoneMatch != null)
+        {
             request = new StripEtagRequest(request, ifMatch, ifNoneMatch);
+            originalEtag = (ifMatch != null) ? ifMatch : ifNoneMatch;
+        }
 
         // wrap the request if we can decompress.
         if (decompressEncoding != null)
@@ -337,7 +341,7 @@ public class CompressionHandler extends Handler.Wrapper
         {
             // The response may vary based on the presence or lack of Accept-Encoding.
             response.getHeaders().ensureField(varyAcceptEncoding);
-            response = newCompressionResponse(request, response, compressEncoding, config);
+            response = newCompressionResponse(request, response, compressEncoding, config, originalEtag);
         }
 
         if (LOG.isDebugEnabled())
@@ -365,13 +369,13 @@ public class CompressionHandler extends Handler.Wrapper
         return compression;
     }
 
-    private Response newCompressionResponse(Request request, Response response, String compressEncoding, CompressionConfig config)
+    private Response newCompressionResponse(Request request, Response response, String compressEncoding, CompressionConfig config, String originalEtag)
     {
         Compression compression = getCompression(compressEncoding);
         if (compression == null)
             return response;
 
-        return new CompressionResponse(request, response, compression, config);
+        return new CompressionResponse(request, response, compression, config, originalEtag);
     }
 
     private Request newDecompressionRequest(Request request, String decompressEncoding)

--- a/jetty-core/jetty-compression/jetty-compression-server/src/main/java/org/eclipse/jetty/compression/server/internal/CompressionResponse.java
+++ b/jetty-core/jetty-compression/jetty-compression-server/src/main/java/org/eclipse/jetty/compression/server/internal/CompressionResponse.java
@@ -38,14 +38,59 @@ public class CompressionResponse extends Response.Wrapper
 
     private final Compression compression;
     private final CompressionConfig config;
+    private final String originalEtag;
     private final AtomicReference<State> state = new AtomicReference<>(State.MIGHT_COMPRESS);
     private EncoderSink encoderSink;
 
-    public CompressionResponse(Request request, Response wrapped, Compression compression, CompressionConfig config)
+    public CompressionResponse(Request request, Response wrapped, Compression compression, CompressionConfig config, String originalEtag)
     {
         super(request, wrapped);
         this.compression = compression;
         this.config = config;
+        this.originalEtag = originalEtag;
+    }
+
+    @Override
+    public HttpFields.Mutable getHeaders()
+    {
+        if (originalEtag == null)
+            return super.getHeaders();
+
+        // To handle the 304 Not Modified case, we need to ensure that the ETag
+        // Now need to re-add the compression etag suffix that was stripped
+        // from the request before the handling request.
+        return new HttpFields.Mutable.Wrapper(super.getHeaders())
+        {
+            @Override
+            public HttpField onAddField(HttpField field)
+            {
+                if (getStatus() == HttpStatus.NOT_MODIFIED_304)
+                {
+                    if (field.getHeader() == HttpHeader.ETAG)
+                    {
+                        return new HttpField(HttpHeader.ETAG, originalEtag);
+                    }
+                }
+
+                return field;
+            }
+
+            @Override
+            public HttpField onReplaceField(HttpField oldField, HttpField newField)
+            {
+                return onAddField(newField);
+            }
+        };
+    }
+
+    @Override
+    public void setStatus(int code)
+    {
+        if (code == HttpStatus.NOT_MODIFIED_304)
+        {
+            getHeaders().put(HttpHeader.ETAG, originalEtag);
+        }
+        super.setStatus(code);
     }
 
     @Override

--- a/jetty-core/jetty-compression/jetty-compression-tests/src/test/java/org/eclipse/jetty/compression/CompressionHandlerTest.java
+++ b/jetty-core/jetty-compression/jetty-compression-tests/src/test/java/org/eclipse/jetty/compression/CompressionHandlerTest.java
@@ -59,8 +59,10 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class CompressionHandlerTest extends AbstractCompressionTest
@@ -918,6 +920,168 @@ public class CompressionHandlerTest extends AbstractCompressionTest
             .send();
         assertThat(response.getStatus(), is(status));
         assertFalse(response.getHeaders().contains(HttpHeader.CONTENT_ENCODING), "Status code " + status + " should not be compressed");
+    }
+
+    /**
+     * <p>Test of a child handler that handles If-None-Match behavior.</p>
+     *
+     * <p>Child will call setStatus(304) first, then set the ETag header.</p>
+     */
+    @Test
+    public void testIfNoneMatchNotModifiedEtag() throws Exception
+    {
+        pool = new ArrayByteBufferPool.Tracking();
+        GzipCompression gzipCompression = new GzipCompression();
+        gzipCompression.setByteBufferPool(pool);
+
+        String resourceName = "texts/quotes.txt";
+        String resourceContentType = "text/plain;charset=utf-8";
+        String requestedPath = "/path/to/quotes.txt";
+
+        Path resourcePath = MavenPaths.findTestResourceFile(resourceName);
+        byte[] resourceBody = Files.readAllBytes(resourcePath);
+
+        CompressionHandler compressionHandler = new CompressionHandler();
+        compressionHandler.putCompression(gzipCompression);
+
+        CompressionConfig config = CompressionConfig.builder()
+            .build();
+
+        compressionHandler.putConfiguration("/", config);
+        compressionHandler.setHandler(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                response.getHeaders().put(HttpHeader.CONTENT_TYPE, resourceContentType);
+                String etag = request.getHeaders().get(HttpHeader.IF_NONE_MATCH);
+                if (etag != null)
+                {
+                    // status first
+                    response.setStatus(HttpStatus.NOT_MODIFIED_304);
+                    response.getHeaders().put(HttpHeader.ETAG, etag);
+                    // No write
+                    callback.succeeded();
+                }
+                else
+                {
+                    response.getHeaders().put(HttpHeader.ETAG, "W\"deadbeef\"");
+                    response.setStatus(HttpStatus.OK_200);
+                    response.write(true, ByteBuffer.wrap(resourceBody), callback);
+                }
+                return true;
+            }
+        });
+
+        startServer(compressionHandler);
+
+        client.getContentDecoderFactories().clear();
+
+        // Initial request, to get actual etag value.
+        ContentResponse response = client.newRequest(server.getURI())
+            .headers(h -> h.put(HttpHeader.ACCEPT_ENCODING, "gzip"))
+            .path(requestedPath)
+            .send();
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        assertTrue(response.getHeaders().contains(HttpHeader.CONTENT_ENCODING));
+        HttpField etagField = response.getHeaders().getField(HttpHeader.ETAG);
+        assertNotNull(etagField);
+        String etag = etagField.getValue();
+
+        // Next request, using etag, should produce a 304 Not Modified response
+        response = client.newRequest(server.getURI())
+            .headers(h ->
+            {
+                h.put(HttpHeader.ACCEPT_ENCODING, "gzip");
+                h.put(HttpHeader.IF_NONE_MATCH, etag);
+            })
+            .path(requestedPath)
+            .send();
+        assertThat(response.getStatus(), is(HttpStatus.NOT_MODIFIED_304));
+        etagField = response.getHeaders().getField(HttpHeader.ETAG);
+        assertNotNull(etagField);
+        assertEquals(etag, etagField.getValue());
+    }
+
+    /**
+     * <p>Test of a child handler that handles If-None-Match behavior.</p>
+     *
+     * <p>Child will set the ETag header first, then call setStatus(304).</p>
+     */
+    @Test
+    public void testIfNoneMatchEtagNotModified() throws Exception
+    {
+        pool = new ArrayByteBufferPool.Tracking();
+        GzipCompression gzipCompression = new GzipCompression();
+        gzipCompression.setByteBufferPool(pool);
+
+        String resourceName = "texts/quotes.txt";
+        String resourceContentType = "text/plain;charset=utf-8";
+        String requestedPath = "/path/to/quotes.txt";
+
+        Path resourcePath = MavenPaths.findTestResourceFile(resourceName);
+        byte[] resourceBody = Files.readAllBytes(resourcePath);
+
+        CompressionHandler compressionHandler = new CompressionHandler();
+        compressionHandler.putCompression(gzipCompression);
+
+        CompressionConfig config = CompressionConfig.builder()
+            .build();
+
+        compressionHandler.putConfiguration("/", config);
+        compressionHandler.setHandler(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                response.getHeaders().put(HttpHeader.CONTENT_TYPE, resourceContentType);
+                String etag = request.getHeaders().get(HttpHeader.IF_NONE_MATCH);
+                if (etag != null)
+                {
+                    // header first
+                    response.getHeaders().put(HttpHeader.ETAG, etag);
+                    response.setStatus(HttpStatus.NOT_MODIFIED_304);
+                    // No write
+                    callback.succeeded();
+                }
+                else
+                {
+                    response.getHeaders().put(HttpHeader.ETAG, "W\"deadbeef\"");
+                    response.setStatus(HttpStatus.OK_200);
+                    response.write(true, ByteBuffer.wrap(resourceBody), callback);
+                }
+                return true;
+            }
+        });
+
+        startServer(compressionHandler);
+
+        client.getContentDecoderFactories().clear();
+
+        // Initial request, to get actual etag value.
+        ContentResponse response = client.newRequest(server.getURI())
+            .headers(h -> h.put(HttpHeader.ACCEPT_ENCODING, "gzip"))
+            .path(requestedPath)
+            .send();
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        assertTrue(response.getHeaders().contains(HttpHeader.CONTENT_ENCODING));
+        HttpField etagField = response.getHeaders().getField(HttpHeader.ETAG);
+        assertNotNull(etagField);
+        String etag = etagField.getValue();
+
+        // Next request, using etag, should produce a 304 Not Modified response
+        response = client.newRequest(server.getURI())
+            .headers(h ->
+            {
+                h.put(HttpHeader.ACCEPT_ENCODING, "gzip");
+                h.put(HttpHeader.IF_NONE_MATCH, etag);
+            })
+            .path(requestedPath)
+            .send();
+        assertThat(response.getStatus(), is(HttpStatus.NOT_MODIFIED_304));
+        etagField = response.getHeaders().getField(HttpHeader.ETAG);
+        assertNotNull(etagField);
+        assertEquals(etag, etagField.getValue());
     }
 
     private void dumpResponse(org.eclipse.jetty.client.Response response)


### PR DESCRIPTION
Addresses the 4 behaviors seen from child handlers of `CompressionHandler`.

1. child sets response ETag header, then response status 200, then writes.
2. child sets response ETag header, then response status 304, then doesn't write.
3. child sets response status 200, then response ETag header, then writes.
3. child sets response status 304, then response ETag header, then doesn't write.

Fixes #14137 