### PR TITLE
Preserve `HttpCompliance` across `HttpFields` copies

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/ComplianceViolation.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/ComplianceViolation.java
@@ -185,22 +185,16 @@ public interface ComplianceViolation
     {
         public static final String VIOLATIONS_ATTR_KEY = "org.eclipse.jetty.http.compliance.violations";
 
-        private final List<Event> events;
+        private final List<Event> events = new ArrayList<>();
 
         public CapturingListener()
         {
-            this(null);
-        }
-
-        private CapturingListener(List<Event> events)
-        {
-            this.events = events;
         }
 
         @Override
         public Listener initialize()
         {
-            return new CapturingListener(new ArrayList<>());
+            return new CapturingListener();
         }
 
         @Override

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -112,6 +112,8 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
      */
     static Mutable build(HttpFields fields)
     {
+        if (fields instanceof org.eclipse.jetty.http.MutableHttpFields.Complying complying)
+            return new org.eclipse.jetty.http.MutableHttpFields.Compliant(complying.getHttpCompliance(), complying.getNotifyViolation(), fields);
         return new org.eclipse.jetty.http.MutableHttpFields(fields);
     }
 
@@ -132,6 +134,8 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
      */
     static Mutable build(HttpFields fields, HttpField replaceField)
     {
+        if (fields instanceof org.eclipse.jetty.http.MutableHttpFields.Complying complying)
+            return new org.eclipse.jetty.http.MutableHttpFields.Compliant(complying.getHttpCompliance(), complying.getNotifyViolation(), fields, replaceField);
         return new org.eclipse.jetty.http.MutableHttpFields(fields, replaceField);
     }
 
@@ -147,12 +151,19 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
      */
     static Mutable build(HttpFields fields, EnumSet<HttpHeader> removeFields)
     {
+        if (fields instanceof org.eclipse.jetty.http.MutableHttpFields.Complying complying)
+            return new org.eclipse.jetty.http.MutableHttpFields.Compliant(complying.getHttpCompliance(), complying.getNotifyViolation(), fields, removeFields);
         return new org.eclipse.jetty.http.MutableHttpFields(fields, removeFields);
     }
 
     static Mutable build(HttpCompliance httpCompliance, BiConsumer<ComplianceViolation, String> notifyViolation)
     {
         return new org.eclipse.jetty.http.MutableHttpFields.Compliant(httpCompliance, notifyViolation);
+    }
+
+    static Mutable build(HttpCompliance httpCompliance, BiConsumer<ComplianceViolation, String> notifyViolation, HttpFields fields)
+    {
+        return new org.eclipse.jetty.http.MutableHttpFields.Compliant(httpCompliance, notifyViolation, fields);
     }
 
     /**

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MutableHttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MutableHttpFields.java
@@ -596,7 +596,13 @@ class MutableHttpFields implements HttpFields.Mutable
         }
     }
 
-    public static class Compliant extends org.eclipse.jetty.http.MutableHttpFields
+    interface Complying
+    {
+        HttpCompliance getHttpCompliance();
+        BiConsumer<ComplianceViolation, String> getNotifyViolation();
+    }
+
+    public static class Compliant extends org.eclipse.jetty.http.MutableHttpFields implements Complying
     {
         private final HttpCompliance _httpCompliance;
         private final BiConsumer<ComplianceViolation, String> _notifyViolation;
@@ -605,6 +611,39 @@ class MutableHttpFields implements HttpFields.Mutable
         {
             _httpCompliance = httpCompliance;
             _notifyViolation = notifyViolation;
+        }
+
+        public Compliant(HttpCompliance httpCompliance, BiConsumer<ComplianceViolation, String> notifyViolation, HttpFields fields)
+        {
+            super(fields);
+            _httpCompliance = httpCompliance;
+            _notifyViolation = notifyViolation;
+        }
+
+        public Compliant(HttpCompliance httpCompliance, BiConsumer<ComplianceViolation, String> notifyViolation, HttpFields fields, HttpField replaceField)
+        {
+            super(fields, replaceField);
+            _httpCompliance = httpCompliance;
+            _notifyViolation = notifyViolation;
+        }
+
+        public Compliant(HttpCompliance httpCompliance, BiConsumer<ComplianceViolation, String> notifyViolation, HttpFields fields, EnumSet<HttpHeader> removeFields)
+        {
+            super(fields, removeFields);
+            _httpCompliance = httpCompliance;
+            _notifyViolation = notifyViolation;
+        }
+
+        @Override
+        public HttpCompliance getHttpCompliance()
+        {
+            return _httpCompliance;
+        }
+
+        @Override
+        public BiConsumer<ComplianceViolation, String> getNotifyViolation()
+        {
+            return _notifyViolation;
         }
 
         @Override
@@ -622,20 +661,44 @@ class MutableHttpFields implements HttpFields.Mutable
         @Override
         protected HttpFields newImmutableHttpFields(HttpField[] fields, int size)
         {
-            return new org.eclipse.jetty.http.ImmutableHttpFields(fields, size)
-            {
-                @Override
-                public QuotedCSV newQuotedCSV(boolean keepQuotes)
-                {
-                    return new QuotedCSV.Compliant(_httpCompliance, _notifyViolation, keepQuotes);
-                }
+            return new ImmutableHttpFields(_httpCompliance, _notifyViolation, fields, size);
+        }
 
-                @Override
-                public QuotedQualityCSV newQuotedQualityCSV(ToIntFunction<String> secondaryOrdering)
-                {
-                    return new QuotedQualityCSV.Compliant(_httpCompliance, _notifyViolation, secondaryOrdering);
-                }
-            };
+        private static class ImmutableHttpFields extends org.eclipse.jetty.http.ImmutableHttpFields implements Complying
+        {
+            private final HttpCompliance _httpCompliance;
+            private final BiConsumer<ComplianceViolation, String> _notifyViolation;
+
+            private ImmutableHttpFields(HttpCompliance httpCompliance, BiConsumer<ComplianceViolation, String> notifyViolation, HttpField[] fields, int size)
+            {
+                super(fields, size);
+                _httpCompliance = httpCompliance;
+                _notifyViolation = notifyViolation;
+            }
+
+            @Override
+            public HttpCompliance getHttpCompliance()
+            {
+                return _httpCompliance;
+            }
+
+            @Override
+            public BiConsumer<ComplianceViolation, String> getNotifyViolation()
+            {
+                return _notifyViolation;
+            }
+
+            @Override
+            public QuotedCSV newQuotedCSV(boolean keepQuotes)
+            {
+                return new QuotedCSV.Compliant(_httpCompliance, _notifyViolation, keepQuotes);
+            }
+
+            @Override
+            public QuotedQualityCSV newQuotedQualityCSV(ToIntFunction<String> secondaryOrdering)
+            {
+                return new QuotedQualityCSV.Compliant(_httpCompliance, _notifyViolation, secondaryOrdering);
+            }
         }
     }
 }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HostHeaderCustomizer.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HostHeaderCustomizer.java
@@ -65,7 +65,8 @@ public class HostHeaderCustomizer implements HttpConfiguration.Customizer
             : request.getHttpURI();
 
         HttpFields original = request.getHeaders();
-        HttpFields.Mutable builder = HttpFields.build(original.size() + 1);
+        HttpConfiguration configuration = request.getConnectionMetaData().getHttpConfiguration();
+        HttpFields.Mutable builder = HttpFields.build(configuration.getHttpCompliance(), configuration::notifyViolation); // TODO pass original.size() + 1
         builder.add(new HostPortHttpField(host, port));
         builder.add(request.getHeaders());
         HttpFields headers = builder.asImmutable();

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -111,7 +111,7 @@ public class HttpChannelState implements HttpChannel, Components
     private final ConnectionMetaData _connectionMetaData;
     private final SerializedInvoker _readInvoker;
     private final SerializedInvoker _writeInvoker;
-    private final ResponseHttpFields _responseHeaders = new ResponseHttpFields();
+    private final ResponseHttpFields _responseHeaders;
     private Thread _handling;
     private boolean _handled;
     private StreamSendState _streamSendState = StreamSendState.SENDING;
@@ -133,6 +133,7 @@ public class HttpChannelState implements HttpChannel, Components
     public HttpChannelState(ConnectionMetaData connectionMetaData)
     {
         _connectionMetaData = connectionMetaData;
+        _responseHeaders = new ResponseHttpFields(connectionMetaData.getHttpConfiguration());
         // The SerializedInvoker is used to prevent infinite recursion of callbacks calling methods calling callbacks etc.
         _readInvoker = new HttpChannelSerializedInvoker(HttpChannelState.class.getSimpleName() + "_readInvoker", connectionMetaData.getConnector().getExecutor());
         _writeInvoker = new HttpChannelSerializedInvoker(HttpChannelState.class.getSimpleName() + "_writeInvoker", connectionMetaData.getConnector().getExecutor());
@@ -1745,7 +1746,7 @@ public class HttpChannelState implements HttpChannel, Components
         {
             httpChannelState._committedContentLength = -1;
             HttpFields original = super.getResponseHttpFields(httpChannelState);
-            ResponseHttpFields httpFields = new ResponseHttpFields();
+            ResponseHttpFields httpFields = new ResponseHttpFields(httpChannelState._connectionMetaData.getHttpConfiguration());
 
             for (HttpField field : original)
             {

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/ResponseHttpFields.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/ResponseHttpFields.java
@@ -20,6 +20,7 @@ import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.PreEncodedHttpField;
+import org.eclipse.jetty.server.HttpConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,9 +31,9 @@ public class ResponseHttpFields extends HttpFields.Mutable.Wrapper
     private static final Logger LOG = LoggerFactory.getLogger(ResponseHttpFields.class);
     private final AtomicBoolean _committed = new AtomicBoolean();
 
-    public ResponseHttpFields()
+    public ResponseHttpFields(HttpConfiguration configuration)
     {
-        super(HttpFields.build());
+        super(HttpFields.build(configuration.getHttpCompliance(), configuration::notifyViolation));
     }
 
     public HttpFields.Mutable getMutableHttpFields()

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiResponse.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiResponse.java
@@ -35,6 +35,7 @@ import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.io.WriteThroughWriter;
+import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.session.ManagedSession;
@@ -522,7 +523,9 @@ public class ServletApiResponse implements HttpServletResponse
             Map<String, String> map = trailers.get();
             if (map == null)
                 return null;
-            HttpFields.Mutable fields = HttpFields.build(map.size());
+            Request request = getResponse().getRequest();
+            HttpConfiguration configuration = request.getConnectionMetaData().getHttpConfiguration();
+            HttpFields.Mutable fields = HttpFields.build(configuration.getHttpCompliance(), configuration::notifyViolation); // TODO pass map.size()
             for (Map.Entry<String, String> e : map.entrySet())
             {
                 fields.add(e.getKey(), e.getValue());

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletCoreRequest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletCoreRequest.java
@@ -36,6 +36,7 @@ import org.eclipse.jetty.io.content.InputStreamContentSource;
 import org.eclipse.jetty.server.Components;
 import org.eclipse.jetty.server.ConnectionMetaData;
 import org.eclipse.jetty.server.Context;
+import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpStream;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Session;
@@ -81,7 +82,8 @@ public class ServletCoreRequest implements Request
         _servletContextRequest = ServletContextRequest.getServletContextRequest(_servletRequest);
         _attributes = attributes == null ? _servletContextRequest : attributes;
 
-        HttpFields.Mutable fields = HttpFields.build();
+        HttpConfiguration configuration = _servletContextRequest.getConnectionMetaData().getHttpConfiguration();
+        HttpFields.Mutable fields = HttpFields.build(configuration.getHttpCompliance(), configuration::notifyViolation);
 
         Enumeration<String> headerNames = request.getHeaderNames();
         while (headerNames.hasMoreElements())

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletApiResponse.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletApiResponse.java
@@ -558,7 +558,9 @@ public class ServletApiResponse implements HttpServletResponse
             Map<String, String> map = trailers.get();
             if (map == null)
                 return null;
-            HttpFields.Mutable fields = HttpFields.build(map.size());
+            Request request = getResponse().getRequest();
+            HttpConfiguration configuration = request.getConnectionMetaData().getHttpConfiguration();
+            HttpFields.Mutable fields = HttpFields.build(configuration.getHttpCompliance(), configuration::notifyViolation); // TODO pass map.size()
             for (Map.Entry<String, String> e : map.entrySet())
             {
                 fields.add(e.getKey(), e.getValue());

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletCoreRequest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletCoreRequest.java
@@ -36,6 +36,7 @@ import org.eclipse.jetty.io.content.InputStreamContentSource;
 import org.eclipse.jetty.server.Components;
 import org.eclipse.jetty.server.ConnectionMetaData;
 import org.eclipse.jetty.server.Context;
+import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpStream;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Session;
@@ -81,7 +82,8 @@ public class ServletCoreRequest implements Request
         _servletContextRequest = ServletContextRequest.getServletContextRequest(_servletRequest);
         _attributes = attributes == null ? _servletContextRequest : attributes;
 
-        HttpFields.Mutable fields = HttpFields.build();
+        HttpConfiguration configuration = _servletContextRequest.getConnectionMetaData().getHttpConfiguration();
+        HttpFields.Mutable fields = HttpFields.build(configuration.getHttpCompliance(), configuration::notifyViolation);
 
         Enumeration<String> headerNames = request.getHeaderNames();
         while (headerNames.hasMoreElements())

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
@@ -963,7 +963,9 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
             if (action == HttpChannelState.Action.DISPATCH)
             {
                 ByteBuffer content = null;
-                HttpFields.Mutable fields = HttpFields.build();
+                org.eclipse.jetty.server.Request request = _request.getCoreRequest();
+                HttpConfiguration configuration = request.getConnectionMetaData().getHttpConfiguration();
+                HttpFields.Mutable fields = HttpFields.build(configuration.getHttpCompliance(), configuration::notifyViolation);
 
                 ErrorHandler handler = getServer().getBean(ErrorHandler.class);
                 if (handler != null)

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ServletCoreRequest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ServletCoreRequest.java
@@ -34,6 +34,7 @@ import org.eclipse.jetty.io.content.InputStreamContentSource;
 import org.eclipse.jetty.server.Components;
 import org.eclipse.jetty.server.ConnectionMetaData;
 import org.eclipse.jetty.server.Context;
+import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpStream;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Session;
@@ -80,7 +81,8 @@ public class ServletCoreRequest implements Request
         _coreContextRequest = coreContextRequest;
         _attributes = attributes;
 
-        HttpFields.Mutable fields = HttpFields.build();
+        HttpConfiguration configuration = coreContextRequest.getConnectionMetaData().getHttpConfiguration();
+        HttpFields.Mutable fields = HttpFields.build(configuration.getHttpCompliance(), configuration::notifyViolation);
 
         Enumeration<String> headerNames = request.getHeaderNames();
         while (headerNames.hasMoreElements())

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ComplianceViolations2616Test.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ComplianceViolations2616Test.java
@@ -30,23 +30,32 @@ import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.ee9.nested.HttpChannel;
 import org.eclipse.jetty.http.ComplianceViolation;
 import org.eclipse.jetty.http.HttpCompliance;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.logging.StacklessLogging;
+import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.LocalConnector;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Server;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.eclipse.jetty.util.Callback;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 
 public class ComplianceViolations2616Test
 {
-    private static Server server;
-    private static LocalConnector connector;
+    private Server server;
+    private LocalConnector connector;
+    private HttpConfiguration config;
 
     public static class ReportViolationsFilter implements Filter
     {
@@ -94,15 +103,17 @@ public class ComplianceViolations2616Test
             {
                 out.printf("[%s] = [%s]%n", name, req.getHeader(name));
             }
+            if (headerNames.contains("Accept-Language"))
+                out.printf("Locale = [%s]%n", req.getLocale());
         }
     }
 
-    @BeforeAll
-    public static void startServer() throws Exception
+    @BeforeEach
+    public void startServer() throws Exception
     {
         server = new Server();
 
-        HttpConfiguration config = new HttpConfiguration();
+        config = new HttpConfiguration();
         config.setSendServerVersion(false);
         config.setHttpCompliance(HttpCompliance.RFC2616_LEGACY);
         config.addComplianceViolationListener(new ComplianceViolation.CapturingListener());
@@ -116,18 +127,70 @@ public class ComplianceViolations2616Test
 
         context.addServlet(DumpRequestHeadersServlet.class, "/dump/*");
         context.addFilter(ReportViolationsFilter.class, "/*", EnumSet.of(DispatcherType.REQUEST));
-
-        server.setHandler(context);
+        server.setHandler(new Handler.Wrapper(context.get())
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            {
+                request = new Request.Wrapper(request)
+                {
+                    @Override
+                    public HttpFields getHeaders()
+                    {
+                        return HttpFields.build(super.getHeaders());
+                    }
+                };
+                return getHandler().handle(request, response, callback);
+            }
+        });
         server.addConnector(connector);
 
         server.start();
     }
 
-    @AfterAll
-    public static void stopServer() throws Exception
+    @AfterEach
+    public void stopServer() throws Exception
     {
         server.stop();
         server.join();
+    }
+
+    @Test
+    public void testQualityCsvWithBadQuotesAllowedByCompliance() throws Exception
+    {
+        StringBuffer req1 = new StringBuffer();
+        req1.append("GET /dump/ HTTP/1.1\r\n");
+        req1.append("Host: local\r\n");
+        req1.append("Accept: */*\r\n");
+        req1.append("Accept-Language: 1'\"6000\r\n");
+        req1.append("Connection: close\r\n");
+        req1.append("\r\n");
+
+        String response = connector.getResponse(req1.toString());
+        assertThat("Response status", response, containsString("HTTP/1.1 200 OK"));
+        assertThat("Response headers", response, not(containsString("X-Http-Violation-0n")));
+        assertThat("Response body", response, containsString("Locale = ["));
+    }
+
+    @Test
+    public void testQualityCsvWithBadQuotesRejectedByCompliance() throws Exception
+    {
+        try (StacklessLogging ignore = new StacklessLogging(HttpChannel.class))
+        {
+            config.setHttpCompliance(HttpCompliance.RFC9110);
+
+            StringBuffer req1 = new StringBuffer();
+            req1.append("GET /dump/ HTTP/1.1\r\n");
+            req1.append("Host: local\r\n");
+            req1.append("Accept: */*\r\n");
+            req1.append("Accept-Language: 1'\"6000\r\n");
+            req1.append("Connection: close\r\n");
+            req1.append("\r\n");
+
+            String response = connector.getResponse(req1.toString());
+            assertThat("Response status", response, containsString("HTTP/1.1 500 Server Error"));
+            assertThat("Response body", response, containsString("Bad Quotes in Token"));
+        }
     }
 
     @Test

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/GzipHandlerInputTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/GzipHandlerInputTest.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Stream;
 import java.util.zip.GZIPOutputStream;
 
@@ -34,8 +35,11 @@ import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.Request;
 import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
+import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
@@ -62,7 +66,9 @@ public class GzipHandlerInputTest
     public void init() throws Exception
     {
         server = new Server();
-        ServerConnector connector = new ServerConnector(server);
+        HttpConfiguration config = new HttpConfiguration();
+        config.setHttpCompliance(HttpCompliance.RFC2616);
+        ServerConnector connector = new ServerConnector(server, new HttpConnectionFactory(config));
         server.addConnector(connector);
 
         GzipHandler gzipHandler = new GzipHandler();
@@ -138,7 +144,11 @@ public class GzipHandlerInputTest
         };
         Request request = client.newRequest(destURI)
             .method(HttpMethod.POST)
-            .headers((headers) -> headers.put(HttpHeader.CONTENT_ENCODING, "gzip"))
+            .headers((headers) ->
+            {
+                headers.put(HttpHeader.CONTENT_ENCODING, "gzip");
+                headers.put("Accept-Language", "1'\"6000");
+            })
             .body(bytesRequestContent);
         ContentResponse response = request.send();
 
@@ -158,6 +168,9 @@ public class GzipHandlerInputTest
         @Override
         protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException
         {
+            Locale locale = req.getLocale();
+            System.out.println(locale);
+
             InputStream input = req.getInputStream();
             byte[] buf = input.readAllBytes();
             resp.setCharacterEncoding("utf-8");


### PR DESCRIPTION
WIP; this needs more/better tests, and there could be other places where `HttpCompliance` isn't preserved.

Fixes #14397