### PR TITLE
Issue #14138 - Add Vary: Accept-Encoding header when compression is possible

### DIFF
--- a/documentation/jetty/modules/programming-guide/pages/server/http.adoc
+++ b/documentation/jetty/modules/programming-guide/pages/server/http.adoc
@@ -987,6 +987,9 @@ In the case above, you need `--enable-native-access=com.aayushatharva.brotli4j`.
 `CompressionHandler` is a `Handler.Wrapper` that inspects the request and, if the conditions are met, it wraps the request and the response to eventually perform decompression of the request content or compression of the response content.
 The decompression/compression is not performed until the web application reads request content or writes response content.
 
+`CompressionHandler` automatically adds the `Vary: Accept-Encoding` response header when the request method supports compression (by default `GET` and `POST`).
+This header is added regardless of whether the client sends an `Accept-Encoding` request header, ensuring that caching proxies correctly handle responses that may vary based on client compression capabilities.
+
 `CompressionHandler` comes with a default configuration, but can be explicitly configured through a `CompressionConfig` object that can be constructed via the builder pattern.
 
 Furthermore, `CompressionHandler` can be configured either at the server level, or at the context level.

--- a/jetty-core/jetty-compression/jetty-compression-server/src/main/java/org/eclipse/jetty/compression/server/CompressionHandler.java
+++ b/jetty-core/jetty-compression/jetty-compression-server/src/main/java/org/eclipse/jetty/compression/server/CompressionHandler.java
@@ -328,11 +328,17 @@ public class CompressionHandler extends Handler.Wrapper
         if (decompressEncoding != null)
             request = newDecompressionRequest(request, decompressEncoding);
 
+        // Add Vary header if compression is possible for this request (method + path match).
+        // This must be added regardless of whether Accept-Encoding was present, so caching
+        // proxies know the response may vary based on Accept-Encoding.
+        if (config.isCompressMethodSupported(request.getMethod()))
+        {
+            response.getHeaders().ensureField(varyAcceptEncoding);
+        }
+
         // wrap the response if we can deflate.
         if (compressEncoding != null)
         {
-            // The response may vary based on the presence or lack of Accept-Encoding.
-            response.getHeaders().ensureField(varyAcceptEncoding);
             response = newCompressionResponse(request, response, compressEncoding, config, originalEtag);
         }
 

--- a/jetty-core/jetty-compression/jetty-compression-server/src/main/java/org/eclipse/jetty/compression/server/CompressionHandler.java
+++ b/jetty-core/jetty-compression/jetty-compression-server/src/main/java/org/eclipse/jetty/compression/server/CompressionHandler.java
@@ -328,9 +328,7 @@ public class CompressionHandler extends Handler.Wrapper
         if (decompressEncoding != null)
             request = newDecompressionRequest(request, decompressEncoding);
 
-        // Add Vary header if compression is possible for this request (method + path match).
-        // This must be added regardless of whether Accept-Encoding was present, so caching
-        // proxies know the response may vary based on Accept-Encoding.
+        // Add Vary header if compression is possible for this method.
         if (config.isCompressMethodSupported(request.getMethod()))
         {
             response.getHeaders().ensureField(varyAcceptEncoding);

--- a/jetty-core/jetty-compression/jetty-compression-tests/src/test/java/org/eclipse/jetty/compression/CompressionHandlerTest.java
+++ b/jetty-core/jetty-compression/jetty-compression-tests/src/test/java/org/eclipse/jetty/compression/CompressionHandlerTest.java
@@ -69,8 +69,10 @@ import org.slf4j.LoggerFactory;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -1183,6 +1185,92 @@ public class CompressionHandlerTest extends AbstractCompressionTest
                 assertThat(decoded, is("This line should be flushed\nThis line should be seen afterwards\n"));
             }
         }
+    }
+
+    /**
+     * Test that Vary: Accept-Encoding header is present even when client does not
+     * send Accept-Encoding header, as long as compression is possible for the path/method.
+     * This is important for caching proxies.
+     */
+    @ParameterizedTest
+    @MethodSource("compressions")
+    public void testVaryHeaderWithoutAcceptEncoding(Class<Compression> compressionClass) throws Exception
+    {
+        newCompression(compressionClass);
+        String message = "Hello Jetty!\n".repeat(10);
+
+        CompressionHandler compressionHandler = new CompressionHandler();
+        compressionHandler.putCompression(compression);
+        compressionHandler.setHandler(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                response.setStatus(200);
+                response.getHeaders().put(HttpHeader.CONTENT_TYPE, "text/plain;charset=utf-8");
+                Content.Sink.write(response, true, message, callback);
+                return true;
+            }
+        });
+
+        startServer(compressionHandler);
+
+        URI serverURI = server.getURI();
+        client.getContentDecoderFactories().clear();
+
+        // Request WITHOUT Accept-Encoding header
+        ContentResponse response = client.newRequest(serverURI.getHost(), serverURI.getPort())
+            .method(HttpMethod.GET)
+            // Intentionally NOT setting Accept-Encoding header
+            .path("/hello")
+            .send();
+
+        assertThat(response.getStatus(), is(200));
+        // Response should NOT be compressed (no Accept-Encoding sent)
+        assertFalse(response.getHeaders().contains(HttpHeader.CONTENT_ENCODING));
+        // But Vary header SHOULD be present (compression was possible)
+        assertThat(response.getHeaders().get(HttpHeader.VARY), containsString("Accept-Encoding"));
+        // Content should be uncompressed
+        assertThat(response.getContentAsString(), is(message));
+    }
+
+    /**
+     * Test that Vary header is NOT present when method does not support compression.
+     */
+    @Test
+    public void testNoVaryHeaderForExcludedMethod() throws Exception
+    {
+        pool = new ArrayByteBufferPool.Tracking();
+        GzipCompression gzipCompression = new GzipCompression();
+        gzipCompression.setByteBufferPool(pool);
+
+        CompressionHandler compressionHandler = new CompressionHandler();
+        compressionHandler.putCompression(gzipCompression);
+        // Default config only includes GET and POST for compression
+        compressionHandler.setHandler(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                response.setStatus(200);
+                response.getHeaders().put(HttpHeader.CONTENT_TYPE, "text/plain");
+                Content.Sink.write(response, true, "OK", callback);
+                return true;
+            }
+        });
+
+        startServer(compressionHandler);
+
+        // OPTIONS request - not included in default compress methods
+        ContentResponse response = client.newRequest(server.getURI())
+            .method(HttpMethod.OPTIONS)
+            .headers(h -> h.put(HttpHeader.ACCEPT_ENCODING, "gzip"))
+            .path("/hello")
+            .send();
+
+        assertThat(response.getStatus(), is(200));
+        // Vary header should NOT be present because OPTIONS is not a compress method
+        assertThat(response.getHeaders().get(HttpHeader.VARY), nullValue());
     }
 
     private void dumpResponse(org.eclipse.jetty.client.Response response)


### PR DESCRIPTION
Fixes #14138

- Move Vary header addition outside the compression check in `CompressionHandler`
- Add `testVaryHeaderWithoutAcceptEncoding` test to verify Vary is present without Accept-Encoding
- Add `testNoVaryHeaderForExcludedMethod` test to verify Vary is absent for excluded methods