### PR TITLE
Issue #108 - Add permanent redirect caching to HttpClient

### DIFF
--- a/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/client/http/HTTPClientDocs.java
+++ b/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/client/http/HTTPClientDocs.java
@@ -49,6 +49,7 @@ import org.eclipse.jetty.client.InputStreamResponseListener;
 import org.eclipse.jetty.client.OutputStreamRequestContent;
 import org.eclipse.jetty.client.PathRequestContent;
 import org.eclipse.jetty.client.PathResponseListener;
+import org.eclipse.jetty.client.PermanentRedirectCache;
 import org.eclipse.jetty.client.ProxyConfiguration;
 import org.eclipse.jetty.client.Request;
 import org.eclipse.jetty.client.Response;
@@ -737,6 +738,24 @@ public class HTTPClientDocs
 
         httpClient.setHttpCookieStore(new GoogleOnlyCookieStore());
         // end::filteringCookieStore[]
+    }
+
+    public void permanentRedirectCache() throws Exception
+    {
+        // tag::permanentRedirectCache[]
+        HttpClient httpClient = new HttpClient();
+
+        // Enable caching of permanent redirects with max 1000 entries.
+        httpClient.setPermanentRedirectCache(new PermanentRedirectCache.Default(1000));
+
+        httpClient.start();
+
+        // First request to http://example.com/old -> 301 -> http://example.com/new
+        // makes 2 round-trips and caches the redirect.
+
+        // Second request to http://example.com/old goes directly to /new
+        // making only 1 round-trip.
+        // end::permanentRedirectCache[]
     }
 
     public void addAuthentication() throws Exception

--- a/documentation/jetty/modules/programming-guide/pages/client/http.adoc
+++ b/documentation/jetty/modules/programming-guide/pages/client/http.adoc
@@ -851,6 +851,26 @@ jakarta.servlet.http.Cookie cookie = new Cookie("foo", URLEncoder.encode("bar;ba
 Jetty validates all cookie names and values being added to the `HttpServletResponse` via the `addCookie(Cookie)` method.
 If an illegal value is discovered Jetty will throw an `IllegalArgumentException` with the details.
 
+[[redirect-cache]]
+== Permanent Redirect Caching
+
+By default, `HttpClient` follows redirects but does not cache them.
+This means that repeated requests to a URL that returns a permanent redirect (301 or 308) will each incur the redirect round-trip.
+
+You can enable permanent redirect caching to optimize this:
+
+[,java,indent=0]
+----
+include::code:example$src/main/java/org/eclipse/jetty/docs/programming/client/http/HTTPClientDocs.java[tag=permanentRedirectCache]
+----
+
+The cache stores permanent redirects (status codes 301 and 308) and applies them to subsequent requests, including any method transformations (for example, POST to GET for 301).
+
+The `PermanentRedirectCache.Default` implementation accepts a maximum size parameter to limit memory usage.
+When the limit is reached, least-recently-used entries are evicted.
+
+To disable caching (the default), do not set a cache or set it to `null`.
+
 [[authentication]]
 == HttpClient Authentication Support
 

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/CachingRedirectProtocolHandler.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/CachingRedirectProtocolHandler.java
@@ -1,0 +1,130 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.client;
+
+import java.net.URI;
+
+import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * <p>A protocol handler that handles redirect status codes and caches permanent redirects (301, 308).</p>
+ * <p>This handler extends the standard redirect behavior by storing permanent redirects
+ * in a {@link PermanentRedirectCache} for later reuse.</p>
+ */
+public class CachingRedirectProtocolHandler implements ProtocolHandler, Response.Listener
+{
+    public static final String NAME = "caching-redirect";
+    private static final Logger LOG = LoggerFactory.getLogger(CachingRedirectProtocolHandler.class);
+
+    private final HttpRedirector redirector;
+    private final PermanentRedirectCache cache;
+
+    public CachingRedirectProtocolHandler(HttpClient client, PermanentRedirectCache cache)
+    {
+        this.redirector = new HttpRedirector(client);
+        this.cache = cache;
+    }
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public boolean accept(Request request, Response response)
+    {
+        return redirector.isRedirect(response) && request.isFollowRedirects();
+    }
+
+    @Override
+    public Response.Listener getResponseListener()
+    {
+        return this;
+    }
+
+    @Override
+    public boolean onHeader(Response response, HttpField field)
+    {
+        // Avoid that the content is decoded, which could generate
+        // errors, since we are discarding the response content anyway.
+        return field.getHeader() != HttpHeader.CONTENT_ENCODING;
+    }
+
+    @Override
+    public void onSuccess(Response response)
+    {
+        // The request may still be sending content, stop it.
+        Request request = response.getRequest();
+        if (request.getBody() != null)
+            request.abort(new HttpRequestException("Aborting request after receiving a %d response".formatted(response.getStatus()), request));
+    }
+
+    @Override
+    public void onComplete(Result result)
+    {
+        Request request = result.getRequest();
+        Response response = result.getResponse();
+
+        // Cache permanent redirects before delegating to the redirector
+        int status = response.getStatus();
+        if (isPermanentRedirect(status))
+        {
+            cacheRedirect(request, response, status);
+        }
+
+        redirector.redirect(request, response, null);
+    }
+
+    private boolean isPermanentRedirect(int status)
+    {
+        return status == HttpStatus.MOVED_PERMANENTLY_301 || status == HttpStatus.PERMANENT_REDIRECT_308;
+    }
+
+    private void cacheRedirect(Request request, Response response, int status)
+    {
+        URI targetURI = redirector.extractRedirectURI(response);
+        if (targetURI == null)
+            return;
+
+        String targetMethod = redirector.computeRedirectMethod(request, response);
+        if (targetMethod == null)
+            return;
+
+        String key = PermanentRedirectCache.normalizeURI(request);
+        PermanentRedirectCache.CachedRedirect cached = new PermanentRedirectCache.CachedRedirect(
+            targetURI,
+            targetMethod,
+            status,
+            System.currentTimeMillis()
+        );
+
+        cache.put(key, cached);
+
+        if (LOG.isDebugEnabled())
+            LOG.debug("Cached {} redirect: {} -> {}", status, key, targetURI);
+    }
+
+    /**
+     * @return the {@link HttpRedirector} used by this handler
+     */
+    public HttpRedirector getRedirector()
+    {
+        return redirector;
+    }
+}

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -143,6 +143,7 @@ public class HttpClient extends ContainerLifeCycle implements AutoCloseable
     private boolean useInputDirectByteBuffers = true;
     private boolean useOutputDirectByteBuffers = true;
     private Sweeper destinationSweeper;
+    private PermanentRedirectCache permanentRedirectCache;
 
     /**
      * Creates a HttpClient instance that can perform HTTP/1.1 requests to non-TLS and TLS destinations.
@@ -233,7 +234,15 @@ public class HttpClient extends ContainerLifeCycle implements AutoCloseable
         handlers.put(new ContinueProtocolHandler());
         handlers.put(new ProcessingProtocolHandler());
         handlers.put(new EarlyHintsProtocolHandler());
-        handlers.put(new RedirectProtocolHandler(this));
+        if (permanentRedirectCache != null)
+        {
+            handlers.put(new CachingRedirectProtocolHandler(this, permanentRedirectCache));
+            requestListeners.addQueuedListener(this::applyCachedRedirect);
+        }
+        else
+        {
+            handlers.put(new RedirectProtocolHandler(this));
+        }
         handlers.put(new WWWAuthenticationProtocolHandler(this));
         handlers.put(new ProxyAuthenticationProtocolHandler(this));
         handlers.put(new UpgradeProtocolHandler());
@@ -259,6 +268,33 @@ public class HttpClient extends ContainerLifeCycle implements AutoCloseable
         }
     }
 
+    private void applyCachedRedirect(Request request)
+    {
+        if (permanentRedirectCache == null)
+            return;
+
+        String key = PermanentRedirectCache.normalizeURI(request);
+        PermanentRedirectCache.CachedRedirect cached = permanentRedirectCache.get(key);
+        if (cached == null)
+            return;
+
+        URI targetURI = cached.targetURI();
+        if (LOG.isDebugEnabled())
+            LOG.debug("Applying cached redirect: {} -> {}", key, targetURI);
+
+        request.scheme(targetURI.getScheme());
+        request.host(targetURI.getHost());
+        int port = targetURI.getPort();
+        if (port > 0)
+            request.port(port);
+        String path = targetURI.getRawPath();
+        String query = targetURI.getRawQuery();
+        if (query != null)
+            path = path + "?" + query;
+        request.path(path);
+        request.method(cached.targetMethod());
+    }
+
     @Override
     protected void doStop() throws Exception
     {
@@ -274,6 +310,8 @@ public class HttpClient extends ContainerLifeCycle implements AutoCloseable
         requestListeners.clear();
         authenticationStore.clearAuthentications();
         authenticationStore.clearAuthenticationResults();
+        if (permanentRedirectCache != null)
+            permanentRedirectCache.clear();
 
         super.doStop();
     }
@@ -334,6 +372,28 @@ public class HttpClient extends ContainerLifeCycle implements AutoCloseable
         if (isStarted())
             throw new IllegalStateException();
         this.authenticationStore = authenticationStore;
+    }
+
+    /**
+     * Get the permanent redirect cache associated with this instance.
+     * @return the permanent redirect cache, or null if caching is disabled
+     */
+    public PermanentRedirectCache getPermanentRedirectCache()
+    {
+        return permanentRedirectCache;
+    }
+
+    /**
+     * Set the permanent redirect cache associated with this instance.
+     * When set, permanent redirects (301, 308) will be cached and subsequent
+     * requests to the same URI will skip the redirect round-trip.
+     * @param cache the permanent redirect cache, or null to disable caching
+     */
+    public void setPermanentRedirectCache(PermanentRedirectCache cache)
+    {
+        if (isStarted())
+            throw new IllegalStateException();
+        this.permanentRedirectCache = cache;
     }
 
     /**

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRedirector.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRedirector.java
@@ -270,6 +270,46 @@ public class HttpRedirector
     }
 
     /**
+     * Computes the HTTP method to use for a redirect request.
+     *
+     * @param request the original request
+     * @param response the redirect response
+     * @return the HTTP method to use for the redirect, or null if the redirect is not valid
+     */
+    public String computeRedirectMethod(Request request, Response response)
+    {
+        int status = response.getStatus();
+        String method = request.getMethod();
+        return switch (status)
+        {
+            case HttpStatus.MOVED_PERMANENTLY_301 ->
+            {
+                if (HttpMethod.GET.is(method) || HttpMethod.HEAD.is(method) || HttpMethod.PUT.is(method))
+                    yield method;
+                else if (HttpMethod.POST.is(method))
+                    yield HttpMethod.GET.asString();
+                yield null;
+            }
+            case HttpStatus.MOVED_TEMPORARILY_302 ->
+            {
+                if (HttpMethod.HEAD.is(method) || HttpMethod.PUT.is(method))
+                    yield method;
+                else
+                    yield HttpMethod.GET.asString();
+            }
+            case HttpStatus.SEE_OTHER_303 ->
+            {
+                if (HttpMethod.HEAD.is(method))
+                    yield method;
+                else
+                    yield HttpMethod.GET.asString();
+            }
+            case HttpStatus.TEMPORARY_REDIRECT_307, HttpStatus.PERMANENT_REDIRECT_308 -> method;
+            default -> null;
+        };
+    }
+
+    /**
      * Extracts and sanitizes (by making it absolute and escaping paths and query parameters)
      * the redirect URI of the given {@code response}.
      *

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/PermanentRedirectCache.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/PermanentRedirectCache.java
@@ -1,0 +1,233 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.client;
+
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * <p>A cache for permanent HTTP redirects (301, 308).</p>
+ * <p>When enabled, subsequent requests to previously-redirected URIs
+ * skip the redirect round-trip by applying the cached redirect directly.</p>
+ */
+public interface PermanentRedirectCache
+{
+    /**
+     * <p>Gets a cached redirect for the given normalized URI.</p>
+     *
+     * @param normalizedURI the normalized URI key
+     * @return the cached redirect, or null if not found
+     */
+    CachedRedirect get(String normalizedURI);
+
+    /**
+     * <p>Caches a permanent redirect.</p>
+     *
+     * @param normalizedURI the normalized URI key
+     * @param redirect the redirect to cache
+     */
+    void put(String normalizedURI, CachedRedirect redirect);
+
+    /**
+     * <p>Removes a cached redirect.</p>
+     *
+     * @param normalizedURI the normalized URI key
+     * @return true if a redirect was removed
+     */
+    boolean remove(String normalizedURI);
+
+    /**
+     * <p>Clears all cached redirects.</p>
+     */
+    void clear();
+
+    /**
+     * @return the number of cached redirects
+     */
+    int size();
+
+    /**
+     * <p>Normalizes a request URI into a cache key.</p>
+     * <p>The key includes scheme, host, port, path, and query.</p>
+     *
+     * @param request the request to normalize
+     * @return the normalized URI string
+     */
+    static String normalizeURI(Request request)
+    {
+        String scheme = request.getScheme();
+        String host = request.getHost();
+        int port = request.getPort();
+        port = HttpClient.normalizePort(scheme, port);
+        String path = request.getPath();
+        if (path == null || path.isEmpty())
+            path = "/";
+        String query = request.getQuery();
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(scheme).append("://").append(host);
+        if (port > 0)
+            sb.append(":").append(port);
+        sb.append(path);
+        if (query != null && !query.isEmpty())
+            sb.append("?").append(query);
+        return sb.toString();
+    }
+
+    /**
+     * <p>A cached redirect entry.</p>
+     *
+     * @param targetURI the target URI to redirect to
+     * @param targetMethod the HTTP method to use for the redirected request
+     * @param statusCode the original redirect status code (301 or 308)
+     * @param creationTime the time this entry was created
+     */
+    record CachedRedirect(URI targetURI, String targetMethod, int statusCode, long creationTime) {}
+
+    /**
+     * <p>A no-op implementation that does not cache any redirects.</p>
+     */
+    class Empty implements PermanentRedirectCache
+    {
+        @Override
+        public CachedRedirect get(String normalizedURI)
+        {
+            return null;
+        }
+
+        @Override
+        public void put(String normalizedURI, CachedRedirect redirect)
+        {
+        }
+
+        @Override
+        public boolean remove(String normalizedURI)
+        {
+            return false;
+        }
+
+        @Override
+        public void clear()
+        {
+        }
+
+        @Override
+        public int size()
+        {
+            return 0;
+        }
+    }
+
+    /**
+     * <p>Default implementation using a size-bounded LRU cache.</p>
+     */
+    class Default implements PermanentRedirectCache
+    {
+        private final ReadWriteLock lock = new ReentrantReadWriteLock();
+        private final Map<String, CachedRedirect> cache;
+
+        /**
+         * Creates a cache with the specified maximum size.
+         *
+         * @param maxSize the maximum number of entries (must be positive)
+         */
+        public Default(int maxSize)
+        {
+            if (maxSize <= 0)
+                throw new IllegalArgumentException("maxSize must be positive");
+
+            this.cache = new LinkedHashMap<>(16, 0.75f, true)
+            {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<String, CachedRedirect> eldest)
+                {
+                    return size() > maxSize;
+                }
+            };
+        }
+
+        @Override
+        public CachedRedirect get(String normalizedURI)
+        {
+            lock.readLock().lock();
+            try
+            {
+                return cache.get(normalizedURI);
+            }
+            finally
+            {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public void put(String normalizedURI, CachedRedirect redirect)
+        {
+            lock.writeLock().lock();
+            try
+            {
+                cache.put(normalizedURI, redirect);
+            }
+            finally
+            {
+                lock.writeLock().unlock();
+            }
+        }
+
+        @Override
+        public boolean remove(String normalizedURI)
+        {
+            lock.writeLock().lock();
+            try
+            {
+                return cache.remove(normalizedURI) != null;
+            }
+            finally
+            {
+                lock.writeLock().unlock();
+            }
+        }
+
+        @Override
+        public void clear()
+        {
+            lock.writeLock().lock();
+            try
+            {
+                cache.clear();
+            }
+            finally
+            {
+                lock.writeLock().unlock();
+            }
+        }
+
+        @Override
+        public int size()
+        {
+            lock.readLock().lock();
+            try
+            {
+                return cache.size();
+            }
+            finally
+            {
+                lock.readLock().unlock();
+            }
+        }
+    }
+}

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/PermanentRedirectCacheTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/PermanentRedirectCacheTest.java
@@ -1,0 +1,524 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.client;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.util.Callback;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PermanentRedirectCacheTest extends AbstractHttpClientServerTest
+{
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void test301Cached(Scenario scenario) throws Exception
+    {
+        AtomicInteger redirectCount = new AtomicInteger();
+        start(scenario, new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
+            {
+                String path = Request.getPathInContext(request);
+                if ("/old".equals(path))
+                {
+                    redirectCount.incrementAndGet();
+                    response.setStatus(HttpStatus.MOVED_PERMANENTLY_301);
+                    response.getHeaders().put(HttpHeader.LOCATION, scenario.getScheme() + "://localhost:" + connector.getLocalPort() + "/new");
+                    callback.succeeded();
+                }
+                else if ("/new".equals(path))
+                {
+                    response.setStatus(HttpStatus.OK_200);
+                    response.write(true, ByteBuffer.wrap("ok".getBytes(StandardCharsets.UTF_8)), callback);
+                }
+                else
+                {
+                    response.setStatus(HttpStatus.NOT_FOUND_404);
+                    callback.succeeded();
+                }
+                return true;
+            }
+        });
+
+        startClient(scenario, httpClient -> httpClient.setPermanentRedirectCache(new PermanentRedirectCache.Default(100)));
+
+        // First request - should follow redirect and cache it
+        ContentResponse response1 = client.newRequest("localhost", connector.getLocalPort())
+            .scheme(scenario.getScheme())
+            .path("/old")
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(HttpStatus.OK_200, response1.getStatus());
+        assertEquals("ok", response1.getContentAsString());
+        assertEquals(1, redirectCount.get());
+        assertEquals(1, client.getPermanentRedirectCache().size());
+
+        // Second request - should use cached redirect (no server redirect)
+        ContentResponse response2 = client.newRequest("localhost", connector.getLocalPort())
+            .scheme(scenario.getScheme())
+            .path("/old")
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(HttpStatus.OK_200, response2.getStatus());
+        assertEquals("ok", response2.getContentAsString());
+        // Redirect count should still be 1 - the server was not asked to redirect
+        assertEquals(1, redirectCount.get());
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void test308Cached(Scenario scenario) throws Exception
+    {
+        AtomicInteger redirectCount = new AtomicInteger();
+        byte[] data = new byte[]{0, 1, 2, 3, 4, 5, 6, 7};
+
+        start(scenario, new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback) throws Exception
+            {
+                String path = Request.getPathInContext(request);
+                if ("/old".equals(path))
+                {
+                    redirectCount.incrementAndGet();
+                    response.setStatus(HttpStatus.PERMANENT_REDIRECT_308);
+                    response.getHeaders().put(HttpHeader.LOCATION, scenario.getScheme() + "://localhost:" + connector.getLocalPort() + "/new");
+                    callback.succeeded();
+                }
+                else if ("/new".equals(path))
+                {
+                    // Verify POST method preserved
+                    assertEquals("POST", request.getMethod());
+                    response.setStatus(HttpStatus.OK_200);
+                    // Echo back the content
+                    ByteBuffer buffer = ByteBuffer.allocate(data.length);
+                    while (buffer.hasRemaining())
+                    {
+                        org.eclipse.jetty.io.Content.Chunk chunk = request.read();
+                        if (chunk == null)
+                        {
+                            Thread.sleep(10);
+                            continue;
+                        }
+                        if (chunk.hasRemaining())
+                            buffer.put(chunk.getByteBuffer());
+                        chunk.release();
+                        if (chunk.isLast())
+                            break;
+                    }
+                    buffer.flip();
+                    response.write(true, buffer, callback);
+                }
+                else
+                {
+                    response.setStatus(HttpStatus.NOT_FOUND_404);
+                    callback.succeeded();
+                }
+                return true;
+            }
+        });
+
+        startClient(scenario, httpClient -> httpClient.setPermanentRedirectCache(new PermanentRedirectCache.Default(100)));
+
+        // First request - POST with body, 308 preserves method
+        ContentResponse response1 = client.newRequest("localhost", connector.getLocalPort())
+            .scheme(scenario.getScheme())
+            .method(HttpMethod.POST)
+            .path("/old")
+            .body(new ByteBufferRequestContent(ByteBuffer.wrap(data)))
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(HttpStatus.OK_200, response1.getStatus());
+        assertArrayEquals(data, response1.getContent());
+        assertEquals(1, redirectCount.get());
+
+        // Second request - should use cached redirect
+        ContentResponse response2 = client.newRequest("localhost", connector.getLocalPort())
+            .scheme(scenario.getScheme())
+            .method(HttpMethod.POST)
+            .path("/old")
+            .body(new ByteBufferRequestContent(ByteBuffer.wrap(data)))
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(HttpStatus.OK_200, response2.getStatus());
+        assertArrayEquals(data, response2.getContent());
+        // Redirect count should still be 1
+        assertEquals(1, redirectCount.get());
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void test301PostToGet(Scenario scenario) throws Exception
+    {
+        AtomicInteger redirectCount = new AtomicInteger();
+
+        start(scenario, new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
+            {
+                String path = Request.getPathInContext(request);
+                if ("/old".equals(path))
+                {
+                    redirectCount.incrementAndGet();
+                    response.setStatus(HttpStatus.MOVED_PERMANENTLY_301);
+                    response.getHeaders().put(HttpHeader.LOCATION, scenario.getScheme() + "://localhost:" + connector.getLocalPort() + "/new");
+                    callback.succeeded();
+                }
+                else if ("/new".equals(path))
+                {
+                    // 301 converts POST to GET
+                    assertEquals("GET", request.getMethod());
+                    response.setStatus(HttpStatus.OK_200);
+                    response.write(true, ByteBuffer.wrap("ok".getBytes(StandardCharsets.UTF_8)), callback);
+                }
+                else
+                {
+                    response.setStatus(HttpStatus.NOT_FOUND_404);
+                    callback.succeeded();
+                }
+                return true;
+            }
+        });
+
+        startClient(scenario, httpClient -> httpClient.setPermanentRedirectCache(new PermanentRedirectCache.Default(100)));
+
+        // First request - POST converted to GET
+        ContentResponse response1 = client.newRequest("localhost", connector.getLocalPort())
+            .scheme(scenario.getScheme())
+            .method(HttpMethod.POST)
+            .path("/old")
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(HttpStatus.OK_200, response1.getStatus());
+        assertEquals(1, redirectCount.get());
+
+        // Second request as POST - cached redirect should convert to GET
+        ContentResponse response2 = client.newRequest("localhost", connector.getLocalPort())
+            .scheme(scenario.getScheme())
+            .method(HttpMethod.POST)
+            .path("/old")
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(HttpStatus.OK_200, response2.getStatus());
+        // Redirect count should still be 1
+        assertEquals(1, redirectCount.get());
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testCrossOriginRedirect(Scenario scenario) throws Exception
+    {
+        AtomicInteger redirectCount = new AtomicInteger();
+
+        start(scenario, new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
+            {
+                String path = Request.getPathInContext(request);
+                String host = Request.getServerName(request);
+                if ("/old".equals(path) && "localhost".equals(host))
+                {
+                    redirectCount.incrementAndGet();
+                    response.setStatus(HttpStatus.MOVED_PERMANENTLY_301);
+                    // Redirect to 127.0.0.1 (different host)
+                    response.getHeaders().put(HttpHeader.LOCATION, scenario.getScheme() + "://127.0.0.1:" + connector.getLocalPort() + "/new");
+                    callback.succeeded();
+                }
+                else if ("/new".equals(path))
+                {
+                    response.setStatus(HttpStatus.OK_200);
+                    response.write(true, ByteBuffer.wrap("ok".getBytes(StandardCharsets.UTF_8)), callback);
+                }
+                else
+                {
+                    response.setStatus(HttpStatus.NOT_FOUND_404);
+                    callback.succeeded();
+                }
+                return true;
+            }
+        });
+
+        startClient(scenario, httpClient -> httpClient.setPermanentRedirectCache(new PermanentRedirectCache.Default(100)));
+
+        // First request
+        ContentResponse response1 = client.newRequest("localhost", connector.getLocalPort())
+            .scheme(scenario.getScheme())
+            .path("/old")
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(HttpStatus.OK_200, response1.getStatus());
+        assertEquals(1, redirectCount.get());
+        assertEquals(1, client.getPermanentRedirectCache().size());
+
+        // Second request - should use cached cross-origin redirect
+        ContentResponse response2 = client.newRequest("localhost", connector.getLocalPort())
+            .scheme(scenario.getScheme())
+            .path("/old")
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(HttpStatus.OK_200, response2.getStatus());
+        assertEquals(1, redirectCount.get());
+    }
+
+    @Test
+    public void testCacheEviction() throws Exception
+    {
+        PermanentRedirectCache.Default cache = new PermanentRedirectCache.Default(2);
+
+        cache.put("uri1", new PermanentRedirectCache.CachedRedirect(
+            java.net.URI.create("http://example.com/1"), "GET", 301, System.currentTimeMillis()));
+        cache.put("uri2", new PermanentRedirectCache.CachedRedirect(
+            java.net.URI.create("http://example.com/2"), "GET", 301, System.currentTimeMillis()));
+
+        assertEquals(2, cache.size());
+        assertNotNull(cache.get("uri1"));
+        assertNotNull(cache.get("uri2"));
+
+        // Adding third entry should evict the least recently used
+        cache.put("uri3", new PermanentRedirectCache.CachedRedirect(
+            java.net.URI.create("http://example.com/3"), "GET", 301, System.currentTimeMillis()));
+
+        assertEquals(2, cache.size());
+        assertNotNull(cache.get("uri2"));
+        assertNotNull(cache.get("uri3"));
+    }
+
+    @Test
+    public void testCacheClearedOnStop() throws Exception
+    {
+        HttpClient httpClient = new HttpClient();
+        PermanentRedirectCache.Default cache = new PermanentRedirectCache.Default(100);
+        httpClient.setPermanentRedirectCache(cache);
+        httpClient.start();
+
+        cache.put("uri1", new PermanentRedirectCache.CachedRedirect(
+            java.net.URI.create("http://example.com/1"), "GET", 301, System.currentTimeMillis()));
+
+        assertEquals(1, cache.size());
+
+        httpClient.stop();
+
+        assertEquals(0, cache.size());
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testDisabledCache(Scenario scenario) throws Exception
+    {
+        AtomicInteger redirectCount = new AtomicInteger();
+
+        start(scenario, new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
+            {
+                String path = Request.getPathInContext(request);
+                if ("/old".equals(path))
+                {
+                    redirectCount.incrementAndGet();
+                    response.setStatus(HttpStatus.MOVED_PERMANENTLY_301);
+                    response.getHeaders().put(HttpHeader.LOCATION, scenario.getScheme() + "://localhost:" + connector.getLocalPort() + "/new");
+                    callback.succeeded();
+                }
+                else if ("/new".equals(path))
+                {
+                    response.setStatus(HttpStatus.OK_200);
+                    response.write(true, ByteBuffer.wrap("ok".getBytes(StandardCharsets.UTF_8)), callback);
+                }
+                else
+                {
+                    response.setStatus(HttpStatus.NOT_FOUND_404);
+                    callback.succeeded();
+                }
+                return true;
+            }
+        });
+
+        // No cache set - default behavior
+        startClient(scenario, null);
+
+        // First request
+        ContentResponse response1 = client.newRequest("localhost", connector.getLocalPort())
+            .scheme(scenario.getScheme())
+            .path("/old")
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(HttpStatus.OK_200, response1.getStatus());
+        assertEquals(1, redirectCount.get());
+
+        // Second request - redirect should happen again (no caching)
+        ContentResponse response2 = client.newRequest("localhost", connector.getLocalPort())
+            .scheme(scenario.getScheme())
+            .path("/old")
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(HttpStatus.OK_200, response2.getStatus());
+        assertEquals(2, redirectCount.get());
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testCacheMiss(Scenario scenario) throws Exception
+    {
+        AtomicInteger redirectCount = new AtomicInteger();
+
+        start(scenario, new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
+            {
+                String path = Request.getPathInContext(request);
+                if ("/old".equals(path))
+                {
+                    redirectCount.incrementAndGet();
+                    response.setStatus(HttpStatus.MOVED_PERMANENTLY_301);
+                    response.getHeaders().put(HttpHeader.LOCATION, scenario.getScheme() + "://localhost:" + connector.getLocalPort() + "/new");
+                    callback.succeeded();
+                }
+                else if ("/new".equals(path) || "/direct".equals(path))
+                {
+                    response.setStatus(HttpStatus.OK_200);
+                    response.write(true, ByteBuffer.wrap("ok".getBytes(StandardCharsets.UTF_8)), callback);
+                }
+                else
+                {
+                    response.setStatus(HttpStatus.NOT_FOUND_404);
+                    callback.succeeded();
+                }
+                return true;
+            }
+        });
+
+        startClient(scenario, httpClient -> httpClient.setPermanentRedirectCache(new PermanentRedirectCache.Default(100)));
+
+        // Request to uncached URI
+        ContentResponse response1 = client.newRequest("localhost", connector.getLocalPort())
+            .scheme(scenario.getScheme())
+            .path("/direct")
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(HttpStatus.OK_200, response1.getStatus());
+        assertEquals(0, redirectCount.get());
+        assertEquals(0, client.getPermanentRedirectCache().size());
+
+        // Now request to redirecting URI
+        ContentResponse response2 = client.newRequest("localhost", connector.getLocalPort())
+            .scheme(scenario.getScheme())
+            .path("/old")
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(HttpStatus.OK_200, response2.getStatus());
+        assertEquals(1, redirectCount.get());
+        assertEquals(1, client.getPermanentRedirectCache().size());
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testTemporaryRedirectNotCached(Scenario scenario) throws Exception
+    {
+        AtomicInteger redirectCount = new AtomicInteger();
+
+        start(scenario, new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
+            {
+                String path = Request.getPathInContext(request);
+                if ("/old".equals(path))
+                {
+                    redirectCount.incrementAndGet();
+                    response.setStatus(HttpStatus.TEMPORARY_REDIRECT_307);
+                    response.getHeaders().put(HttpHeader.LOCATION, scenario.getScheme() + "://localhost:" + connector.getLocalPort() + "/new");
+                    callback.succeeded();
+                }
+                else if ("/new".equals(path))
+                {
+                    response.setStatus(HttpStatus.OK_200);
+                    response.write(true, ByteBuffer.wrap("ok".getBytes(StandardCharsets.UTF_8)), callback);
+                }
+                else
+                {
+                    response.setStatus(HttpStatus.NOT_FOUND_404);
+                    callback.succeeded();
+                }
+                return true;
+            }
+        });
+
+        startClient(scenario, httpClient -> httpClient.setPermanentRedirectCache(new PermanentRedirectCache.Default(100)));
+
+        // First request - 307 should not be cached
+        ContentResponse response1 = client.newRequest("localhost", connector.getLocalPort())
+            .scheme(scenario.getScheme())
+            .path("/old")
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(HttpStatus.OK_200, response1.getStatus());
+        assertEquals(1, redirectCount.get());
+        assertEquals(0, client.getPermanentRedirectCache().size());
+
+        // Second request - redirect should happen again (not cached)
+        ContentResponse response2 = client.newRequest("localhost", connector.getLocalPort())
+            .scheme(scenario.getScheme())
+            .path("/old")
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(HttpStatus.OK_200, response2.getStatus());
+        assertEquals(2, redirectCount.get());
+    }
+
+    @Override
+    protected void startClient(Scenario scenario) throws Exception
+    {
+        // Don't auto-start client - tests will configure and start it via startClient(scenario, config)
+    }
+
+    protected void startClient(Scenario scenario, java.util.function.Consumer<HttpClient> config) throws Exception
+    {
+        super.startClient(scenario, config);
+    }
+}


### PR DESCRIPTION
Fixes #108                                                                                                                                                                         
                                               
Add opt-in caching for permanent HTTP redirects (301, 308) to avoid redundant round-trips.                                                                                         

- `PermanentRedirectCache`: Interface with `Default` (LRU) and `Empty` implementations                                                                                             
- `CachingRedirectProtocolHandler`: Caches permanent redirects before delegating to `HttpRedirector`                                                                               
- `HttpClient`: New `setPermanentRedirectCache()` method; `QueuedListener` rewrites requests using cached redirects                                                                
- `HttpRedirector`: Added public `computeRedirectMethod()` for method transformation logic
