### PR TITLE
Fixes #14330 - VirtualThreadPool can create unlimited threads while doc mentions otherwise.

### DIFF
--- a/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/ArchitectureDocs.java
+++ b/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/ArchitectureDocs.java
@@ -82,7 +82,7 @@ public class ArchitectureDocs
 
         // Configurable, bounded, virtual thread executor (preferred).
         VirtualThreadPool virtualExecutor = new VirtualThreadPool();
-        virtualExecutor.setMaxThreads(128);
+        virtualExecutor.setMaxConcurrentTasks(128);
         threadPool.setVirtualThreadsExecutor(virtualExecutor);
 
         // For server-side usage.
@@ -103,8 +103,8 @@ public class ArchitectureDocs
     {
         // tag::virtualVirtual[]
         VirtualThreadPool threadPool = new VirtualThreadPool();
-        // Limit the max number of current virtual threads.
-        threadPool.setMaxThreads(200);
+        // Limit the max number of concurrent tasks run by virtual threads.
+        threadPool.setMaxConcurrentTasks(200);
         // Track, with details, virtual threads usage.
         threadPool.setTracking(true);
         threadPool.setDetailedDump(true);

--- a/documentation/jetty/modules/operations-guide/pages/modules/standard.adoc
+++ b/documentation/jetty/modules/operations-guide/pages/modules/standard.adoc
@@ -973,8 +973,12 @@ The specific properties to configure virtual threads are:
 `jetty.threadPool.virtual.namePrefix`::
 The name prefix to use for the virtual thread names.
 
-`jetty.threadPool.virtual.inheritInheritableThreadLocals`::
-Whether virtual threads inherit the values of `InheritableThreadLocal` variables.
+`jetty.threadPool.virtual.tracking`::
+Whether to track virtual threads so that they appear in a xref:troubleshooting/index.adoc#dump[Server Dump] even when they are unmounted.
+
+`jetty.threadPool.virtual.maxConcurrentTasks`::
+The number of concurrent tasks run by virtual threads.
+This property limits resource usage, avoiding that virtual threads run an unlimited number of concurrent tasks when the system is under load.
 
 [[threadpool-virtual-preview]]
 == Module `threadpool-virtual-preview`

--- a/documentation/jetty/modules/programming-guide/pages/arch/threads.adoc
+++ b/documentation/jetty/modules/programming-guide/pages/arch/threads.adoc
@@ -397,12 +397,20 @@ Defaulting the number of reserved threads to zero ensures that the <<execution-s
 include::code:example$src/main/java/org/eclipse/jetty/docs/programming/ArchitectureDocs.java[tags=virtualVirtual]
 ----
 
-Despite the name, `VirtualThreadPool` does not pool virtual threads, but allows you to impose a limit on the maximum number of current virtual threads, using a `Semaphore`.
+Despite the name, `VirtualThreadPool` does not pool virtual threads, but allows you to impose a limit on the maximum number of concurrent tasks run by virtual threads, using a `Semaphore`.
 
-Limiting the number of current virtual threads helps to limit resource usage in applications, especially in case of load spikes.
-When an unlimited number of virtual threads is allowed, the server might be brought down due to resource (typically memory) exhaustion.
+Limiting the number of concurrent tasks run by virtual threads helps to limit resource usage in applications, especially in the case of load spikes.
+When an unlimited number of tasks run by virtual threads is allowed, the server might be brought down due to resource (typically memory) exhaustion.
 
-Furthermore, you can configure it to track virtual threads so that a xref:troubleshooting/component-dump.adoc[Jetty component dump] will show all virtual threads currently in use, including those that are unmounted.
+Furthermore, you can configure `VirtualThreadPool` to track virtual threads so that a xref:troubleshooting/component-dump.adoc[Jetty component dump] will show all virtual threads currently in use, including those that are unmounted.
+
+[NOTE]
+====
+`VirtualThreadPool` does not queue the tasks submitted to it but rather spawns a virtual thread to run the task.
+When the virtual thread runs, it attempts to acquire a permit from the `Semaphore`, and only if it succeeds to acquire the permit then the task is run.
+
+This means that there may be more virtual threads than permits, but it is guaranteed that the number of concurrent tasks run by virtual threads is limited by the `Semaphore`.
+====
 
 [[thread-pool-virtual-threads-pinning]]
 ==== Virtual Threads Pinning

--- a/jetty-core/jetty-server/src/main/config/etc/jetty-threadpool-all-virtual.xml
+++ b/jetty-core/jetty-server/src/main/config/etc/jetty-threadpool-all-virtual.xml
@@ -3,7 +3,7 @@
 
 <Configure>
   <New id="threadPool" class="org.eclipse.jetty.util.thread.VirtualThreadPool">
-    <Arg type="int"><Property name="jetty.threadPool.maxThreads" default="200" /></Arg>
+    <Arg type="int"><Property name="jetty.threadPool.maxConcurrentTasks"  deprecated="jetty.threadPool.maxThreads" default="200" /></Arg>
     <Set name="name" property="jetty.threadPool.namePrefix" />
     <Set name="tracking" property="jetty.threadPool.tracking" />
     <Set name="detailedDump" property="jetty.threadPool.detailedDump" />

--- a/jetty-core/jetty-server/src/main/config/etc/jetty-threadpool-virtual.xml
+++ b/jetty-core/jetty-server/src/main/config/etc/jetty-threadpool-virtual.xml
@@ -19,7 +19,7 @@
               <Default><Ref refid="namePrefix" />-virtual-</Default>
             </Property>
           </Set>
-          <Set name="maxThreads" property="jetty.threadPool.virtual.maxThreads" />
+          <Set name="maxThreads"><Property name="jetty.threadPool.virtual.maxConcurrentTasks" deprecated="jetty.threadPool.virtual.maxThreads" default="200" /></Set>
           <Set name="tracking" property="jetty.threadPool.virtual.tracking" />
           <Set name="detailedDump" property="jetty.threadPool.detailedDump" />
         </New>

--- a/jetty-core/jetty-server/src/main/config/modules/threadpool-all-virtual.mod
+++ b/jetty-core/jetty-server/src/main/config/modules/threadpool-all-virtual.mod
@@ -16,8 +16,8 @@ etc/jetty-threadpool-all-virtual.xml
 ## Virtual threads name prefix.
 #jetty.threadPool.namePrefix=vtp<hashCode>
 
-## Maximum number of current virtual threads.
-#jetty.threadPool.maxThreads=200
+## Maximum number of concurrent tasks run by virtual threads.
+#jetty.threadPool.maxConcurrentTasks=200
 
 ## Whether to track virtual threads so they appear
 ## in the dump even if they are unmounted.

--- a/jetty-core/jetty-server/src/main/config/modules/threadpool-virtual.mod
+++ b/jetty-core/jetty-server/src/main/config/modules/threadpool-virtual.mod
@@ -37,8 +37,8 @@ etc/jetty-threadpool-virtual.xml
 ## Virtual threads name prefix.
 #jetty.threadPool.virtual.namePrefix=qtp<hashCode>-virtual-
 
-## Max number of current virtual threads.
-#jetty.threadPool.virtual.maxThreads=200
+## Max number of concurrent tasks run by virtual threads.
+#jetty.threadPool.virtual.maxConcurrentTasks=200
 
 ## Whether to track virtual threads so they appear
 ## in the dump even if they are unmounted.

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/VirtualThreadPool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/VirtualThreadPool.java
@@ -29,9 +29,10 @@ import org.slf4j.LoggerFactory;
 
 /**
  * <p>An implementation of {@link ThreadPool} interface that does not pool, but instead uses {@link VirtualThreads}.</p>
- * <p>It is possible to specify the max number of concurrent virtual threads that can be spawned, to help limiting
- * resource usage in applications, especially in case of load spikes, where an unlimited number of virtual threads
- * may be spawned, compete for resources, and eventually bring the system down due to memory exhaustion.</p>
+ * <p>It is possible to specify the max number of concurrent tasks run by virtual threads, to help limiting
+ * resource usage in applications, especially in the case of load spikes.
+ * An unlimited number of tasks run concurrently by virtual threads may compete for resources and eventually
+ * bring the system down due to memory exhaustion.</p>
  */
 @ManagedObject("A thread non-pool for virtual threads")
 public class VirtualThreadPool extends ContainerLifeCycle implements ThreadPool, Dumpable, TryExecutor, VirtualThreads.Configurable
@@ -40,7 +41,7 @@ public class VirtualThreadPool extends ContainerLifeCycle implements ThreadPool,
 
     private final AutoLock.WithCondition _joinLock = new AutoLock.WithCondition();
     private String _name;
-    private int _maxThreads;
+    private int _maxTasks;
     private boolean _tracking;
     private boolean _detailedDump;
     private Thread _keepAlive;
@@ -53,11 +54,11 @@ public class VirtualThreadPool extends ContainerLifeCycle implements ThreadPool,
         this(200);
     }
 
-    public VirtualThreadPool(int maxThreads)
+    public VirtualThreadPool(int maxTasks)
     {
         if (!VirtualThreads.areSupported())
             throw new IllegalStateException("Virtual Threads not supported");
-        _maxThreads = maxThreads;
+        _maxTasks = maxTasks;
     }
 
     /**
@@ -84,22 +85,42 @@ public class VirtualThreadPool extends ContainerLifeCycle implements ThreadPool,
     }
 
     /**
-     * @return the maximum number of concurrent virtual threads
+     * @return the maximum number of concurrent tasks run by virtual threads
+     * @deprecated use {@link #getMaxConcurrentTasks()} instead
      */
-    @ManagedAttribute("The max number of concurrent virtual threads")
+    @Deprecated(forRemoval = true, since = "12.1.6")
     public int getMaxThreads()
     {
-        return _maxThreads;
+        return getMaxConcurrentTasks();
     }
 
     /**
-     * @param maxThreads the maximum number of concurrent virtual threads
+     * @param maxTasks the maximum number of concurrent tasks run by virtual threads
+     * @deprecated use {@link #setMaxConcurrentTasks(int)} instead
      */
-    public void setMaxThreads(int maxThreads)
+    @Deprecated(forRemoval = true, since = "12.1.6")
+    public void setMaxThreads(int maxTasks)
+    {
+        setMaxConcurrentTasks(maxTasks);
+    }
+
+    /**
+     * @return the maximum number of concurrent tasks run by virtual threads
+     */
+    @ManagedAttribute("The max number of concurrent tasks run by virtual threads")
+    public int getMaxConcurrentTasks()
+    {
+        return _maxTasks;
+    }
+
+    /**
+     * @param maxConcurrentTasks the maximum number of concurrent tasks run by virtual threads
+     */
+    public void setMaxConcurrentTasks(int maxConcurrentTasks)
     {
         if (isRunning())
             throw new IllegalStateException(getState());
-        _maxThreads = maxThreads;
+        _maxTasks = maxConcurrentTasks;
     }
 
     /**
@@ -163,13 +184,14 @@ public class VirtualThreadPool extends ContainerLifeCycle implements ThreadPool,
                 ? VirtualThreads.getDefaultVirtualThreadsExecutor()
                 : VirtualThreads.getNamedVirtualThreadsExecutor(_name));
         }
-        if (_tracking && !(_virtualExecutor instanceof TrackingExecutor))
+        if (isTracking() && !(_virtualExecutor instanceof TrackingExecutor))
             _virtualExecutor = new TrackingExecutor(_virtualExecutor, isDetailedDump());
         addBean(_virtualExecutor);
 
-        if (_maxThreads > 0)
+        int maxTasks = getMaxConcurrentTasks();
+        if (maxTasks > 0)
         {
-            _semaphore = new Semaphore(_maxThreads);
+            _semaphore = new Semaphore(maxTasks);
             addBean(_semaphore);
         }
 
@@ -271,7 +293,7 @@ public class VirtualThreadPool extends ContainerLifeCycle implements ThreadPool,
                     // The caller of execute(Runnable) cannot be blocked,
                     // as it is unknown whether it is a virtual thread.
                     // But this is a virtual thread, so acquiring a permit here
-                    // blocks the virtual thread, but does not pin the carrier.
+                    // blocks the virtual thread but does not pin the carrier.
                     semaphore.acquire();
                     task.run();
                 }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/thread/VirtualThreadPoolTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/thread/VirtualThreadPoolTest.java
@@ -150,10 +150,10 @@ public class VirtualThreadPoolTest
     }
 
     @Test
-    public void testMaxThreads() throws Exception
+    public void testMaxConcurrentTasks() throws Exception
     {
         VirtualThreadPool vtp = new VirtualThreadPool();
-        vtp.setMaxThreads(1);
+        vtp.setMaxConcurrentTasks(1);
         vtp.start();
 
         AtomicBoolean run1 = new AtomicBoolean();


### PR DESCRIPTION
Updated the documentation to say that it is the number of concurrent tasks that it is limited, not the number of virtual threads.