### PR TITLE
Fix `HttpChannelState` mistakenly aborting in certain cases when the `ErrorHandler` is successfully writing back a response

### DIFF
--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
@@ -2175,11 +2175,15 @@ public class HttpClientTest extends AbstractHttpClientServerTest
         httpConfig.setMaxResponseHeaderSize(2 * capacity);
         client.setMaxResponseHeadersSize(4 * capacity);
 
-        assertThrows(ExecutionException.class, () -> client.newRequest("localhost", connector.getLocalPort())
+        ContentResponse response = client.newRequest("localhost", connector.getLocalPort())
             .scheme(scenario.getScheme())
             .headers(h -> h.put("X-Capacity", capacity))
             .timeout(5, TimeUnit.SECONDS)
-            .send());
+            .send();
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR_500, response.getStatus());
+        assertFalse(response.getHeaders().contains(HttpFields.CONNECTION_CLOSE));
+        assertThat(response.getContentAsString(), containsString("Response Header Fields Too Large"));
     }
 
     @ParameterizedTest

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.client;
 
 import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -2241,7 +2242,7 @@ public class HttpClientTest extends AbstractHttpClientServerTest
 
     @ParameterizedTest
     @ArgumentsSource(ScenarioProvider.class)
-    public void testUnconsumedRequestContentWithNonLastWriteThenTrow(Scenario scenario) throws Exception
+    public void testUnconsumedRequestContentWithNonLastWriteThenThrow(Scenario scenario) throws Exception
     {
         start(scenario, new Handler.Abstract()
         {
@@ -2258,6 +2259,7 @@ public class HttpClientTest extends AbstractHttpClientServerTest
             }
         });
 
+        AtomicReference<Throwable> failureRef = new AtomicReference<>();
         AtomicReference<Response> responseRef = new AtomicReference<>();
         CountDownLatch latch = new CountDownLatch(1);
         AsyncRequestContent content = new AsyncRequestContent(ByteBuffer.allocate(1024));
@@ -2265,15 +2267,17 @@ public class HttpClientTest extends AbstractHttpClientServerTest
             .scheme(scenario.getScheme())
             .method(HttpMethod.POST)
             .body(content)
-            .onResponseSuccess(response ->
+            .onComplete(listener ->
             {
-                responseRef.set(response);
+                failureRef.set(listener.getFailure());
+                responseRef.set(listener.getResponse());
                 latch.countDown();
             })
             .send(null);
         // Do not complete the request content.
 
         assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertInstanceOf(EOFException.class, failureRef.get());
         Response response = responseRef.get();
         assertEquals(HttpStatus.OK_200, response.getStatus());
 

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
@@ -68,6 +68,7 @@ import org.eclipse.jetty.server.internal.HttpChannelState;
 import org.eclipse.jetty.toolchain.test.Net;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
+import org.eclipse.jetty.util.Blocker;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.Fields;
@@ -87,6 +88,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -2198,6 +2200,84 @@ public class HttpClientTest extends AbstractHttpClientServerTest
             .send());
 
         assertInstanceOf(IllegalArgumentException.class, failure.getCause());
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testUnconsumedRequestContentWithLastWrite(Scenario scenario) throws Exception
+    {
+        start(scenario, new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(org.eclipse.jetty.server.Request request, org.eclipse.jetty.server.Response response, Callback callback) throws Exception
+            {
+                // Do not consume the request content.
+                response.write(true, null, callback);
+                return true;
+            }
+        });
+
+        AtomicReference<Response> responseRef = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        AsyncRequestContent content = new AsyncRequestContent(ByteBuffer.allocate(1024));
+        client.newRequest("localhost", connector.getLocalPort())
+            .scheme(scenario.getScheme())
+            .method(HttpMethod.POST)
+            .body(content)
+            .onResponseSuccess(response ->
+            {
+                responseRef.set(response);
+                latch.countDown();
+            })
+            .send(null);
+        // Do not complete the request content.
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        Response response = responseRef.get();
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+
+        await().atMost(5, TimeUnit.SECONDS).until(connector::getConnectedEndPoints, empty());
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testUnconsumedRequestContentWithNonLastWriteThenTrow(Scenario scenario) throws Exception
+    {
+        start(scenario, new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(org.eclipse.jetty.server.Request request, org.eclipse.jetty.server.Response response, Callback callback) throws Exception
+            {
+                try (Blocker.Callback cb = Blocker.callback())
+                {
+                    response.write(false, null, cb);
+                    cb.block();
+                }
+                // Throwing will fail the Handler callback.
+                throw new ArithmeticException();
+            }
+        });
+
+        AtomicReference<Response> responseRef = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        AsyncRequestContent content = new AsyncRequestContent(ByteBuffer.allocate(1024));
+        client.newRequest("localhost", connector.getLocalPort())
+            .scheme(scenario.getScheme())
+            .method(HttpMethod.POST)
+            .body(content)
+            .onResponseSuccess(response ->
+            {
+                responseRef.set(response);
+                latch.countDown();
+            })
+            .send(null);
+        // Do not complete the request content.
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        Response response = responseRef.get();
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+
+        await().atMost(5, TimeUnit.SECONDS).until(connector::getConnectedEndPoints, empty());
     }
 
     private void assertCopyRequest(Request original)

--- a/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/ServerFCGIConnection.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/ServerFCGIConnection.java
@@ -188,7 +188,11 @@ public class ServerFCGIConnection extends AbstractMetaDataConnection implements 
                     // must be called as the last release for it to be able to null out the
                     // inputBuffer field exactly when the latter isn't used anymore.
                     if (parse(inputBuffer.getByteBuffer()))
+                    {
+                        if (stream == null && inputBuffer.isEmpty())
+                            releaseInputBuffer();
                         return;
+                    }
                 }
                 else if (read == 0)
                 {

--- a/jetty-core/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ReverseProxyTest.java
+++ b/jetty-core/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ReverseProxyTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -169,14 +170,10 @@ public class ReverseProxyTest extends AbstractProxyTest
                 // Use "+" because in HTTP/2 is Huffman encoded in more than 8 bits.
                 response.getHeaders().put("X-Large", "+".repeat(maxResponseHeadersSize));
 
-                // With HTTP/1.1, calling response.write() would fail the Handler callback
-                // which would trigger ErrorHandler and result in a 500 to the proxy.
-//                response.write(true, null, callback);
-
-                // With HTTP/1.1, succeeding the callback before the actual last write
-                // results in skipping the ErrorHandler and aborting the response and
-                // the connection, which the proxy interprets as a 502.
-                // HTTP/2 always behaves by aborting the connection.
+                // With HTTP/1.1, calling response.write() or callback.succeeded()
+                // would trigger ErrorHandler and result in a 500 to the proxy.
+                // With HTTP/2, the HpackContext cannot be rolled back, so the
+                // connection is aborted, which the proxy interprets as a 502.
                 callback.succeeded();
                 return true;
             }
@@ -215,8 +212,16 @@ public class ReverseProxyTest extends AbstractProxyTest
             .timeout(5, TimeUnit.SECONDS)
             .send();
 
-        assertTrue(serverToProxyFailureLatch.await(5, TimeUnit.SECONDS));
-        assertEquals(HttpStatus.BAD_GATEWAY_502, response.getStatus());
+        if (httpVersion.compareTo(HttpVersion.HTTP_2) < 0)
+        {
+            assertFalse(serverToProxyFailureLatch.await(1, TimeUnit.SECONDS));
+            assertEquals(HttpStatus.INTERNAL_SERVER_ERROR_500, response.getStatus());
+        }
+        else
+        {
+            assertTrue(serverToProxyFailureLatch.await(5, TimeUnit.SECONDS));
+            assertEquals(HttpStatus.BAD_GATEWAY_502, response.getStatus());
+        }
     }
 
     @ParameterizedTest

--- a/jetty-core/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ReverseProxyTest.java
+++ b/jetty-core/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ReverseProxyTest.java
@@ -174,6 +174,7 @@ public class ReverseProxyTest extends AbstractProxyTest
                 // would trigger ErrorHandler and result in a 500 to the proxy.
                 // With HTTP/2, the HpackContext cannot be rolled back, so the
                 // connection is aborted, which the proxy interprets as a 502.
+                // The same for HTTP/3 and QpackContext.
                 callback.succeeded();
                 return true;
             }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -1394,7 +1394,8 @@ public class HttpChannelState implements HttpChannel, Components
                 httpChannel = _request.lockedGetHttpChannelState();
                 httpChannel.lockedStreamSendCompleted(true);
             }
-            httpChannel._writeInvoker.run(Invocable.from(callback.getInvocationType(), callback::succeeded));
+            if (callback != null)
+                httpChannel._writeInvoker.run(Invocable.from(callback.getInvocationType(), callback::succeeded));
         }
 
         /**
@@ -1421,7 +1422,8 @@ public class HttpChannelState implements HttpChannel, Components
                 httpChannel = _request.lockedGetHttpChannelState();
                 httpChannel.lockedStreamSendCompleted(false);
             }
-            httpChannel._writeInvoker.run(() -> HttpChannelState.failed(callback, x));
+            if (callback != null)
+                httpChannel._writeInvoker.run(() -> HttpChannelState.failed(callback, x));
         }
 
         @Override

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -124,8 +124,9 @@ public class HttpChannelState implements HttpChannel, Components
     private Runnable _onContentAvailable;
     private Predicate<TimeoutException> _onIdleTimeout;
     private Content.Chunk _readFailure;
-    private Throwable _consumeAvailableFailure;
     private Consumer<Throwable> _onFailure;
+    private Throwable _consumeAvailableFailure;
+    private Throwable _writeFailure;
     private Throwable _callbackFailure;
     private Attributes _cache;
     private boolean _expects100Continue;
@@ -615,7 +616,7 @@ public class HttpChannelState implements HttpChannel, Components
     private Throwable lockedCompleteStreamFailure()
     {
         assert _lock.isHeldByCurrentThread();
-        Throwable completeStreamFailure = _lastWriteCallback._failure; // TODO move as HttpChannelState._writeFailure
+        Throwable completeStreamFailure = _writeFailure;
         if (completeStreamFailure == null)
             completeStreamFailure = _response._writeFailure;  // TODO move as HttpChannelState._writeFailure
         if (completeStreamFailure == null)
@@ -783,8 +784,6 @@ public class HttpChannelState implements HttpChannel, Components
 
     private class LastWriteCallback implements Callback
     {
-        private Throwable _failure; // TODO move as HttpChannelState._writeFailure
-
         /**
          * Called only as {@link Callback} by last write from {@link ChannelCallback#succeeded}
          */
@@ -814,7 +813,7 @@ public class HttpChannelState implements HttpChannel, Components
                 _streamSendState = StreamSendState.LAST_COMPLETE;
                 completeStream = _handling == null; // if we have not handled yet or have completed handling
                 stream = _stream;
-                _failure = failure;
+                _writeFailure = failure;
                 _callbackFailure = ExceptionUtil.combine(failure, _callbackFailure);
                 completeStreamFailure = lockedCompleteStreamFailure();
             }
@@ -1359,7 +1358,7 @@ public class HttpChannelState implements HttpChannel, Components
                 // Have we failed in some way?
                 if (writeFailure != null)
                 {
-                    httpChannelState._lastWriteCallback._failure = writeFailure;
+                    httpChannelState._writeFailure = writeFailure;
                     Throwable failure = writeFailure;
                     httpChannelState._writeInvoker.run(() -> HttpChannelState.failed(callback, failure));
                     return;

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -617,15 +617,14 @@ public class HttpChannelState implements HttpChannel, Components
     private Throwable lockedCompleteStreamFailure()
     {
         assert _lock.isHeldByCurrentThread();
-        if (_streamSendState != StreamSendState.FAILED)
-            return null;
         Throwable completeStreamFailure = _lastWriteFailure;
         if (completeStreamFailure == null)
             completeStreamFailure = _writeFailure;
         if (completeStreamFailure == null)
             completeStreamFailure = _consumeAvailableFailure;
-        // Check for committed response with a non-last write then throwing an exception.
-        if (completeStreamFailure == null)
+        // Check the case for a committed response with a non-last
+        // successful write, then throwing an exception.
+        if (completeStreamFailure == null && _streamSendState == StreamSendState.FAILED)
             completeStreamFailure = _callbackFailure;
         return completeStreamFailure;
     }
@@ -818,7 +817,6 @@ public class HttpChannelState implements HttpChannel, Components
                 completeStream = _handling == null; // if we have not handled yet or have completed handling
                 stream = _stream;
                 _lastWriteFailure = failure;
-                _callbackFailure = ExceptionUtil.combine(failure, _callbackFailure);
                 completeStreamFailure = lockedCompleteStreamFailure();
             }
 
@@ -1583,7 +1581,7 @@ public class HttpChannelState implements HttpChannel, Components
             MetaData.Response responseMetaData = null;
             boolean completeStream = false;
             ErrorResponse errorResponse = null;
-            Callback failedCallback = null;
+            Callback writeCallback = null;
             Throwable completeStreamFailure;
 
             try (AutoLock ignored = _request._lock.lock())
@@ -1611,6 +1609,7 @@ public class HttpChannelState implements HttpChannel, Components
                     // persistent otherwise RequestLog.log() would be able to read
                     // x-www-form-urlencoded parameters in one case and not the other.
                     Throwable unconsumed = stream.consumeAvailable();
+                    httpChannelState._consumeAvailableFailure = unconsumed;
                     if (httpChannelState.getConnectionMetaData().isPersistent() && !httpChannelState._expects100Continue)
                         failure = ExceptionUtil.combine(failure, unconsumed);
                     else if (failure != null && unconsumed != null)
@@ -1688,7 +1687,7 @@ public class HttpChannelState implements HttpChannel, Components
                         {
                             // We are currently writing so fail the app callback now and let the write completion handle the failure
                             Runnable task = response.lockedFailWrite(failure);
-                            failedCallback = Callback.from(task, httpChannelState._lastWriteCallback);
+                            writeCallback = Callback.from(task, httpChannelState._lastWriteCallback);
                         }
                         else
                         {
@@ -1706,7 +1705,7 @@ public class HttpChannelState implements HttpChannel, Components
                         {
                             // We are currently writing so fail the app callback now and let the write completion handle the failure
                             Runnable task = response.lockedFailWrite(failure);
-                            failedCallback = Callback.from(task, httpChannelState._lastWriteCallback);
+                            writeCallback = Callback.from(task, httpChannelState._lastWriteCallback);
                         }
                         else if (!httpChannelState.lockedIsLastStreamSendCompleted())
                         {
@@ -1722,8 +1721,8 @@ public class HttpChannelState implements HttpChannel, Components
             if (LOG.isDebugEnabled())
                 LOG.debug("succeeded: failure={} doLastStreamSend={} {}", failure, doLastStreamSend, this);
 
-            if (failedCallback != null)
-                failedCallback.failed(Objects.requireNonNullElseGet(failure, IOException::new));
+            if (writeCallback != null)
+                writeCallback.failed(Objects.requireNonNullElseGet(failure, IOException::new));
             else if (errorResponse != null)
                 Response.writeError(request, errorResponse, new ErrorCallback(request, errorResponse, stream, failure), failure);
             else if (doLastStreamSend)

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -1427,7 +1427,7 @@ public class HttpChannelState implements HttpChannel, Components
                 callback = _writeCallback;
                 _writeCallback = null;
                 httpChannel = _request.lockedGetHttpChannelState();
-                httpChannel._writeFailure = x;
+                httpChannel._writeFailure = x; // TODO
                 httpChannel.lockedStreamSendCompleted(false);
             }
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -611,6 +611,17 @@ public class HttpChannelState implements HttpChannel, Components
         return true;
     }
 
+    private Throwable lockedCompleteStreamFailure()
+    {
+        assert _lock.isHeldByCurrentThread();
+        Throwable completeStreamFailure = _lastWriteCallback._failure; // TODO move as HttpChannelState._writeFailure
+        if (completeStreamFailure == null)
+            completeStreamFailure = _response._writeFailure;  // TODO move as HttpChannelState._writeFailure
+        if (completeStreamFailure == null)
+            completeStreamFailure = _request._consumeAvailableFailure;  // TODO move as HttpChannelState._consumeAvailableFailure
+        return completeStreamFailure;
+    }
+
     @Override
     public String toString()
     {
@@ -630,6 +641,9 @@ public class HttpChannelState implements HttpChannel, Components
         }
     }
 
+    /**
+     * Reminder: when a stream is failed, it aborts the connection.
+     */
     private void completeStream(HttpStream stream, Throwable failure)
     {
         try
@@ -732,6 +746,7 @@ public class HttpChannelState implements HttpChannel, Components
 
             HttpStream stream;
             Throwable failure;
+            Throwable completeStreamFailure;
             boolean completeStream;
             boolean callbackCompleted;
             boolean lastStreamSendComplete;
@@ -745,6 +760,7 @@ public class HttpChannelState implements HttpChannel, Components
                 callbackCompleted = _callbackCompleted;
                 lastStreamSendComplete = lockedIsLastStreamSendCompleted();
                 completeStream = callbackCompleted && lastStreamSendComplete;
+                completeStreamFailure = lockedCompleteStreamFailure();
 
                 if (LOG.isDebugEnabled())
                     LOG.debug("handler invoked: completeStream={} failure={} callbackCompleted={} {}", completeStream, failure, callbackCompleted, HttpChannelState.this);
@@ -754,11 +770,7 @@ public class HttpChannelState implements HttpChannel, Components
                 LOG.debug("stream={}, failure={}, callbackCompleted={}, completeStream={}", stream, failure, callbackCompleted, completeStream);
 
             if (completeStream)
-            {
-                if (LOG.isDebugEnabled())
-                    LOG.debug("completeStream({}, {})", stream, Objects.toString(failure));
-                completeStream(stream, failure);
-            }
+                completeStream(stream, completeStreamFailure);
         }
 
         @Override
@@ -770,6 +782,8 @@ public class HttpChannelState implements HttpChannel, Components
 
     private class LastWriteCallback implements Callback
     {
+        private Throwable _failure; // TODO move as HttpChannelState._writeFailure
+
         /**
          * Called only as {@link Callback} by last write from {@link ChannelCallback#succeeded}
          */
@@ -792,16 +806,20 @@ public class HttpChannelState implements HttpChannel, Components
         {
             HttpStream stream;
             boolean completeStream;
+            Throwable completeStreamFailure;
             try (AutoLock ignored = _lock.lock())
             {
                 assert _callbackCompleted;
                 _streamSendState = StreamSendState.LAST_COMPLETE;
                 completeStream = _handling == null; // if we have not handled yet or have completed handling
                 stream = _stream;
-                failure = _callbackFailure = ExceptionUtil.combine(_callbackFailure, failure);
+                _failure = failure;
+                _callbackFailure = ExceptionUtil.combine(failure, _callbackFailure);
+                completeStreamFailure = lockedCompleteStreamFailure();
             }
+
             if (completeStream)
-                completeStream(stream, failure);
+                completeStream(stream, completeStreamFailure);
         }
 
         @Override
@@ -823,6 +841,7 @@ public class HttpChannelState implements HttpChannel, Components
         private HttpChannelState _httpChannelState;
         private Request _loggedRequest;
         private HttpFields _trailers;
+        private Throwable _consumeAvailableFailure;
 
         ChannelRequest(HttpChannelState httpChannelState, MetaData.Request metaData)
         {
@@ -1001,7 +1020,15 @@ public class HttpChannelState implements HttpChannel, Components
                 stream = httpChannel._stream;
             }
 
-            return stream.consumeAvailable() == null;
+            Throwable failure = stream.consumeAvailable();
+            if (failure != null)
+            {
+                try (AutoLock ignored = _lock.lock())
+                {
+                    _consumeAvailableFailure = failure;
+                }
+            }
+            return failure == null;
         }
 
         @Override
@@ -1331,6 +1358,7 @@ public class HttpChannelState implements HttpChannel, Components
                 // Have we failed in some way?
                 if (writeFailure != null)
                 {
+                    httpChannelState._lastWriteCallback._failure = writeFailure;
                     Throwable failure = writeFailure;
                     httpChannelState._writeInvoker.run(() -> HttpChannelState.failed(callback, failure));
                     return;
@@ -1563,6 +1591,7 @@ public class HttpChannelState implements HttpChannel, Components
             boolean completeStream = false;
             ErrorResponse errorResponse = null;
             Callback failedCallback = null;
+            Throwable completeStreamFailure;
 
             try (AutoLock ignored = _request._lock.lock())
             {
@@ -1674,6 +1703,8 @@ public class HttpChannelState implements HttpChannel, Components
                         }
                     }
                 }
+
+                completeStreamFailure = completeStream ? httpChannelState.lockedCompleteStreamFailure() : null;
             }
 
             if (LOG.isDebugEnabled())
@@ -1686,7 +1717,7 @@ public class HttpChannelState implements HttpChannel, Components
             else if (doLastStreamSend)
                 stream.send(_request._metaData, responseMetaData, true, null, response);
             else if (completeStream)
-                httpChannelState.completeStream(stream, failure);
+                httpChannelState.completeStream(stream, completeStreamFailure);
             else if (LOG.isDebugEnabled())
                 LOG.debug("No action on succeeded {}", this);
         }
@@ -1799,11 +1830,9 @@ public class HttpChannelState implements HttpChannel, Components
             boolean needLastWrite;
             MetaData.Response responseMetaData = null;
             HttpChannelState httpChannelState;
-            Throwable failure;
             try (AutoLock ignored = _request._lock.lock())
             {
                 httpChannelState = _request.getHttpChannelState();
-                failure = _failure;
 
                 // Did the ErrorHandler do the last write?
                 needLastWrite = httpChannelState.lockedLastStreamSend();
@@ -1812,19 +1841,9 @@ public class HttpChannelState implements HttpChannel, Components
             }
 
             if (needLastWrite)
-            {
-                _stream.send(_request._metaData, responseMetaData, true, null,
-                    Callback.from(() -> httpChannelState._lastWriteCallback.failed(failure),
-                        x ->
-                        {
-                            ExceptionUtil.addSuppressedIfNotAssociated(failure, x);
-                            httpChannelState._lastWriteCallback.failed(failure);
-                        }));
-            }
+                _stream.send(_request._metaData, responseMetaData, true, null, httpChannelState._lastWriteCallback);
             else
-            {
-                HttpChannelState.failed(httpChannelState._lastWriteCallback, failure);
-            }
+                httpChannelState._lastWriteCallback.succeeded();
         }
 
         /**

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -624,6 +624,7 @@ public class HttpChannelState implements HttpChannel, Components
             completeStreamFailure = _writeFailure;
         if (completeStreamFailure == null)
             completeStreamFailure = _consumeAvailableFailure;
+        // Check for committed response with a non-last write then throwing an exception.
         if (completeStreamFailure == null)
             completeStreamFailure = _callbackFailure;
         return completeStreamFailure;

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -127,6 +127,7 @@ public class HttpChannelState implements HttpChannel, Components
     private Consumer<Throwable> _onFailure;
     private Throwable _consumeAvailableFailure;
     private Throwable _writeFailure;
+    private Throwable _lastWriteFailure;
     private Throwable _callbackFailure;
     private Attributes _cache;
     private boolean _expects100Continue;
@@ -616,9 +617,9 @@ public class HttpChannelState implements HttpChannel, Components
     private Throwable lockedCompleteStreamFailure()
     {
         assert _lock.isHeldByCurrentThread();
-        Throwable completeStreamFailure = _writeFailure;
+        Throwable completeStreamFailure = _lastWriteFailure;
         if (completeStreamFailure == null)
-            completeStreamFailure = _response._writeFailure;  // TODO move as HttpChannelState._writeFailure
+            completeStreamFailure = _writeFailure;  // TODO move as HttpChannelState._writeFailure
         if (completeStreamFailure == null)
             completeStreamFailure = _consumeAvailableFailure;
         return completeStreamFailure;
@@ -813,7 +814,7 @@ public class HttpChannelState implements HttpChannel, Components
                 _streamSendState = StreamSendState.LAST_COMPLETE;
                 completeStream = _handling == null; // if we have not handled yet or have completed handling
                 stream = _stream;
-                _writeFailure = failure;
+                _lastWriteFailure = failure;
                 _callbackFailure = ExceptionUtil.combine(failure, _callbackFailure);
                 completeStreamFailure = lockedCompleteStreamFailure();
             }
@@ -1206,7 +1207,6 @@ public class HttpChannelState implements HttpChannel, Components
         private long _contentBytesWritten;
         private Supplier<HttpFields> _trailers;
         private Callback _writeCallback;
-        private Throwable _writeFailure;
 
         private ChannelResponse(ChannelRequest request)
         {
@@ -1239,8 +1239,8 @@ public class HttpChannelState implements HttpChannel, Components
             _writeCallback = null;
 
             Runnable cancellation = _request.getHttpStream().cancelSend(x, writeCallback);
-
-            _writeFailure = ExceptionUtil.combine(_writeFailure, x);
+            HttpChannelState httpChannelState = _request._httpChannelState;
+            httpChannelState._writeFailure = ExceptionUtil.combine(httpChannelState._writeFailure, x);
             return cancellation;
         }
 
@@ -1307,7 +1307,7 @@ public class HttpChannelState implements HttpChannel, Components
             {
                 httpChannelState = _request.lockedGetHttpChannelState();
                 long totalWritten = _contentBytesWritten + length;
-                writeFailure = _writeFailure;
+                writeFailure = httpChannelState._writeFailure;
 
                 if (writeFailure == null)
                 {
@@ -1358,7 +1358,7 @@ public class HttpChannelState implements HttpChannel, Components
                 // Have we failed in some way?
                 if (writeFailure != null)
                 {
-                    httpChannelState._writeFailure = writeFailure;
+                    httpChannelState._lastWriteFailure = writeFailure;
                     Throwable failure = writeFailure;
                     httpChannelState._writeInvoker.run(() -> HttpChannelState.failed(callback, failure));
                     return;
@@ -1422,10 +1422,10 @@ public class HttpChannelState implements HttpChannel, Components
             HttpChannelState httpChannel;
             try (AutoLock ignored = _request._lock.lock())
             {
-                _writeFailure = x;
                 callback = _writeCallback;
                 _writeCallback = null;
                 httpChannel = _request.lockedGetHttpChannelState();
+                httpChannel._writeFailure = x;
                 httpChannel.lockedStreamSendCompleted(false);
             }
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -622,6 +622,8 @@ public class HttpChannelState implements HttpChannel, Components
             completeStreamFailure = _writeFailure;  // TODO move as HttpChannelState._writeFailure
         if (completeStreamFailure == null)
             completeStreamFailure = _consumeAvailableFailure;
+        if (completeStreamFailure == null && _streamSendState == StreamSendState.FAILED)
+            completeStreamFailure = _callbackFailure;
         return completeStreamFailure;
     }
 
@@ -748,7 +750,6 @@ public class HttpChannelState implements HttpChannel, Components
             }
 
             HttpStream stream;
-            Throwable failure;
             Throwable completeStreamFailure;
             boolean completeStream;
             boolean callbackCompleted;
@@ -759,18 +760,17 @@ public class HttpChannelState implements HttpChannel, Components
                 stream = _stream;
                 _handling = null;
                 _handled = true;
-                failure = _callbackFailure;
                 callbackCompleted = _callbackCompleted;
                 lastStreamSendComplete = lockedIsLastStreamSendCompleted();
                 completeStream = callbackCompleted && lastStreamSendComplete;
                 completeStreamFailure = lockedCompleteStreamFailure();
 
                 if (LOG.isDebugEnabled())
-                    LOG.debug("handler invoked: completeStream={} failure={} callbackCompleted={} {}", completeStream, failure, callbackCompleted, HttpChannelState.this);
+                    LOG.debug("handler invoked: completeStream={} failure={} callbackCompleted={} {}", completeStream, completeStreamFailure, callbackCompleted, HttpChannelState.this);
             }
 
             if (LOG.isDebugEnabled())
-                LOG.debug("stream={}, failure={}, callbackCompleted={}, completeStream={}", stream, failure, callbackCompleted, completeStream);
+                LOG.debug("stream={}, failure={}, callbackCompleted={}, completeStream={}", stream, completeStreamFailure, callbackCompleted, completeStream);
 
             if (completeStream)
                 completeStream(stream, completeStreamFailure);

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -124,6 +124,7 @@ public class HttpChannelState implements HttpChannel, Components
     private Runnable _onContentAvailable;
     private Predicate<TimeoutException> _onIdleTimeout;
     private Content.Chunk _readFailure;
+    private Throwable _consumeAvailableFailure;
     private Consumer<Throwable> _onFailure;
     private Throwable _callbackFailure;
     private Attributes _cache;
@@ -618,7 +619,7 @@ public class HttpChannelState implements HttpChannel, Components
         if (completeStreamFailure == null)
             completeStreamFailure = _response._writeFailure;  // TODO move as HttpChannelState._writeFailure
         if (completeStreamFailure == null)
-            completeStreamFailure = _request._consumeAvailableFailure;  // TODO move as HttpChannelState._consumeAvailableFailure
+            completeStreamFailure = _consumeAvailableFailure;
         return completeStreamFailure;
     }
 
@@ -841,7 +842,6 @@ public class HttpChannelState implements HttpChannel, Components
         private HttpChannelState _httpChannelState;
         private Request _loggedRequest;
         private HttpFields _trailers;
-        private Throwable _consumeAvailableFailure;
 
         ChannelRequest(HttpChannelState httpChannelState, MetaData.Request metaData)
         {
@@ -1013,10 +1013,11 @@ public class HttpChannelState implements HttpChannel, Components
         @Override
         public boolean consumeAvailable()
         {
+            HttpChannelState httpChannel;
             HttpStream stream;
             try (AutoLock ignored = _lock.lock())
             {
-                HttpChannelState httpChannel = lockedGetHttpChannelState();
+                httpChannel = lockedGetHttpChannelState();
                 stream = httpChannel._stream;
             }
 
@@ -1025,7 +1026,7 @@ public class HttpChannelState implements HttpChannel, Components
             {
                 try (AutoLock ignored = _lock.lock())
                 {
-                    _consumeAvailableFailure = failure;
+                    httpChannel._consumeAvailableFailure = failure;
                 }
             }
             return failure == null;

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -619,7 +619,7 @@ public class HttpChannelState implements HttpChannel, Components
         assert _lock.isHeldByCurrentThread();
         if (_streamSendState != StreamSendState.FAILED)
             return null;
-        Throwable completeStreamFailure = _lastWriteFailure; // TODO move as HttpChannelState._writeFailure
+        Throwable completeStreamFailure = _lastWriteFailure;
         if (completeStreamFailure == null)
             completeStreamFailure = _writeFailure;
         if (completeStreamFailure == null)

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -814,7 +814,7 @@ public class HttpChannelState implements HttpChannel, Components
             try (AutoLock ignored = _lock.lock())
             {
                 assert _callbackCompleted;
-                _streamSendState = StreamSendState.LAST_COMPLETE;
+                _streamSendState = failure == null ? StreamSendState.LAST_COMPLETE : StreamSendState.FAILED;
                 completeStream = _handling == null; // if we have not handled yet or have completed handling
                 stream = _stream;
                 _lastWriteFailure = failure;

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -617,12 +617,14 @@ public class HttpChannelState implements HttpChannel, Components
     private Throwable lockedCompleteStreamFailure()
     {
         assert _lock.isHeldByCurrentThread();
-        Throwable completeStreamFailure = _lastWriteFailure;
+        if (_streamSendState != StreamSendState.FAILED)
+            return null;
+        Throwable completeStreamFailure = _lastWriteFailure; // TODO move as HttpChannelState._writeFailure
         if (completeStreamFailure == null)
-            completeStreamFailure = _writeFailure;  // TODO move as HttpChannelState._writeFailure
+            completeStreamFailure = _writeFailure;
         if (completeStreamFailure == null)
             completeStreamFailure = _consumeAvailableFailure;
-        if (completeStreamFailure == null && _streamSendState == StreamSendState.FAILED)
+        if (completeStreamFailure == null)
             completeStreamFailure = _callbackFailure;
         return completeStreamFailure;
     }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -614,7 +614,7 @@ public class HttpChannelState implements HttpChannel, Components
         return true;
     }
 
-    private Throwable lockedCompleteStreamFailure()
+    private Throwable lockedGetCompleteStreamFailure()
     {
         assert _lock.isHeldByCurrentThread();
 
@@ -764,7 +764,7 @@ public class HttpChannelState implements HttpChannel, Components
                 callbackCompleted = _callbackCompleted;
                 lastStreamSendComplete = lockedIsLastStreamSendCompleted();
                 completeStream = callbackCompleted && lastStreamSendComplete;
-                completeStreamFailure = lockedCompleteStreamFailure();
+                completeStreamFailure = lockedGetCompleteStreamFailure();
 
                 if (LOG.isDebugEnabled())
                     LOG.debug("handler invoked: completeStream={} failure={} callbackCompleted={} {}", completeStream, completeStreamFailure, callbackCompleted, HttpChannelState.this);
@@ -816,7 +816,7 @@ public class HttpChannelState implements HttpChannel, Components
                 completeStream = _handling == null; // if we have not handled yet or have completed handling
                 stream = _stream;
                 _lastWriteFailure = failure;
-                completeStreamFailure = lockedCompleteStreamFailure();
+                completeStreamFailure = lockedGetCompleteStreamFailure();
             }
 
             if (completeStream)
@@ -1714,7 +1714,7 @@ public class HttpChannelState implements HttpChannel, Components
                     }
                 }
 
-                completeStreamFailure = completeStream ? httpChannelState.lockedCompleteStreamFailure() : null;
+                completeStreamFailure = completeStream ? httpChannelState.lockedGetCompleteStreamFailure() : null;
             }
 
             if (LOG.isDebugEnabled())

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -617,15 +617,14 @@ public class HttpChannelState implements HttpChannel, Components
     private Throwable lockedCompleteStreamFailure()
     {
         assert _lock.isHeldByCurrentThread();
-        Throwable completeStreamFailure = _lastWriteFailure;
-        if (completeStreamFailure == null)
-            completeStreamFailure = _writeFailure;
-        if (completeStreamFailure == null)
-            completeStreamFailure = _consumeAvailableFailure;
-        // Check the case for a committed response with a non-last
-        // successful write, then throwing an exception.
-        if (completeStreamFailure == null && _streamSendState == StreamSendState.FAILED)
-            completeStreamFailure = _callbackFailure;
+
+        Throwable completeStreamFailure = ExceptionUtil.combine(_lastWriteFailure,
+            ExceptionUtil.combine(_writeFailure, _consumeAvailableFailure));
+        // Check the case for a committed response with a
+        // non-last successful write, then throwing an exception.
+        if (_streamSendState == StreamSendState.FAILED)
+            completeStreamFailure = ExceptionUtil.combine(completeStreamFailure, _callbackFailure);
+
         return completeStreamFailure;
     }
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -1016,23 +1016,14 @@ public class HttpChannelState implements HttpChannel, Components
         @Override
         public boolean consumeAvailable()
         {
-            HttpChannelState httpChannel;
-            HttpStream stream;
             try (AutoLock ignored = _lock.lock())
             {
-                httpChannel = lockedGetHttpChannelState();
-                stream = httpChannel._stream;
+                HttpChannelState httpChannel = lockedGetHttpChannelState();
+                HttpStream stream = httpChannel._stream;
+                Throwable failure = stream.consumeAvailable();
+                httpChannel._consumeAvailableFailure = failure;
+                return failure == null;
             }
-
-            Throwable failure = stream.consumeAvailable();
-            if (failure != null)
-            {
-                try (AutoLock ignored = _lock.lock())
-                {
-                    httpChannel._consumeAvailableFailure = failure;
-                }
-            }
-            return failure == null;
         }
 
         @Override
@@ -1300,6 +1291,8 @@ public class HttpChannelState implements HttpChannel, Components
         @Override
         public void write(boolean last, ByteBuffer content, Callback callback)
         {
+            Callback writeCallback = Objects.requireNonNullElse(callback, NOOP);
+
             long length = BufferUtil.length(content);
 
             HttpChannelState httpChannelState;
@@ -1319,7 +1312,7 @@ public class HttpChannelState implements HttpChannel, Components
                         if (_writeCallback instanceof InterimCallback interimCallback)
                         {
                             // Do this write after the interim callback.
-                            interimCallback.whenComplete((v, t) -> write(last, content, callback));
+                            interimCallback.whenComplete((v, t) -> write(last, content, writeCallback));
                             return;
                         }
                         writeFailure = new WritePendingException();
@@ -1342,7 +1335,7 @@ public class HttpChannelState implements HttpChannel, Components
                             {
                                 String message = lengthError.formatted(totalWritten, contentLength);
                                 if (LOG.isDebugEnabled())
-                                    LOG.debug("fail {} {}", callback, message);
+                                    LOG.debug("fail {} {}", writeCallback, message);
                                 writeFailure = new IOException(message);
                             }
                         }
@@ -1355,7 +1348,7 @@ public class HttpChannelState implements HttpChannel, Components
 
                 if (writeFailure == NOTHING_TO_SEND)
                 {
-                    httpChannelState._writeInvoker.run(Invocable.from(callback.getInvocationType(), callback::succeeded));
+                    httpChannelState._writeInvoker.run(Invocable.from(writeCallback.getInvocationType(), writeCallback::succeeded));
                     return;
                 }
                 // Have we failed in some way?
@@ -1363,12 +1356,12 @@ public class HttpChannelState implements HttpChannel, Components
                 {
                     httpChannelState._lastWriteFailure = writeFailure;
                     Throwable failure = writeFailure;
-                    httpChannelState._writeInvoker.run(() -> HttpChannelState.failed(callback, failure));
+                    httpChannelState._writeInvoker.run(() -> HttpChannelState.failed(writeCallback, failure));
                     return;
                 }
 
                 // No failure, do the actual stream send using the ChannelResponse as the callback.
-                _writeCallback = callback;
+                _writeCallback = writeCallback;
                 _contentBytesWritten = totalWritten;
                 stream = httpChannelState._stream;
                 if (_httpFields.commit())
@@ -1401,9 +1394,7 @@ public class HttpChannelState implements HttpChannel, Components
                 httpChannel = _request.lockedGetHttpChannelState();
                 httpChannel.lockedStreamSendCompleted(true);
             }
-
-            if (callback != null)
-                httpChannel._writeInvoker.run(Invocable.from(callback.getInvocationType(), callback::succeeded));
+            httpChannel._writeInvoker.run(Invocable.from(callback.getInvocationType(), callback::succeeded));
         }
 
         /**
@@ -1430,18 +1421,7 @@ public class HttpChannelState implements HttpChannel, Components
                 httpChannel = _request.lockedGetHttpChannelState();
                 httpChannel.lockedStreamSendCompleted(false);
             }
-
-            if (callback != null)
-                httpChannel._writeInvoker.run(() ->
-                {
-                    HttpChannelState.failed(callback, x);
-                    // The above failure invokes the error handler, so the failure must not be stored beforehand
-                    // otherwise the error handler's Response.write() call would see it and fail.
-                    try (AutoLock ignored = _request._lock.lock())
-                    {
-                        httpChannel._writeFailure = x;
-                    }
-                });
+            httpChannel._writeInvoker.run(() -> HttpChannelState.failed(callback, x));
         }
 
         @Override

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -1427,12 +1427,20 @@ public class HttpChannelState implements HttpChannel, Components
                 callback = _writeCallback;
                 _writeCallback = null;
                 httpChannel = _request.lockedGetHttpChannelState();
-                httpChannel._writeFailure = x; // TODO
                 httpChannel.lockedStreamSendCompleted(false);
             }
 
             if (callback != null)
-                httpChannel._writeInvoker.run(() -> HttpChannelState.failed(callback, x));
+                httpChannel._writeInvoker.run(() ->
+                {
+                    HttpChannelState.failed(callback, x);
+                    // The above failure invokes the error handler, so the failure must not be stored beforehand
+                    // otherwise the error handler's Response.write() call would see it and fail.
+                    try (AutoLock ignored = _request._lock.lock())
+                    {
+                        httpChannel._writeFailure = x;
+                    }
+                });
         }
 
         @Override

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -1659,10 +1659,29 @@ public class HttpChannelState implements HttpChannel, Components
                 {
                     doLastStreamSend = httpChannelState.lockedLastStreamSend();
                     if (doLastStreamSend)
-                        response._writeCallback = httpChannelState._lastWriteCallback;
+                    {
+                        LastWriteCallback lastWriteCallback = httpChannelState._lastWriteCallback;
+                        if (stream.isCommitted())
+                        {
+                            response._writeCallback = lastWriteCallback;
+                        }
+                        else
+                        {
+                            ErrorResponse errResponse = new ErrorResponse(request);
+                            response._writeCallback = Callback.from(lastWriteCallback.getInvocationType(), lastWriteCallback::succeeded, x ->
+                            {
+                                if (stream.isCommitted())
+                                    lastWriteCallback.failed(x);
+                                else
+                                    Response.writeError(request, errResponse, new ErrorCallback(request, errResponse, stream, x), x);
+                            });
+                        }
+                    }
                     // or complete the stream if everything is done.
                     else if (httpChannelState.lockedIsLastStreamSendCompleted())
+                    {
                         completeStream = httpChannelState._handled;
+                    }
                 }
                 else
                 {
@@ -1841,10 +1860,11 @@ public class HttpChannelState implements HttpChannel, Components
             boolean needLastWrite;
             MetaData.Response responseMetaData = null;
             HttpChannelState httpChannelState;
+            Callback lastWriteCallback;
             try (AutoLock ignored = _request._lock.lock())
             {
                 httpChannelState = _request.getHttpChannelState();
-
+                lastWriteCallback = httpChannelState._lastWriteCallback;
                 // Did the ErrorHandler do the last write?
                 needLastWrite = httpChannelState.lockedLastStreamSend();
                 if (needLastWrite && _errorResponse.getResponseHttpFields().commit())
@@ -1852,9 +1872,9 @@ public class HttpChannelState implements HttpChannel, Components
             }
 
             if (needLastWrite)
-                _stream.send(_request._metaData, responseMetaData, true, null, httpChannelState._lastWriteCallback);
+                _stream.send(_request._metaData, responseMetaData, true, null, lastWriteCallback);
             else
-                httpChannelState._lastWriteCallback.succeeded();
+                lastWriteCallback.succeeded();
         }
 
         /**

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
@@ -849,13 +849,13 @@ public class HttpChannelTest
             .add(HttpHeader.HOST, "localhost")
             .put(HttpHeader.CONTENT_LENGTH, 10)
             .asImmutable();
-        MetaData.Request request = new MetaData.Request("POST", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields, 0);
+        MetaData.Request request = new MetaData.Request("POST", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields, 10);
 
         Runnable task = channel.onRequest(request);
         task.run();
 
         assertThat(stream.isComplete(), is(true));
-        assertThat(stream.getFailure(), nullValue());
+        assertThat(stream.getFailure(), notNullValue());
         assertThat(stream.getResponse(), notNullValue());
         assertThat(stream.getResponse().getStatus(), equalTo(200));
         assertThat(stream.getResponseHeaders().get(HttpHeader.CONTENT_TYPE), equalTo(MimeTypes.Type.TEXT_PLAIN_UTF_8.asString()));
@@ -892,13 +892,13 @@ public class HttpChannelTest
             .add(HttpHeader.HOST, "localhost")
             .put(HttpHeader.CONTENT_LENGTH, 10)
             .asImmutable();
-        MetaData.Request request = new MetaData.Request("POST", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields, 0);
+        MetaData.Request request = new MetaData.Request("POST", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields, 10);
 
         Runnable task = channel.onRequest(request);
         task.run();
 
         assertThat(stream.isComplete(), is(true));
-        assertThat(stream.getFailure(), nullValue());
+        assertThat(stream.getFailure(), notNullValue());
         assertThat(stream.getResponse(), notNullValue());
         assertThat(stream.getResponse().getStatus(), equalTo(200));
         assertThat(stream.getResponseHeaders().get(HttpHeader.CONTENT_TYPE), equalTo(MimeTypes.Type.TEXT_PLAIN_UTF_8.asString()));

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
@@ -1597,10 +1597,7 @@ public class HttpChannelTest
         boolean failed = events.contains(CompletionTestEvent.FAIL);
 
         assertThat(stream.isComplete(), is(true));
-        if (errorHandler != null && !expectErrorResponse && failed)
-            assertThat(stream.getFailure(), notNullValue());
-        else
-            assertThat(stream.getFailure(), nullValue());
+        assertThat(stream.getFailure(), nullValue());
         if (!failed || expectErrorResponse)
         {
             assertThat(stream.getResponse(), notNullValue());

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
@@ -1597,9 +1597,9 @@ public class HttpChannelTest
         boolean failed = events.contains(CompletionTestEvent.FAIL);
 
         assertThat(stream.isComplete(), is(true));
-        assertThat(stream.getFailure(), nullValue());
         if (!failed || expectErrorResponse)
         {
+            assertThat(stream.getFailure(), nullValue());
             assertThat(stream.getResponse(), notNullValue());
             assertThat(stream.getResponse().getStatus(), equalTo(failed ? 500 : 200));
             assertThat(stream.getResponseHeaders().get("Test"), failed ? nullValue() : equalTo("Value"));
@@ -1607,6 +1607,7 @@ public class HttpChannelTest
         }
         else
         {
+            assertThat(stream.getFailure(), notNullValue());
             assertThat(stream.getResponse(), nullValue());
         }
     }

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
@@ -538,7 +538,7 @@ public class HttpChannelTest
             task.run();
         }
         assertThat(stream.isComplete(), is(true));
-        assertThat(stream.getFailure(), nullValue());
+        assertThat(stream.getFailure(), notNullValue());
         assertThat(stream.getResponse(), notNullValue());
         assertThat(stream.getResponse().getStatus(), equalTo(200));
     }

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
@@ -14,7 +14,9 @@
 package org.eclipse.jetty.server;
 
 import java.io.IOException;
+import java.net.Socket;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -41,6 +43,7 @@ import org.eclipse.jetty.server.handler.DumpHandler;
 import org.eclipse.jetty.server.handler.EchoHandler;
 import org.eclipse.jetty.server.handler.HelloHandler;
 import org.eclipse.jetty.server.internal.HttpChannelState;
+import org.eclipse.jetty.util.Blocker;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.FutureCallback;
@@ -76,13 +79,13 @@ public class HttpChannelTest
     Server _server;
 
     @BeforeEach
-    public void beforeEach() throws Exception
+    public void beforeEach()
     {
         _server = new Server();
     }
 
     @AfterEach
-    public void afterEach() throws Exception
+    public void afterEach()
     {
         LifeCycle.stop(_server);
     }
@@ -390,8 +393,6 @@ public class HttpChannelTest
 
         assertTrue(stream.waitForComplete(5, TimeUnit.SECONDS));
         assertThat(stream.isComplete(), is(true));
-        if (stream.getFailure() != null)
-            stream.getFailure().printStackTrace();
         assertThat(stream.getFailure(), nullValue());
         assertThat(stream.getResponse(), notNullValue());
         assertThat(stream.getResponse().getStatus(), equalTo(200));
@@ -458,7 +459,7 @@ public class HttpChannelTest
         }
 
         assertThat(stream.isComplete(), is(true));
-        assertThat(stream.getFailure(), notNullValue());
+        assertThat(stream.getFailure(), nullValue());
         assertThat(stream.getResponse(), notNullValue());
         assertThat(stream.getResponse().getStatus(), equalTo(500));
         assertThat(stream.getResponseHeaders().get(HttpHeader.CONTENT_TYPE), containsString("text/html"));
@@ -537,7 +538,7 @@ public class HttpChannelTest
             task.run();
         }
         assertThat(stream.isComplete(), is(true));
-        assertThat(stream.getFailure(), notNullValue());
+        assertThat(stream.getFailure(), nullValue());
         assertThat(stream.getResponse(), notNullValue());
         assertThat(stream.getResponse().getStatus(), equalTo(200));
     }
@@ -577,6 +578,7 @@ public class HttpChannelTest
     @Test
     public void testInsufficientContentWritten1() throws Exception
     {
+        AtomicReference<Throwable> writeFailureRef = new AtomicReference<>();
         Handler handler = new Handler.Abstract.NonBlocking()
         {
             @Override
@@ -586,7 +588,7 @@ public class HttpChannelTest
                 response.getHeaders().put(HttpHeader.CONTENT_LENGTH, 10);
                 try (StacklessLogging ignore = new StacklessLogging(Response.class))
                 {
-                    response.write(true, BufferUtil.toBuffer("12345"), callback);
+                    response.write(true, BufferUtil.toBuffer("12345"), Callback.from(callback, writeFailureRef::set));
                 }
                 return true;
             }
@@ -600,19 +602,76 @@ public class HttpChannelTest
         String rawRequest = """
             GET / HTTP/1.1
             Host: local
-            Connection: close
             
             """;
 
         HttpTester.Response response = HttpTester.parseResponse(localConnector.getResponse(rawRequest));
         assertEquals(500, response.getStatus());
+        assertFalse(response.contains(HttpHeader.CONNECTION, "close"));
         assertThat(response.getContent(), containsString("5 &lt; 10"));
 
+        Throwable x = writeFailureRef.get();
+        assertThat(x, notNullValue());
+
         HttpStreamCaptureFailure capture = HttpStreamCaptureFailure.captureRef.get();
-        assertTrue(capture.failLatch.await(5, TimeUnit.SECONDS));
+        assertFalse(capture.failLatch.await(1, TimeUnit.SECONDS));
         Throwable failure = capture.failRef.get();
-        assertThat(failure, notNullValue());
-        assertThat(failure.getMessage(), containsString("5 < 10"));
+        assertThat(failure, nullValue());
+    }
+
+    @Test
+    public void testInsufficientContentWritten1Committed() throws Exception
+    {
+        AtomicReference<Throwable> writeFailureRef = new AtomicReference<>();
+        Handler handler = new Handler.Abstract.NonBlocking()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            {
+                request.addHttpStreamWrapper(HttpStreamCaptureFailure::asWrapper);
+                response.getHeaders().put(HttpHeader.CONTENT_LENGTH, 10);
+
+                try (Blocker.Callback cb = Blocker.callback())
+                {
+                    response.write(false, BufferUtil.toBuffer("0"), cb);
+                    cb.block();
+                }
+
+                try (StacklessLogging ignore = new StacklessLogging(Response.class))
+                {
+                    response.write(true, BufferUtil.toBuffer("12345"), Callback.from(callback, writeFailureRef::set));
+                }
+                return true;
+            }
+        };
+        _server.setHandler(handler);
+
+        ServerConnector serverConnector = new ServerConnector(_server);
+        _server.addConnector(serverConnector);
+        _server.start();
+
+        String rawRequest = """
+            GET / HTTP/1.1
+            Host: local
+            
+            """;
+
+        try (Socket socket = new Socket("localhost", serverConnector.getLocalPort()))
+        {
+            socket.getOutputStream().write(rawRequest.getBytes(StandardCharsets.UTF_8));
+            socket.getOutputStream().flush();
+
+            HttpTester.Response response = HttpTester.parseResponse(HttpTester.from(socket.getInputStream()));
+            assertThat(response, nullValue());
+
+            Throwable x = writeFailureRef.get();
+            assertThat(x, notNullValue());
+
+            HttpStreamCaptureFailure capture = HttpStreamCaptureFailure.captureRef.get();
+            assertTrue(capture.failLatch.await(5, TimeUnit.SECONDS));
+            Throwable failure = capture.failRef.get();
+            assertThat(failure, notNullValue());
+        }
     }
 
     @Test
@@ -678,8 +737,9 @@ public class HttpChannelTest
         }
 
         assertThat(stream.isComplete(), is(true));
-        assertThat(stream.getFailure(), notNullValue());
-        assertThat(stream.getFailure().getMessage(), containsString("10 > 5"));
+        assertThat(stream.getFailure(), nullValue());
+        assertThat(stream.getFailure(), nullValue());
+        assertThat(stream.getResponseHeaders().contains(HttpFields.CONNECTION_CLOSE), is(false));
         assertThat(stream.getResponse(), notNullValue());
         assertThat(stream.getResponse().getStatus(), is(500));
         assertThat(stream.getResponseContentAsString(), containsString("10 &gt; 5"));
@@ -714,7 +774,6 @@ public class HttpChannelTest
         String rawRequest = """
             GET / HTTP/1.1
             Host: local
-            Connection: close
             
             """;
 
@@ -760,7 +819,7 @@ public class HttpChannelTest
         assertThat(stream.getResponseHeaders().get(HttpHeader.CONTENT_TYPE), equalTo(MimeTypes.Type.TEXT_PLAIN_UTF_8.asString()));
         assertThat(BufferUtil.toString(stream.getResponseContent()), equalTo(helloHandler.getMessage()));
 
-        assertThat(stream.getResponseHeaders().get(HttpHeader.CONNECTION), nullValue());
+        assertThat(stream.getResponseHeaders().contains(HttpFields.CONNECTION_CLOSE), is(false));
         assertThat(stream.read(), sameInstance(Content.Chunk.EOF));
     }
 
@@ -802,7 +861,7 @@ public class HttpChannelTest
         assertThat(stream.getResponseHeaders().get(HttpHeader.CONTENT_TYPE), equalTo(MimeTypes.Type.TEXT_PLAIN_UTF_8.asString()));
         assertThat(BufferUtil.toString(stream.getResponseContent()), equalTo("12345"));
 
-        assertThat(stream.getResponseHeaders().get(HttpHeader.CONNECTION), nullValue());
+        assertThat(stream.getResponseHeaders().contains(HttpFields.CONNECTION_CLOSE), is(false));
         assertThat(stream.read(), nullValue());
     }
 
@@ -845,7 +904,7 @@ public class HttpChannelTest
         assertThat(stream.getResponseHeaders().get(HttpHeader.CONTENT_TYPE), equalTo(MimeTypes.Type.TEXT_PLAIN_UTF_8.asString()));
         assertThat(BufferUtil.toString(stream.getResponseContent()), equalTo("12345"));
 
-        assertThat(stream.getResponseHeaders().get(HttpHeader.CONNECTION), equalTo(HttpHeaderValue.CLOSE.asString()));
+        assertThat(stream.getResponseHeaders().contains(HttpFields.CONNECTION_CLOSE), is(true));
         assertThat(stream.read(), nullValue());
     }
 
@@ -893,6 +952,7 @@ public class HttpChannelTest
         assertThat(stream.getResponse().getStatus(), equalTo(200));
         assertThat(stream.getResponseHeaders().get(HttpHeader.CONTENT_TYPE), nullValue());
         assertThat(stream.getResponseHeaders().getLongField(HttpHeader.CONTENT_LENGTH), equalTo(0L));
+        assertThat(stream.getResponseHeaders().contains(HttpFields.CONNECTION_CLOSE), is(false));
         assertThat(BufferUtil.toString(stream.getResponseContent()), equalTo(""));
     }
 
@@ -1006,6 +1066,7 @@ public class HttpChannelTest
         assertThat(stream.getResponse(), notNullValue());
         assertThat(stream.getResponse().getStatus(), equalTo(200));
         assertThat(stream.getResponseHeaders().get(HttpHeader.CONTENT_TYPE), equalTo(MimeTypes.Type.TEXT_PLAIN_8859_1.asString()));
+        assertThat(stream.getResponseHeaders().contains(HttpFields.CONNECTION_CLOSE), is(false));
         assertThat(BufferUtil.toString(stream.getResponseContent()), equalTo(message));
 
         Iterator<String> timeline = history.iterator();
@@ -1082,6 +1143,7 @@ public class HttpChannelTest
         assertThat(stream.getResponse(), notNullValue());
         assertThat(stream.getResponse().getStatus(), equalTo(200));
         assertThat(stream.getResponseHeaders().get(HttpHeader.CONTENT_TYPE), equalTo(MimeTypes.Type.TEXT_PLAIN_8859_1.asString()));
+        assertThat(stream.getResponseHeaders().contains(HttpFields.CONNECTION_CLOSE), is(false));
         assertThat(BufferUtil.toString(stream.getResponseContent()), equalTo(message));
 
         HttpFields trailersRcv = stream.getResponseTrailers();
@@ -1165,6 +1227,7 @@ public class HttpChannelTest
         assertThat(stream.getFailure(), nullValue());
         assertThat(stream.getResponse(), notNullValue());
         assertThat(stream.getResponse().getStatus(), equalTo(200));
+        assertThat(stream.getResponseHeaders().contains(HttpFields.CONNECTION_CLOSE), is(false));
         assertThat(BufferUtil.toString(stream.getResponseContent()), equalTo("contentSize=" + (chunks * data.remaining())));
     }
 
@@ -1383,7 +1446,7 @@ public class HttpChannelTest
         assertFalse(stream.isDemanding());
     }
 
-    enum CompletionTestEvent
+    public enum CompletionTestEvent
     {
         PROCESSED,
         WRITE,
@@ -1534,12 +1597,16 @@ public class HttpChannelTest
         boolean failed = events.contains(CompletionTestEvent.FAIL);
 
         assertThat(stream.isComplete(), is(true));
-        assertThat(stream.getFailure(), failed ? notNullValue() : nullValue());
+        if (errorHandler != null && !expectErrorResponse && failed)
+            assertThat(stream.getFailure(), notNullValue());
+        else
+            assertThat(stream.getFailure(), nullValue());
         if (!failed || expectErrorResponse)
         {
             assertThat(stream.getResponse(), notNullValue());
             assertThat(stream.getResponse().getStatus(), equalTo(failed ? 500 : 200));
             assertThat(stream.getResponseHeaders().get("Test"), failed ? nullValue() : equalTo("Value"));
+            assertThat(stream.getResponseHeaders().contains(HttpFields.CONNECTION_CLOSE), is(false));
         }
         else
         {

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/LargeHeaderTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/LargeHeaderTest.java
@@ -13,15 +13,16 @@
 
 package org.eclipse.jetty.server;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.Writer;
 import java.net.Socket;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -30,9 +31,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.jetty.http.HttpException;
+import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.http.MimeTypes;
+import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.IO;
@@ -124,32 +127,21 @@ public class LargeHeaderTest
         LifeCycle.stop(server);
     }
 
-    private static String readResponse(Socket socket, int xCount, InputStream input) throws IOException
-    {
-        ByteArrayOutputStream readBytes = new ByteArrayOutputStream();
-        int bufferSize = 65535;
-        byte[] buffer = new byte[bufferSize];
-        int lenRead;
-        int lenTotal = 0;
-
-        LOG.debug("X-Count: {} - Reading Response from {}->{}", xCount, socket.getLocalSocketAddress(), socket.getRemoteSocketAddress());
-
-        while (true)
-        {
-            lenRead = input.read(buffer, 0, bufferSize);
-            if (lenRead < 0)
-                break;
-            readBytes.write(buffer, 0, lenRead);
-            lenTotal += lenRead;
-        }
-
-        LOG.debug("X-Count: {} - Read {} bytes of Response from {}->{}", xCount, lenTotal, socket.getLocalAddress(), socket.getRemoteSocketAddress());
-        return readBytes.toString(UTF_8);
-    }
-
     @Test
     public void testLargeHeader() throws Throwable
     {
+        server.setErrorHandler(new ErrorHandler()
+        {
+            @Override
+            protected void htmlRow(Writer writer, String tag, Object value) throws IOException
+            {
+                writer.write(tag);
+                writer.write(": ");
+                writer.write(Objects.toString(value));
+                writer.write("\n");
+            }
+        });
+
         URI serverURI = server.getURI();
         String rawRequest = "GET / HTTP/1.1\r\n" +
             "Host: " + serverURI.getAuthority() + "\r\n" +
@@ -162,8 +154,11 @@ public class LargeHeaderTest
             output.write(rawRequest.getBytes(UTF_8));
             output.flush();
 
-            String rawResponse = readResponse(client, 1, input);
-            assertThat(rawResponse, containsString(" 500 "));
+            HttpTester.Response response = HttpTester.parseResponse(HttpTester.from(input));
+            assertThat(response.getStatus(), is(500));
+            assertThat(response.contains(HttpFields.CONNECTION_CLOSE), is(false));
+            assertThat(response.getContent(), containsString("STATUS: 500"));
+            assertThat(response.getContent(), containsString("MESSAGE: Response Header Fields Too Large"));
         }
     }
 
@@ -283,7 +278,7 @@ public class LargeHeaderTest
     }
 
     @Test
-    public void testLargeHeaderNewConnectionsSequential() throws Throwable
+    public void testLargeHeaderNewConnectionsSequential()
     {
         URI serverURI = server.getURI();
         String rawRequest = "GET / HTTP/1.1\r\n" +
@@ -307,22 +302,22 @@ public class LargeHeaderTest
                 output.flush();
 
                 long start = NanoTime.now();
-                String rawResponse = readResponse(client, count, input);
+                HttpTester.Response response = HttpTester.parseResponse(HttpTester.from(input));
                 if (NanoTime.secondsSince(start) >= 1)
                     LOG.warn("X-Count: {} - Slow Response", count);
 
-                if (rawResponse.isEmpty())
+                if (response == null)
                 {
                     LOG.warn("X-Count: {} - Empty Raw Response", count);
                     countEmpty.incrementAndGet();
                     break;
                 }
-                HttpTester.Response response = HttpTester.parseResponse(rawResponse);
                 int status = response.getStatus();
                 if (status == 500)
                 {
                     long contentLength = response.getLongField(HttpHeader.CONTENT_LENGTH);
                     String responseBody = response.getContent();
+                    assertThat(response.contains(HttpFields.CONNECTION_CLOSE), is(false));
                     assertThat((long)responseBody.length(), is(contentLength));
                     assertThat(responseBody, containsString(EXPECTED_ERROR_TEXT));
                     count500.incrementAndGet();

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/StatisticsHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/StatisticsHandlerTest.java
@@ -599,7 +599,7 @@ public class StatisticsHandlerTest
         assertEquals(0, _statsHandler.getResponses4xx(), "stats.responses4xx");
         assertEquals(1, _statsHandler.getResponses5xx(), "stats.responses5xx");
         assertEquals(1, _statsHandler.getHandlingFailures(), "stats.handlingFailures");
-        assertEquals(1, _statsHandler.getFailures(), "stats.errors");
+        assertEquals(0, _statsHandler.getFailures(), "stats.errors");
     }
 
     @Test
@@ -639,7 +639,7 @@ public class StatisticsHandlerTest
         assertEquals(0, _statsHandler.getResponses4xx(), "stats.responses4xx");
         assertEquals(1, _statsHandler.getResponses5xx(), "stats.responses5xx");
         assertEquals(0, _statsHandler.getHandlingFailures(), "stats.handlingFailures");
-        assertEquals(1, _statsHandler.getFailures(), "stats.errors");
+        assertEquals(0, _statsHandler.getFailures(), "stats.errors");
     }
 
     @Test
@@ -690,7 +690,7 @@ public class StatisticsHandlerTest
         assertEquals(0, _statsHandler.getResponses4xx(), "stats.responses4xx");
         assertEquals(1, _statsHandler.getResponses5xx(), "stats.responses5xx");
         assertEquals(0, _statsHandler.getHandlingFailures(), "stats.handlingFailures");
-        assertEquals(1, _statsHandler.getFailures(), "stats.errors");
+        assertEquals(0, _statsHandler.getFailures(), "stats.errors");
     }
 
     @Test

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-infinispan/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sessions/jetty-ee10-test-sessions-infinispan/pom.xml
@@ -176,6 +176,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <skipTests>true</skipTests>
           <includes>
             <include>**/*.java</include>
           </includes>

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-sessions/jetty-ee11-test-sessions-infinispan/pom.xml
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-sessions/jetty-ee11-test-sessions-infinispan/pom.xml
@@ -177,6 +177,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <skipTests>true</skipTests>
           <includes>
             <include>**/*.java</include>
           </includes>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-infinispan/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sessions/jetty-ee9-test-sessions-infinispan/pom.xml
@@ -196,6 +196,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <skipTests>true</skipTests>
           <includes>
             <include>**/*.java</include>
           </includes>


### PR DESCRIPTION
While working on the overhaul of the `ComplianceViolation.Listener` reporting (https://github.com/jetty/jetty.project/pull/14090), an unrelated bug surfaced: we sometimes abort a response after the `ErrorHandler` manages to successfully write a response without even adding the `Connection: close` header.

This is wrong from an HTTP protocol perspective: since the client isn't told that the connection is going to be closed by the server, it may attempt to reuse it to send another request which it may fail writing, or fail reading the response, or be lucky enough to write the request and read the response before the TCP connection actually is closed.

This PR is about making the necessary changes so that when the `ErrorHandler` manages to successfully write a response, the connection is never aborted while it always is when writing the response fails (network issue) or the response was already committed.

Fixes https://github.com/jetty/jetty.project/issues/14327