### PR TITLE
Fixes #14373 - Response listener that avoids any data copies.

### DIFF
--- a/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/client/http/HTTPClientDocs.java
+++ b/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/client/http/HTTPClientDocs.java
@@ -499,8 +499,9 @@ public class HTTPClientDocs
                 {
                     if (!result.isFailed())
                     {
-                        byte[] responseContent = getContent();
-                        // Your logic here
+                        // The Content.Source must be fully consumed.
+                        Content.Source source = takeContentAsContentSource();
+                        // Your logic here.
                     }
                 }
             });

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractResponseListener.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractResponseListener.java
@@ -198,7 +198,7 @@ public abstract class AbstractResponseListener implements Response.Listener
     {
         if (accumulator instanceof RetainableByteBuffer.DynamicCapacity dynamic)
             return dynamic.takeContentSource();
-        return Content.Source.from(accumulator.getByteBuffer());
+        return Content.Source.from(ByteBuffer.wrap(getContent()));
     }
 
     private byte[] take()

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractResponseListener.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractResponseListener.java
@@ -17,6 +17,7 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 
@@ -25,6 +26,7 @@ import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.RetainableByteBuffer;
+import org.eclipse.jetty.io.content.ChunksContentSource;
 
 public abstract class AbstractResponseListener implements Response.Listener
 {
@@ -198,7 +200,16 @@ public abstract class AbstractResponseListener implements Response.Listener
     {
         if (accumulator instanceof RetainableByteBuffer.DynamicCapacity dynamic)
             return dynamic.takeContentSource();
-        return Content.Source.from(ByteBuffer.wrap(getContent()));
+
+        RetainableByteBuffer buffer = accumulator.take();
+        Content.Chunk c;
+        if (buffer instanceof Content.Chunk chunk)
+            c = chunk;
+        else
+            c = Content.Chunk.asChunk(buffer.getByteBuffer(), true, buffer);
+        ChunksContentSource chunksContentSource = new ChunksContentSource(List.of(c));
+        buffer.release();
+        return chunksContentSource;
     }
 
     private byte[] take()

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractResponseListener.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractResponseListener.java
@@ -17,7 +17,6 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 
@@ -26,7 +25,6 @@ import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.RetainableByteBuffer;
-import org.eclipse.jetty.io.content.ChunksContentSource;
 
 public abstract class AbstractResponseListener implements Response.Listener
 {

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractResponseListener.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractResponseListener.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.client;
 
-import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
@@ -189,7 +188,17 @@ public abstract class AbstractResponseListener implements Response.Listener
      */
     public InputStream getContentAsInputStream()
     {
-        return new ByteArrayInputStream(getContent());
+        return Content.Source.asInputStream(getContentAsContentSource());
+    }
+
+    /**
+     * @return the content as {@link Content.Source}
+     */
+    public Content.Source getContentAsContentSource()
+    {
+        if (accumulator instanceof RetainableByteBuffer.DynamicCapacity dynamic)
+            return dynamic.takeContentSource();
+        return Content.Source.from(accumulator.getByteBuffer());
     }
 
     private byte[] take()

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractResponseListener.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractResponseListener.java
@@ -187,7 +187,8 @@ public abstract class AbstractResponseListener implements Response.Listener
 
     /**
      * Return the content as {@link InputStream}. A copy of the content is kept in memory to
-     * allow the following {@code getContent*() calls to read the same content.
+     * allow the following {@code getContent*()} and {@code takeContent*()} calls to read the
+     * content again.
      * @return the content as {@link InputStream}
      */
     public InputStream getContentAsInputStream()
@@ -197,7 +198,8 @@ public abstract class AbstractResponseListener implements Response.Listener
 
     /**
      * Take the content and return it as {@link InputStream}.
-     * Following {@code getContent*()} and {@code takeContent*()} calls will see an empty content.
+     * Following {@code getContent*()} and {@code takeContent*()} calls will see an empty
+     * content.
      * @return the content as {@link InputStream}
      */
     public InputStream takeContentAsInputStream()

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractResponseListener.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractResponseListener.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.client;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
@@ -189,6 +190,8 @@ public abstract class AbstractResponseListener implements Response.Listener
      */
     public InputStream getContentAsInputStream()
     {
+        if (content != null)
+            return new ByteArrayInputStream(content);
         return Content.Source.asInputStream(getContentAsContentSource());
     }
 

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractResponseListener.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractResponseListener.java
@@ -28,6 +28,16 @@ import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.RetainableByteBuffer;
 import org.eclipse.jetty.util.BufferUtil;
 
+/**
+ * <p>Instances of this class are not reusable, so one must be allocated for each request.</p>
+ * <p>The content may be retrieved from {@link #onSuccess(Response)} or {@link #onComplete(Result)}
+ * via one of the {@code getContent*()} or {@code takeContent*()} methods.</p>
+ * <p>IMPORTANT: The content MUST be consumed by calling one of the {@code getContent*()} or
+ * {@code takeContent*()} methods otherwise the backing buffers may be leaked. If either of
+ * {@link #takeContentAsInputStream()} or {@link #takeContentAsContentSource()} is called, the content
+ * MUST be read until the end (or closed/failed appropriately) otherwise the backing buffers of the unread
+ * content may also be leaked.</p>
+ */
 public abstract class AbstractResponseListener implements Response.Listener
 {
     private final RetainableByteBuffer.Mutable accumulator;
@@ -127,13 +137,6 @@ public abstract class AbstractResponseListener implements Response.Listener
     }
 
     @Override
-    public void onSuccess(Response response)
-    {
-        // Always take here to be sure the accumulator is released.
-        content = take();
-    }
-
-    @Override
     public void onFailure(Response response, Throwable failure)
     {
         accumulator.clear();
@@ -219,8 +222,13 @@ public abstract class AbstractResponseListener implements Response.Listener
         if (content == null && accumulator instanceof RetainableByteBuffer.DynamicCapacity dynamic)
             result = dynamic.takeContentSource();
         else
-            result = Content.Source.from(ByteBuffer.wrap(getContent()));
-        // When the content is taken, further getContent* and takeContent* calls will find an empty content.
+            result = Content.Source.from(ByteBuffer.wrap(takeContent()));
+        return result;
+    }
+
+    private byte[] takeContent()
+    {
+        byte[] result = getContent();
         content = BufferUtil.EMPTY_BYTES;
         return result;
     }

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractResponseListener.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractResponseListener.java
@@ -25,6 +25,7 @@ import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.RetainableByteBuffer;
+import org.eclipse.jetty.util.BufferUtil;
 
 public abstract class AbstractResponseListener implements Response.Listener
 {
@@ -196,9 +197,14 @@ public abstract class AbstractResponseListener implements Response.Listener
      */
     public Content.Source getContentAsContentSource()
     {
-        if (accumulator instanceof RetainableByteBuffer.DynamicCapacity dynamic)
+        // Take the DynamicCapacity's content source only if the content hasn't been already taken.
+        if (content == null && accumulator instanceof RetainableByteBuffer.DynamicCapacity dynamic)
+        {
+            // When the content is taken, further getContent* calls will find an empty content.
+            content = BufferUtil.EMPTY_BYTES;
             return dynamic.takeContentSource();
-        return Content.Source.from(ByteBuffer.wrap(take()));
+        }
+        return Content.Source.from(ByteBuffer.wrap(getContent()));
     }
 
     private byte[] take()

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractResponseListener.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractResponseListener.java
@@ -186,28 +186,41 @@ public abstract class AbstractResponseListener implements Response.Listener
     }
 
     /**
+     * Return the content as {@link InputStream}. A copy of the content is kept in memory to
+     * allow the following {@code getContent*() calls to read the same content.
      * @return the content as {@link InputStream}
      */
     public InputStream getContentAsInputStream()
     {
-        if (content != null)
-            return new ByteArrayInputStream(content);
-        return Content.Source.asInputStream(getContentAsContentSource());
+        return new ByteArrayInputStream(getContent());
     }
 
     /**
+     * Take the content and return it as {@link InputStream}.
+     * Following {@code getContent*()} and {@code takeContent*()} calls will see an empty content.
+     * @return the content as {@link InputStream}
+     */
+    public InputStream takeContentAsInputStream()
+    {
+        return Content.Source.asInputStream(takeContentAsContentSource());
+    }
+
+    /**
+     * Take the content and return it as {@link Content.Source}.
+     * Following {@code getContent*()} and {@code takeContent*()} calls will see an empty content.
      * @return the content as {@link Content.Source}
      */
-    public Content.Source getContentAsContentSource()
+    public Content.Source takeContentAsContentSource()
     {
+        Content.Source result;
         // Take the DynamicCapacity's content source only if the content hasn't been already taken.
         if (content == null && accumulator instanceof RetainableByteBuffer.DynamicCapacity dynamic)
-        {
-            // When the content is taken, further getContent* calls will find an empty content.
-            content = BufferUtil.EMPTY_BYTES;
-            return dynamic.takeContentSource();
-        }
-        return Content.Source.from(ByteBuffer.wrap(getContent()));
+            result = dynamic.takeContentSource();
+        else
+            result = Content.Source.from(ByteBuffer.wrap(getContent()));
+        // When the content is taken, further getContent* and takeContent* calls will find an empty content.
+        content = BufferUtil.EMPTY_BYTES;
+        return result;
     }
 
     private byte[] take()

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractResponseListener.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractResponseListener.java
@@ -200,16 +200,7 @@ public abstract class AbstractResponseListener implements Response.Listener
     {
         if (accumulator instanceof RetainableByteBuffer.DynamicCapacity dynamic)
             return dynamic.takeContentSource();
-
-        RetainableByteBuffer buffer = accumulator.take();
-        Content.Chunk c;
-        if (buffer instanceof Content.Chunk chunk)
-            c = chunk;
-        else
-            c = Content.Chunk.asChunk(buffer.getByteBuffer(), true, buffer);
-        ChunksContentSource chunksContentSource = new ChunksContentSource(List.of(c));
-        buffer.release();
-        return chunksContentSource;
+        return Content.Source.from(ByteBuffer.wrap(take()));
     }
 
     private byte[] take()

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/BufferingResponseListener.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/BufferingResponseListener.java
@@ -13,15 +13,11 @@
 
 package org.eclipse.jetty.client;
 
-import org.eclipse.jetty.client.Response.Listener;
 import org.eclipse.jetty.io.RetainableByteBuffer;
 
 /**
- * <p>Implementation of {@link Listener} that buffers the response content
+ * <p>Implementation of {@link AbstractResponseListener} that buffers the response content
  * by copying it up to a maximum length specified to the constructors.</p>
- * <p>The content may be retrieved from {@link #onSuccess(Response)} or {@link #onComplete(Result)}
- * via {@link #getContent()} or {@link #getContentAsString()}.</p>
- * <p>Instances of this class are not reusable, so one must be allocated for each request.</p>
  * <p>Use {@link RetainingResponseListener} for a more efficient
  * implementation that does not copy the content bytes.</p>
  */

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/RetainingResponseListener.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/RetainingResponseListener.java
@@ -18,13 +18,18 @@ import org.eclipse.jetty.io.RetainableByteBuffer;
 /**
  * <p>Implementation of {@link Response.Listener} that retains the response
  * content without copying it, up to a configurable number of bytes.</p>
- * <p>The content may be retrieved from {@link #onSuccess(Response)} or {@link #onComplete(Result)}
- * via {@link #getContent()} or {@link #getContentAsString()}.</p>
  * <p>Instances of this class are not reusable, so one must be allocated for each request.</p>
- * <p>The implementation retains the response content chunks, and converts them into a {@code byte[]}
- * upon response success, returned by {@link #getContent()}.</p>
- * <p>Subclasses overriding {@link #onSuccess(Response)} or {@link #onFailure(Response, Throwable)}
- * must always call the {@code super} method to guarantee that the retained chunks are released.</p>
+ * <p>The content may be retrieved from {@link #onSuccess(Response)} or {@link #onComplete(Result)}
+ * via one of the {@code getContent*()} methods.</p>
+ * <p>If {@link #getContent()} or {@link #getContentAsString()} is called first, then the content is copied
+ * into a {@code byte[]} and all further calls will read this {@code byte[]}, while if
+ * {@link #getContentAsInputStream()} or {@link #getContentAsContentSource()} is called first, the content will be
+ * read without copying it, but further {@code getContent*()} calls will see an empty content.</p>
+ * <p>ATTENTION: {@link #onSuccess(Response)} is overridden to avoid copying the contents into a {@code byte[]},
+ * so this means the contents MUST be consumed by calling one of the {@code getContent*()} methods
+ * otherwise the backing buffers will be leaked. If a streaming method like {@link #getContentAsInputStream()}
+ * or {@link #getContentAsContentSource()} is called, the contents MUST be read until the end
+ * (or closed/failed appropriately) otherwise the backing buffers of the unread content will also be leaked.</p>
  */
 public abstract class RetainingResponseListener extends AbstractResponseListener
 {

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/RetainingResponseListener.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/RetainingResponseListener.java
@@ -38,4 +38,10 @@ public abstract class RetainingResponseListener extends AbstractResponseListener
         // A DynamicCapacity that always retains.
         super(new RetainableByteBuffer.DynamicCapacity(null, maxLength, 0));
     }
+
+    @Override
+    public void onSuccess(Response response)
+    {
+        // Make sure the content is not taken on success.
+    }
 }

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/RetainingResponseListener.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/RetainingResponseListener.java
@@ -16,17 +16,8 @@ package org.eclipse.jetty.client;
 import org.eclipse.jetty.io.RetainableByteBuffer;
 
 /**
- * <p>Implementation of {@link Response.Listener} that retains the response
+ * <p>Implementation of {@link AbstractResponseListener} that retains the response
  * content without copying it, up to a configurable number of bytes.</p>
- * <p>Instances of this class are not reusable, so one must be allocated for each request.</p>
- * <p>The content may be retrieved from {@link #onSuccess(Response)} or {@link #onComplete(Result)}
- * via one of the {@code getContent*()} or {@code takeContent*()} methods.</p>
- * <p>IMPORTANT: {@link #onSuccess(Response)} is overridden to avoid copying the contents into a {@code byte[]},
- * so this means the contents MUST be consumed by calling one of the {@code getContent*()} or
- * {@code takeContent*()} methods otherwise the backing buffers may be leaked. If a streaming method like
- * {@link #takeContentAsInputStream()} or {@link #takeContentAsContentSource()} is called, the content
- * MUST be read until the end (or closed/failed appropriately) otherwise the backing buffers of the unread
- * content may also be leaked.</p>
  */
 public abstract class RetainingResponseListener extends AbstractResponseListener
 {
@@ -39,11 +30,5 @@ public abstract class RetainingResponseListener extends AbstractResponseListener
     {
         // A DynamicCapacity that always retains.
         super(new RetainableByteBuffer.DynamicCapacity(null, maxLength, 0));
-    }
-
-    @Override
-    public void onSuccess(Response response)
-    {
-        // Make sure the content is not taken on success.
     }
 }

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/RetainingResponseListener.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/RetainingResponseListener.java
@@ -20,16 +20,13 @@ import org.eclipse.jetty.io.RetainableByteBuffer;
  * content without copying it, up to a configurable number of bytes.</p>
  * <p>Instances of this class are not reusable, so one must be allocated for each request.</p>
  * <p>The content may be retrieved from {@link #onSuccess(Response)} or {@link #onComplete(Result)}
- * via one of the {@code getContent*()} methods.</p>
- * <p>If {@link #getContent()} or {@link #getContentAsString()} is called first, then the content is copied
- * into a {@code byte[]} and all further calls will read this {@code byte[]}, while if
- * {@link #getContentAsInputStream()} or {@link #getContentAsContentSource()} is called first, the content will be
- * read without copying it, but further {@code getContent*()} calls will see an empty content.</p>
- * <p>ATTENTION: {@link #onSuccess(Response)} is overridden to avoid copying the contents into a {@code byte[]},
- * so this means the contents MUST be consumed by calling one of the {@code getContent*()} methods
- * otherwise the backing buffers will be leaked. If a streaming method like {@link #getContentAsInputStream()}
- * or {@link #getContentAsContentSource()} is called, the contents MUST be read until the end
- * (or closed/failed appropriately) otherwise the backing buffers of the unread content will also be leaked.</p>
+ * via one of the {@code getContent*()} or {@code takeContent*()} methods.</p>
+ * <p>IMPORTANT: {@link #onSuccess(Response)} is overridden to avoid copying the contents into a {@code byte[]},
+ * so this means the contents MUST be consumed by calling one of the {@code getContent*()} or
+ * {@code takeContent*()} methods otherwise the backing buffers may be leaked. If a streaming method like
+ * {@link #takeContentAsInputStream()} or {@link #takeContentAsContentSource()} is called, the content
+ * MUST be read until the end (or closed/failed appropriately) otherwise the backing buffers of the unread
+ * content may also be leaked.</p>
  */
 public abstract class RetainingResponseListener extends AbstractResponseListener
 {

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/AbstractHttpClientServerTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/AbstractHttpClientServerTest.java
@@ -21,6 +21,7 @@ import java.util.stream.Stream;
 import org.eclipse.jetty.client.transport.HttpClientTransportOverHTTP;
 import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.io.ArrayByteBufferPool;
+import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.ClientConnector;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
@@ -107,10 +108,13 @@ public abstract class AbstractHttpClientServerTest
         if (client != null)
         {
             LifeCycle.stop(client);
-            ArrayByteBufferPool.Tracking clientBufferPool = (ArrayByteBufferPool.Tracking)client.getClientConnector().getByteBufferPool();
-            await().atMost(5, java.util.concurrent.TimeUnit.SECONDS).untilAsserted(() ->
-                assertThat("client leaks: " + clientBufferPool.dumpLeaks(), clientBufferPool.getLeaks().size(), is(0))
-            );
+            ByteBufferPool byteBufferPool = client.getClientConnector().getByteBufferPool();
+            if (byteBufferPool instanceof ArrayByteBufferPool.Tracking trackingPool)
+            {
+                await().atMost(5, java.util.concurrent.TimeUnit.SECONDS).untilAsserted(() ->
+                    assertThat("client leaks: " + trackingPool.dumpLeaks(), trackingPool.getLeaks().size(), is(0))
+                );
+            }
         }
 
         if (server != null)

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/AbstractHttpClientServerTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/AbstractHttpClientServerTest.java
@@ -21,7 +21,6 @@ import java.util.stream.Stream;
 import org.eclipse.jetty.client.transport.HttpClientTransportOverHTTP;
 import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.io.ArrayByteBufferPool;
-import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.ClientConnector;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
@@ -108,13 +107,10 @@ public abstract class AbstractHttpClientServerTest
         if (client != null)
         {
             LifeCycle.stop(client);
-            ByteBufferPool byteBufferPool = client.getClientConnector().getByteBufferPool();
-            if (byteBufferPool instanceof ArrayByteBufferPool.Tracking trackingPool)
-            {
-                await().atMost(5, java.util.concurrent.TimeUnit.SECONDS).untilAsserted(() ->
-                    assertThat("client leaks: " + trackingPool.dumpLeaks(), trackingPool.getLeaks().size(), is(0))
-                );
-            }
+            ArrayByteBufferPool.Tracking clientBufferPool = (ArrayByteBufferPool.Tracking)client.getClientConnector().getByteBufferPool();
+            await().atMost(5, java.util.concurrent.TimeUnit.SECONDS).untilAsserted(() ->
+                assertThat("client leaks: " + clientBufferPool.dumpLeaks(), clientBufferPool.getLeaks().size(), is(0))
+            );
         }
 
         if (server != null)

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/AbstractHttpClientServerTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/AbstractHttpClientServerTest.java
@@ -20,12 +20,14 @@ import java.util.stream.Stream;
 
 import org.eclipse.jetty.client.transport.HttpClientTransportOverHTTP;
 import org.eclipse.jetty.http.HttpScheme;
+import org.eclipse.jetty.io.ArrayByteBufferPool;
 import org.eclipse.jetty.io.ClientConnector;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.util.SocketAddressResolver;
+import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.util.thread.ScheduledExecutorScheduler;
@@ -34,6 +36,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public abstract class AbstractHttpClientServerTest
 {
@@ -53,7 +59,7 @@ public abstract class AbstractHttpClientServerTest
         {
             QueuedThreadPool serverThreads = new QueuedThreadPool();
             serverThreads.setName("server");
-            server = new Server(serverThreads);
+            server = new Server(serverThreads, null, new ArrayByteBufferPool.Tracking());
         }
         connector = new ServerConnector(server, scenario.newServerSslContextFactory());
         connector.setPort(0);
@@ -82,6 +88,7 @@ public abstract class AbstractHttpClientServerTest
         clientConnector.setExecutor(executor);
         Scheduler scheduler = new ScheduledExecutorScheduler("client-scheduler", false);
         clientConnector.setScheduler(scheduler);
+        clientConnector.setByteBufferPool(new ArrayByteBufferPool.Tracking());
         client = newHttpClient(transport.apply(clientConnector));
         client.setSocketAddressResolver(new SocketAddressResolver.Sync());
         if (config != null)
@@ -95,13 +102,21 @@ public abstract class AbstractHttpClientServerTest
     }
 
     @AfterEach
-    public void disposeClient() throws Exception
+    public void dispose() throws Exception
     {
-        if (client != null)
-        {
-            client.stop();
-            client = null;
-        }
+        LifeCycle.stop(client);
+
+        ArrayByteBufferPool.Tracking clientBufferPool = (ArrayByteBufferPool.Tracking)client.getClientConnector().getByteBufferPool();
+        await().atMost(5, java.util.concurrent.TimeUnit.SECONDS).untilAsserted(() ->
+            assertThat("client leaks: " + clientBufferPool.dumpLeaks(), clientBufferPool.getLeaks().size(), is(0))
+        );
+
+        ArrayByteBufferPool.Tracking serverBufferPool = (ArrayByteBufferPool.Tracking)server.getByteBufferPool();
+        await().atMost(5, java.util.concurrent.TimeUnit.SECONDS).untilAsserted(() ->
+            assertThat("server leaks: " + serverBufferPool.dumpLeaks(), serverBufferPool.getLeaks().size(), is(0))
+        );
+
+        LifeCycle.stop(server);
     }
 
     @AfterEach

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/AbstractHttpClientServerTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/AbstractHttpClientServerTest.java
@@ -104,19 +104,23 @@ public abstract class AbstractHttpClientServerTest
     @AfterEach
     public void dispose() throws Exception
     {
-        LifeCycle.stop(client);
+        if (client != null)
+        {
+            LifeCycle.stop(client);
+            ArrayByteBufferPool.Tracking clientBufferPool = (ArrayByteBufferPool.Tracking)client.getClientConnector().getByteBufferPool();
+            await().atMost(5, java.util.concurrent.TimeUnit.SECONDS).untilAsserted(() ->
+                assertThat("client leaks: " + clientBufferPool.dumpLeaks(), clientBufferPool.getLeaks().size(), is(0))
+            );
+        }
 
-        ArrayByteBufferPool.Tracking clientBufferPool = (ArrayByteBufferPool.Tracking)client.getClientConnector().getByteBufferPool();
-        await().atMost(5, java.util.concurrent.TimeUnit.SECONDS).untilAsserted(() ->
-            assertThat("client leaks: " + clientBufferPool.dumpLeaks(), clientBufferPool.getLeaks().size(), is(0))
-        );
-
-        ArrayByteBufferPool.Tracking serverBufferPool = (ArrayByteBufferPool.Tracking)server.getByteBufferPool();
-        await().atMost(5, java.util.concurrent.TimeUnit.SECONDS).untilAsserted(() ->
-            assertThat("server leaks: " + serverBufferPool.dumpLeaks(), serverBufferPool.getLeaks().size(), is(0))
-        );
-
-        LifeCycle.stop(server);
+        if (server != null)
+        {
+            ArrayByteBufferPool.Tracking serverBufferPool = (ArrayByteBufferPool.Tracking)server.getByteBufferPool();
+            await().atMost(5, java.util.concurrent.TimeUnit.SECONDS).untilAsserted(() ->
+                assertThat("server leaks: " + serverBufferPool.dumpLeaks(), serverBufferPool.getLeaks().size(), is(0))
+            );
+            LifeCycle.stop(server);
+        }
     }
 
     @AfterEach

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientAuthenticationTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientAuthenticationTest.java
@@ -29,6 +29,7 @@ import java.util.function.IntFunction;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpURI;
+import org.eclipse.jetty.io.ArrayByteBufferPool;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.security.Authenticator;
 import org.eclipse.jetty.security.Constraint;
@@ -95,7 +96,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
 
     private void start(Scenario scenario, Authenticator authenticator, Handler handler) throws Exception
     {
-        server = new Server();
+        server = new Server(null, null, new ArrayByteBufferPool.Tracking());
         Path realmFile = MavenTestingUtils.getTestResourcePath("realm.properties");
         LoginService loginService = new HashLoginService(realm, ResourceFactory.root().newResource(realmFile));
         server.addBean(loginService);

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientGZIPTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientGZIPTest.java
@@ -316,7 +316,7 @@ public class HttpClientGZIPTest extends AbstractHttpClientServerTest
         {
             content[i] = (byte)digits.charAt(random.nextInt(digits.length()));
         }
-        start(scenario, new EmptyServerHandler()
+        startServer(scenario, new EmptyServerHandler()
         {
             @Override
             protected void service(Request request, org.eclipse.jetty.server.Response response) throws Exception
@@ -328,6 +328,7 @@ public class HttpClientGZIPTest extends AbstractHttpClientServerTest
                 gzip.finish();
             }
         });
+        startClient(scenario, httpClient -> httpClient.setByteBufferPool(null));
 
         ByteBufferPool pool = client.getByteBufferPool();
         assumeTrue(pool instanceof ArrayByteBufferPool);

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientGZIPTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientGZIPTest.java
@@ -328,7 +328,8 @@ public class HttpClientGZIPTest extends AbstractHttpClientServerTest
                 gzip.finish();
             }
         });
-        startClient(scenario, httpClient -> httpClient.setByteBufferPool(null));
+        // Set a tracking pool with the same values as the HttpClient's default ArrayByteBufferPool.
+        startClient(scenario, httpClient -> httpClient.setByteBufferPool(new ArrayByteBufferPool.Tracking(0, 2048, 65536, 100)));
 
         ByteBufferPool pool = client.getByteBufferPool();
         assumeTrue(pool instanceof ArrayByteBufferPool);

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
@@ -57,6 +57,7 @@ import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.io.ArrayByteBufferPool;
 import org.eclipse.jetty.io.ClientConnector;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.EndPoint;
@@ -1563,6 +1564,7 @@ public class HttpClientTest extends AbstractHttpClientServerTest
                 };
             }
         });
+        client.setByteBufferPool(new ArrayByteBufferPool.Tracking());
         client.start();
 
         CountDownLatch latch = new CountDownLatch(2);

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
@@ -2168,7 +2168,7 @@ public class HttpClientTest extends AbstractHttpClientServerTest
             protected void service(org.eclipse.jetty.server.Request request, org.eclipse.jetty.server.Response response)
             {
                 int capacity = (int)request.getHeaders().getLongField("X-Capacity");
-                // Overflow the max request headers size, should generate a 500.
+                // Overflow the max response headers size, should generate a 500.
                 response.getHeaders().put("X-Large", "A".repeat(3 * capacity));
             }
         });

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/RetainingResponseListenerTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/RetainingResponseListenerTest.java
@@ -77,6 +77,59 @@ public class RetainingResponseListenerTest extends AbstractHttpClientServerTest
         assertEquals(-1, inputStream.read());
         // Read again at EOF to be sure -1 is returned again.
         assertEquals(-1, inputStream.read());
+        // Further getContent() calls see an empty byte[].
+        assertEquals(0, listener.getContent().length);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testContentIsCopiedWithInputStreamIfGetContentIsCalledFirst(Scenario scenario) throws Exception
+    {
+        start(scenario, new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                response.write(true, ByteBuffer.allocate(1), callback);
+                return true;
+            }
+        });
+
+        List<ByteBuffer> byteBuffers = new ArrayList<>();
+        RetainingResponseListener listener = new RetainingResponseListener()
+        {
+        };
+        ContentResponse response = client.newRequest("localhost", connector.getLocalPort())
+            .scheme(scenario.getScheme())
+            .onResponseContent((r, b) -> byteBuffers.add(b))
+            .onResponseContentAsync(listener)
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+
+        // Force copying the content into a byte[].
+        listener.getContent();
+        InputStream inputStream = listener.getContentAsInputStream();
+
+        // Modify the content so that we can check if there was a copy.
+        assertEquals(1, byteBuffers.size());
+        ByteBuffer byteBuffer = byteBuffers.get(0);
+        assertEquals(1, byteBuffer.remaining());
+        byte modified = 1;
+        byteBuffer.put(0, modified);
+
+        // Read from the input stream.
+        int read = inputStream.read();
+        // If we read the modified value, there was no data copy.
+        assertEquals(0, read);
+        // We must be at EOF.
+        assertEquals(-1, inputStream.read());
+        // Read again at EOF to be sure -1 is returned again.
+        assertEquals(-1, inputStream.read());
+        // Further getContent() calls see the content's byte[].
+        assertEquals(1, listener.getContent().length);
+        assertEquals(0, listener.getContent()[0]);
     }
 
     @ParameterizedTest
@@ -110,5 +163,44 @@ public class RetainingResponseListenerTest extends AbstractHttpClientServerTest
         byte[] bytes = inputStream.readAllBytes();
 
         assertArrayEquals(content, bytes);
+        // Further getContent() calls see an empty byte[].
+        assertEquals(0, listener.getContent().length);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testInputStreamReadAllBytesFromByteArrayCopy(Scenario scenario) throws Exception
+    {
+        byte[] content = new byte[1024 * 1024];
+        ThreadLocalRandom.current().nextBytes(content);
+        start(scenario, new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                response.write(true, ByteBuffer.wrap(content), callback);
+                return true;
+            }
+        });
+
+        RetainingResponseListener listener = new RetainingResponseListener()
+        {
+        };
+        ContentResponse response = client.newRequest("localhost", connector.getLocalPort())
+            .scheme(scenario.getScheme())
+            .onResponseContentAsync(listener)
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+
+        // Force copying the content into a byte[].
+        listener.getContent();
+        InputStream inputStream = listener.getContentAsInputStream();
+        byte[] bytes = inputStream.readAllBytes();
+
+        assertArrayEquals(content, bytes);
+        // Further getContent() calls see the same byte[].
+        assertArrayEquals(content, listener.getContent());
     }
 }

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/RetainingResponseListenerTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/RetainingResponseListenerTest.java
@@ -109,6 +109,6 @@ public class RetainingResponseListenerTest extends AbstractHttpClientServerTest
         InputStream inputStream = listener.getContentAsInputStream();
         byte[] bytes = inputStream.readAllBytes();
 
-        assertArrayEquals( content, bytes);
+        assertArrayEquals(content, bytes);
     }
 }

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/RetainingResponseListenerTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/RetainingResponseListenerTest.java
@@ -60,30 +60,31 @@ public class RetainingResponseListenerTest extends AbstractHttpClientServerTest
 
         assertEquals(HttpStatus.OK_200, response.getStatus());
 
-        InputStream inputStream = listener.getContentAsInputStream();
+        try (InputStream inputStream = listener.takeContentAsInputStream())
+        {
+            // Modify the content so that we can check if there was a copy.
+            assertEquals(1, byteBuffers.size());
+            ByteBuffer byteBuffer = byteBuffers.get(0);
+            assertEquals(1, byteBuffer.remaining());
+            byte modified = 1;
+            byteBuffer.put(0, modified);
 
-        // Modify the content so that we can check if there was a copy.
-        assertEquals(1, byteBuffers.size());
-        ByteBuffer byteBuffer = byteBuffers.get(0);
-        assertEquals(1, byteBuffer.remaining());
-        byte modified = 1;
-        byteBuffer.put(0, modified);
-
-        // Read from the input stream.
-        int read = inputStream.read();
-        // If we read the modified value, there was no data copy.
-        assertEquals(modified, read);
-        // We must be at EOF.
-        assertEquals(-1, inputStream.read());
-        // Read again at EOF to be sure -1 is returned again.
-        assertEquals(-1, inputStream.read());
-        // Further getContent() calls see an empty byte[].
-        assertEquals(0, listener.getContent().length);
+            // Read from the input stream.
+            int read = inputStream.read();
+            // If we read the modified value, there was no data copy.
+            assertEquals(modified, read);
+            // We must be at EOF.
+            assertEquals(-1, inputStream.read());
+            // Read again at EOF to be sure -1 is returned again.
+            assertEquals(-1, inputStream.read());
+            // Further getContent() calls see an empty byte[].
+            assertEquals(0, listener.getContent().length);
+        }
     }
 
     @ParameterizedTest
     @ArgumentsSource(ScenarioProvider.class)
-    public void testContentIsCopiedWithInputStreamIfGetContentIsCalledFirst(Scenario scenario) throws Exception
+    public void testContentIsCopiedWithInputStream(Scenario scenario) throws Exception
     {
         start(scenario, new Handler.Abstract()
         {
@@ -108,28 +109,27 @@ public class RetainingResponseListenerTest extends AbstractHttpClientServerTest
 
         assertEquals(HttpStatus.OK_200, response.getStatus());
 
-        // Force copying the content into a byte[].
-        listener.getContent();
-        InputStream inputStream = listener.getContentAsInputStream();
+        try (InputStream inputStream = listener.getContentAsInputStream())
+        {
+            // Modify the content so that we can check if there was a copy.
+            assertEquals(1, byteBuffers.size());
+            ByteBuffer byteBuffer = byteBuffers.get(0);
+            assertEquals(1, byteBuffer.remaining());
+            byte modified = 1;
+            byteBuffer.put(0, modified);
 
-        // Modify the content so that we can check if there was a copy.
-        assertEquals(1, byteBuffers.size());
-        ByteBuffer byteBuffer = byteBuffers.get(0);
-        assertEquals(1, byteBuffer.remaining());
-        byte modified = 1;
-        byteBuffer.put(0, modified);
-
-        // Read from the input stream.
-        int read = inputStream.read();
-        // If we read the modified value, there was no data copy.
-        assertEquals(0, read);
-        // We must be at EOF.
-        assertEquals(-1, inputStream.read());
-        // Read again at EOF to be sure -1 is returned again.
-        assertEquals(-1, inputStream.read());
-        // Further getContent() calls see the content's byte[].
-        assertEquals(1, listener.getContent().length);
-        assertEquals(0, listener.getContent()[0]);
+            // Read from the input stream.
+            int read = inputStream.read();
+            // If we read the modified value, there was no data copy.
+            assertEquals(0, read);
+            // We must be at EOF.
+            assertEquals(-1, inputStream.read());
+            // Read again at EOF to be sure -1 is returned again.
+            assertEquals(-1, inputStream.read());
+            // Further getContent() calls see the content's byte[].
+            assertEquals(1, listener.getContent().length);
+            assertEquals(0, listener.getContent()[0]);
+        }
     }
 
     @ParameterizedTest
@@ -159,12 +159,14 @@ public class RetainingResponseListenerTest extends AbstractHttpClientServerTest
 
         assertEquals(HttpStatus.OK_200, response.getStatus());
 
-        InputStream inputStream = listener.getContentAsInputStream();
-        byte[] bytes = inputStream.readAllBytes();
+        try (InputStream inputStream = listener.takeContentAsInputStream())
+        {
+            byte[] bytes = inputStream.readAllBytes();
 
-        assertArrayEquals(content, bytes);
-        // Further getContent() calls see an empty byte[].
-        assertEquals(0, listener.getContent().length);
+            assertArrayEquals(content, bytes);
+            // Further getContent() calls see an empty byte[].
+            assertEquals(0, listener.getContent().length);
+        }
     }
 
     @ParameterizedTest
@@ -194,8 +196,6 @@ public class RetainingResponseListenerTest extends AbstractHttpClientServerTest
 
         assertEquals(HttpStatus.OK_200, response.getStatus());
 
-        // Force copying the content into a byte[].
-        listener.getContent();
         InputStream inputStream = listener.getContentAsInputStream();
         byte[] bytes = inputStream.readAllBytes();
 

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/RetainingResponseListenerTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/RetainingResponseListenerTest.java
@@ -17,6 +17,7 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jetty.http.HttpStatus;
@@ -27,6 +28,7 @@ import org.eclipse.jetty.util.Callback;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RetainingResponseListenerTest extends AbstractHttpClientServerTest
@@ -71,5 +73,39 @@ public class RetainingResponseListenerTest extends AbstractHttpClientServerTest
         int read = inputStream.read();
         // If we read the modified value, there was no data copy.
         assertEquals(modified, read);
+        assertEquals(-1, inputStream.read());
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testInputStreamReadAllBytes(Scenario scenario) throws Exception
+    {
+        byte[] content = new byte[1024 * 1024];
+        ThreadLocalRandom.current().nextBytes(content);
+        start(scenario, new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                response.write(true, ByteBuffer.wrap(content), callback);
+                return true;
+            }
+        });
+
+        RetainingResponseListener listener = new RetainingResponseListener()
+        {
+        };
+        ContentResponse response = client.newRequest("localhost", connector.getLocalPort())
+            .scheme(scenario.getScheme())
+            .onResponseContentAsync(listener)
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+
+        InputStream inputStream = listener.getContentAsInputStream();
+        byte[] bytes = inputStream.readAllBytes();
+
+        assertArrayEquals( content, bytes);
     }
 }

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/RetainingResponseListenerTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/RetainingResponseListenerTest.java
@@ -1,0 +1,75 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.client;
+
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.Callback;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RetainingResponseListenerTest extends AbstractHttpClientServerTest
+{
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testContentIsNotCopiedWithInputStream(Scenario scenario) throws Exception
+    {
+        start(scenario, new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                response.write(true, ByteBuffer.allocate(1), callback);
+                return true;
+            }
+        });
+
+        List<ByteBuffer> byteBuffers = new ArrayList<>();
+        RetainingResponseListener listener = new RetainingResponseListener()
+        {
+        };
+        ContentResponse response = client.newRequest("localhost", connector.getLocalPort())
+            .scheme(scenario.getScheme())
+            .onResponseContent((r, b) -> byteBuffers.add(b))
+            .onResponseContentAsync(listener)
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+
+        InputStream inputStream = listener.getContentAsInputStream();
+
+        // Modify the content so that we can check if there was a copy.
+        assertEquals(1, byteBuffers.size());
+        ByteBuffer byteBuffer = byteBuffers.get(0);
+        assertEquals(1, byteBuffer.remaining());
+        byte modified = 1;
+        byteBuffer.put(0, modified);
+
+        // Read from the input stream.
+        int read = inputStream.read();
+        // If we read the modified value, there was no data copy.
+        assertEquals(modified, read);
+    }
+}

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/RetainingResponseListenerTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/RetainingResponseListenerTest.java
@@ -73,6 +73,9 @@ public class RetainingResponseListenerTest extends AbstractHttpClientServerTest
         int read = inputStream.read();
         // If we read the modified value, there was no data copy.
         assertEquals(modified, read);
+        // We must be at EOF.
+        assertEquals(-1, inputStream.read());
+        // Read again at EOF to be sure -1 is returned again.
         assertEquals(-1, inputStream.read());
     }
 

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/util/SPNEGOAuthenticationTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/util/SPNEGOAuthenticationTest.java
@@ -33,6 +33,7 @@ import org.eclipse.jetty.client.InputStreamRequestContent;
 import org.eclipse.jetty.client.Request;
 import org.eclipse.jetty.client.Response;
 import org.eclipse.jetty.client.SPNEGOAuthentication;
+import org.eclipse.jetty.io.ArrayByteBufferPool;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.security.Constraint;
 import org.eclipse.jetty.security.HashLoginService;
@@ -124,7 +125,7 @@ public class SPNEGOAuthenticationTest extends AbstractHttpClientServerTest
 
     private void startSPNEGO(Scenario scenario, Handler handler) throws Exception
     {
-        server = new Server();
+        server = new Server(null, null, new ArrayByteBufferPool.Tracking());
         HashLoginService hashLoginService = new HashLoginService(realm, ResourceFactory.of(server).newResource(realmPropsPath));
         SPNEGOLoginService spnegoLoginService = new SPNEGOLoginService(realm, hashLoginService);
         spnegoLoginService.setKeyTabPath(serviceKeyTabPath);

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -1878,7 +1878,7 @@ public class HttpParser
             switch (_state)
             {
                 case EOF_CONTENT:
-                    _contentChunk = buffer.asReadOnlyBuffer();
+                    _contentChunk = buffer.slice();
                     _contentPosition += remaining;
                     buffer.position(buffer.position() + remaining);
                     if (_handler.content(_contentChunk))
@@ -1895,18 +1895,17 @@ public class HttpParser
                     }
                     else
                     {
-                        _contentChunk = buffer.asReadOnlyBuffer();
-
-                        // limit content by expected size if _contentLength is >= 0 (i.e.: not infinite)
+                        int length = remaining;
+                        // Limit the content by the expected length if _contentLength is >= 0 (i.e.: not infinite).
                         if (_contentLength > -1 && remaining > content)
                         {
-                            // We can cast remaining to an int as we know that it is smaller than
-                            // or equal to length which is already an int.
-                            _contentChunk.limit(_contentChunk.position() + (int)content);
+                            // The cast to int is safe, since remaining is an int.
+                            length = (int)content;
                         }
+                        _contentChunk = buffer.slice(buffer.position(), length);
 
-                        _contentPosition += _contentChunk.remaining();
-                        buffer.position(buffer.position() + _contentChunk.remaining());
+                        _contentPosition += length;
+                        buffer.position(buffer.position() + length);
 
                         if (_handler.content(_contentChunk))
                             return true;
@@ -2025,14 +2024,12 @@ public class HttpParser
                     }
                     else
                     {
-                        _contentChunk = buffer.asReadOnlyBuffer();
+                        int length = Math.min(remaining, chunkLength);
+                        _contentChunk = buffer.slice(buffer.position(), length);
 
-                        if (remaining > chunkLength)
-                            _contentChunk.limit(_contentChunk.position() + chunkLength);
-                        chunkLength = _contentChunk.remaining();
-                        _contentPosition += chunkLength;
-                        _chunkOffset += chunkLength;
-                        buffer.position(buffer.position() + chunkLength);
+                        _contentPosition += length;
+                        _chunkOffset += length;
+                        buffer.position(buffer.position() + length);
                         if (_handler.content(_contentChunk))
                             return true;
                     }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/RetainableByteBuffer.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/RetainableByteBuffer.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Objects;
 
+import org.eclipse.jetty.io.content.ChunksContentSource;
 import org.eclipse.jetty.util.Blocker;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
@@ -2461,6 +2462,23 @@ public interface RetainableByteBuffer extends Retainable
                     }.iterate();
                 }
             }
+        }
+
+        public Content.Source takeContentSource()
+        {
+            List<Content.Chunk> list = new ArrayList<>();
+            Iterator<RetainableByteBuffer> iterator = _buffers.iterator();
+            while (iterator.hasNext())
+            {
+                RetainableByteBuffer buffer = iterator.next();
+                if (buffer instanceof Content.Chunk chunk)
+                    list.add(chunk);
+                else
+                    list.add(Content.Chunk.asChunk(buffer.getByteBuffer(), !iterator.hasNext(), buffer));
+            }
+            ChunksContentSource contentSource = new ChunksContentSource(list);
+            release();
+            return contentSource;
         }
 
         @Override

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/RetainableByteBuffer.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/RetainableByteBuffer.java
@@ -2477,7 +2477,10 @@ public interface RetainableByteBuffer extends Retainable
                     list.add(Content.Chunk.asChunk(buffer.getByteBuffer(), !iterator.hasNext(), buffer));
             }
             ChunksContentSource contentSource = new ChunksContentSource(list);
-            release();
+            for (RetainableByteBuffer buffer : _buffers)
+                buffer.release();
+            _buffers.clear();
+            _aggregate = null;
             return contentSource;
         }
 

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/RetainableByteBuffer.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/RetainableByteBuffer.java
@@ -2049,7 +2049,11 @@ public interface RetainableByteBuffer extends Retainable
                 return;
             _aggregate = null;
             for (RetainableByteBuffer rbb : _buffers)
+            {
+                if (rbb instanceof DynamicCapacity dynamicCapacity)
+                    dynamicCapacity.clear();
                 rbb.release();
+            }
             _buffers.clear();
         }
 
@@ -2467,21 +2471,33 @@ public interface RetainableByteBuffer extends Retainable
         public Content.Source takeContentSource()
         {
             List<Content.Chunk> list = new ArrayList<>();
-            Iterator<RetainableByteBuffer> iterator = _buffers.iterator();
-            while (iterator.hasNext())
+            for (RetainableByteBuffer buffer : _buffers)
             {
-                RetainableByteBuffer buffer = iterator.next();
                 if (buffer instanceof Content.Chunk chunk)
                     list.add(chunk);
+                else if (buffer instanceof DynamicCapacity dynamic)
+                    list.addAll(flattenToChunks(dynamic));
                 else
-                    list.add(Content.Chunk.asChunk(buffer.getByteBuffer(), !iterator.hasNext(), buffer));
+                    list.add(Content.Chunk.asChunk(buffer.getByteBuffer(), false, buffer));
             }
             ChunksContentSource contentSource = new ChunksContentSource(list);
-            for (RetainableByteBuffer buffer : _buffers)
-                buffer.release();
-            _buffers.clear();
-            _aggregate = null;
+            clear();
             return contentSource;
+        }
+
+        private static List<Content.Chunk> flattenToChunks(DynamicCapacity dynamic)
+        {
+            List<Content.Chunk> list = new ArrayList<>();
+            for (RetainableByteBuffer buffer : dynamic._buffers)
+            {
+                if (buffer instanceof Content.Chunk chunk)
+                    list.add(chunk);
+                else if (buffer instanceof DynamicCapacity d)
+                    list.addAll(flattenToChunks(d));
+                else
+                    list.add(Content.Chunk.asChunk(buffer.getByteBuffer(), false, buffer));
+            }
+            return list;
         }
 
         @Override

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/ChunksContentSource.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/ChunksContentSource.java
@@ -82,10 +82,11 @@ public class ChunksContentSource implements Content.Source
                 return terminated;
             if (iterator == null)
                 iterator = chunks.iterator();
-            chunk = iterator.next();
+            boolean hasNext = iterator.hasNext();
+            chunk = hasNext ? iterator.next() : null;
             if (chunk != null && chunk.isLast())
                 terminated = Content.Chunk.next(chunk);
-            if (terminated == null && !iterator.hasNext())
+            if (terminated == null && !hasNext)
                 terminated = Content.Chunk.EOF;
         }
         return chunk;

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/ChunksContentSource.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/content/ChunksContentSource.java
@@ -83,7 +83,7 @@ public class ChunksContentSource implements Content.Source
             if (iterator == null)
                 iterator = chunks.iterator();
             boolean hasNext = iterator.hasNext();
-            chunk = hasNext ? iterator.next() : null;
+            chunk = hasNext ? iterator.next() : Content.Chunk.EOF;
             if (chunk != null && chunk.isLast())
                 terminated = Content.Chunk.next(chunk);
             if (terminated == null && !hasNext)

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/RetainableByteBufferTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/RetainableByteBufferTest.java
@@ -39,6 +39,7 @@ import org.eclipse.jetty.util.Utf8StringBuilder;
 import org.eclipse.jetty.util.thread.TimerScheduler;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -55,6 +56,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -1539,5 +1541,72 @@ public class RetainableByteBufferTest
         assertThat(buffer.size(), is(size));
 
         assertTrue(buffer.release());
+    }
+
+    @Test
+    public void testNestedDynamicCapacityClear()
+    {
+        ArrayByteBufferPool.Tracking pool = new ArrayByteBufferPool.Tracking();
+        ByteBufferPool.Sized sized = new ByteBufferPool.Sized(pool, false, 10);
+        RetainableByteBuffer.DynamicCapacity root = new RetainableByteBuffer.DynamicCapacity(sized, 1024, 0);
+
+        Mutable mutable1 = pool.acquire(1, false);
+        mutable1.putShort((short)1);
+        root.add(mutable1);
+        RetainableByteBuffer.DynamicCapacity sub = new RetainableByteBuffer.DynamicCapacity(sized, 1024, 0);
+        Mutable mutable2 = pool.acquire(2, false);
+        mutable2.putShort((short)2);
+        sub.add(mutable2);
+        assertThat(sub.remaining(), is(2));
+        mutable2.retain();
+        root.add(sub);
+        Mutable mutable3 = pool.acquire(3, false);
+        mutable3.putShort((short)3);
+        root.add(mutable3);
+        assertThat(root.remaining(), is(6));
+        root.clear();
+        assertThat(root.remaining(), is(0));
+        assertThat(mutable2.release(), is(true));
+
+        assertThat(pool.getLeaks().size(), is(0));
+    }
+
+    @Test
+    public void testNestedDynamicCapacityTakeContentSource()
+    {
+        ArrayByteBufferPool.Tracking pool = new ArrayByteBufferPool.Tracking();
+        ByteBufferPool.Sized sized = new ByteBufferPool.Sized(pool, false, 10);
+        RetainableByteBuffer.DynamicCapacity root = new RetainableByteBuffer.DynamicCapacity(sized, 1024, 0);
+
+        Mutable mutable1 = pool.acquire(1, false);
+        mutable1.putShort((short)1);
+        root.add(mutable1);
+        RetainableByteBuffer.DynamicCapacity sub = new RetainableByteBuffer.DynamicCapacity(sized, 1024, 0);
+        Mutable mutable2 = pool.acquire(2, false);
+        mutable2.putShort((short)2);
+        sub.add(mutable2);
+        assertThat(sub.remaining(), is(2));
+        mutable2.retain();
+        root.add(sub);
+        Mutable mutable3 = pool.acquire(3, false);
+        mutable3.putShort((short)3);
+        root.add(mutable3);
+        assertThat(root.remaining(), is(6));
+
+        Content.Source source = root.takeContentSource();
+        assertThat(root.remaining(), is(0));
+        for (int i = 0; i < 3; i++)
+        {
+            Content.Chunk read = source.read();
+            assertInstanceOf(RetainableByteBuffer.FixedCapacity.class, read);
+            assertFalse(read.isLast());
+            read.release();
+        }
+        Content.Chunk last = source.read();
+        assertTrue(last.isLast());
+        assertTrue(last.isEmpty());
+
+        assertThat(mutable2.release(), is(true));
+        assertThat(pool.getLeaks().size(), is(0));
     }
 }

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/content/ChunksContentSourceTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/content/ChunksContentSourceTest.java
@@ -1,0 +1,33 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.io.content;
+
+import java.util.List;
+import org.eclipse.jetty.io.Content;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ChunksContentSourceTest
+{
+    @Test
+    public void testEmptyCollectionReadsEOF()
+    {
+        ChunksContentSource contentSource = new ChunksContentSource(List.of());
+        Content.Chunk read = contentSource.read();
+        assertFalse(read.getByteBuffer().hasRemaining());
+        assertTrue(read.isLast());
+    }
+}

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/content/ChunksContentSourceTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/content/ChunksContentSourceTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.io.content;
 
 import java.util.List;
+
 import org.eclipse.jetty.io.Content;
 import org.junit.jupiter.api.Test;
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
@@ -45,6 +45,7 @@ import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.eclipse.jetty.server.internal.HttpChannelState;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.ExceptionUtil;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.slf4j.Logger;
@@ -678,12 +679,13 @@ public interface Response extends Content.Sink
             }
             catch (Throwable e)
             {
-                if (cause != null && cause != e)
-                    cause.addSuppressed(e);
+                cause = ExceptionUtil.combine(cause, e);
+                if (logger.isDebugEnabled())
+                    logger.debug("writeError: failure in error handling", cause);
             }
         }
 
-        // fall back to very empty error page
+        // Fall back to a very empty error page.
         response.getHeaders().put(ErrorHandler.ERROR_CACHE_CONTROL);
         response.write(true, null, callback);
     }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -811,7 +811,11 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
                 _content = content;
                 _lastContent = last;
                 _callback = callback;
-                _header = null;
+                if (_header != null)
+                {
+                    _header.release();
+                    _header = null;
+                }
                 if (getConnector().isShutdown())
                     _generator.setPersistent(false);
                 return true;

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -811,11 +811,11 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
                 _content = content;
                 _lastContent = last;
                 _callback = callback;
-                if (_header != null)
-                {
-                    _header.release();
-                    _header = null;
-                }
+                // Cannot call reset unless we are
+                // finished with the previous send.
+                assert _header == null;
+                assert _chunk == null;
+                _shutdownOut = false;
                 if (getConnector().isShutdown())
                     _generator.setPersistent(false);
                 return true;
@@ -1026,17 +1026,14 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
         }
 
         @Override
-        public void onFailure(final Throwable x)
-        {
-            Callback callback = takeCallbackAndReset();
-            if (callback != null)
-                callback.failed(x);
-        }
-
-        @Override
         protected void onCompleteFailure(Throwable cause)
         {
+            // Failing the callback may re-enter SendCallback to write the error
+            // response, release the buffers used previously in the failed response.
+            Callback callback = takeCallbackAndReset();
             release();
+            if (callback != null)
+                callback.failed(cause);
         }
 
         @Override


### PR DESCRIPTION
* Implemented `AbstractResponseListener.getContentAsContentSource()` which can then be used for a more performant implementation of `getContentAsInputStream()` that does not perform data copy.
* Changed `HttpParser` to produce slices, rather than non-sliced read-only content ByteBuffers. In this way applications cannot peek before or after the content buffer. Removing read-only-ness would allow for testing, and it may be considered a feature, especially in the client where a content listener would be able to modify what the next content listener sees.
* Implemented `RetainableByteBuffer.DynamicCapacity.takeContentSource()` to pull out the content as a `Content.Source` without the data copy performed by `takeByteArray()`.