### PR TITLE
Issue #14360 - update missing entries in ee8-bom

### DIFF
--- a/jetty-ee8/jetty-ee8-bom/pom.xml
+++ b/jetty-ee8/jetty-ee8-bom/pom.xml
@@ -28,7 +28,17 @@
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
+        <artifactId>jetty-ee8-cdi</artifactId>
+        <version>12.1.6-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-glassfish-jstl</artifactId>
+        <version>12.1.6-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee8</groupId>
+        <artifactId>jetty-ee8-jaspi</artifactId>
         <version>12.1.6-SNAPSHOT</version>
       </dependency>
       <dependency>
@@ -79,6 +89,16 @@
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-webapp</artifactId>
+        <version>12.1.6-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee8.osgi</groupId>
+        <artifactId>jetty-ee8-osgi-boot</artifactId>
+        <version>12.1.6-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee8.osgi</groupId>
+        <artifactId>jetty-ee8-osgi-boot-jsp</artifactId>
         <version>12.1.6-SNAPSHOT</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
## Closes #14360 

Update the ee8-bom with entries which were included in the ee9-bom but do not exist in the ee8 one.

Note: this is excluding `fcgi-proxy` (which does exist in the ee9-bom) because there is no ee8 version of this right now.