### PR TITLE
Issue #10355 - simplification and improvements for Http3Fields

### DIFF
--- a/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/metadata/Http3Fields.java
+++ b/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/metadata/Http3Fields.java
@@ -19,9 +19,8 @@ import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.ListIterator;
+import java.util.NoSuchElementException;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
@@ -33,7 +32,7 @@ import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.http.PreEncodedHttpField;
 import org.eclipse.jetty.util.StringUtil;
 
-public class Http3Fields implements HttpFields
+public class Http3Fields implements Iterable<HttpField>
 {
     public static final HttpField[] STATUSES = new HttpField[599];
     private static final EnumSet<HttpHeader> IGNORED_HEADERS = EnumSet.of(HttpHeader.CONNECTION, HttpHeader.KEEP_ALIVE,
@@ -112,70 +111,88 @@ public class Http3Fields implements HttpFields
                     contentLengthHeader = new HttpField(HttpHeader.CONTENT_LENGTH, String.valueOf(contentLength));
             }
         }
-
     }
 
-    @Override
-    public HttpFields asImmutable()
-    {
-        return HttpFields.from(stream().toArray(HttpField[]::new));
-    }
-
-    @Override
-    public HttpField getField(int index)
-    {
-        return stream().skip(index).findFirst().orElse(null);
-    }
-
-    @Override
-    public int size()
-    {
-        // TODO this is very inefficient
-        return Math.toIntExact(stream().count());
-    }
-
-    @Override
-    public Stream<HttpField> stream()
-    {
-        Stream<HttpField> pseudoHeadersStream = pseudoHeaders.stream();
-        if (httpFields == null)
-            return pseudoHeadersStream;
-
-        Stream<HttpField> httpFieldStream = httpFields.stream().filter(this::filterIgnored);
-
-        if (contentLengthHeader != null)
-            return Stream.concat(pseudoHeadersStream, Stream.concat(httpFieldStream, Stream.of(contentLengthHeader)));
-        else
-            return Stream.concat(pseudoHeadersStream, httpFieldStream);
-    }
-
-    private boolean filterIgnored(HttpField field)
+    private HttpField filterIgnored(HttpField field)
     {
         HttpHeader header = field.getHeader();
 
         // If the header is specifically ignored skip it (Connection Specific Headers).
         if (header != null && IGNORED_HEADERS.contains(header))
-            return false;
-
-        // If this is the TE header field it can only have the value "trailers".
-        if ((header == HttpHeader.TE) && !field.contains("trailers"))
-            return false;
+            return null;
 
         // Remove the headers nominated by the Connection header field.
         String name = field.getLowerCaseName();
-        return hopHeaders == null || !hopHeaders.contains(name);
+        if (hopHeaders != null && hopHeaders.contains(name))
+            return null;
+
+        // If this is the TE header field it can only have the value "trailers".
+        if (header == HttpHeader.TE)
+        {
+            if ("trailers".equalsIgnoreCase(field.getValue()))
+                return TE_TRAILERS;
+            else
+                return null;
+        }
+
+        return field;
     }
 
     @Override
     public Iterator<HttpField> iterator()
     {
-        return stream().iterator();
-    }
+        return new Iterator<>()
+        {
+            private final Iterator<HttpField> _pseudoHeaderIterator = pseudoHeaders.iterator();
+            private final Iterator<HttpField> _httpFieldsIterator = (httpFields == null) ? null : httpFields.iterator();
+            private boolean _contentLengthDone;
+            private HttpField _next;
 
-    @Override
-    public ListIterator<HttpField> listIterator(int index)
-    {
-        // TODO this is very inefficient and toList returns an unmodifiable list
-        return stream().toList().listIterator(index);
+            @Override
+            public boolean hasNext()
+            {
+                if (_next != null)
+                    return true;
+
+                if (_pseudoHeaderIterator.hasNext())
+                {
+                    _next = _pseudoHeaderIterator.next();
+                    return true;
+                }
+
+                if (_httpFieldsIterator != null)
+                {
+                    while (_httpFieldsIterator.hasNext())
+                    {
+                        HttpField field = _httpFieldsIterator.next();
+                        field = filterIgnored(field);
+                        if (field != null)
+                        {
+                            _next = field;
+                            return true;
+                        }
+                    }
+                }
+
+                if (!_contentLengthDone && contentLengthHeader != null)
+                {
+                    _contentLengthDone = true;
+                    _next = contentLengthHeader;
+                    return true;
+                }
+
+                return false;
+            }
+
+            @Override
+            public HttpField next()
+            {
+                if (!hasNext())
+                    throw new NoSuchElementException();
+                HttpField field = _next;
+                _next = null;
+                return field;
+            }
+        };
     }
 }


### PR DESCRIPTION
## Closes #10355

- `Http3Fields` is only used for iteration so does not require implementing `HttpFields`, this also greatly simplifies the implementation.
- Introduce better handling of TE: trailers using the `PreEncodedHttpField`.