### PR TITLE
improve debug output for flaky BinaryStreamTest

### DIFF
--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/WebSocketTester.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/WebSocketTester.java
@@ -210,18 +210,26 @@ public class WebSocketTester implements AutoCloseable
     {
         ByteBuffer actualPayload = ByteBuffer.allocate(expectedMessage.remaining());
 
-        Frame frame = framesQueue.poll(5, TimeUnit.SECONDS);
-        assertThat("Initial Frame.opCode", frame.getOpCode(), is(expectedDataOp));
-
-        actualPayload.put(frame.getPayload());
-        while (!frame.isFin())
+        try
         {
-            frame = framesQueue.poll(5, TimeUnit.SECONDS);
-            assertThat("Frame.opCode", frame.getOpCode(), is(OpCode.CONTINUATION));
+            Frame frame = framesQueue.poll(5, TimeUnit.SECONDS);
+            assertThat("Initial Frame.opCode", frame.getOpCode(), is(expectedDataOp));
+
             actualPayload.put(frame.getPayload());
+            while (!frame.isFin())
+            {
+                frame = framesQueue.poll(5, TimeUnit.SECONDS);
+                assertThat("Frame.opCode", frame.getOpCode(), is(OpCode.CONTINUATION));
+                actualPayload.put(frame.getPayload());
+            }
+            actualPayload.flip();
+            ByteBufferAssert.assertEquals("Actual Message Payload", actualPayload, expectedMessage);
         }
-        actualPayload.flip();
-        ByteBufferAssert.assertEquals("Actual Message Payload", actualPayload, expectedMessage);
+        catch (Throwable t)
+        {
+            LOG.info("Actual Message Payload {}", BufferUtil.toDetailString(actualPayload));
+            throw t;
+        }
     }
 
     public void assertExpected(BlockingQueue<Frame> framesQueue, List<Frame> expect) throws InterruptedException

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/server/BinaryStreamTest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/server/BinaryStreamTest.java
@@ -41,8 +41,8 @@ import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.websocket.core.CloseStatus;
 import org.eclipse.jetty.websocket.core.Frame;
 import org.eclipse.jetty.websocket.core.OpCode;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,11 +57,11 @@ public class BinaryStreamTest
 {
     private static final String PATH = "/echo";
 
-    private static LocalServer server;
-    private static JakartaWebSocketClientContainer wsClient;
+    private LocalServer server;
+    private JakartaWebSocketClientContainer wsClient;
 
-    @BeforeAll
-    public static void startServer() throws Exception
+    @BeforeEach
+    public  void startServer() throws Exception
     {
         server = new LocalServer();
         server.start();
@@ -72,8 +72,8 @@ public class BinaryStreamTest
         wsClient.start();
     }
 
-    @AfterAll
-    public static void stopServer() throws Exception
+    @AfterEach
+    public void stopServer() throws Exception
     {
         wsClient.stop();
         server.stop();
@@ -265,16 +265,24 @@ public class BinaryStreamTest
         public void echo(Session session, InputStream input) throws IOException
         {
             byte[] buffer = new byte[128];
+            int readCount = 0;
+            int read;
             try (OutputStream output = session.getBasicRemote().getSendStream())
             {
-                int readCount = 0;
-                int read;
                 while ((read = input.read(buffer)) >= 0)
                 {
                     output.write(buffer, 0, read);
                     readCount += read;
                 }
-                LOG.debug("Read {} bytes", readCount);
+            }
+            catch (Throwable t)
+            {
+                LOG.warn("Error from ServerBinaryStreamer", t);
+                throw t;
+            }
+            finally
+            {
+                LOG.info("Read {} bytes", readCount);
             }
         }
     }

--- a/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-tests/src/main/java/org/eclipse/jetty/ee11/websocket/jakarta/tests/WebSocketTester.java
+++ b/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-tests/src/main/java/org/eclipse/jetty/ee11/websocket/jakarta/tests/WebSocketTester.java
@@ -210,18 +210,26 @@ public class WebSocketTester implements AutoCloseable
     {
         ByteBuffer actualPayload = ByteBuffer.allocate(expectedMessage.remaining());
 
-        Frame frame = framesQueue.poll(5, TimeUnit.SECONDS);
-        assertThat("Initial Frame.opCode", frame.getOpCode(), is(expectedDataOp));
-
-        actualPayload.put(frame.getPayload());
-        while (!frame.isFin())
+        try
         {
-            frame = framesQueue.poll(5, TimeUnit.SECONDS);
-            assertThat("Frame.opCode", frame.getOpCode(), is(OpCode.CONTINUATION));
+            Frame frame = framesQueue.poll(5, TimeUnit.SECONDS);
+            assertThat("Initial Frame.opCode", frame.getOpCode(), is(expectedDataOp));
+
             actualPayload.put(frame.getPayload());
+            while (!frame.isFin())
+            {
+                frame = framesQueue.poll(5, TimeUnit.SECONDS);
+                assertThat("Frame.opCode", frame.getOpCode(), is(OpCode.CONTINUATION));
+                actualPayload.put(frame.getPayload());
+            }
+            actualPayload.flip();
+            ByteBufferAssert.assertEquals("Actual Message Payload", actualPayload, expectedMessage);
         }
-        actualPayload.flip();
-        ByteBufferAssert.assertEquals("Actual Message Payload", actualPayload, expectedMessage);
+        catch (Throwable t)
+        {
+            LOG.info("Actual Message Payload {}", BufferUtil.toDetailString(actualPayload));
+            throw t;
+        }
     }
 
     public void assertExpected(BlockingQueue<Frame> framesQueue, List<Frame> expect) throws InterruptedException

--- a/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee11/websocket/jakarta/tests/server/BinaryStreamTest.java
+++ b/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee11/websocket/jakarta/tests/server/BinaryStreamTest.java
@@ -41,8 +41,8 @@ import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.websocket.core.CloseStatus;
 import org.eclipse.jetty.websocket.core.Frame;
 import org.eclipse.jetty.websocket.core.OpCode;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,11 +57,11 @@ public class BinaryStreamTest
 {
     private static final String PATH = "/echo";
 
-    private static LocalServer server;
-    private static JakartaWebSocketClientContainer wsClient;
+    private LocalServer server;
+    private JakartaWebSocketClientContainer wsClient;
 
-    @BeforeAll
-    public static void startServer() throws Exception
+    @BeforeEach
+    public void startServer() throws Exception
     {
         server = new LocalServer();
         server.start();
@@ -72,8 +72,8 @@ public class BinaryStreamTest
         wsClient.start();
     }
 
-    @AfterAll
-    public static void stopServer() throws Exception
+    @AfterEach
+    public void stopServer() throws Exception
     {
         wsClient.stop();
         server.stop();
@@ -265,16 +265,24 @@ public class BinaryStreamTest
         public void echo(Session session, InputStream input) throws IOException
         {
             byte[] buffer = new byte[128];
+            int readCount = 0;
+            int read;
             try (OutputStream output = session.getBasicRemote().getSendStream())
             {
-                int readCount = 0;
-                int read;
                 while ((read = input.read(buffer)) >= 0)
                 {
                     output.write(buffer, 0, read);
                     readCount += read;
                 }
-                LOG.debug("Read {} bytes", readCount);
+            }
+            catch (Throwable t)
+            {
+                LOG.warn("Error from ServerBinaryStreamer", t);
+                throw t;
+            }
+            finally
+            {
+                LOG.info("Read {} bytes", readCount);
             }
         }
     }


### PR DESCRIPTION
Add extra output from BinaryStreamTest which will help get more information on flaky tests if they occur.

Also avoid using static fields in this test, as this has caused issues in tests elsewhere.

I have seen this failure on jenkins builds however cannot reproduce the failure locally, or see any obvious reason for the failure.

see failure from https://jenkins.webtide.net/blue/organizations/jenkins/jetty.project/detail/PR-14263/4/tests