### PR TITLE
Fix flaky `testSimpleIdleRead()`

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -655,6 +655,7 @@ public class HttpChannelState implements HttpChannel, Components
                 listener.onRequestEnd(_request);
 
             // This is THE ONLY PLACE the stream is succeeded or failed.
+            LOG.atDebug().setCause(failure).log("completing the stream of {}", this);
             if (failure == null)
                 stream.succeeded();
             else

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ServletTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ServletTest.java
@@ -148,7 +148,7 @@ public class ServletTest
                 Content-Length: 10
                 
                 """;
-            endPoint.addInput(request);
+            endPoint.addInputAndExecute(request);
             endPoint.addInput("1234567890");
             HttpTester.Response response = HttpTester.parseResponse(endPoint.getResponse(false, 5, TimeUnit.SECONDS));
             assertThat(response.getStatus(), is(HttpStatus.OK_200));


### PR DESCRIPTION
The first `addInput()` may make the local connector use the main thread to execute the handler; since the latter is blocking the test method is then stuck in `addInput()` until the idle timeout fires.

The test always fail on the assertions of the first request, as reflected by the stack trace captured by @joakime : https://github.com/jetty/jetty.project/issues/11327#issuecomment-3720979560

Fixes #11327