### PR TITLE
Issue #14319 - Fix ZSTD byte duplication at 128KB boundary

### DIFF
--- a/jetty-core/jetty-compression/jetty-compression-zstandard/src/main/java/org/eclipse/jetty/compression/zstandard/internal/ZstandardEncoderSink.java
+++ b/jetty-core/jetty-compression/jetty-compression-zstandard/src/main/java/org/eclipse/jetty/compression/zstandard/internal/ZstandardEncoderSink.java
@@ -152,8 +152,8 @@ public class ZstandardEncoderSink extends EncoderSink
                     Callback writeCallback = Callback.from(Invocable.InvocationType.NON_BLOCKING, outputBuf::release);
                     if (inputBuf.hasRemaining())
                     {
-                        // rollback unprocessed inputBuf to content buffer position.
-                        content.position(originalPosition);
+                        // Adjust position to account for bytes already consumed by zstd.
+                        content.position(originalPosition + inputBuf.getByteBuffer().position());
                     }
                     // we are about to return, release inputBuffer
                     inputBuf.release();

--- a/jetty-core/jetty-compression/jetty-compression-zstandard/src/main/java/org/eclipse/jetty/compression/zstandard/internal/ZstandardEncoderSink.java
+++ b/jetty-core/jetty-compression/jetty-compression-zstandard/src/main/java/org/eclipse/jetty/compression/zstandard/internal/ZstandardEncoderSink.java
@@ -107,16 +107,10 @@ public class ZstandardEncoderSink extends EncoderSink
         if (buffer.isDirect())
         {
             int length = Math.min(buffer.remaining(), size);
-
-            // Create a slice limited to 'length' bytes.
-            // The slice has independent position/limit but shares the underlying data.
             ByteBuffer slice = buffer.slice();
             slice.limit(length);
             slice.order(ByteOrder.LITTLE_ENDIAN); // zstandard requirement
-
-            // Advance original buffer's position (consistent with heap buffer path).
             buffer.position(buffer.position() + length);
-
             return RetainableByteBuffer.wrap(slice);
         }
 

--- a/jetty-core/jetty-compression/jetty-compression-zstandard/src/main/java/org/eclipse/jetty/compression/zstandard/internal/ZstandardEncoderSink.java
+++ b/jetty-core/jetty-compression/jetty-compression-zstandard/src/main/java/org/eclipse/jetty/compression/zstandard/internal/ZstandardEncoderSink.java
@@ -106,8 +106,18 @@ public class ZstandardEncoderSink extends EncoderSink
     {
         if (buffer.isDirect())
         {
-            buffer.order(ByteOrder.LITTLE_ENDIAN); // zstandard requirement
-            return RetainableByteBuffer.wrap(buffer);
+            int length = Math.min(buffer.remaining(), size);
+
+            // Create a slice limited to 'length' bytes.
+            // The slice has independent position/limit but shares the underlying data.
+            ByteBuffer slice = buffer.slice();
+            slice.limit(length);
+            slice.order(ByteOrder.LITTLE_ENDIAN); // zstandard requirement
+
+            // Advance original buffer's position (consistent with heap buffer path).
+            buffer.position(buffer.position() + length);
+
+            return RetainableByteBuffer.wrap(slice);
         }
 
         RetainableByteBuffer direct = compression.acquireByteBuffer(size);

--- a/jetty-core/jetty-compression/jetty-compression-zstandard/src/main/java/org/eclipse/jetty/compression/zstandard/internal/ZstandardEncoderSink.java
+++ b/jetty-core/jetty-compression/jetty-compression-zstandard/src/main/java/org/eclipse/jetty/compression/zstandard/internal/ZstandardEncoderSink.java
@@ -106,33 +106,18 @@ public class ZstandardEncoderSink extends EncoderSink
     {
         if (buffer.isDirect())
         {
-            int length = Math.min(buffer.remaining(), size);
-            // Slice so returned buffer starts at position 0, same as heap path.
-            ByteBuffer slice = buffer.slice();
-            slice.limit(length);
-            slice.order(ByteOrder.LITTLE_ENDIAN); // zstandard requirement
-            // Adjust position to account for bytes already consumed by zstd.
-            buffer.position(buffer.position() + length);
-            return RetainableByteBuffer.wrap(slice);
+            buffer.order(ByteOrder.LITTLE_ENDIAN); // zstandard requirement
+            return RetainableByteBuffer.wrap(buffer);
         }
 
-        RetainableByteBuffer direct = compression.acquireByteBuffer(size);
-
-        // Remember the original pos/limit
         int pos = buffer.position();
-        int limit = buffer.limit();
         int length = Math.min(buffer.remaining(), size);
-        buffer.limit(pos + length);
-
-        BufferUtil.flipToFill(direct.getByteBuffer());
-        direct.getByteBuffer().put(buffer);
-
-        BufferUtil.flipToFlush(direct.getByteBuffer(), 0);
-
-        // consume length on original buffer
-        buffer.limit(limit);
-        buffer.position(pos + length);
-
+        RetainableByteBuffer direct = compression.acquireByteBuffer(size);
+        ByteBuffer directBuf = direct.getByteBuffer();
+        directBuf.clear();
+        directBuf.put(0, buffer, pos, length);
+        directBuf.limit(length);
+        // buffer.position() is NOT modified - tracking happens in continueOp()
         return direct;
     }
 
@@ -144,6 +129,7 @@ public class ZstandardEncoderSink extends EncoderSink
         while (BufferUtil.hasContent(content))
         {
             int originalPosition = content.position();
+            boolean isDirect = content.isDirect();
             // content must be a direct bytebuffer, and we have to assume that the size
             // of the content buffer can be huge (multi megabyte or bigger), so lets
             // process the content one limited direct buffer at a time.
@@ -156,16 +142,17 @@ public class ZstandardEncoderSink extends EncoderSink
                 if (outputBuf.getByteBuffer().hasRemaining())
                 {
                     Callback writeCallback = Callback.from(Invocable.InvocationType.NON_BLOCKING, outputBuf::release);
-                    if (inputBuf.hasRemaining())
-                    {
-                        // Adjust position to account for bytes already consumed by zstd.
+                    // For heap buffers, manually track position (ZSTD operated on a copy).
+                    // For direct buffers, ZSTD already advanced content.position().
+                    if (!isDirect)
                         content.position(originalPosition + inputBuf.getByteBuffer().position());
-                    }
-                    // we are about to return, release inputBuffer
                     inputBuf.release();
                     return new WriteRecord(false, outputBuf.getByteBuffer(), writeCallback);
                 }
             }
+            // Chunk fully consumed - update position for heap buffers.
+            if (!isDirect)
+                content.position(originalPosition + inputBuf.getByteBuffer().position());
             inputBuf.release();
         }
         outputBuf.release();

--- a/jetty-core/jetty-compression/jetty-compression-zstandard/src/main/java/org/eclipse/jetty/compression/zstandard/internal/ZstandardEncoderSink.java
+++ b/jetty-core/jetty-compression/jetty-compression-zstandard/src/main/java/org/eclipse/jetty/compression/zstandard/internal/ZstandardEncoderSink.java
@@ -107,9 +107,11 @@ public class ZstandardEncoderSink extends EncoderSink
         if (buffer.isDirect())
         {
             int length = Math.min(buffer.remaining(), size);
+            // Slice so returned buffer starts at position 0, same as heap path.
             ByteBuffer slice = buffer.slice();
             slice.limit(length);
             slice.order(ByteOrder.LITTLE_ENDIAN); // zstandard requirement
+            // Adjust position to account for bytes already consumed by zstd.
             buffer.position(buffer.position() + length);
             return RetainableByteBuffer.wrap(slice);
         }

--- a/jetty-core/jetty-compression/jetty-compression-zstandard/src/main/java/org/eclipse/jetty/compression/zstandard/internal/ZstandardEncoderSink.java
+++ b/jetty-core/jetty-compression/jetty-compression-zstandard/src/main/java/org/eclipse/jetty/compression/zstandard/internal/ZstandardEncoderSink.java
@@ -129,7 +129,6 @@ public class ZstandardEncoderSink extends EncoderSink
         while (BufferUtil.hasContent(content))
         {
             int originalPosition = content.position();
-            boolean isDirect = content.isDirect();
             // content must be a direct bytebuffer, and we have to assume that the size
             // of the content buffer can be huge (multi megabyte or bigger), so lets
             // process the content one limited direct buffer at a time.
@@ -144,14 +143,14 @@ public class ZstandardEncoderSink extends EncoderSink
                     Callback writeCallback = Callback.from(Invocable.InvocationType.NON_BLOCKING, outputBuf::release);
                     // For heap buffers, manually track position (ZSTD operated on a copy).
                     // For direct buffers, ZSTD already advanced content.position().
-                    if (!isDirect)
+                    if (!content.isDirect())
                         content.position(originalPosition + inputBuf.getByteBuffer().position());
                     inputBuf.release();
                     return new WriteRecord(false, outputBuf.getByteBuffer(), writeCallback);
                 }
             }
             // Chunk fully consumed - update position for heap buffers.
-            if (!isDirect)
+            if (!content.isDirect())
                 content.position(originalPosition + inputBuf.getByteBuffer().position());
             inputBuf.release();
         }

--- a/jetty-core/jetty-compression/jetty-compression-zstandard/src/test/java/org/eclipse/jetty/compression/zstandard/ZstandardEncoderSinkTest.java
+++ b/jetty-core/jetty-compression/jetty-compression-zstandard/src/test/java/org/eclipse/jetty/compression/zstandard/ZstandardEncoderSinkTest.java
@@ -146,7 +146,7 @@ public class ZstandardEncoderSinkTest extends AbstractZstdTest
         }
     }
 
-    public static Stream<Arguments> directBufferCases()
+    public static Stream<Arguments> largeDirectBufferCases()
     {
         return Stream.of(
             // dataSize, bufferSize, startOffset
@@ -159,8 +159,8 @@ public class ZstandardEncoderSinkTest extends AbstractZstdTest
     }
 
     @ParameterizedTest
-    @MethodSource("directBufferCases")
-    public void testDirectBuffer(int dataSize, int bufferSize, int startOffset) throws Exception
+    @MethodSource("largeDirectBufferCases")
+    public void testLargeDirectBuffer(int dataSize, int bufferSize, int startOffset) throws Exception
     {
         startZstd();
 

--- a/jetty-core/jetty-compression/jetty-compression-zstandard/src/test/java/org/eclipse/jetty/compression/zstandard/ZstandardEncoderSinkTest.java
+++ b/jetty-core/jetty-compression/jetty-compression-zstandard/src/test/java/org/eclipse/jetty/compression/zstandard/ZstandardEncoderSinkTest.java
@@ -18,6 +18,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Stream;
 
@@ -137,5 +138,110 @@ public class ZstandardEncoderSinkTest extends AbstractZstdTest
             ExecutionException thrown = assertThrows(ExecutionException.class, callback2::get);
             assertInstanceOf(IllegalStateException.class, thrown.getCause());
         }
+    }
+
+    public static Stream<Arguments> directBufferCases()
+    {
+        return Stream.of(
+            // dataSize, bufferSize, startOffset
+            Arguments.of(1024, 64 * 1024, 0),         // Small data, position 0
+            Arguments.of(1024, 64 * 1024, 512),       // Small data, non-zero position
+            Arguments.of(200 * 1024, 64 * 1024, 0),   // Large data exceeding bufferSize, position 0
+            Arguments.of(200 * 1024, 64 * 1024, 100), // Large data exceeding bufferSize, non-zero position
+            Arguments.of(21847 * 6, 132 * 1024, 0)    // Match frequentFlushing test size with direct buffer
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("directBufferCases")
+    public void testDirectBuffer(int dataSize, int bufferSize, int startOffset) throws Exception
+    {
+        startZstd();
+
+        // Generate test data
+        byte[] originalData = new byte[dataSize];
+        new Random(42).nextBytes(originalData);
+
+        // Create a direct buffer with extra space at the beginning to test non-zero positions
+        ByteBuffer directBuffer = ByteBuffer.allocateDirect(dataSize + startOffset);
+
+        // Fill the prefix area with garbage (to verify we don't accidentally read it)
+        for (int i = 0; i < startOffset; i++)
+        {
+            directBuffer.put((byte)0xFF);
+        }
+
+        // Put the actual data
+        directBuffer.put(originalData);
+
+        // Position the buffer to start at the offset where real data begins
+        directBuffer.position(startOffset);
+        directBuffer.limit(startOffset + dataSize);
+
+        byte[] compressed;
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream())
+        {
+            Content.Sink fileSink = Content.Sink.from(baos);
+            ZstandardEncoderConfig config = new ZstandardEncoderConfig();
+            config.setBufferSize(bufferSize);
+            Content.Sink encoderSink = zstd.newEncoderSink(fileSink, config);
+
+            Callback.Completable callback = new Callback.Completable();
+            encoderSink.write(true, directBuffer, callback);
+            callback.get();
+            compressed = baos.toByteArray();
+        }
+
+        // Verify the buffer position was properly advanced to the end
+        assertThat(directBuffer.remaining(), is(0));
+
+        // Verify decompressed content matches original
+        byte[] decompressed = decompress(compressed);
+        assertThat(decompressed.length, is(originalData.length));
+        for (int i = 0; i < originalData.length; i++)
+        {
+            assertThat("Mismatch at byte " + i, decompressed[i], is(originalData[i]));
+        }
+    }
+
+    @Test
+    public void testDirectBufferFrequentFlushing() throws Exception
+    {
+        startZstd();
+
+        int lineCount = 21847;
+        StringBuilder expected = new StringBuilder();
+        for (int i = 1; i <= lineCount; i++)
+        {
+            expected.append(String.format("%05d\n", i));
+        }
+
+        byte[] compressed;
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream())
+        {
+            Content.Sink fileSink = Content.Sink.from(baos);
+            ZstandardEncoderConfig config = new ZstandardEncoderConfig();
+            config.setBufferSize(132 * 1024);
+            Content.Sink encoderSink = zstd.newEncoderSink(fileSink, config);
+
+            // Write each line using a direct buffer
+            for (int i = 1; i <= lineCount; i++)
+            {
+                String line = String.format("%05d\n", i);
+                byte[] lineBytes = line.getBytes(UTF_8);
+                ByteBuffer directLine = ByteBuffer.allocateDirect(lineBytes.length);
+                directLine.put(lineBytes);
+                directLine.flip();
+
+                boolean isLast = (i == lineCount);
+                Callback.Completable callback = new Callback.Completable();
+                encoderSink.write(isLast, directLine, callback);
+                callback.get();
+            }
+            compressed = baos.toByteArray();
+        }
+
+        String decompressed = new String(decompress(compressed), UTF_8);
+        assertEquals(expected.toString(), decompressed);
     }
 }

--- a/jetty-core/jetty-compression/jetty-compression-zstandard/src/test/java/org/eclipse/jetty/compression/zstandard/ZstandardEncoderSinkTest.java
+++ b/jetty-core/jetty-compression/jetty-compression-zstandard/src/test/java/org/eclipse/jetty/compression/zstandard/ZstandardEncoderSinkTest.java
@@ -19,12 +19,14 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Stream;
 
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.util.Callback;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -36,52 +38,24 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ZstandardEncoderSinkTest extends AbstractZstdTest
 {
-    @Test
-    public void testFrequentFlushingAtBoundarySmallBuffer() throws Exception
+    public static Stream<Arguments> frequentFlushingCases()
     {
-        startZstd();
-
-        // Build expected content: 21847 lines of "NNNNN\n" (6 bytes each)
-        // 21845 * 6 = 131070 bytes, just under 128KB boundary
-        StringBuilder expected = new StringBuilder();
-        for (int i = 1; i <= 21847; i++)
-        {
-            expected.append(String.format("%05d\n", i));
-        }
-
-        byte[] compressed;
-        try (ByteArrayOutputStream baos = new ByteArrayOutputStream())
-        {
-            Content.Sink fileSink = Content.Sink.from(baos);
-            // Use default config (8KB buffer)
-            Content.Sink encoderSink = zstd.newEncoderSink(fileSink);
-
-            // Write each line separately (frequent flushing)
-            for (int i = 1; i <= 21847; i++)
-            {
-                String line = String.format("%05d\n", i);
-                boolean isLast = (i == 21847);
-                Callback.Completable callback = new Callback.Completable();
-                encoderSink.write(isLast, ByteBuffer.wrap(line.getBytes(UTF_8)), callback);
-                callback.get();
-            }
-            compressed = baos.toByteArray();
-        }
-
-        // Decompress and verify - should match exactly
-        String decompressed = new String(decompress(compressed), UTF_8);
-        assertEquals(expected.toString(), decompressed);
+        return Stream.of(
+            // lineCount, bufferSize (-1 means default)
+            Arguments.of(21847, -1),
+            Arguments.of(21847, 132 * 1024),
+            Arguments.of(50000, 132 * 1024)
+        );
     }
 
-    @Test
-    public void testFrequentFlushingAtBoundaryLargeBuffer() throws Exception
+    @ParameterizedTest
+    @MethodSource("frequentFlushingCases")
+    public void testFrequentFlushing(int lineCount, int bufferSize) throws Exception
     {
         startZstd();
 
-        // Build expected content: 21847 lines of "NNNNN\n" (6 bytes each)
-        // 21845 * 6 = 131070 bytes, just under 128KB boundary
         StringBuilder expected = new StringBuilder();
-        for (int i = 1; i <= 21847; i++)
+        for (int i = 1; i <= lineCount; i++)
         {
             expected.append(String.format("%05d\n", i));
         }
@@ -90,16 +64,22 @@ public class ZstandardEncoderSinkTest extends AbstractZstdTest
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream())
         {
             Content.Sink fileSink = Content.Sink.from(baos);
-            // Use larger buffer (132KB as recommended by zstd)
-            ZstandardEncoderConfig config = new ZstandardEncoderConfig();
-            config.setBufferSize(132 * 1024);
-            Content.Sink encoderSink = zstd.newEncoderSink(fileSink, config);
+            Content.Sink encoderSink;
+            if (bufferSize > 0)
+            {
+                ZstandardEncoderConfig config = new ZstandardEncoderConfig();
+                config.setBufferSize(bufferSize);
+                encoderSink = zstd.newEncoderSink(fileSink, config);
+            }
+            else
+            {
+                encoderSink = zstd.newEncoderSink(fileSink);
+            }
 
-            // Write each line separately (frequent flushing)
-            for (int i = 1; i <= 21847; i++)
+            for (int i = 1; i <= lineCount; i++)
             {
                 String line = String.format("%05d\n", i);
-                boolean isLast = (i == 21847);
+                boolean isLast = (i == lineCount);
                 Callback.Completable callback = new Callback.Completable();
                 encoderSink.write(isLast, ByteBuffer.wrap(line.getBytes(UTF_8)), callback);
                 callback.get();
@@ -107,46 +87,6 @@ public class ZstandardEncoderSinkTest extends AbstractZstdTest
             compressed = baos.toByteArray();
         }
 
-        // Decompress and verify - should match exactly
-        String decompressed = new String(decompress(compressed), UTF_8);
-        assertEquals(expected.toString(), decompressed);
-    }
-
-    @Test
-    public void testFrequentFlushingLargeBufferMultipleIterations() throws Exception
-    {
-        startZstd();
-
-        // Build expected content: 50000 lines of "NNNNN\n" (6 bytes each) = 300KB
-        // This exceeds 132KB buffer, forcing multiple iterations
-        StringBuilder expected = new StringBuilder();
-        for (int i = 1; i <= 50000; i++)
-        {
-            expected.append(String.format("%05d\n", i));
-        }
-
-        byte[] compressed;
-        try (ByteArrayOutputStream baos = new ByteArrayOutputStream())
-        {
-            Content.Sink fileSink = Content.Sink.from(baos);
-            // Use larger buffer (132KB as recommended by zstd)
-            ZstandardEncoderConfig config = new ZstandardEncoderConfig();
-            config.setBufferSize(132 * 1024);
-            Content.Sink encoderSink = zstd.newEncoderSink(fileSink, config);
-
-            // Write each line separately (frequent flushing)
-            for (int i = 1; i <= 50000; i++)
-            {
-                String line = String.format("%05d\n", i);
-                boolean isLast = (i == 50000);
-                Callback.Completable callback = new Callback.Completable();
-                encoderSink.write(isLast, ByteBuffer.wrap(line.getBytes(UTF_8)), callback);
-                callback.get();
-            }
-            compressed = baos.toByteArray();
-        }
-
-        // Decompress and verify - should match exactly
         String decompressed = new String(decompress(compressed), UTF_8);
         assertEquals(expected.toString(), decompressed);
     }

--- a/jetty-core/jetty-compression/jetty-compression-zstandard/src/test/java/org/eclipse/jetty/compression/zstandard/ZstandardEncoderSinkTest.java
+++ b/jetty-core/jetty-compression/jetty-compression-zstandard/src/test/java/org/eclipse/jetty/compression/zstandard/ZstandardEncoderSinkTest.java
@@ -36,16 +36,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ZstandardEncoderSinkTest extends AbstractZstdTest
 {
-    /**
-     * Test that frequent flushing causes byte duplication at the 128KB boundary with small buffer.
-     */
     @Test
     public void testFrequentFlushingAtBoundarySmallBuffer() throws Exception
     {
         startZstd();
 
-        // Build expected content: 21847 lines of "XXXXX\n" (6 bytes each)
-        // 21845 * 6 = 131070 bytes, which is just under 128KB boundary
+        // Build expected content: 21847 lines of "NNNNN\n" (6 bytes each)
+        // 21845 * 6 = 131070 bytes, just under 128KB boundary
         StringBuilder expected = new StringBuilder();
         for (int i = 1; i <= 21847; i++)
         {
@@ -76,18 +73,13 @@ public class ZstandardEncoderSinkTest extends AbstractZstdTest
         assertEquals(expected.toString(), decompressed);
     }
 
-    /**
-     * Test that frequent flushing works correctly with recommended 132KB buffer.
-     * Note: This test uses data that fits entirely in 132KB buffer, so it may
-     * pass simply by avoiding multiple iterations through the encoder loop.
-     */
     @Test
     public void testFrequentFlushingAtBoundaryLargeBuffer() throws Exception
     {
         startZstd();
 
-        // Build expected content: 21847 lines of "XXXXX\n" (6 bytes each)
-        // 21845 * 6 = 131070 bytes, which is just under 128KB boundary
+        // Build expected content: 21847 lines of "NNNNN\n" (6 bytes each)
+        // 21845 * 6 = 131070 bytes, just under 128KB boundary
         StringBuilder expected = new StringBuilder();
         for (int i = 1; i <= 21847; i++)
         {
@@ -120,16 +112,12 @@ public class ZstandardEncoderSinkTest extends AbstractZstdTest
         assertEquals(expected.toString(), decompressed);
     }
 
-    /**
-     * Test with data exceeding 132KB to force multiple iterations even with large buffer.
-     * 50000 lines * 6 bytes = 300KB, requiring multiple buffer fills even with 132KB buffer.
-     */
     @Test
     public void testFrequentFlushingLargeBufferMultipleIterations() throws Exception
     {
         startZstd();
 
-        // Build expected content: 50000 lines of "XXXXX\n" (6 bytes each) = 300KB
+        // Build expected content: 50000 lines of "NNNNN\n" (6 bytes each) = 300KB
         // This exceeds 132KB buffer, forcing multiple iterations
         StringBuilder expected = new StringBuilder();
         for (int i = 1; i <= 50000; i++)

--- a/jetty-core/jetty-compression/jetty-compression-zstandard/src/test/java/org/eclipse/jetty/compression/zstandard/ZstandardEncoderSinkTest.java
+++ b/jetty-core/jetty-compression/jetty-compression-zstandard/src/test/java/org/eclipse/jetty/compression/zstandard/ZstandardEncoderSinkTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -191,10 +192,6 @@ public class ZstandardEncoderSinkTest extends AbstractZstdTest
         assertThat(directBuffer.remaining(), is(0));
 
         byte[] decompressed = decompress(compressed);
-        assertThat(decompressed.length, is(originalData.length));
-        for (int i = 0; i < originalData.length; i++)
-        {
-            assertThat("Mismatch at byte " + i, decompressed[i], is(originalData[i]));
-        }
+        assertArrayEquals(originalData, decompressed);
     }
 }

--- a/jetty-core/jetty-compression/jetty-compression-zstandard/src/test/java/org/eclipse/jetty/compression/zstandard/ZstandardEncoderSinkTest.java
+++ b/jetty-core/jetty-compression/jetty-compression-zstandard/src/test/java/org/eclipse/jetty/compression/zstandard/ZstandardEncoderSinkTest.java
@@ -158,23 +158,13 @@ public class ZstandardEncoderSinkTest extends AbstractZstdTest
     {
         startZstd();
 
-        // Generate test data
         byte[] originalData = new byte[dataSize];
         new Random(42).nextBytes(originalData);
 
-        // Create a direct buffer with extra space at the beginning to test non-zero positions
         ByteBuffer directBuffer = ByteBuffer.allocateDirect(dataSize + startOffset);
-
-        // Fill the prefix area with garbage (to verify we don't accidentally read it)
         for (int i = 0; i < startOffset; i++)
-        {
             directBuffer.put((byte)0xFF);
-        }
-
-        // Put the actual data
         directBuffer.put(originalData);
-
-        // Position the buffer to start at the offset where real data begins
         directBuffer.position(startOffset);
         directBuffer.limit(startOffset + dataSize);
 
@@ -192,10 +182,8 @@ public class ZstandardEncoderSinkTest extends AbstractZstdTest
             compressed = baos.toByteArray();
         }
 
-        // Verify the buffer position was properly advanced to the end
         assertThat(directBuffer.remaining(), is(0));
 
-        // Verify decompressed content matches original
         byte[] decompressed = decompress(compressed);
         assertThat(decompressed.length, is(originalData.length));
         for (int i = 0; i < originalData.length; i++)
@@ -224,7 +212,6 @@ public class ZstandardEncoderSinkTest extends AbstractZstdTest
             config.setBufferSize(132 * 1024);
             Content.Sink encoderSink = zstd.newEncoderSink(fileSink, config);
 
-            // Write each line using a direct buffer
             for (int i = 1; i <= lineCount; i++)
             {
                 String line = String.format("%05d\n", i);

--- a/jetty-core/jetty-compression/jetty-compression-zstandard/src/test/java/org/eclipse/jetty/compression/zstandard/ZstandardEncoderSinkTest.java
+++ b/jetty-core/jetty-compression/jetty-compression-zstandard/src/test/java/org/eclipse/jetty/compression/zstandard/ZstandardEncoderSinkTest.java
@@ -42,16 +42,17 @@ public class ZstandardEncoderSinkTest extends AbstractZstdTest
     public static Stream<Arguments> frequentFlushingCases()
     {
         return Stream.of(
-            // lineCount, bufferSize (-1 means default)
-            Arguments.of(21847, -1),
-            Arguments.of(21847, 132 * 1024),
-            Arguments.of(50000, 132 * 1024)
+            // lineCount, bufferSize (-1 means default), useDirect
+            Arguments.of(21847, -1, false),
+            Arguments.of(21847, 132 * 1024, false),
+            Arguments.of(50000, 132 * 1024, false),
+            Arguments.of(21847, 132 * 1024, true)
         );
     }
 
     @ParameterizedTest
     @MethodSource("frequentFlushingCases")
-    public void testFrequentFlushing(int lineCount, int bufferSize) throws Exception
+    public void testFrequentFlushing(int lineCount, int bufferSize, boolean useDirect) throws Exception
     {
         startZstd();
 
@@ -80,9 +81,14 @@ public class ZstandardEncoderSinkTest extends AbstractZstdTest
             for (int i = 1; i <= lineCount; i++)
             {
                 String line = String.format("%05d\n", i);
+                byte[] lineBytes = line.getBytes(UTF_8);
+                ByteBuffer buffer = useDirect ? ByteBuffer.allocateDirect(lineBytes.length) : ByteBuffer.allocate(lineBytes.length);
+                buffer.put(lineBytes);
+                buffer.flip();
+
                 boolean isLast = (i == lineCount);
                 Callback.Completable callback = new Callback.Completable();
-                encoderSink.write(isLast, ByteBuffer.wrap(line.getBytes(UTF_8)), callback);
+                encoderSink.write(isLast, buffer, callback);
                 callback.get();
             }
             compressed = baos.toByteArray();
@@ -190,45 +196,5 @@ public class ZstandardEncoderSinkTest extends AbstractZstdTest
         {
             assertThat("Mismatch at byte " + i, decompressed[i], is(originalData[i]));
         }
-    }
-
-    @Test
-    public void testDirectBufferFrequentFlushing() throws Exception
-    {
-        startZstd();
-
-        int lineCount = 21847;
-        StringBuilder expected = new StringBuilder();
-        for (int i = 1; i <= lineCount; i++)
-        {
-            expected.append(String.format("%05d\n", i));
-        }
-
-        byte[] compressed;
-        try (ByteArrayOutputStream baos = new ByteArrayOutputStream())
-        {
-            Content.Sink fileSink = Content.Sink.from(baos);
-            ZstandardEncoderConfig config = new ZstandardEncoderConfig();
-            config.setBufferSize(132 * 1024);
-            Content.Sink encoderSink = zstd.newEncoderSink(fileSink, config);
-
-            for (int i = 1; i <= lineCount; i++)
-            {
-                String line = String.format("%05d\n", i);
-                byte[] lineBytes = line.getBytes(UTF_8);
-                ByteBuffer directLine = ByteBuffer.allocateDirect(lineBytes.length);
-                directLine.put(lineBytes);
-                directLine.flip();
-
-                boolean isLast = (i == lineCount);
-                Callback.Completable callback = new Callback.Completable();
-                encoderSink.write(isLast, directLine, callback);
-                callback.get();
-            }
-            compressed = baos.toByteArray();
-        }
-
-        String decompressed = new String(decompress(compressed), UTF_8);
-        assertEquals(expected.toString(), decompressed);
     }
 }

--- a/jetty-core/jetty-compression/jetty-compression-zstandard/src/test/java/org/eclipse/jetty/compression/zstandard/ZstandardEncoderSinkTest.java
+++ b/jetty-core/jetty-compression/jetty-compression-zstandard/src/test/java/org/eclipse/jetty/compression/zstandard/ZstandardEncoderSinkTest.java
@@ -36,6 +36,133 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ZstandardEncoderSinkTest extends AbstractZstdTest
 {
+    /**
+     * Test that frequent flushing causes byte duplication at the 128KB boundary with small buffer.
+     */
+    @Test
+    public void testFrequentFlushingAtBoundarySmallBuffer() throws Exception
+    {
+        startZstd();
+
+        // Build expected content: 21847 lines of "XXXXX\n" (6 bytes each)
+        // 21845 * 6 = 131070 bytes, which is just under 128KB boundary
+        StringBuilder expected = new StringBuilder();
+        for (int i = 1; i <= 21847; i++)
+        {
+            expected.append(String.format("%05d\n", i));
+        }
+
+        byte[] compressed;
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream())
+        {
+            Content.Sink fileSink = Content.Sink.from(baos);
+            // Use default config (8KB buffer)
+            Content.Sink encoderSink = zstd.newEncoderSink(fileSink);
+
+            // Write each line separately (frequent flushing)
+            for (int i = 1; i <= 21847; i++)
+            {
+                String line = String.format("%05d\n", i);
+                boolean isLast = (i == 21847);
+                Callback.Completable callback = new Callback.Completable();
+                encoderSink.write(isLast, ByteBuffer.wrap(line.getBytes(UTF_8)), callback);
+                callback.get();
+            }
+            compressed = baos.toByteArray();
+        }
+
+        // Decompress and verify - should match exactly
+        String decompressed = new String(decompress(compressed), UTF_8);
+        assertEquals(expected.toString(), decompressed);
+    }
+
+    /**
+     * Test that frequent flushing works correctly with recommended 132KB buffer.
+     * Note: This test uses data that fits entirely in 132KB buffer, so it may
+     * pass simply by avoiding multiple iterations through the encoder loop.
+     */
+    @Test
+    public void testFrequentFlushingAtBoundaryLargeBuffer() throws Exception
+    {
+        startZstd();
+
+        // Build expected content: 21847 lines of "XXXXX\n" (6 bytes each)
+        // 21845 * 6 = 131070 bytes, which is just under 128KB boundary
+        StringBuilder expected = new StringBuilder();
+        for (int i = 1; i <= 21847; i++)
+        {
+            expected.append(String.format("%05d\n", i));
+        }
+
+        byte[] compressed;
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream())
+        {
+            Content.Sink fileSink = Content.Sink.from(baos);
+            // Use larger buffer (132KB as recommended by zstd)
+            ZstandardEncoderConfig config = new ZstandardEncoderConfig();
+            config.setBufferSize(132 * 1024);
+            Content.Sink encoderSink = zstd.newEncoderSink(fileSink, config);
+
+            // Write each line separately (frequent flushing)
+            for (int i = 1; i <= 21847; i++)
+            {
+                String line = String.format("%05d\n", i);
+                boolean isLast = (i == 21847);
+                Callback.Completable callback = new Callback.Completable();
+                encoderSink.write(isLast, ByteBuffer.wrap(line.getBytes(UTF_8)), callback);
+                callback.get();
+            }
+            compressed = baos.toByteArray();
+        }
+
+        // Decompress and verify - should match exactly
+        String decompressed = new String(decompress(compressed), UTF_8);
+        assertEquals(expected.toString(), decompressed);
+    }
+
+    /**
+     * Test with data exceeding 132KB to force multiple iterations even with large buffer.
+     * 50000 lines * 6 bytes = 300KB, requiring multiple buffer fills even with 132KB buffer.
+     */
+    @Test
+    public void testFrequentFlushingLargeBufferMultipleIterations() throws Exception
+    {
+        startZstd();
+
+        // Build expected content: 50000 lines of "XXXXX\n" (6 bytes each) = 300KB
+        // This exceeds 132KB buffer, forcing multiple iterations
+        StringBuilder expected = new StringBuilder();
+        for (int i = 1; i <= 50000; i++)
+        {
+            expected.append(String.format("%05d\n", i));
+        }
+
+        byte[] compressed;
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream())
+        {
+            Content.Sink fileSink = Content.Sink.from(baos);
+            // Use larger buffer (132KB as recommended by zstd)
+            ZstandardEncoderConfig config = new ZstandardEncoderConfig();
+            config.setBufferSize(132 * 1024);
+            Content.Sink encoderSink = zstd.newEncoderSink(fileSink, config);
+
+            // Write each line separately (frequent flushing)
+            for (int i = 1; i <= 50000; i++)
+            {
+                String line = String.format("%05d\n", i);
+                boolean isLast = (i == 50000);
+                Callback.Completable callback = new Callback.Completable();
+                encoderSink.write(isLast, ByteBuffer.wrap(line.getBytes(UTF_8)), callback);
+                callback.get();
+            }
+            compressed = baos.toByteArray();
+        }
+
+        // Decompress and verify - should match exactly
+        String decompressed = new String(decompress(compressed), UTF_8);
+        assertEquals(expected.toString(), decompressed);
+    }
+
     @ParameterizedTest
     @MethodSource("textResources")
     public void testEncodeText(String textResourceName) throws Exception


### PR DESCRIPTION
Fixes #14319

When ZSTD compression produces output before consuming all input bytes, the encoder incorrectly rolled back to the original buffer position instead of accounting for bytes already consumed by zstd. This caused byte duplication at the 128KB boundary.

- `continueOp()`: Change `content.position(originalPosition)` to `content.position(originalPosition + inputBuf.getByteBuffer().position())` for heap buffers only
- `ensureDirect()`: Refactored per review feedback - uses absolute `put()` and doesn't modify source buffer position (position tracking now happens solely in `continueOp()`) 
