### PR TITLE
Issue #14264 - Send Redirect should allow for URI Fragment.

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/UriCompliance.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/UriCompliance.java
@@ -203,6 +203,12 @@ public final class UriCompliance implements ComplianceViolation.Mode
     public static final UriCompliance DEFAULT = new UriCompliance("DEFAULT", RFC3986.getAllowed());
 
     /**
+     * The default compliance mode for HTTP Redirects ({@code Location} header)
+     * that is {@link #DEFAULT}, but allows for {@link Violation#FRAGMENT}
+     */
+    public static final UriCompliance DEFAULT_REDIRECT = new UriCompliance("DEFAULT_REDIRECT", of(Violation.FRAGMENT));
+
+    /**
      * JETTY_11 compliance mode that models Jetty 11 DEFAULT behavior by allowing:
      * <ul>
      *     <li>{@link Violation#AMBIGUOUS_PATH_SEGMENT}</li>

--- a/jetty-core/jetty-server/src/main/config/modules/http-config.mod
+++ b/jetty-core/jetty-server/src/main/config/modules/http-config.mod
@@ -78,9 +78,8 @@ etc/jetty-http-config.xml
 # jetty.httpConfig.uriCompliance=DEFAULT
 
 ## URI Compliance mode for HTTP Response Redirects (the Location header)
-## URI Compliance: DEFAULT, LEGACY, RFC3986, RFC3986_UNAMBIGUOUS, UNSAFE
-## append `,FRAGMENT` to allow URI fragments (`#foo`) to be sent
-# jetty.httpConfig.redirectUriCompliance=DEFAULT,FRAGMENT
+## URI Compliance: DEFAULT, DEFAULT_REDIRECT, LEGACY, RFC3986, RFC3986_UNAMBIGUOUS, UNSAFE
+# jetty.httpConfig.redirectUriCompliance=DEFAULT_REDIRECT
 
 ## Cookie compliance mode for parsing request Cookie headers: RFC6265_STRICT, RFC6265, RFC6265_LEGACY, RFC2965, RFC2965_LEGACY
 # jetty.httpConfig.requestCookieCompliance=RFC6265

--- a/jetty-core/jetty-server/src/main/config/modules/http-config.mod
+++ b/jetty-core/jetty-server/src/main/config/modules/http-config.mod
@@ -73,11 +73,14 @@ etc/jetty-http-config.xml
 ## HTTP Compliance: STRICT, RFC9110, RFC7230, RFC7230_LEGACY, RFC2616, RFC2616_LEGACY, LEGACY
 # jetty.httpConfig.compliance=RFC9110
 
+## URI Compliance mode for HTTP Requests
 ## URI Compliance: DEFAULT, LEGACY, RFC3986, RFC3986_UNAMBIGUOUS, UNSAFE
 # jetty.httpConfig.uriCompliance=DEFAULT
 
+## URI Compliance mode for HTTP Response Redirects (the Location header)
 ## URI Compliance: DEFAULT, LEGACY, RFC3986, RFC3986_UNAMBIGUOUS, UNSAFE
-# jetty.httpConfig.redirectUriCompliance=DEFAULT
+## append `,FRAGMENT` to allow URI fragments (`#foo`) to be sent
+# jetty.httpConfig.redirectUriCompliance=DEFAULT,FRAGMENT
 
 ## Cookie compliance mode for parsing request Cookie headers: RFC6265_STRICT, RFC6265, RFC6265_LEGACY, RFC2965, RFC2965_LEGACY
 # jetty.httpConfig.requestCookieCompliance=RFC6265

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java
@@ -16,7 +16,6 @@ package org.eclipse.jetty.server;
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -83,8 +82,7 @@ public class HttpConfiguration implements Dumpable
     private long _minResponseDataRate;
     private HttpCompliance _httpCompliance = HttpCompliance.RFC9110;
     private UriCompliance _uriCompliance = UriCompliance.DEFAULT;
-    // HTTP (RFC9110) outgoing redirect (`Location` header) are allowed to have FRAGMENT.
-    private UriCompliance _redirectUriCompliance = new UriCompliance("RedirectDefault", EnumSet.of(UriCompliance.Violation.FRAGMENT));
+    private UriCompliance _redirectUriCompliance = UriCompliance.DEFAULT_REDIRECT;
     private CookieCompliance _requestCookieCompliance = CookieCompliance.RFC6265;
     private CookieCompliance _responseCookieCompliance = CookieCompliance.RFC6265;
     private MultiPartCompliance _multiPartCompliance = MultiPartCompliance.RFC7578;

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java
@@ -83,8 +83,8 @@ public class HttpConfiguration implements Dumpable
     private long _minResponseDataRate;
     private HttpCompliance _httpCompliance = HttpCompliance.RFC9110;
     private UriCompliance _uriCompliance = UriCompliance.DEFAULT;
-    // Redirects are allowed to have FRAGMENT
-    private UriCompliance _redirectUriCompliance = new UriCompliance("3986RedirectDefault", EnumSet.of(UriCompliance.Violation.FRAGMENT));
+    // HTTP (RFC9110) outgoing redirect (`Location` header) are allowed to have FRAGMENT.
+    private UriCompliance _redirectUriCompliance = new UriCompliance("RedirectDefault", EnumSet.of(UriCompliance.Violation.FRAGMENT));
     private CookieCompliance _requestCookieCompliance = CookieCompliance.RFC6265;
     private CookieCompliance _responseCookieCompliance = CookieCompliance.RFC6265;
     private MultiPartCompliance _multiPartCompliance = MultiPartCompliance.RFC7578;
@@ -686,24 +686,44 @@ public class HttpConfiguration implements Dumpable
         _httpCompliance = httpCompliance;
     }
 
-    @ManagedAttribute("The URI compliance mode")
+    /**
+     * The URI Compliance for HTTP Requests.
+     *
+     * @return the URI Compliance in use for HTTP Requests.
+     */
+    @ManagedAttribute("The URI compliance mode for HTTP Requests")
     public UriCompliance getUriCompliance()
     {
         return _uriCompliance;
     }
 
+    /**
+     * The URI Compliance for HTTP Response Redirects (the {@code Location} header)
+     *
+     * @return the URI Compliance in use for HTTP Response Redirects.
+     */
+    @ManagedAttribute("The URI Compliance mode for HTTP Response Redirects")
     public UriCompliance getRedirectUriCompliance()
     {
         return _redirectUriCompliance;
     }
 
+    /**
+     * URI Compliance for HTTP Requests.
+     *
+     * @param uriCompliance the {@link UriCompliance} to apply for HTTP requests.
+     */
     public void setUriCompliance(UriCompliance uriCompliance)
     {
         _uriCompliance = uriCompliance;
     }
 
     /**
-     * @param uriCompliance The {@link UriCompliance} to apply in {@link Response#toRedirectURI(Request, String)} or {@code null}.
+     * URI Compliance for HTTP Redirects.
+     *
+     * @param uriCompliance The {@link UriCompliance} to apply in HTTP Redirects.
+     * @see Response#toRedirectURI(Request, String)
+     * @see <a href="https://javadoc.io/doc/jakarta.servlet/jakarta.servlet-api/latest/jakarta.servlet/jakarta/servlet/http/HttpServletResponse.html">Jakarta Servlet API: HttpServletResponse.sendRedirect()</a>
      */
     public void setRedirectUriCompliance(UriCompliance uriCompliance)
     {

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.server;
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -82,7 +83,8 @@ public class HttpConfiguration implements Dumpable
     private long _minResponseDataRate;
     private HttpCompliance _httpCompliance = HttpCompliance.RFC9110;
     private UriCompliance _uriCompliance = UriCompliance.DEFAULT;
-    private UriCompliance _redirectUriCompliance = UriCompliance.DEFAULT;
+    // Redirects are allowed to have FRAGMENT
+    private UriCompliance _redirectUriCompliance = new UriCompliance("3986RedirectDefault", EnumSet.of(UriCompliance.Violation.FRAGMENT));
     private CookieCompliance _requestCookieCompliance = CookieCompliance.RFC6265;
     private CookieCompliance _responseCookieCompliance = CookieCompliance.RFC6265;
     private MultiPartCompliance _multiPartCompliance = MultiPartCompliance.RFC7578;

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RedirectTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/RedirectTest.java
@@ -1,0 +1,78 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.server;
+
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RedirectTest
+{
+    private Server server;
+    private LocalConnector localConnector;
+
+    public Server startServer(HttpConfiguration httpConfiguration, Handler handler) throws Exception
+    {
+        server = new Server();
+        localConnector = new LocalConnector(server, new HttpConnectionFactory(httpConfiguration));
+        server.addConnector(localConnector);
+
+        server.setHandler(handler);
+        server.start();
+        return server;
+    }
+
+    @AfterEach
+    public void stopServer()
+    {
+        LifeCycle.stop(server);
+    }
+
+    @Test
+    public void testSendRedirectWithFragment() throws Exception
+    {
+        final int redirectCode = HttpStatus.MOVED_TEMPORARILY_302;
+        final String redirectLocation = "http://local/path/to/resource#fragment";
+
+        Handler.Abstract handler = new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                Response.sendRedirect(request, response, callback, redirectCode, redirectLocation, false);
+                return true;
+            }
+        };
+
+        HttpConfiguration httpConfiguration = new HttpConfiguration();
+        startServer(httpConfiguration, handler);
+
+        String rawRequest = """
+            GET /test HTTP/1.1
+            Host: local
+            Connection: close
+            
+            """;
+
+        String rawResponse = localConnector.getResponse(rawRequest);
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertEquals(redirectCode, response.getStatus());
+        assertEquals(redirectLocation, response.get("Location"));
+    }
+}


### PR DESCRIPTION
The HttpConfiguration.redirectUriCompliance should allow FRAGMENT in URI.
That is allowed per HTTP spec.

Fixes #14264