### PR TITLE
Fixes #14442 - Allow splitting of Transfer-Encoding chunks.

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpClientConnectionFactory.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpClientConnectionFactory.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jetty.client.transport.internal.HttpConnectionOverHTTP;
+import org.eclipse.jetty.http.HttpGenerator;
 import org.eclipse.jetty.io.ClientConnectionFactory;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.util.TypeUtil;
@@ -29,6 +30,7 @@ public class HttpClientConnectionFactory implements ClientConnectionFactory
     public static final Info HTTP11 = new HTTP11();
 
     private boolean initializeConnections;
+    private int transferEncodingChunkMaxLength = HttpGenerator.DEFAULT_CHUNK_MAX_LENGTH;
 
     /**
      * @return whether newly created connections should be initialized with an {@code OPTIONS * HTTP/1.1} request
@@ -46,11 +48,30 @@ public class HttpClientConnectionFactory implements ClientConnectionFactory
         this.initializeConnections = initialize;
     }
 
+    /**
+     * @return the transfer-encoding content chunk max length
+     */
+    public int getTransferEncodingChunkMaxLength()
+    {
+        return transferEncodingChunkMaxLength;
+    }
+
+    /**
+     * @param chunkMaxLength the transfer-encoding content chunk max length
+     */
+    public void setTransferEncodingChunkMaxLength(int chunkMaxLength)
+    {
+        if (transferEncodingChunkMaxLength <= 0)
+            throw new IllegalArgumentException("invalid transfer-encoding chunk max length");
+        transferEncodingChunkMaxLength = chunkMaxLength;
+    }
+
     @Override
     public org.eclipse.jetty.io.Connection newConnection(EndPoint endPoint, Map<String, Object> context)
     {
         HttpConnectionOverHTTP connection = new HttpConnectionOverHTTP(endPoint, context);
         connection.setInitialize(isInitializeConnections());
+        connection.setTransferEncodingChunkMaxLength(getTransferEncodingChunkMaxLength());
         return customize(connection, context);
     }
 

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpClientTransportOverHTTP.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpClientTransportOverHTTP.java
@@ -136,4 +136,20 @@ public class HttpClientTransportOverHTTP extends AbstractConnectorHttpClientTran
     {
         factory.setInitializeConnections(initialize);
     }
+
+    /**
+     * @return the transfer-encoding content chunk max length
+     */
+    public int getTransferEncodingChunkMaxLength()
+    {
+        return factory.getTransferEncodingChunkMaxLength();
+    }
+
+    /**
+     * @param chunkMaxLength the transfer-encoding content chunk max length
+     */
+    public void setTransferEncodingChunkMaxLength(int chunkMaxLength)
+    {
+        factory.setTransferEncodingChunkMaxLength(chunkMaxLength);
+    }
 }

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpConnectionOverHTTP.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpConnectionOverHTTP.java
@@ -189,6 +189,22 @@ public class HttpConnectionOverHTTP extends AbstractConnection implements IConne
         this.initialize = initialize;
     }
 
+    /**
+     * @return the transfer-encoding content chunk max length
+     */
+    public int getTransferEncodingChunkMaxLength()
+    {
+        return getHttpChannel().getHttpSender().getHttpGenerator().getChunkMaxLength();
+    }
+
+    /**
+     * @param chunkMaxLength the transfer-encoding content chunk max length
+     */
+    public void setTransferEncodingChunkMaxLength(int chunkMaxLength)
+    {
+        getHttpChannel().getHttpSender().getHttpGenerator().setChunkMaxLength(chunkMaxLength);
+    }
+
     @Override
     public InvocationType getInvocationType()
     {

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpSenderOverHTTP.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpSenderOverHTTP.java
@@ -42,7 +42,7 @@ public class HttpSenderOverHTTP extends HttpSender
     private final IteratingCallback contentCallback = new ContentCallback();
     private final HttpGenerator generator = new HttpGenerator();
     private MetaData.Request metaData;
-    private ByteBuffer contentByteBuffer;
+    private ByteBuffer content;
     private boolean lastContent;
     private Callback callback;
     private boolean shutdown;
@@ -58,12 +58,17 @@ public class HttpSenderOverHTTP extends HttpSender
         return (HttpChannelOverHTTP)super.getHttpChannel();
     }
 
+    public HttpGenerator getHttpGenerator()
+    {
+        return generator;
+    }
+
     @Override
     protected void sendHeaders(HttpExchange exchange, ByteBuffer contentBuffer, boolean lastContent, Callback callback)
     {
         try
         {
-            this.contentByteBuffer = contentBuffer;
+            this.content = contentBuffer;
             this.lastContent = lastContent;
             this.callback = callback;
             HttpRequest request = exchange.getRequest();
@@ -89,7 +94,7 @@ public class HttpSenderOverHTTP extends HttpSender
     {
         try
         {
-            this.contentByteBuffer = contentBuffer;
+            this.content = contentBuffer;
             this.lastContent = lastContent;
             this.callback = callback;
             if (LOG.isDebugEnabled())
@@ -159,16 +164,17 @@ public class HttpSenderOverHTTP extends HttpSender
             int requestHeadersSize = httpClient.getRequestBufferSize();
             int maxRequestHeadersSize = httpClient.getMaxRequestHeadersSize();
             boolean useDirectByteBuffers = httpClient.isUseOutputDirectByteBuffers();
+            int chunkMaxLength = generator.getChunkMaxLength();
             while (true)
             {
                 ByteBuffer headerByteBuffer = headerBuffer == null ? null : headerBuffer.getByteBuffer();
                 ByteBuffer chunkByteBuffer = chunkBuffer == null ? null : chunkBuffer.getByteBuffer();
-                HttpGenerator.Result result = generator.generateRequest(metaData, headerByteBuffer, chunkByteBuffer, contentByteBuffer, lastContent);
+                HttpGenerator.Result result = generator.generateRequest(metaData, headerByteBuffer, chunkByteBuffer, content, lastContent);
                 if (LOG.isDebugEnabled())
                     LOG.debug("Generated headers ({} bytes), chunk ({} bytes), content ({} bytes) - {}/{} for {}",
                         headerByteBuffer == null ? -1 : headerByteBuffer.remaining(),
                         chunkByteBuffer == null ? -1 : chunkByteBuffer.remaining(),
-                        contentByteBuffer == null ? -1 : contentByteBuffer.remaining(),
+                        content == null ? -1 : content.remaining(),
                         result, generator, exchange.getRequest());
                 switch (result)
                 {
@@ -213,8 +219,15 @@ public class HttpSenderOverHTTP extends HttpSender
                             headerByteBuffer = BufferUtil.EMPTY_BUFFER;
                         if (chunkByteBuffer == null)
                             chunkByteBuffer = BufferUtil.EMPTY_BUFFER;
+                        ByteBuffer contentByteBuffer = content;
                         if (contentByteBuffer == null)
                             contentByteBuffer = BufferUtil.EMPTY_BUFFER;
+                        if (generator.isChunking() && contentByteBuffer.remaining() > chunkMaxLength)
+                        {
+                            ByteBuffer slice = contentByteBuffer.slice(contentByteBuffer.position(), chunkMaxLength);
+                            contentByteBuffer.position(contentByteBuffer.position() + chunkMaxLength);
+                            contentByteBuffer = slice;
+                        }
                         long bytes = headerByteBuffer.remaining() + chunkByteBuffer.remaining() + contentByteBuffer.remaining();
                         getHttpChannel().getHttpConnection().addBytesOut(bytes);
                         endPoint.write(this, headerByteBuffer, chunkByteBuffer, contentByteBuffer);
@@ -253,7 +266,6 @@ public class HttpSenderOverHTTP extends HttpSender
         {
             headerBuffer = Retainable.release(headerBuffer);
             chunkBuffer = Retainable.release(chunkBuffer);
-            contentByteBuffer = null;
         }
 
         @Override
@@ -274,7 +286,6 @@ public class HttpSenderOverHTTP extends HttpSender
         {
             headerBuffer = Retainable.release(headerBuffer);
             chunkBuffer = Retainable.release(chunkBuffer);
-            contentByteBuffer = null;
         }
     }
 
@@ -293,13 +304,14 @@ public class HttpSenderOverHTTP extends HttpSender
             HttpClient httpClient = getHttpChannel().getHttpDestination().getHttpClient();
             ByteBufferPool bufferPool = httpClient.getByteBufferPool();
             boolean useDirectByteBuffers = httpClient.isUseOutputDirectByteBuffers();
+            int chunkMaxLength = generator.getChunkMaxLength();
             while (true)
             {
                 ByteBuffer chunkByteBuffer = chunkBuffer == null ? null : chunkBuffer.getByteBuffer();
-                HttpGenerator.Result result = generator.generateRequest(null, null, chunkByteBuffer, contentByteBuffer, lastContent);
+                HttpGenerator.Result result = generator.generateRequest(null, null, chunkByteBuffer, content, lastContent);
                 if (LOG.isDebugEnabled())
                     LOG.debug("Generated content ({} bytes, last={}) - {}/{}",
-                        contentByteBuffer == null ? -1 : contentByteBuffer.remaining(),
+                        content == null ? -1 : content.remaining(),
                         lastContent, result, generator);
                 switch (result)
                 {
@@ -316,10 +328,20 @@ public class HttpSenderOverHTTP extends HttpSender
                     case FLUSH:
                     {
                         EndPoint endPoint = getHttpChannel().getHttpConnection().getEndPoint();
-                        if (chunkByteBuffer != null)
-                            endPoint.write(this, chunkByteBuffer, contentByteBuffer);
-                        else
-                            endPoint.write(this, contentByteBuffer);
+                        if (chunkByteBuffer == null)
+                            chunkByteBuffer = BufferUtil.EMPTY_BUFFER;
+                        ByteBuffer contentByteBuffer = content;
+                        if (contentByteBuffer == null)
+                            contentByteBuffer = BufferUtil.EMPTY_BUFFER;
+                        if (generator.isChunking() && contentByteBuffer.remaining() > chunkMaxLength)
+                        {
+                            ByteBuffer slice = contentByteBuffer.slice(contentByteBuffer.position(), chunkMaxLength);
+                            contentByteBuffer.position(contentByteBuffer.position() + chunkMaxLength);
+                            contentByteBuffer = slice;
+                        }
+                        long bytes = chunkByteBuffer.remaining() + contentByteBuffer.remaining();
+                        getHttpChannel().getHttpConnection().addBytesOut(bytes);
+                        endPoint.write(this, chunkByteBuffer, contentByteBuffer);
                         return Action.SCHEDULED;
                     }
                     case SHUTDOWN_OUT:
@@ -359,10 +381,7 @@ public class HttpSenderOverHTTP extends HttpSender
 
         private void release()
         {
-            if (chunkBuffer != null)
-                chunkBuffer.release();
-            chunkBuffer = null;
-            contentByteBuffer = null;
+            chunkBuffer = Retainable.release(chunkBuffer);
         }
     }
 }

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/TransferEncodingChunkTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/TransferEncodingChunkTest.java
@@ -1,0 +1,265 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.client;
+
+import java.io.EOFException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.client.transport.HttpClientTransportOverHTTP;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TransferEncodingChunkTest
+{
+    private static final Logger LOG = LoggerFactory.getLogger(TransferEncodingChunkTest.class);
+
+    private HttpClient client;
+
+    private void startClient(int chunkMaxLength) throws Exception
+    {
+        HttpClientTransportOverHTTP transport = new HttpClientTransportOverHTTP();
+        transport.setTransferEncodingChunkMaxLength(chunkMaxLength);
+        client = new HttpClient(transport);
+        client.start();
+    }
+
+    @AfterEach
+    public void dispose()
+    {
+        LifeCycle.stop(client);
+    }
+
+    @Test
+    public void testChunkMaxLengthFlushThenContent() throws Exception
+    {
+        int chunkMaxLength = 1024;
+        startClient(chunkMaxLength);
+
+        try (ServerSocket server = new ServerSocket(0))
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("server listening on {}", server.getLocalSocketAddress());
+
+            byte[] content = new byte[2 * chunkMaxLength];
+            ThreadLocalRandom.current().nextBytes(content);
+            byte[] encodedContent = Base64.getEncoder().encode(content);
+
+            CountDownLatch responseLatch = new CountDownLatch(1);
+            AsyncRequestContent asyncContent = new AsyncRequestContent();
+            client.newRequest("localhost", server.getLocalPort())
+                .body(asyncContent)
+                .timeout(5, TimeUnit.SECONDS)
+                .send(r ->
+                {
+                    assertTrue(r.isSucceeded());
+                    assertEquals(HttpStatus.OK_200, r.getResponse().getStatus());
+                    responseLatch.countDown();
+                });
+
+            // Avoid that the headers and the chunk are sent in the same write.
+            Thread.sleep(500);
+            asyncContent.write(true, ByteBuffer.wrap(encodedContent), Callback.NOOP);
+
+            Socket socket = server.accept();
+            socket.setSoTimeout(500);
+            InputStream input = socket.getInputStream();
+            byte[] b = new byte[512];
+            List<byte[]> reads = new ArrayList<>();
+            while (true)
+            {
+                int read = input.read(b);
+                if (read > 0)
+                {
+                    reads.add(Arrays.copyOfRange(b, 0, read));
+                    if (read >= 5)
+                    {
+                        // Check if we are at the end of the request.
+                        int i = read - 5;
+                        if (b[i] == '0' && b[i + 1] == '\r' && b[i + 2] == '\n' && b[i + 3] == '\r' && b[i + 4] == '\n')
+                            break;
+                    }
+                }
+                else if (read < 0)
+                {
+                    throw new EOFException();
+                }
+            }
+            byte[] requestBytes = new byte[reads.stream().mapToInt(ba -> ba.length).sum()];
+            int offset = 0;
+            for (byte[] read : reads)
+            {
+                System.arraycopy(read, 0, requestBytes, offset, read.length);
+                offset += read.length;
+            }
+            String requestString = new String(requestBytes, StandardCharsets.UTF_8);
+
+            // The request must contain chunks of chunkMaxLength.
+            int count = encodedContent.length / chunkMaxLength;
+            int index = -1;
+            for (int i = 0; i < count; ++i)
+            {
+                index = requestString.indexOf("\r\n%x\r\n".formatted(chunkMaxLength), index + 1);
+                assertThat(index, greaterThan(0));
+            }
+            // Check that there are no extra bytes after the request end.
+            try
+            {
+                int read = input.read(b);
+                fail("unexpected read of %d bytes ".formatted(read));
+            }
+            catch (SocketTimeoutException ignored)
+            {
+            }
+
+            // Verify that the content is the same that was sent.
+            HttpTester.Request request = HttpTester.parseRequest(requestString);
+            byte[] decodedContent = Base64.getDecoder().decode(request.getContent());
+            assertArrayEquals(content, decodedContent);
+
+            OutputStream output = socket.getOutputStream();
+            output.write("""
+                HTTP/1.1 200 OK
+                Content-Length: 0
+                
+                """.getBytes(StandardCharsets.UTF_8));
+            output.flush();
+
+            assertTrue(responseLatch.await(5, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    public void testChunkMaxLengthContentWithTrailers() throws Exception
+    {
+        int chunkMaxLength = 512;
+        startClient(chunkMaxLength);
+
+        try (ServerSocket server = new ServerSocket(0))
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("server listening on {}", server.getLocalSocketAddress());
+
+            byte[] content = new byte[2 * chunkMaxLength];
+            ThreadLocalRandom.current().nextBytes(content);
+            byte[] encodedContent = Base64.getEncoder().encode(content);
+
+            // Setting the trailers implies using Transfer-Encoding: chunked.
+            HttpFields trailers = HttpFields.build().put("Force-Chunking", "Z");
+            CountDownLatch responseLatch = new CountDownLatch(1);
+            client.newRequest("localhost", server.getLocalPort())
+                .body(new BytesRequestContent(encodedContent))
+                .trailersSupplier(() -> trailers)
+                .timeout(5, TimeUnit.SECONDS)
+                .send(r ->
+                {
+                    assertTrue(r.isSucceeded());
+                    assertEquals(HttpStatus.OK_200, r.getResponse().getStatus());
+                    responseLatch.countDown();
+                });
+
+            Socket socket = server.accept();
+            socket.setSoTimeout(500);
+            InputStream input = socket.getInputStream();
+            byte[] b = new byte[512];
+            List<byte[]> reads = new ArrayList<>();
+            while (true)
+            {
+                int read = input.read(b);
+                if (read > 0)
+                {
+                    reads.add(Arrays.copyOfRange(b, 0, read));
+                    if (read >= 5)
+                    {
+                        // Check if we are at the end of the request.
+                        int i = read - 5;
+                        if (b[i] == 'Z' && b[i + 1] == '\r' && b[i + 2] == '\n' && b[i + 3] == '\r' && b[i + 4] == '\n')
+                            break;
+                    }
+                }
+                else if (read < 0)
+                {
+                    throw new EOFException();
+                }
+            }
+            byte[] requestBytes = new byte[reads.stream().mapToInt(ba -> ba.length).sum()];
+            int offset = 0;
+            for (byte[] read : reads)
+            {
+                System.arraycopy(read, 0, requestBytes, offset, read.length);
+                offset += read.length;
+            }
+            String requestString = new String(requestBytes, StandardCharsets.UTF_8);
+
+            // The request must contain chunks of chunkMaxLength.
+            int count = encodedContent.length / chunkMaxLength;
+            int index = -1;
+            for (int i = 0; i < count; ++i)
+            {
+                index = requestString.indexOf("\r\n%x\r\n".formatted(chunkMaxLength), index + 1);
+                assertThat(index, greaterThan(0));
+            }
+            // Check that there are no extra bytes after the request end.
+            try
+            {
+                int read = input.read(b);
+                fail("unexpected read of %d bytes ".formatted(read));
+            }
+            catch (SocketTimeoutException ignored)
+            {
+            }
+
+            // Verify that the content is the same that was sent.
+            HttpTester.Request request = HttpTester.parseRequest(requestString);
+            byte[] decodedContent = Base64.getDecoder().decode(request.getContent());
+            assertArrayEquals(content, decodedContent);
+
+            OutputStream output = socket.getOutputStream();
+            output.write("""
+                HTTP/1.1 200 OK
+                Content-Length: 0
+                
+                """.getBytes(StandardCharsets.UTF_8));
+            output.flush();
+
+            assertTrue(responseLatch.await(5, TimeUnit.SECONDS));
+        }
+    }
+}

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpGenerator.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpGenerator.java
@@ -39,17 +39,24 @@ import static org.eclipse.jetty.http.HttpStatus.INTERNAL_SERVER_ERROR_500;
  */
 public class HttpGenerator
 {
-    private static final Logger LOG = LoggerFactory.getLogger(HttpGenerator.class);
-
+    /**
+     * <p>The default max number of bytes of the content of a transfer-encoding chunk, {@value}.</p>
+     */
+    public static final int DEFAULT_CHUNK_MAX_LENGTH = 1024 * 1024 * 1024;
+    /**
+     * The number of bytes for the buffer allocation of the chunk size part, {@value}.
+     */
+    public static final int CHUNK_SIZE = 12;
     public static final boolean __STRICT = Boolean.getBoolean("org.eclipse.jetty.http.HttpGenerator.STRICT");
-    private static final byte[] __colon_space = new byte[]{':', ' '};
     public static final MetaData.Response CONTINUE_100_INFO = new MetaData.Response(100, null, HttpVersion.HTTP_1_1, HttpFields.EMPTY);
+
+    private static final Logger LOG = LoggerFactory.getLogger(HttpGenerator.class);
+    private static final byte[] __colon_space = new byte[]{':', ' '};
     private static final Index<Boolean> ASSUMED_CONTENT_METHODS = new Index.Builder<Boolean>()
         .caseSensitive(false)
         .with(HttpMethod.POST.asString(), Boolean.TRUE)
         .with(HttpMethod.PUT.asString(), Boolean.TRUE)
         .build();
-    public static final int CHUNK_SIZE = 12;
 
     // states
     public enum State
@@ -82,10 +89,7 @@ public class HttpGenerator
     private Boolean _persistent = null;
     private boolean _needCRLF = false;
     private int _maxHeaderBytes;
-
-    public HttpGenerator()
-    {
-    }
+    private int _chunkMaxLength = DEFAULT_CHUNK_MAX_LENGTH;
 
     public void reset()
     {
@@ -106,6 +110,18 @@ public class HttpGenerator
     public void setMaxHeaderBytes(int maxHeaderBytes)
     {
         _maxHeaderBytes = maxHeaderBytes;
+    }
+
+    public int getChunkMaxLength()
+    {
+        return _chunkMaxLength;
+    }
+
+    public void setChunkMaxLength(int chunkMaxLength)
+    {
+        if (chunkMaxLength <= 0)
+            throw new IllegalArgumentException("invalid chunk max length");
+        _chunkMaxLength = chunkMaxLength;
     }
 
     public State getState()
@@ -214,15 +230,17 @@ public class HttpGenerator
                     }
                     else
                     {
-                        // handle the content.
-                        int len = BufferUtil.length(content);
-                        if (len > 0)
+                        int contentLength = BufferUtil.length(content);
+                        int committedLength = contentLength;
+                        if (committedLength > 0)
                         {
-                            _contentPrepared += len;
                             if (isChunking())
-                                prepareChunk(header, len);
+                                committedLength = prepareChunk(header, committedLength);
+                            _contentPrepared += committedLength;
                         }
-                        _state = last ? State.COMPLETING : State.COMMITTED;
+                        _state = State.COMMITTED;
+                        if (last && committedLength == contentLength)
+                            _state = State.COMPLETING;
                     }
 
                     return Result.FLUSH;
@@ -270,28 +288,28 @@ public class HttpGenerator
 
     private Result committed(ByteBuffer chunk, ByteBuffer content, boolean last)
     {
-        int len = BufferUtil.length(content);
-
-        // handle the content.
-        if (len > 0)
+        int contentLength = BufferUtil.length(content);
+        int committedLength = contentLength;
+        if (committedLength > 0)
         {
             if (isChunking())
             {
                 if (chunk == null)
                     return Result.NEED_CHUNK;
                 BufferUtil.clearToFill(chunk);
-                prepareChunk(chunk, len);
+                committedLength = prepareChunk(chunk, committedLength);
                 BufferUtil.flipToFlush(chunk, 0);
             }
-            _contentPrepared += len;
+            _contentPrepared += committedLength;
         }
 
         if (last)
         {
-            _state = State.COMPLETING;
-            return len > 0 ? Result.FLUSH : Result.CONTINUE;
+            if (committedLength == contentLength)
+                _state = State.COMPLETING;
+            return committedLength > 0 ? Result.FLUSH : Result.CONTINUE;
         }
-        return len > 0 ? Result.FLUSH : Result.DONE;
+        return committedLength > 0 ? Result.FLUSH : Result.DONE;
     }
 
     private Result completing(ByteBuffer chunk, ByteBuffer content)
@@ -401,15 +419,17 @@ public class HttpGenerator
 
                     generateHeaders(header, content, last);
 
-                    // handle the content.
-                    int len = BufferUtil.length(content);
-                    if (len > 0)
+                    int contentLength = BufferUtil.length(content);
+                    int committedLength = contentLength;
+                    if (committedLength > 0)
                     {
-                        _contentPrepared += len;
                         if (isChunking() && !head)
-                            prepareChunk(header, len);
+                            committedLength = prepareChunk(header, committedLength);
+                        _contentPrepared += committedLength;
                     }
-                    _state = last ? State.COMPLETING : State.COMMITTED;
+                    _state = State.COMMITTED;
+                    if (last && committedLength == contentLength)
+                        _state = State.COMPLETING;
                 }
                 catch (BufferOverflowException e)
                 {
@@ -474,7 +494,7 @@ public class HttpGenerator
         startTunnel();
     }
 
-    private void prepareChunk(ByteBuffer chunk, int remaining)
+    private int prepareChunk(ByteBuffer chunk, long remaining)
     {
         // if we need CRLF add this to header
         if (_needCRLF)
@@ -483,14 +503,17 @@ public class HttpGenerator
         // Add the chunk size to the header
         if (remaining > 0)
         {
-            BufferUtil.putHexInt(chunk, remaining);
+            int length = (int)Math.min(getChunkMaxLength(), remaining);
+            BufferUtil.putHexInt(chunk, length);
             BufferUtil.putCRLF(chunk);
             _needCRLF = true;
+            return length;
         }
         else
         {
             chunk.put(LAST_CHUNK);
             _needCRLF = false;
+            return 0;
         }
     }
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpTester.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpTester.java
@@ -519,6 +519,13 @@ public class HttpTester
                             }
                             if (BufferUtil.hasContent(content))
                             {
+                                int chunkMaxLength = generator.getChunkMaxLength();
+                                if (generator.isChunking() && content.remaining() > chunkMaxLength)
+                                {
+                                    ByteBuffer slice = content.slice(content.position(), chunkMaxLength);
+                                    content.position(content.position() + chunkMaxLength);
+                                    content = slice;
+                                }
                                 out.write(BufferUtil.toArray(content));
                                 BufferUtil.clear(content);
                             }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnectionFactory.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConnectionFactory.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.server;
 
 import java.util.Objects;
 
+import org.eclipse.jetty.http.HttpGenerator;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.io.Connection;
 import org.eclipse.jetty.io.EndPoint;
@@ -30,6 +31,7 @@ import org.eclipse.jetty.util.annotation.Name;
 public class HttpConnectionFactory extends AbstractConnectionFactory implements HttpConfiguration.ConnectionFactory
 {
     private final HttpConfiguration _config;
+    private int _transferEncodingChunkMaxLength = HttpGenerator.DEFAULT_CHUNK_MAX_LENGTH;
 
     public HttpConnectionFactory()
     {
@@ -85,10 +87,23 @@ public class HttpConnectionFactory extends AbstractConnectionFactory implements 
         _config.setUseOutputDirectByteBuffers(useOutputDirectByteBuffers);
     }
 
+    public int getTransferEncodingChunkMaxLength()
+    {
+        return _transferEncodingChunkMaxLength;
+    }
+
+    public void setTransferEncodingChunkMaxLength(int transferEncodingChunkMaxLength)
+    {
+        if (transferEncodingChunkMaxLength <= 0)
+            throw new IllegalArgumentException("invalid transfer-encoding chunk max length");
+        _transferEncodingChunkMaxLength = transferEncodingChunkMaxLength;
+    }
+
     @Override
     public Connection newConnection(Connector connector, EndPoint endPoint)
     {
         HttpConnection connection = new HttpConnection(_config, connector, endPoint);
+        connection.setTransferEncodingChunkMaxLength(getTransferEncodingChunkMaxLength());
         return configure(connection, connector, endPoint);
     }
 }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -295,6 +295,16 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
         getHttpConfiguration().setUseOutputDirectByteBuffers(useOutputDirectByteBuffers);
     }
 
+    public int getTransferEncodingChunkMaxLength()
+    {
+        return _generator.getChunkMaxLength();
+    }
+
+    public void setTransferEncodingChunkMaxLength(int transferEncodingChunkMaxLength)
+    {
+        _generator.setChunkMaxLength(transferEncodingChunkMaxLength);
+    }
+
     @Override
     public ByteBuffer onUpgradeFrom()
     {
@@ -835,6 +845,7 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
             int responseHeadersSize = getHttpConfiguration().getResponseHeaderSize();
             int maxResponseHeadersSize = getHttpConfiguration().getMaxResponseHeaderSize();
             boolean useDirectByteBuffers = isUseOutputDirectByteBuffers();
+            int chunkMaxLength = getTransferEncodingChunkMaxLength();
             while (true)
             {
                 ByteBuffer headerByteBuffer = _header == null ? null : _header.getByteBuffer();
@@ -912,37 +923,29 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
                             gatherWrite += 2;
                             bytes += _chunk.remaining();
                         }
-                        if (BufferUtil.hasContent(_content))
+                        ByteBuffer contentByteBuffer = _content;
+                        if (BufferUtil.hasContent(contentByteBuffer))
                         {
                             gatherWrite += 1;
-                            bytes += _content.remaining();
+                            if (_generator.isChunking() && contentByteBuffer.remaining() > chunkMaxLength)
+                            {
+                                ByteBuffer slice = contentByteBuffer.slice(contentByteBuffer.position(), chunkMaxLength);
+                                contentByteBuffer.position(contentByteBuffer.position() + chunkMaxLength);
+                                contentByteBuffer = slice;
+                            }
+                            bytes += contentByteBuffer.remaining();
                         }
                         _bytesOut.addAndGet(bytes);
                         switch (gatherWrite)
                         {
-                            case 7:
-                                getEndPoint().write(this, headerByteBuffer, chunkByteBuffer, _content);
-                                break;
-                            case 6:
-                                getEndPoint().write(this, headerByteBuffer, chunkByteBuffer);
-                                break;
-                            case 5:
-                                getEndPoint().write(this, headerByteBuffer, _content);
-                                break;
-                            case 4:
-                                getEndPoint().write(this, headerByteBuffer);
-                                break;
-                            case 3:
-                                getEndPoint().write(this, chunkByteBuffer, _content);
-                                break;
-                            case 2:
-                                getEndPoint().write(this, chunkByteBuffer);
-                                break;
-                            case 1:
-                                getEndPoint().write(this, _content);
-                                break;
-                            default:
-                                succeeded();
+                            case 7 -> getEndPoint().write(this, headerByteBuffer, chunkByteBuffer, contentByteBuffer);
+                            case 6 -> getEndPoint().write(this, headerByteBuffer, chunkByteBuffer);
+                            case 5 -> getEndPoint().write(this, headerByteBuffer, contentByteBuffer);
+                            case 4 -> getEndPoint().write(this, headerByteBuffer);
+                            case 3 -> getEndPoint().write(this, chunkByteBuffer, contentByteBuffer);
+                            case 2 -> getEndPoint().write(this, chunkByteBuffer);
+                            case 1 -> getEndPoint().write(this, contentByteBuffer);
+                            default -> succeeded();
                         }
 
                         return Action.SCHEDULED;

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/TransferEncodingChunkTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/TransferEncodingChunkTest.java
@@ -1,0 +1,263 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.server;
+
+import java.io.EOFException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.util.Blocker;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TransferEncodingChunkTest
+{
+    private Server server;
+    private ServerConnector connector;
+
+    private void startServer(Handler handler) throws Exception
+    {
+        server = new Server();
+        connector = new ServerConnector(server);
+        server.addConnector(connector);
+        server.setHandler(handler);
+        server.start();
+    }
+
+    @AfterEach
+    public void dispose()
+    {
+        LifeCycle.stop(server);
+    }
+
+    @Test
+    public void testChunkMaxLengthFlushThenContent() throws Exception
+    {
+        int chunkMaxLength = 1024;
+        byte[] content = new byte[2 * chunkMaxLength];
+        ThreadLocalRandom.current().nextBytes(content);
+        byte[] encodedContent = Base64.getEncoder().encode(content);
+        startServer((Handler)new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            {
+                // Send headers with Transfer-Encoding: chunked.
+                try (Blocker.Callback blocker = Blocker.callback())
+                {
+                    response.write(false, null, blocker);
+                    blocker.block();
+                }
+
+                // Send a content that is larger than the chunk max length.
+                response.write(true, ByteBuffer.wrap(encodedContent), callback);
+                return true;
+            }
+        });
+
+        // Limit the chunk length.
+        connector.getConnectionFactory(HttpConnectionFactory.class)
+            .setTransferEncodingChunkMaxLength(chunkMaxLength);
+
+        try (Socket client = new Socket("localhost", connector.getLocalPort()))
+        {
+            String request = """
+                GET / HTTP/1.1
+                Host: localhost
+                
+                """;
+            OutputStream output = client.getOutputStream();
+            output.write(request.getBytes(StandardCharsets.UTF_8));
+            output.flush();
+
+            client.setSoTimeout(500);
+
+            // We really want to check the structure of
+            // the response so we don't use HttpTester.
+
+            InputStream input = client.getInputStream();
+            byte[] b = new byte[512];
+            List<byte[]> reads = new ArrayList<>();
+            while (true)
+            {
+                int read = input.read(b);
+                if (read > 0)
+                {
+                    reads.add(Arrays.copyOfRange(b, 0, read));
+                    if (read >= 5)
+                    {
+                        // Check if we are at the end of the response.
+                        int i = read - 5;
+                        if (b[i] == '0' && b[i + 1] == '\r' && b[i + 2] == '\n' && b[i + 3] == '\r' && b[i + 4] == '\n')
+                            break;
+                    }
+                }
+                else if (read < 0)
+                {
+                    throw new EOFException();
+                }
+            }
+            byte[] responseBytes = new byte[reads.stream().mapToInt(ba -> ba.length).sum()];
+            int offset = 0;
+            for (byte[] read : reads)
+            {
+                System.arraycopy(read, 0, responseBytes, offset, read.length);
+                offset += read.length;
+            }
+            String responseString = new String(responseBytes, StandardCharsets.UTF_8);
+
+            // The response must contain chunks of chunkMaxLength.
+            int count = encodedContent.length / chunkMaxLength;
+            int index = -1;
+            for (int i = 0; i < count; ++i)
+            {
+                index = responseString.indexOf("\r\n%x\r\n".formatted(chunkMaxLength), index + 1);
+                assertThat(index, greaterThan(0));
+            }
+            // Check that there are no extra bytes after the response end.
+            try
+            {
+                int read = input.read(b);
+                fail("unexpected read of %d bytes ".formatted(read));
+            }
+            catch (SocketTimeoutException ignored)
+            {
+            }
+
+            // Verify that the content is the same that was sent.
+            HttpTester.Response response = HttpTester.parseResponse(responseString);
+            assertEquals(HttpStatus.OK_200, response.getStatus());
+            byte[] decodedContent = Base64.getDecoder().decode(response.getContent());
+            assertArrayEquals(content, decodedContent);
+        }
+    }
+
+    @Test
+    public void testChunkMaxLengthContentWithTrailers() throws Exception
+    {
+        int chunkMaxLength = 512;
+        byte[] content = new byte[2 * chunkMaxLength];
+        ThreadLocalRandom.current().nextBytes(content);
+        byte[] encodedContent = Base64.getEncoder().encode(content);
+        startServer((Handler)new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                // Setting the trailers implies using Transfer-Encoding: chunked.
+                HttpFields trailers = HttpFields.build().put("Force-Chunking", "Z");
+                response.setTrailersSupplier(() -> trailers);
+                response.write(true, ByteBuffer.wrap(encodedContent), callback);
+                return true;
+            }
+        });
+
+        // Limit the chunk length.
+        connector.getConnectionFactory(HttpConnectionFactory.class)
+            .setTransferEncodingChunkMaxLength(chunkMaxLength);
+
+        try (Socket client = new Socket("localhost", connector.getLocalPort()))
+        {
+            String request = """
+                GET / HTTP/1.1
+                Host: localhost
+                
+                """;
+            OutputStream output = client.getOutputStream();
+            output.write(request.getBytes(StandardCharsets.UTF_8));
+            output.flush();
+
+            client.setSoTimeout(500);
+
+            // We really want to check the structure of
+            // the response so we don't use HttpTester.
+
+            InputStream input = client.getInputStream();
+            byte[] b = new byte[512];
+            List<byte[]> reads = new ArrayList<>();
+            while (true)
+            {
+                int read = input.read(b);
+                if (read > 0)
+                {
+                    reads.add(Arrays.copyOfRange(b, 0, read));
+                    if (read >= 5)
+                    {
+                        // Check if we are at the end of the response.
+                        // Use the trailer value to find the response end.
+                        int i = read - 5;
+                        if (b[i] == 'Z' && b[i + 1] == '\r' && b[i + 2] == '\n' && b[i + 3] == '\r' && b[i + 4] == '\n')
+                            break;
+                    }
+                }
+                else if (read < 0)
+                {
+                    throw new EOFException();
+                }
+            }
+            byte[] responseBytes = new byte[reads.stream().mapToInt(ba -> ba.length).sum()];
+            int offset = 0;
+            for (byte[] read : reads)
+            {
+                System.arraycopy(read, 0, responseBytes, offset, read.length);
+                offset += read.length;
+            }
+            String responseString = new String(responseBytes, StandardCharsets.UTF_8);
+
+            // The response must contain chunks of chunkMaxLength.
+            int count = encodedContent.length / chunkMaxLength;
+            int index = -1;
+            for (int i = 0; i < count; ++i)
+            {
+                index = responseString.indexOf("\r\n%x\r\n".formatted(chunkMaxLength), index + 1);
+                assertThat(index, greaterThan(0));
+            }
+            // Check that there are no extra bytes after the response end.
+            try
+            {
+                int read = input.read(b);
+                fail("unexpected read of %d bytes ".formatted(read));
+            }
+            catch (SocketTimeoutException ignored)
+            {
+            }
+
+            // Verify that the content is the same that was sent.
+            HttpTester.Response response = HttpTester.parseResponse(responseString);
+            assertEquals(HttpStatus.OK_200, response.getStatus());
+            byte[] decodedContent = Base64.getDecoder().decode(response.getContent());
+            assertArrayEquals(content, decodedContent);
+        }
+    }
+}


### PR DESCRIPTION
* Introduced `HttpConnection.transferEncodingChunkMaxLength`, defaulting to 1 GiB to allow applications to configure chunking.
* Introduced `HttpGenerator.chunkMaxLength` to control the chunk-size produced by the generator.
* Updated `HttpConnection` to slice the content appropriately if it is larger than the chunkMaxLength.