### PR TITLE
Issue #14327 - Handle early EOF in HttpClient when response is already complete

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpReceiverOverHTTP.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpReceiverOverHTTP.java
@@ -26,6 +26,7 @@ import org.eclipse.jetty.client.transport.HttpReceiver;
 import org.eclipse.jetty.client.transport.HttpResponse;
 import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpParser;
 import org.eclipse.jetty.http.HttpStatus;
@@ -545,9 +546,38 @@ public class HttpReceiverOverHTTP extends HttpReceiver implements HttpParser.Res
         HttpExchange exchange = getHttpExchange();
         HttpConnectionOverHTTP connection = getHttpConnection();
         if (exchange == null || unsolicited)
+        {
             connection.close();
-        else
-            failAndClose(new EOFException(String.valueOf(connection)));
+            return;
+        }
+
+        // If headers were received and no body is expected, treat EOF as success.
+        if (state.ordinal() >= State.HEADERS.ordinal() && status > 0)
+        {
+            boolean noBody = HttpStatus.hasNoBody(status);
+            if (!noBody)
+            {
+                long contentLength = exchange.getResponse().getHeaders().getLongField(HttpHeader.CONTENT_LENGTH);
+                noBody = contentLength == 0;
+            }
+            if (noBody)
+            {
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Early EOF with complete response (status={}) in {}", status, this);
+                if (chunk == null)
+                    chunk = Content.Chunk.EOF;
+                state = State.COMPLETE;
+                responseSuccess(this::closeConnection);
+                return;
+            }
+        }
+
+        failAndClose(new EOFException(String.valueOf(connection)));
+    }
+
+    private void closeConnection()
+    {
+        getHttpConnection().close();
     }
 
     @Override

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientBadURITest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientBadURITest.java
@@ -1,0 +1,176 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.client;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class HttpClientBadURITest extends AbstractHttpClientServerTest
+{
+    @Test
+    public void testBadURIEarlyClose() throws Exception
+    {
+        try (ServerSocket serverSocket = new ServerSocket(0))
+        {
+            int port = serverSocket.getLocalPort();
+
+            Thread serverThread = new Thread(() ->
+            {
+                try (Socket socket = serverSocket.accept())
+                {
+                    BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
+                    reader.readLine();
+
+                    OutputStream out = socket.getOutputStream();
+                    String response = "HTTP/1.1 400 Bad Request\r\n" +
+                        "Connection: close\r\n" +
+                        "Content-Length: 0\r\n" +
+                        "\r\n";
+                    out.write(response.getBytes(StandardCharsets.UTF_8));
+                    out.flush();
+                    // Socket closes before client finishes writing.
+                }
+                catch (Exception ignored)
+                {
+                }
+            });
+            serverThread.start();
+
+            startClient(new NormalScenario());
+
+            ContentResponse response = client.newRequest("localhost", port)
+                .path("/foo%2Fbar")
+                .timeout(5, TimeUnit.SECONDS)
+                .send();
+
+            assertEquals(HttpStatus.BAD_REQUEST_400, response.getStatus());
+
+            serverThread.join(5000);
+        }
+    }
+
+    @Test
+    public void testVariousBadURIPatternsEarlyClose() throws Exception
+    {
+        String[] badPaths = {
+            "/foo%2Fbar",
+            "/foo//bar",
+            "/foo/..;/bar",
+            "/foo/%2e%2e;param/bar"
+        };
+
+        for (String badPath : badPaths)
+        {
+            try (ServerSocket serverSocket = new ServerSocket(0))
+            {
+                int port = serverSocket.getLocalPort();
+
+                Thread serverThread = new Thread(() ->
+                {
+                    try (Socket socket = serverSocket.accept())
+                    {
+                        BufferedReader reader = new BufferedReader(
+                            new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
+                        reader.readLine();
+
+                        OutputStream out = socket.getOutputStream();
+                        String response = "HTTP/1.1 400 Bad Request\r\n" +
+                            "Connection: close\r\n" +
+                            "Content-Length: 0\r\n" +
+                            "\r\n";
+                        out.write(response.getBytes(StandardCharsets.UTF_8));
+                        out.flush();
+                    }
+                    catch (Exception ignored)
+                    {
+                    }
+                });
+                serverThread.start();
+
+                startClient(new NormalScenario());
+
+                ContentResponse response = client.newRequest("localhost", port)
+                    .path(badPath)
+                    .timeout(5, TimeUnit.SECONDS)
+                    .send();
+
+                assertEquals(HttpStatus.BAD_REQUEST_400, response.getStatus(),
+                    "Expected 400 for path: " + badPath);
+
+                serverThread.join(5000);
+                disposeClient();
+            }
+        }
+    }
+
+    @Test
+    public void testBadURIProperClose() throws Exception
+    {
+        try (ServerSocket serverSocket = new ServerSocket(0))
+        {
+            int port = serverSocket.getLocalPort();
+
+            Thread serverThread = new Thread(() ->
+            {
+                try (Socket socket = serverSocket.accept())
+                {
+                    BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
+
+                    String line;
+                    while ((line = reader.readLine()) != null && !line.isEmpty())
+                    {
+                        // Consume all headers.
+                    }
+
+                    OutputStream out = socket.getOutputStream();
+                    String response = "HTTP/1.1 400 Bad Request\r\n" +
+                        "Connection: close\r\n" +
+                        "Content-Length: 0\r\n" +
+                        "\r\n";
+                    out.write(response.getBytes(StandardCharsets.UTF_8));
+                    out.flush();
+                }
+                catch (Exception e)
+                {
+                    fail("Server should not fail: " + e.getMessage());
+                }
+            });
+            serverThread.start();
+
+            startClient(new NormalScenario());
+
+            ContentResponse response = client.newRequest("localhost", port)
+                .path("/foo%2Fbar")
+                .timeout(5, TimeUnit.SECONDS)
+                .send();
+
+            assertEquals(HttpStatus.BAD_REQUEST_400, response.getStatus());
+
+            serverThread.join(5000);
+        }
+    }
+}

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientBadURITest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientBadURITest.java
@@ -20,17 +20,89 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import org.eclipse.jetty.http.HttpStatus;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class HttpClientBadURITest extends AbstractHttpClientServerTest
 {
-    @Test
-    public void testBadURIEarlyClose() throws Exception
+    public static Stream<Arguments> earlyCloseScenarios()
+    {
+        return Stream.of(
+            // Status codes where HttpStatus.hasNoBody() returns true
+            Arguments.of(204, "No Content", null),
+            Arguments.of(304, "Not Modified", null),
+            // Status codes requiring Content-Length: 0
+            Arguments.of(400, "Bad Request", "0"),
+            Arguments.of(403, "Forbidden", "0"),
+            Arguments.of(404, "Not Found", "0"),
+            Arguments.of(500, "Internal Server Error", "0")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("earlyCloseScenarios")
+    public void testEarlyClose(int status, String reason, String contentLength) throws Exception
+    {
+        try (ServerSocket serverSocket = new ServerSocket(0))
+        {
+            int port = serverSocket.getLocalPort();
+
+            Thread serverThread = new Thread(() ->
+            {
+                try (Socket socket = serverSocket.accept())
+                {
+                    BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
+                    reader.readLine();
+
+                    OutputStream out = socket.getOutputStream();
+                    StringBuilder response = new StringBuilder();
+                    response.append("HTTP/1.1 ").append(status).append(" ").append(reason).append("\r\n");
+                    response.append("Connection: close\r\n");
+                    if (contentLength != null)
+                        response.append("Content-Length: ").append(contentLength).append("\r\n");
+                    response.append("\r\n");
+                    out.write(response.toString().getBytes(StandardCharsets.UTF_8));
+                    out.flush();
+                }
+                catch (Exception ignored)
+                {
+                }
+            });
+            serverThread.start();
+
+            startClient(new NormalScenario());
+
+            ContentResponse response = client.newRequest("localhost", port)
+                .path("/test")
+                .timeout(5, TimeUnit.SECONDS)
+                .send();
+
+            assertEquals(status, response.getStatus());
+
+            serverThread.join(5000);
+        }
+    }
+
+    public static Stream<Arguments> badPaths()
+    {
+        return Stream.of(
+            Arguments.of("/foo%2Fbar"),
+            Arguments.of("/foo//bar"),
+            Arguments.of("/foo/..;/bar"),
+            Arguments.of("/foo/%2e%2e;param/bar")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("badPaths")
+    public void testBadPathEarlyClose(String path) throws Exception
     {
         try (ServerSocket serverSocket = new ServerSocket(0))
         {
@@ -51,7 +123,6 @@ public class HttpClientBadURITest extends AbstractHttpClientServerTest
                         "\r\n";
                     out.write(response.getBytes(StandardCharsets.UTF_8));
                     out.flush();
-                    // Socket closes before client finishes writing.
                 }
                 catch (Exception ignored)
                 {
@@ -62,109 +133,7 @@ public class HttpClientBadURITest extends AbstractHttpClientServerTest
             startClient(new NormalScenario());
 
             ContentResponse response = client.newRequest("localhost", port)
-                .path("/foo%2Fbar")
-                .timeout(5, TimeUnit.SECONDS)
-                .send();
-
-            assertEquals(HttpStatus.BAD_REQUEST_400, response.getStatus());
-
-            serverThread.join(5000);
-        }
-    }
-
-    @Test
-    public void testVariousBadURIPatternsEarlyClose() throws Exception
-    {
-        String[] badPaths = {
-            "/foo%2Fbar",
-            "/foo//bar",
-            "/foo/..;/bar",
-            "/foo/%2e%2e;param/bar"
-        };
-
-        for (String badPath : badPaths)
-        {
-            try (ServerSocket serverSocket = new ServerSocket(0))
-            {
-                int port = serverSocket.getLocalPort();
-
-                Thread serverThread = new Thread(() ->
-                {
-                    try (Socket socket = serverSocket.accept())
-                    {
-                        BufferedReader reader = new BufferedReader(
-                            new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
-                        reader.readLine();
-
-                        OutputStream out = socket.getOutputStream();
-                        String response = "HTTP/1.1 400 Bad Request\r\n" +
-                            "Connection: close\r\n" +
-                            "Content-Length: 0\r\n" +
-                            "\r\n";
-                        out.write(response.getBytes(StandardCharsets.UTF_8));
-                        out.flush();
-                    }
-                    catch (Exception ignored)
-                    {
-                    }
-                });
-                serverThread.start();
-
-                startClient(new NormalScenario());
-
-                ContentResponse response = client.newRequest("localhost", port)
-                    .path(badPath)
-                    .timeout(5, TimeUnit.SECONDS)
-                    .send();
-
-                assertEquals(HttpStatus.BAD_REQUEST_400, response.getStatus(),
-                    "Expected 400 for path: " + badPath);
-
-                serverThread.join(5000);
-                disposeClient();
-            }
-        }
-    }
-
-    @Test
-    public void testBadURIProperClose() throws Exception
-    {
-        try (ServerSocket serverSocket = new ServerSocket(0))
-        {
-            int port = serverSocket.getLocalPort();
-
-            Thread serverThread = new Thread(() ->
-            {
-                try (Socket socket = serverSocket.accept())
-                {
-                    BufferedReader reader = new BufferedReader(
-                        new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
-
-                    String line;
-                    while ((line = reader.readLine()) != null && !line.isEmpty())
-                    {
-                        // Consume all headers.
-                    }
-
-                    OutputStream out = socket.getOutputStream();
-                    String response = "HTTP/1.1 400 Bad Request\r\n" +
-                        "Connection: close\r\n" +
-                        "Content-Length: 0\r\n" +
-                        "\r\n";
-                    out.write(response.getBytes(StandardCharsets.UTF_8));
-                    out.flush();
-                }
-                catch (Exception e)
-                {
-                    fail("Server should not fail: " + e.getMessage());
-                }
-            });
-            serverThread.start();
-
-            startClient(new NormalScenario());
-
-            ContentResponse response = client.newRequest("localhost", port)
-                .path("/foo%2Fbar")
+                .path(path)
                 .timeout(5, TimeUnit.SECONDS)
                 .send();
 


### PR DESCRIPTION
Related to #14327

This PR explored a client-side fallback for early EOF cases where a response is already complete.

After #14370 fixed the server-side behavior for Jetty, this client-side change is no longer necessary for the reported issue.

The added test was useful for investigation, but it does not provide strong enough coverage to justify keeping the transport behavior change.
