### PR TITLE
Replace `Invocable.ReadyTask` instantiations with `Invocable.from()` calls

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpReceiver.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpReceiver.java
@@ -681,7 +681,7 @@ public abstract class HttpReceiver implements Invocable
         @Override
         public void demand(Runnable demandCallback)
         {
-            Runnable demand = new Invocable.ReadyTask(Invocable.getInvocationType(demandCallback), () -> invoker.run(demandCallback));
+            Runnable demand = Invocable.from(Invocable.getInvocationType(demandCallback), () -> invoker.run(demandCallback));
             source.demand(demand);
         }
 

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/ClientHTTP2StreamEndPoint.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/ClientHTTP2StreamEndPoint.java
@@ -50,7 +50,7 @@ public class ClientHTTP2StreamEndPoint extends HTTP2StreamEndPoint implements HT
     public Runnable onDataAvailable()
     {
         // The InvocationType may change depending on the read callback.
-        return new Invocable.ReadyTask(getInvocationType(), this::processDataAvailable);
+        return Invocable.from(getInvocationType(), this::processDataAvailable);
     }
 
     @Override

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpReceiverOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpReceiverOverHTTP2.java
@@ -140,7 +140,7 @@ public class HttpReceiverOverHTTP2 extends HttpReceiver implements HTTP2Channel.
             return null;
         }
 
-        return new Invocable.ReadyTask(getHttpConnection().getInvocationType(), () ->
+        return Invocable.from(getHttpConnection().getInvocationType(), () ->
         {
             MetaData.Response response = (MetaData.Response)frame.getMetaData();
             HttpResponse httpResponse = exchange.getResponse();
@@ -241,7 +241,7 @@ public class HttpReceiverOverHTTP2 extends HttpReceiver implements HTTP2Channel.
         if (exchange == null)
             return null;
         // Retrieve the InvocationType from the Content.Source, rather than from the Connection.
-        return new Invocable.ReadyTask(getInvocationType(), () -> responseContentAvailable(exchange));
+        return Invocable.from(getInvocationType(), () -> responseContentAvailable(exchange));
     }
 
     @Override
@@ -257,7 +257,7 @@ public class HttpReceiverOverHTTP2 extends HttpReceiver implements HTTP2Channel.
         int error = frame.getError();
         IOException failure = new IOException(ErrorCode.toString(error, "reset_code_" + error));
         Runnable task = () -> callback.completeWith(exchange.getRequest().abort(failure));
-        return new Invocable.ReadyTask(getHttpConnection().getInvocationType(), task);
+        return Invocable.from(getHttpConnection().getInvocationType(), task);
     }
 
     @Override
@@ -270,7 +270,7 @@ public class HttpReceiverOverHTTP2 extends HttpReceiver implements HTTP2Channel.
             return null;
         }
         Runnable task = () -> Promise.completeWith(promise, exchange.getRequest().abort(failure));
-        return new Invocable.ReadyTask(getHttpConnection().getInvocationType(), task);
+        return Invocable.from(getHttpConnection().getInvocationType(), task);
     }
 
     @Override

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
@@ -130,24 +130,20 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
                 throw new HttpException.RuntimeException(HttpStatus.EXPECTATION_FAILED_417);
 
             InvocationType invocationType = Invocable.getInvocationType(handler);
-            return new ReadyTask(invocationType, handler)
+            return Invocable.from(invocationType, () ->
             {
-                @Override
-                public void run()
+                if (_stream.isClosed())
                 {
-                    if (_stream.isClosed())
-                    {
-                        if (LOG.isDebugEnabled())
-                            LOG.debug("HTTP2 request #{}/{} skipped handling, stream already closed {}",
-                                _stream.getId(), Integer.toHexString(_stream.getSession().hashCode()),
-                                _stream);
-                    }
-                    else
-                    {
-                        super.run();
-                    }
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("HTTP2 request #{}/{} skipped handling, stream already closed {}",
+                            _stream.getId(), Integer.toHexString(_stream.getSession().hashCode()),
+                            _stream);
                 }
-            };
+                else
+                {
+                    handler.run();
+                }
+            });
         }
         catch (Throwable x)
         {

--- a/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpReceiverOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpReceiverOverHTTP3.java
@@ -109,7 +109,7 @@ public class HttpReceiverOverHTTP3 extends HttpReceiver
         if (exchange == null)
             return null;
 
-        return new Invocable.ReadyTask(getHttpConnection().getInvocationType(), () ->
+        return Invocable.from(getHttpConnection().getInvocationType(), () ->
         {
             HttpResponse httpResponse = exchange.getResponse();
             MetaData.Response response = (MetaData.Response)frame.getMetaData();
@@ -139,7 +139,7 @@ public class HttpReceiverOverHTTP3 extends HttpReceiver
             return null;
 
         Runnable task = () -> responseContentAvailable(exchange);
-        return new Invocable.ReadyTask(getInvocationType(), task);
+        return Invocable.from(getInvocationType(), task);
     }
 
     Runnable onTrailer(HeadersFrame frame)
@@ -152,7 +152,7 @@ public class HttpReceiverOverHTTP3 extends HttpReceiver
         trailers.forEach(exchange.getResponse()::trailer);
 
         Runnable task = () -> responseSuccess(null);
-        return new Invocable.ReadyTask(getHttpConnection().getInvocationType(), task);
+        return Invocable.from(getHttpConnection().getInvocationType(), task);
     }
 
     Runnable onIdleTimeout(Throwable failure, Promise<Boolean> promise)
@@ -164,7 +164,7 @@ public class HttpReceiverOverHTTP3 extends HttpReceiver
             return null;
         }
         Runnable task = () -> Promise.completeWith(promise, exchange.getRequest().abort(failure));
-        return new Invocable.ReadyTask(getHttpConnection().getInvocationType(), task);
+        return Invocable.from(getHttpConnection().getInvocationType(), task);
     }
 
     Runnable onFailure(Throwable failure)
@@ -173,6 +173,6 @@ public class HttpReceiverOverHTTP3 extends HttpReceiver
             failure = new RetryableRequestException(failure);
         Throwable f = failure;
         Runnable task = () -> responseFailure(f, Promise.noop());
-        return new Invocable.ReadyTask(getHttpConnection().getInvocationType(), task);
+        return Invocable.from(getHttpConnection().getInvocationType(), task);
     }
 }

--- a/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HttpStreamOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HttpStreamOverHTTP3.java
@@ -116,24 +116,20 @@ public class HttpStreamOverHTTP3 implements HttpStream
                 throw new HttpException.RuntimeException(HttpStatus.EXPECTATION_FAILED_417);
 
             InvocationType invocationType = Invocable.getInvocationType(handler);
-            return new ReadyTask(invocationType, handler)
+            return Invocable.from(invocationType, () ->
             {
-                @Override
-                public void run()
+                if (stream.isClosed())
                 {
-                    if (stream.isClosed())
-                    {
-                        if (LOG.isDebugEnabled())
-                            LOG.debug("HTTP3 request #{}/{} skipped handling, stream already closed {}",
-                                stream.getId(), Integer.toHexString(stream.getSession().hashCode()),
-                                stream);
-                    }
-                    else
-                    {
-                        super.run();
-                    }
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("HTTP3 request #{}/{} skipped handling, stream already closed {}",
+                            stream.getId(), Integer.toHexString(stream.getSession().hashCode()),
+                            stream);
                 }
-            };
+                else
+                {
+                    handler.run();
+                }
+            });
         }
         catch (Throwable x)
         {

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -1321,7 +1321,7 @@ public class HttpChannelState implements HttpChannel, Components
 
                 if (writeFailure == NOTHING_TO_SEND)
                 {
-                    httpChannelState._writeInvoker.run(new ReadyTask(callback.getInvocationType(), callback::succeeded));
+                    httpChannelState._writeInvoker.run(Invocable.from(callback.getInvocationType(), callback::succeeded));
                     return;
                 }
                 // Have we failed in some way?
@@ -1368,7 +1368,7 @@ public class HttpChannelState implements HttpChannel, Components
             }
 
             if (callback != null)
-                httpChannel._writeInvoker.run(new ReadyTask(callback.getInvocationType(), callback::succeeded));
+                httpChannel._writeInvoker.run(Invocable.from(callback.getInvocationType(), callback::succeeded));
         }
 
         /**

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -496,8 +496,12 @@ public class HttpChannelState implements HttpChannel, Components
                     }
                 };
 
-                // Serialize all the error actions.
-                task = Invocable.combine(_readInvoker.offer(invokeOnContentAvailable), _writeInvoker.offer(invokeWriteFailure), _readInvoker.offer(invokeOnFailureListeners));
+                // Serialize all the error actions, keep each call on a separate line to help with debugging.
+                task = Invocable.combine(
+                    _readInvoker.offer(invokeOnContentAvailable),
+                    _writeInvoker.offer(invokeWriteFailure),
+                    _readInvoker.offer(invokeOnFailureListeners)
+                );
             }
         }
 

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/thread/strategy/AdaptiveExecutionStrategyTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/thread/strategy/AdaptiveExecutionStrategyTest.java
@@ -27,6 +27,7 @@ import org.eclipse.jetty.util.thread.ReservedThreadExecutor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class AdaptiveExecutionStrategyTest
@@ -43,10 +44,7 @@ public class AdaptiveExecutionStrategyTest
         executor.tryExecute(() ->
         {
         });
-        while (tryExecutor.getAvailable() == 0)
-        {
-            Thread.sleep(10);
-        }
+        await().atMost(5, TimeUnit.SECONDS).until(() -> tryExecutor.getAvailable() != 0);
     }
 
     @AfterEach
@@ -59,11 +57,11 @@ public class AdaptiveExecutionStrategyTest
     @Test
     public void testExceptionThrownByTask() throws Exception
     {
-        try (StacklessLogging ignored = new StacklessLogging(AdaptiveExecutionStrategy.class))
+        try (StacklessLogging ignored = new StacklessLogging(QueuedThreadPool.class))
         {
             AtomicReference<Throwable> detector = new AtomicReference<>();
             CountDownLatch latch = new CountDownLatch(2);
-            BlockingQueue<Invocable.ReadyTask> tasks = new LinkedBlockingQueue<>();
+            BlockingQueue<Invocable.Task> tasks = new LinkedBlockingQueue<>();
             startAES(() ->
             {
                 boolean proceed = detector.compareAndSet(null, new Throwable());
@@ -92,7 +90,7 @@ public class AdaptiveExecutionStrategyTest
             // Start production in another thread.
             aes.dispatch();
 
-            tasks.offer(new Invocable.ReadyTask(Invocable.InvocationType.BLOCKING, () ->
+            tasks.offer(Invocable.from(Invocable.InvocationType.BLOCKING, () ->
             {
                 try
                 {
@@ -111,10 +109,7 @@ public class AdaptiveExecutionStrategyTest
             }));
 
             // Wait until AES is idle.
-            while (!aes.isIdle())
-            {
-                Thread.sleep(10);
-            }
+            await().atMost(5, TimeUnit.SECONDS).until(() -> aes.isIdle());
 
             assertNull(detector.get());
         }


### PR DESCRIPTION
This is the unquestioned part of https://github.com/jetty/jetty.project/pull/14318.