### PR TITLE
Fix flaky `WebSocketOverHTTP2Test.testThrowFromCreator()` test

### DIFF
--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/WebSocketOverHTTP2Test.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/WebSocketOverHTTP2Test.java
@@ -356,7 +356,7 @@ public class WebSocketOverHTTP2Test
         assertTrue(latch.await(5, TimeUnit.SECONDS));
 
         var session = http2Client.getBean(SessionContainer.class).getSessions().stream().findAny().orElseThrow();
-        assertThat(session.getStreams(), is(empty()));
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertThat(session.getStreams(), is(empty())));
     }
 
     @Test


### PR DESCRIPTION
Caught the failure here: https://jenkins.webtide.net/blue/organizations/jenkins/jetty.project/detail/PR-14285/1/tests