### PR TITLE
Fix `HttpURI.parse()` with IPv6 host and no path

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
@@ -1309,6 +1309,7 @@ public interface HttpURI
             int encodedCharacters = 0; // partial state of parsing a % encoded character<x>
             int encodedValue = 0; // the partial encoded value
             boolean dot = false; // set to true if the path contains . or .. segments
+            boolean ipv6Closed = false;
             int end = uri.length();
             _emptySegment = false;
             for (int i = 0; i < end; i++)
@@ -1547,7 +1548,10 @@ public interface HttpURI
                                 URIUtil.validateInetAddress(host);
                                 _host = host;
                                 if (i == end)
+                                {
+                                    ipv6Closed = true;
                                     break;
+                                }
                                 c = uri.charAt(i);
                                 if (c == ':')
                                 {
@@ -1793,7 +1797,10 @@ public interface HttpURI
                     }
                     break;
                 case IPV6:
-                    throw new IllegalArgumentException("No closing ']' for ipv6 in " + uri);
+                    if (!ipv6Closed)
+                        throw new IllegalArgumentException("No closing ']' for ipv6 in " + uri);
+                    _path = "";
+                    break;
                 case PORT_OR_PASSWORD:
                     try
                     {
@@ -1918,7 +1925,7 @@ public interface HttpURI
         {
             if (_violations == null)
                 _violations = EnumSet.of(violation);
-            else 
+            else
                 _violations.add(violation);
         }
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java
@@ -1309,7 +1309,6 @@ public interface HttpURI
             int encodedCharacters = 0; // partial state of parsing a % encoded character<x>
             int encodedValue = 0; // the partial encoded value
             boolean dot = false; // set to true if the path contains . or .. segments
-            boolean ipv6Closed = false;
             int end = uri.length();
             _emptySegment = false;
             for (int i = 0; i < end; i++)
@@ -1549,7 +1548,8 @@ public interface HttpURI
                                 _host = host;
                                 if (i == end)
                                 {
-                                    ipv6Closed = true;
+                                    pathMark = mark = i;
+                                    state = State.PATH;
                                     break;
                                 }
                                 c = uri.charAt(i);
@@ -1797,10 +1797,7 @@ public interface HttpURI
                     }
                     break;
                 case IPV6:
-                    if (!ipv6Closed)
-                        throw new IllegalArgumentException("No closing ']' for ipv6 in " + uri);
-                    _path = "";
-                    break;
+                    throw new IllegalArgumentException("No closing ']' for ipv6 in " + uri);
                 case PORT_OR_PASSWORD:
                     try
                     {

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpURITest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpURITest.java
@@ -889,20 +889,48 @@ public class HttpURITest
             // Simple IPv4 host with port (default path)
             Arguments.of("http://192.0.0.1:8080/", "http", "192.0.0.1", "8080", "/", null, null, null),
 
+            // Simple IPv4 host with port (no path)
+            Arguments.of("http://192.0.0.1:8080", "http", "192.0.0.1", "8080", "", null, null, null),
+
+            // Simple IPv4 host (default path)
+            Arguments.of("http://192.0.0.1/", "http", "192.0.0.1", null, "/", null, null, null),
+
+            // Simple IPv4 host (no path)
+            Arguments.of("http://192.0.0.1", "http", "192.0.0.1", null, "", null, null, null),
+
             // Simple IPv6 host with port (default path)
-
             Arguments.of("http://[2001:db8::1]:8080/", "http", "[2001:db8::1]", "8080", "/", null, null, null),
-            // IPv6 authenticated host with port (default path)
 
+            // Simple IPv6 host with port (no path)
+            Arguments.of("http://[2001:db8::1]:8080", "http", "[2001:db8::1]", "8080", "", null, null, null),
+
+            // IPv6 authenticated host with port (default path)
             Arguments.of("http://user@[2001:db8::1]:8080/", "http", "[2001:db8::1]", "8080", "/", null, null, null),
+
+            // IPv6 authenticated host with port (no path)
+            Arguments.of("http://user@[2001:db8::1]:8080", "http", "[2001:db8::1]", "8080", "", null, null, null),
 
             // Simple IPv6 host no port (default path)
             Arguments.of("http://[2001:db8::1]/", "http", "[2001:db8::1]", null, "/", null, null, null),
             Arguments.of("http://[0:0:0:0:0:ffff:127.0.0.1]/", "http", "[0:0:0:0:0:ffff:127.0.0.1]", null, "/", null, null, null),
             Arguments.of("http://[::ffff:127.0.0.1]/", "http", "[::ffff:127.0.0.1]", null, "/", null, null, null),
 
-            // Scheme-less IPv6, host with port (default path)
+            // Simple IPv6 host no port (no path)
+            Arguments.of("http://[2001:db8::1]", "http", "[2001:db8::1]", null, "", null, null, null),
+            Arguments.of("http://[0:0:0:0:0:ffff:127.0.0.1]", "http", "[0:0:0:0:0:ffff:127.0.0.1]", null, "", null, null, null),
+            Arguments.of("http://[::ffff:127.0.0.1]", "http", "[::ffff:127.0.0.1]", null, "", null, null, null),
+
+            // Scheme-less IPv6 host with port (default path)
             Arguments.of("//[2001:db8::1]:8080/", null, "[2001:db8::1]", "8080", "/", null, null, null),
+
+            // Scheme-less IPv6 host with port (no path)
+            Arguments.of("//[2001:db8::1]:8080", null, "[2001:db8::1]", "8080", "", null, null, null),
+
+            // Scheme-less IPv6 host (default path)
+            Arguments.of("//[2001:db8::1]/", null, "[2001:db8::1]", null, "/", null, null, null),
+
+            // Scheme-less IPv6 host (no path)
+            Arguments.of("//[2001:db8::1]", null, "[2001:db8::1]", null, "", null, null, null),
 
             // Interpreted as relative path of "*" (no host/port/scheme/query/fragment)
             Arguments.of("*", null, null, null, "*", null, null, null),
@@ -1297,9 +1325,13 @@ public class HttpURITest
             "https://user:password@host:notport/path",
             "https://user @host.com/",
             // "https://user#@host.com/", TODO this might cause WhatWG compatibility issues
+            "https://[notIpv6]",
+            "https://bad[0::1::2::3::4]",
             "https://[notIpv6]/",
             "https://bad[0::1::2::3::4]/",
 
+            "http://[fe80::1%25eth0]",
+            "http://[fe80::1%251]",
             "http://[fe80::1%25eth0]/",
             "http://[fe80::1%251]/",
 


### PR DESCRIPTION
`HttpURI.parse()` should not throw `IllegalArgumentException` when given a valid URI containing an IPv6 host and no path e.g. `http://[2001:db8::1]`.