### PR TITLE
[9.4.x] Bump mina-core to 2.2.4 for CVE-2024-52046

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <alpn.api.version>1.1.3.v20160715</alpn.api.version>
     <ant.version>1.10.15</ant.version>
     <apache.avro.version>1.11.4</apache.avro.version>
-    <mina.core.version>2.2.3</mina.core.version>
+    <mina.core.version>2.2.4</mina.core.version>
     <asm.version>9.7.1</asm.version>
     <bndlib.version>6.4.1</bndlib.version>
     <build-support.version>1.5</build-support.version>


### PR DESCRIPTION
This fixes a CVE CVE-2024-52046 which is CRITICAL with 10.0 score.

Even though, affected code path may not have been triggered in jetty project, but presence of mina-core 2.2.3 panics lot of scanners.