### PR TITLE
Properly handle negative `Max-Age` in `RFC6265SetCookieParser`

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/RFC6265SetCookieParser.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/RFC6265SetCookieParser.java
@@ -197,6 +197,8 @@ public class RFC6265SetCookieParser implements SetCookieParser
     {
         try
         {
+            if (HttpCookie.MAX_AGE_ATTRIBUTE.equalsIgnoreCase(name) && Long.parseLong(value) < 0)
+                value = "0";
             cookie.attribute(name, value);
             return true;
         }

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpCookieTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpCookieTest.java
@@ -55,6 +55,8 @@ public class HttpCookieTest
             Arguments.of("A=B; a=", HttpCookie.build("A", "B").attribute("a", "").build()),
             Arguments.of("A=B; a=v", HttpCookie.build("A", "B").attribute("a", "v").build()),
             Arguments.of("A=B; Secure; Path=/", HttpCookie.build("A", "B").secure(true).path("/").build()),
+            Arguments.of("A=B; Max-Age=0", HttpCookie.build("A", "B").maxAge(0).build()),
+            Arguments.of("A=B; Max-Age=-1", HttpCookie.build("A", "B").maxAge(0).build()),
             // Quoted cookie.
             Arguments.of("A=\"1\"", HttpCookie.build("A", "1").build()),
             Arguments.of("A=\"1\"; HttpOnly", HttpCookie.build("A", "1").httpOnly(true).build()),


### PR DESCRIPTION
Parsing a `Set-Cookie` header with a negative `Max-Age` should be treated as the cookie expiring immediately, which is the same as `Max-Age=0`. `RFC6265SetCookieParser` and `HttpCookie` currently treat a negative `Max-Age` attribute the same as removing the `Max-Age` attribute, which is incorrect according to [rfc6265#section-5.2.2](https://datatracker.ietf.org/doc/html/rfc6265#section-5.2.2):
> If delta-seconds is less than or equal to zero (0), let expiry-time be the earliest representable date and time.