### PR TITLE
Issue #14360 - update missing entries in ee8-bom (cherry-pick to 12.0.x)

### DIFF
--- a/jetty-ee8/jetty-ee8-bom/pom.xml
+++ b/jetty-ee8/jetty-ee8-bom/pom.xml
@@ -28,8 +28,18 @@
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
+        <artifactId>jetty-ee8-cdi</artifactId>
+        <version>12.1.6-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-glassfish-jstl</artifactId>
         <version>12.0.32-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee8</groupId>
+        <artifactId>jetty-ee8-jaspi</artifactId>
+        <version>12.1.6-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
@@ -80,6 +90,16 @@
         <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-webapp</artifactId>
         <version>12.0.32-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee8.osgi</groupId>
+        <artifactId>jetty-ee8-osgi-boot</artifactId>
+        <version>12.1.6-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee8.osgi</groupId>
+        <artifactId>jetty-ee8-osgi-boot-jsp</artifactId>
+        <version>12.1.6-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8.websocket</groupId>

--- a/jetty-ee8/jetty-ee8-bom/pom.xml
+++ b/jetty-ee8/jetty-ee8-bom/pom.xml
@@ -29,7 +29,7 @@
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-cdi</artifactId>
-        <version>12.1.6-SNAPSHOT</version>
+        <version>12.0.32-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
@@ -39,7 +39,7 @@
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
         <artifactId>jetty-ee8-jaspi</artifactId>
-        <version>12.1.6-SNAPSHOT</version>
+        <version>12.0.32-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8</groupId>
@@ -94,12 +94,12 @@
       <dependency>
         <groupId>org.eclipse.jetty.ee8.osgi</groupId>
         <artifactId>jetty-ee8-osgi-boot</artifactId>
-        <version>12.1.6-SNAPSHOT</version>
+        <version>12.0.32-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8.osgi</groupId>
         <artifactId>jetty-ee8-osgi-boot-jsp</artifactId>
-        <version>12.1.6-SNAPSHOT</version>
+        <version>12.0.32-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.ee8.websocket</groupId>


### PR DESCRIPTION
## Closes #14360

Cherry pick of the commit from https://github.com/jetty/jetty.project/pull/14361 to Jetty 12.0.x.