### PR TITLE
Use `RetainableByteBuffer.Mutable` in HTTP/3

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/internal/HTTP2Flusher.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/internal/HTTP2Flusher.java
@@ -346,7 +346,6 @@ public class HTTP2Flusher extends IteratingCallback implements Dumpable
 
     private void finish()
     {
-        accumulator.clear();
         processedEntries.forEach(HTTP2Session.Entry::succeeded);
         processedEntries.clear();
         invocationType = InvocationType.NON_BLOCKING;

--- a/jetty-core/jetty-http3/jetty-http3-client/src/main/java/org/eclipse/jetty/http3/client/internal/ClientHTTP3Session.java
+++ b/jetty-core/jetty-http3/jetty-http3-client/src/main/java/org/eclipse/jetty/http3/client/internal/ClientHTTP3Session.java
@@ -55,7 +55,9 @@ public class ClientHTTP3Session extends ClientProtocolSession
 
     private final HTTP3Configuration configuration;
     private final HTTP3SessionClient session;
+    private final InstructionFlusher encoderFlusher;
     private final QpackEncoder encoder;
+    private final InstructionFlusher decoderFlusher;
     private final QpackDecoder decoder;
     private final ControlFlusher controlFlusher;
     private final MessageFlusher messageFlusher;
@@ -76,8 +78,9 @@ public class ClientHTTP3Session extends ClientProtocolSession
 
         long encoderStreamId = quicSession.newStreamId(false);
         StreamEndPoint encoderEndPoint = openInstructionEndPoint(encoderStreamId);
-        InstructionFlusher encoderInstructionFlusher = new InstructionFlusher(getByteBufferPool(), encoderEndPoint, StreamType.ENCODER_STREAM);
-        encoder = new QpackEncoder(new InstructionHandler(encoderInstructionFlusher));
+        encoderFlusher = new InstructionFlusher(getByteBufferPool(), encoderEndPoint, StreamType.ENCODER_STREAM);
+        installBean(encoderFlusher);
+        encoder = new QpackEncoder(new InstructionHandler(encoderFlusher));
         encoder.setMaxHeadersSize(configuration.getMaxRequestHeadersSize());
         installBean(encoder);
         if (LOG.isDebugEnabled())
@@ -85,8 +88,9 @@ public class ClientHTTP3Session extends ClientProtocolSession
 
         long decoderStreamId = quicSession.newStreamId(false);
         StreamEndPoint decoderEndPoint = openInstructionEndPoint(decoderStreamId);
-        InstructionFlusher decoderInstructionFlusher = new InstructionFlusher(getByteBufferPool(), decoderEndPoint, StreamType.DECODER_STREAM);
-        decoder = new QpackDecoder(new InstructionHandler(decoderInstructionFlusher));
+        decoderFlusher = new InstructionFlusher(getByteBufferPool(), decoderEndPoint, StreamType.DECODER_STREAM);
+        installBean(decoderFlusher);
+        decoder = new QpackDecoder(new InstructionHandler(decoderFlusher));
         installBean(decoder);
         if (LOG.isDebugEnabled())
             LOG.debug("created decoder stream #{} on {}", decoderStreamId, decoderEndPoint);
@@ -171,6 +175,15 @@ public class ClientHTTP3Session extends ClientProtocolSession
         SettingsFrame frame = new SettingsFrame(settings);
         if (controlFlusher.offer(frame, Callback.from(Invocable.InvocationType.NON_BLOCKING, session::onOpen, this::failControlStream)))
             controlFlusher.iterate();
+    }
+
+    @Override
+    protected void onStop()
+    {
+        messageFlusher.close();
+        controlFlusher.close();
+        decoderFlusher.close();
+        encoderFlusher.close();
     }
 
     public void onSettings(SettingsFrame frame)

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/ControlFlusher.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/ControlFlusher.java
@@ -42,7 +42,7 @@ public class ControlFlusher extends IteratingCallback
     private final Queue<Entry> queue = new ArrayDeque<>();
     private final StreamEndPoint endPoint;
     private final ControlGenerator generator;
-    private final ByteBufferPool.Accumulator accumulator;
+    private final RetainableByteBuffer.Mutable accumulator;
     private boolean initialized;
     private Throwable terminated;
     private List<Entry> entries;
@@ -52,7 +52,7 @@ public class ControlFlusher extends IteratingCallback
     {
         this.endPoint = endPoint;
         this.generator = new ControlGenerator(byteBufferPool, useDirectByteBuffers);
-        this.accumulator = new ByteBufferPool.Accumulator();
+        this.accumulator = new RetainableByteBuffer.DynamicCapacity(byteBufferPool, true, -1, 0, 0);
     }
 
     public boolean offer(Frame frame, Callback callback)
@@ -86,24 +86,22 @@ public class ControlFlusher extends IteratingCallback
 
         for (Entry entry : entries)
         {
+            if (!initialized)
+            {
+                initialized = true;
+                long streamType = StreamType.CONTROL_STREAM.type();
+                ByteBuffer buffer = ByteBuffer.allocate(VarLenInt.length(streamType));
+                VarLenInt.encode(buffer, streamType);
+                buffer.flip();
+                accumulator.add(buffer);
+            }
             generator.generate(accumulator, endPoint.getStream().getId(), entry.frame, null);
             invocationType = Invocable.combine(invocationType, entry.callback.getInvocationType());
         }
 
-        if (!initialized)
-        {
-            initialized = true;
-            long streamType = StreamType.CONTROL_STREAM.type();
-            ByteBuffer buffer = ByteBuffer.allocate(VarLenInt.length(streamType));
-            VarLenInt.encode(buffer, streamType);
-            buffer.flip();
-            accumulator.insert(0, RetainableByteBuffer.wrap(buffer));
-        }
-
-        List<ByteBuffer> buffers = accumulator.getByteBuffers();
         if (LOG.isDebugEnabled())
-            LOG.debug("writing {} buffers ({} bytes) on {}", buffers.size(), accumulator.getTotalLength(), this);
-        endPoint.write(false, buffers, this);
+            LOG.debug("writing {} bytes on {}", accumulator.size(), this);
+        accumulator.writeTo(endPoint, false, this);
         return Action.SCHEDULED;
     }
 
@@ -113,7 +111,7 @@ public class ControlFlusher extends IteratingCallback
         if (LOG.isDebugEnabled())
             LOG.debug("succeeded to write {} on {}", entries, this);
 
-        accumulator.release();
+        accumulator.clear();
 
         entries.forEach(e -> e.callback.succeeded());
         entries.clear();

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/ControlFlusher.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/ControlFlusher.java
@@ -111,8 +111,6 @@ public class ControlFlusher extends IteratingCallback
         if (LOG.isDebugEnabled())
             LOG.debug("succeeded to write {} on {}", entries, this);
 
-        accumulator.clear();
-
         entries.forEach(e -> e.callback.succeeded());
         entries.clear();
 

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/HTTP3StreamConnection.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/HTTP3StreamConnection.java
@@ -272,9 +272,9 @@ public abstract class HTTP3StreamConnection extends AbstractConnection
                         }
                         else
                         {
+                            // Retain because multiple frames can be parsed from the same QUIC chunk.
+                            quicChunk.retain();
                             Content.Chunk h3Chunk = Content.Chunk.asChunk(dataFrame.getByteBuffer(), dataFrame.isLast(), quicChunk);
-                            // Retain because multiple data can be parsed from the same QUIC data.
-                            h3Chunk.retain();
                             if (h3Chunk.isLast())
                                 tryReleaseData(true);
                             yield h3Chunk;
@@ -408,7 +408,7 @@ public abstract class HTTP3StreamConnection extends AbstractConnection
             LOG.debug("releasing force={} {} on {}", force, quicChunk, this);
         if (quicChunk == null)
             return;
-        if (force || (quicChunk.isLast() && !quicChunk.hasRemaining()))
+        if (force || !quicChunk.hasRemaining())
         {
             quicChunk.release();
             quicChunk = null;

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/InstructionFlusher.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/InstructionFlusher.java
@@ -104,21 +104,6 @@ public class InstructionFlusher extends IteratingCallback
     }
 
     @Override
-    protected void onSuccess()
-    {
-        accumulator.clear();
-    }
-
-    @Override
-    protected void onCompleteSuccess()
-    {
-        if (LOG.isDebugEnabled())
-            LOG.debug("succeeded to write buffers on {}", this);
-
-        accumulator.release();
-    }
-
-    @Override
     protected void onFailure(Throwable failure)
     {
         if (LOG.isDebugEnabled())

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/MessageFlusher.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/MessageFlusher.java
@@ -95,8 +95,6 @@ public class MessageFlusher extends IteratingCallback
         if (LOG.isDebugEnabled())
             LOG.atDebug().setCause(cause).log("failed to generate {} on {}", entry, this);
 
-        accumulator.clear();
-
         entry.callback.failed(cause);
         entry = null;
 
@@ -109,8 +107,6 @@ public class MessageFlusher extends IteratingCallback
         if (LOG.isDebugEnabled())
             LOG.debug("succeeded to write {} on {}", entry, this);
 
-        accumulator.clear();
-
         entry.callback().succeeded();
         entry = null;
 
@@ -121,8 +117,6 @@ public class MessageFlusher extends IteratingCallback
     {
         if (LOG.isDebugEnabled())
             LOG.atDebug().setCause(failure).log("failed to write {} on {}", entry, this);
-
-        accumulator.clear();
 
         entry.callback().failed(failure);
         entry = null;

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/MessageFlusher.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/MessageFlusher.java
@@ -14,6 +14,8 @@
 package org.eclipse.jetty.http3;
 
 import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Objects;
 import java.util.Queue;
 
 import org.eclipse.jetty.http3.frames.Frame;
@@ -36,6 +38,7 @@ public class MessageFlusher extends IteratingCallback
     private final Queue<Entry> entries = new ArrayDeque<>();
     private final MessageGenerator generator;
     private final RetainableByteBuffer.Mutable accumulator;
+    private Throwable terminated;
     private Entry entry;
 
     public MessageFlusher(ByteBufferPool bufferPool, QpackEncoder encoder, boolean useDirectByteBuffers)
@@ -46,11 +49,18 @@ public class MessageFlusher extends IteratingCallback
 
     public boolean offer(StreamEndPoint endPoint, Frame frame, Callback callback)
     {
+        Throwable closed;
         try (AutoLock ignored = lock.lock())
         {
-            entries.offer(new Entry(endPoint, frame, callback));
+            closed = terminated;
+            if (closed == null)
+            {
+                entries.offer(new Entry(endPoint, frame, callback));
+                return true;
+            }
         }
-        return true;
+        callback.failed(closed);
+        return false;
     }
 
     @Override
@@ -68,11 +78,11 @@ public class MessageFlusher extends IteratingCallback
 
         Frame frame = entry.frame;
 
-        long generated = generator.generate(accumulator, entry.endPoint.getStream().getId(), frame, this::onGenerateFailure);
+        StreamEndPoint endPoint = entry.endPoint();
+        long generated = generator.generate(accumulator, endPoint.getStream().getId(), frame, this::onGenerateFailure);
         if (generated < 0)
             return Action.SCHEDULED;
 
-        StreamEndPoint endPoint = entry.endPoint;
         if (LOG.isDebugEnabled())
             LOG.debug("writing {} bytes for stream #{} on {}", accumulator.size(), endPoint.getStream().getId(), this);
 
@@ -101,7 +111,7 @@ public class MessageFlusher extends IteratingCallback
 
         accumulator.clear();
 
-        entry.callback.succeeded();
+        entry.callback().succeeded();
         entry = null;
 
         succeeded();
@@ -114,7 +124,7 @@ public class MessageFlusher extends IteratingCallback
 
         accumulator.clear();
 
-        entry.callback.failed(failure);
+        entry.callback().failed(failure);
         entry = null;
 
         // Failure to write to one StreamEndPoint
@@ -123,11 +133,28 @@ public class MessageFlusher extends IteratingCallback
     }
 
     @Override
+    protected void onFailure(Throwable failure)
+    {
+        List<Entry> allEntries;
+        try (AutoLock ignored = lock.lock())
+        {
+            terminated = failure;
+            allEntries = List.copyOf(entries);
+            entries.clear();
+        }
+        allEntries.forEach(e -> e.callback.failed(failure));
+    }
+
+    @Override
+    protected void onCompleteFailure(Throwable failure)
+    {
+        accumulator.release();
+    }
+
+    @Override
     public InvocationType getInvocationType()
     {
-        if (entry == null)
-            return InvocationType.NON_BLOCKING;
-        return entry.callback.getInvocationType();
+        return Objects.requireNonNullElse(entry.callback(), NOOP).getInvocationType();
     }
 
     private record Entry(StreamEndPoint endPoint, Frame frame, Callback callback)

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/MessageFlusher.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/MessageFlusher.java
@@ -13,15 +13,14 @@
 
 package org.eclipse.jetty.http3;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
-import java.util.List;
 import java.util.Queue;
 
 import org.eclipse.jetty.http3.frames.Frame;
 import org.eclipse.jetty.http3.generator.MessageGenerator;
 import org.eclipse.jetty.http3.qpack.QpackEncoder;
 import org.eclipse.jetty.io.ByteBufferPool;
+import org.eclipse.jetty.io.RetainableByteBuffer;
 import org.eclipse.jetty.quic.common.StreamEndPoint;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.IteratingCallback;
@@ -35,14 +34,14 @@ public class MessageFlusher extends IteratingCallback
 
     private final AutoLock lock = new AutoLock();
     private final Queue<Entry> entries = new ArrayDeque<>();
-    private final ByteBufferPool.Accumulator accumulator;
     private final MessageGenerator generator;
+    private final RetainableByteBuffer.Mutable accumulator;
     private Entry entry;
 
     public MessageFlusher(ByteBufferPool bufferPool, QpackEncoder encoder, boolean useDirectByteBuffers)
     {
-        this.accumulator = new ByteBufferPool.Accumulator();
         this.generator = new MessageGenerator(bufferPool, encoder, useDirectByteBuffers);
+        this.accumulator = new RetainableByteBuffer.DynamicCapacity(bufferPool, true, -1, 0, 0);
     }
 
     public boolean offer(StreamEndPoint endPoint, Frame frame, Callback callback)
@@ -74,11 +73,10 @@ public class MessageFlusher extends IteratingCallback
             return Action.SCHEDULED;
 
         StreamEndPoint endPoint = entry.endPoint;
-        List<ByteBuffer> buffers = accumulator.getByteBuffers();
         if (LOG.isDebugEnabled())
-            LOG.debug("writing {} buffers ({} bytes) for stream #{} on {}", buffers.size(), accumulator.getTotalLength(), endPoint.getStream().getId(), this);
+            LOG.debug("writing {} bytes for stream #{} on {}", accumulator.size(), endPoint.getStream().getId(), this);
 
-        endPoint.write(Frame.isLast(frame), buffers, Callback.from(entry.callback.getInvocationType(), this::onWriteSuccess, this::onWriteFailure));
+        accumulator.writeTo(endPoint, Frame.isLast(frame), Callback.from(entry.callback.getInvocationType(), this::onWriteSuccess, this::onWriteFailure));
         return Action.SCHEDULED;
     }
 
@@ -87,7 +85,7 @@ public class MessageFlusher extends IteratingCallback
         if (LOG.isDebugEnabled())
             LOG.atDebug().setCause(cause).log("failed to generate {} on {}", entry, this);
 
-        accumulator.release();
+        accumulator.clear();
 
         entry.callback.failed(cause);
         entry = null;
@@ -101,7 +99,7 @@ public class MessageFlusher extends IteratingCallback
         if (LOG.isDebugEnabled())
             LOG.debug("succeeded to write {} on {}", entry, this);
 
-        accumulator.release();
+        accumulator.clear();
 
         entry.callback.succeeded();
         entry = null;
@@ -114,7 +112,7 @@ public class MessageFlusher extends IteratingCallback
         if (LOG.isDebugEnabled())
             LOG.atDebug().setCause(failure).log("failed to write {} on {}", entry, this);
 
-        accumulator.release();
+        accumulator.clear();
 
         entry.callback.failed(failure);
         entry = null;

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/MessageFlusher.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/MessageFlusher.java
@@ -95,6 +95,8 @@ public class MessageFlusher extends IteratingCallback
         if (LOG.isDebugEnabled())
             LOG.atDebug().setCause(cause).log("failed to generate {} on {}", entry, this);
 
+        accumulator.clear();
+
         entry.callback.failed(cause);
         entry = null;
 

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/generator/CancelPushGenerator.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/generator/CancelPushGenerator.java
@@ -17,6 +17,7 @@ import java.util.function.Consumer;
 
 import org.eclipse.jetty.http3.frames.Frame;
 import org.eclipse.jetty.io.ByteBufferPool;
+import org.eclipse.jetty.io.RetainableByteBuffer;
 
 public class CancelPushGenerator extends FrameGenerator
 {
@@ -26,7 +27,7 @@ public class CancelPushGenerator extends FrameGenerator
     }
 
     @Override
-    public long generate(ByteBufferPool.Accumulator accumulator, long streamId, Frame frame, Consumer<Throwable> fail)
+    public long generate(RetainableByteBuffer.Mutable accumulator, long streamId, Frame frame, Consumer<Throwable> fail)
     {
         return 0;
     }

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/generator/ControlGenerator.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/generator/ControlGenerator.java
@@ -18,6 +18,7 @@ import java.util.function.Consumer;
 import org.eclipse.jetty.http3.frames.Frame;
 import org.eclipse.jetty.http3.frames.FrameType;
 import org.eclipse.jetty.io.ByteBufferPool;
+import org.eclipse.jetty.io.RetainableByteBuffer;
 
 public class ControlGenerator
 {
@@ -31,7 +32,7 @@ public class ControlGenerator
         generators[FrameType.MAX_PUSH_ID.type()] = new MaxPushIdGenerator(bufferPool);
     }
 
-    public long generate(ByteBufferPool.Accumulator accumulator, long streamId, Frame frame, Consumer<Throwable> fail)
+    public long generate(RetainableByteBuffer.Mutable accumulator, long streamId, Frame frame, Consumer<Throwable> fail)
     {
         return generators[frame.getFrameType().type()].generate(accumulator, streamId, frame, fail);
     }

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/generator/DataGenerator.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/generator/DataGenerator.java
@@ -35,13 +35,13 @@ public class DataGenerator extends FrameGenerator
     }
 
     @Override
-    public long generate(ByteBufferPool.Accumulator accumulator, long streamId, Frame frame, Consumer<Throwable> fail)
+    public long generate(RetainableByteBuffer.Mutable accumulator, long streamId, Frame frame, Consumer<Throwable> fail)
     {
         DataFrame dataFrame = (DataFrame)frame;
         return generateDataFrame(accumulator, dataFrame);
     }
 
-    private long generateDataFrame(ByteBufferPool.Accumulator accumulator, DataFrame frame)
+    private long generateDataFrame(RetainableByteBuffer.Mutable accumulator, DataFrame frame)
     {
         ByteBuffer data = frame.getByteBuffer();
         long dataLength = data.remaining();
@@ -52,8 +52,8 @@ public class DataGenerator extends FrameGenerator
         VarLenInt.encode(byteBuffer, FrameType.DATA.type());
         VarLenInt.encode(byteBuffer, dataLength);
         byteBuffer.flip();
-        accumulator.append(header);
-        accumulator.append(RetainableByteBuffer.wrap(data));
+        accumulator.add(header);
+        accumulator.add(data);
         return headerLength + dataLength;
     }
 }

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/generator/FrameGenerator.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/generator/FrameGenerator.java
@@ -17,6 +17,7 @@ import java.util.function.Consumer;
 
 import org.eclipse.jetty.http3.frames.Frame;
 import org.eclipse.jetty.io.ByteBufferPool;
+import org.eclipse.jetty.io.RetainableByteBuffer;
 
 public abstract class FrameGenerator
 {
@@ -32,5 +33,5 @@ public abstract class FrameGenerator
         return bufferPool;
     }
 
-    public abstract long generate(ByteBufferPool.Accumulator accumulator, long streamId, Frame frame, Consumer<Throwable> fail);
+    public abstract long generate(RetainableByteBuffer.Mutable accumulator, long streamId, Frame frame, Consumer<Throwable> fail);
 }

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/generator/GoAwayGenerator.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/generator/GoAwayGenerator.java
@@ -35,13 +35,13 @@ public class GoAwayGenerator extends FrameGenerator
     }
 
     @Override
-    public long generate(ByteBufferPool.Accumulator accumulator, long streamId, Frame frame, Consumer<Throwable> fail)
+    public long generate(RetainableByteBuffer.Mutable accumulator, long streamId, Frame frame, Consumer<Throwable> fail)
     {
         GoAwayFrame goAwayFrame = (GoAwayFrame)frame;
         return generateGoAwayFrame(accumulator, goAwayFrame);
     }
 
-    private long generateGoAwayFrame(ByteBufferPool.Accumulator accumulator, GoAwayFrame frame)
+    private long generateGoAwayFrame(RetainableByteBuffer.Mutable accumulator, GoAwayFrame frame)
     {
         long lastId = frame.getLastId();
         int lastIdLength = VarLenInt.length(lastId);
@@ -53,7 +53,7 @@ public class GoAwayGenerator extends FrameGenerator
         VarLenInt.encode(byteBuffer, lastIdLength);
         VarLenInt.encode(byteBuffer, lastId);
         byteBuffer.flip();
-        accumulator.append(buffer);
+        accumulator.add(buffer);
         return length;
     }
 }

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/generator/HeadersGenerator.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/generator/HeadersGenerator.java
@@ -47,14 +47,13 @@ public class HeadersGenerator extends FrameGenerator
 
     private long generateHeadersFrame(RetainableByteBuffer.Mutable accumulator, long streamId, HeadersFrame frame, Consumer<Throwable> fail)
     {
-        RetainableByteBuffer buffer;
         // Reserve initial bytes for the frame header bytes.
         int frameTypeLength = VarLenInt.length(FrameType.HEADERS.type());
         int maxHeaderLength = frameTypeLength + VarLenInt.MAX_LENGTH;
         // The capacity of the buffer is larger than maxLength, but we need to enforce at most maxLength.
         int maxLength = encoder.getMaxHeadersSize();
         // Acquire buffer and immediately add to the accumulator so that it is released if a failure occurs.
-        buffer = getByteBufferPool().acquire(maxHeaderLength + maxLength, useDirectByteBuffers);
+        RetainableByteBuffer buffer = getByteBufferPool().acquire(maxHeaderLength + maxLength, useDirectByteBuffers);
         accumulator.add(buffer);
         try
         {

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/generator/HeadersGenerator.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/generator/HeadersGenerator.java
@@ -39,13 +39,13 @@ public class HeadersGenerator extends FrameGenerator
     }
 
     @Override
-    public long generate(ByteBufferPool.Accumulator accumulator, long streamId, Frame frame, Consumer<Throwable> fail)
+    public long generate(RetainableByteBuffer.Mutable accumulator, long streamId, Frame frame, Consumer<Throwable> fail)
     {
         HeadersFrame headersFrame = (HeadersFrame)frame;
         return generateHeadersFrame(accumulator, streamId, headersFrame, fail);
     }
 
-    private long generateHeadersFrame(ByteBufferPool.Accumulator accumulator, long streamId, HeadersFrame frame, Consumer<Throwable> fail)
+    private long generateHeadersFrame(RetainableByteBuffer.Mutable accumulator, long streamId, HeadersFrame frame, Consumer<Throwable> fail)
     {
         RetainableByteBuffer buffer;
         // Reserve initial bytes for the frame header bytes.
@@ -53,9 +53,9 @@ public class HeadersGenerator extends FrameGenerator
         int maxHeaderLength = frameTypeLength + VarLenInt.MAX_LENGTH;
         // The capacity of the buffer is larger than maxLength, but we need to enforce at most maxLength.
         int maxLength = encoder.getMaxHeadersSize();
-        // Acquire buffer and immediately append to the accumulator so that it is released if a failure occurs.
+        // Acquire buffer and immediately add to the accumulator so that it is released if a failure occurs.
         buffer = getByteBufferPool().acquire(maxHeaderLength + maxLength, useDirectByteBuffers);
-        accumulator.append(buffer);
+        accumulator.add(buffer);
         try
         {
             ByteBuffer byteBuffer = buffer.getByteBuffer();

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/generator/MaxPushIdGenerator.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/generator/MaxPushIdGenerator.java
@@ -17,6 +17,7 @@ import java.util.function.Consumer;
 
 import org.eclipse.jetty.http3.frames.Frame;
 import org.eclipse.jetty.io.ByteBufferPool;
+import org.eclipse.jetty.io.RetainableByteBuffer;
 
 public class MaxPushIdGenerator extends FrameGenerator
 {
@@ -26,7 +27,7 @@ public class MaxPushIdGenerator extends FrameGenerator
     }
 
     @Override
-    public long generate(ByteBufferPool.Accumulator accumulator, long streamId, Frame frame, Consumer<Throwable> fail)
+    public long generate(RetainableByteBuffer.Mutable accumulator, long streamId, Frame frame, Consumer<Throwable> fail)
     {
         return 0;
     }

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/generator/MessageGenerator.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/generator/MessageGenerator.java
@@ -19,6 +19,7 @@ import org.eclipse.jetty.http3.frames.Frame;
 import org.eclipse.jetty.http3.frames.FrameType;
 import org.eclipse.jetty.http3.qpack.QpackEncoder;
 import org.eclipse.jetty.io.ByteBufferPool;
+import org.eclipse.jetty.io.RetainableByteBuffer;
 
 public class MessageGenerator
 {
@@ -31,7 +32,7 @@ public class MessageGenerator
         generators[FrameType.PUSH_PROMISE.type()] = new PushPromiseGenerator(bufferPool);
     }
 
-    public long generate(ByteBufferPool.Accumulator accumulator, long streamId, Frame frame, Consumer<Throwable> fail)
+    public long generate(RetainableByteBuffer.Mutable accumulator, long streamId, Frame frame, Consumer<Throwable> fail)
     {
         return generators[frame.getFrameType().type()].generate(accumulator, streamId, frame, fail);
     }

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/generator/PushPromiseGenerator.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/generator/PushPromiseGenerator.java
@@ -17,6 +17,7 @@ import java.util.function.Consumer;
 
 import org.eclipse.jetty.http3.frames.Frame;
 import org.eclipse.jetty.io.ByteBufferPool;
+import org.eclipse.jetty.io.RetainableByteBuffer;
 
 public class PushPromiseGenerator extends FrameGenerator
 {
@@ -26,7 +27,7 @@ public class PushPromiseGenerator extends FrameGenerator
     }
 
     @Override
-    public long generate(ByteBufferPool.Accumulator accumulator, long streamId, Frame frame, Consumer<Throwable> fail)
+    public long generate(RetainableByteBuffer.Mutable accumulator, long streamId, Frame frame, Consumer<Throwable> fail)
     {
         return 0;
     }

--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/generator/SettingsGenerator.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/generator/SettingsGenerator.java
@@ -35,13 +35,13 @@ public class SettingsGenerator extends FrameGenerator
     }
 
     @Override
-    public long generate(ByteBufferPool.Accumulator accumulator, long streamId, Frame frame, Consumer<Throwable> fail)
+    public long generate(RetainableByteBuffer.Mutable accumulator, long streamId, Frame frame, Consumer<Throwable> fail)
     {
         SettingsFrame settingsFrame = (SettingsFrame)frame;
         return generateSettings(accumulator, settingsFrame);
     }
 
-    private long generateSettings(ByteBufferPool.Accumulator accumulator, SettingsFrame frame)
+    private long generateSettings(RetainableByteBuffer.Mutable accumulator, SettingsFrame frame)
     {
         int length = 0;
         Map<Long, Long> settings = frame.getSettings();
@@ -61,7 +61,7 @@ public class SettingsGenerator extends FrameGenerator
             VarLenInt.encode(byteBuffer, e.getValue());
         }
         BufferUtil.flipToFlush(byteBuffer, 0);
-        accumulator.append(buffer);
+        accumulator.add(buffer);
         return capacity;
     }
 }

--- a/jetty-core/jetty-http3/jetty-http3-common/src/test/java/org/eclipse/jetty/http3/internal/DataGenerateParseTest.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/test/java/org/eclipse/jetty/http3/internal/DataGenerateParseTest.java
@@ -25,6 +25,7 @@ import org.eclipse.jetty.http3.parser.MessageParser;
 import org.eclipse.jetty.http3.parser.ParserListener;
 import org.eclipse.jetty.http3.qpack.QpackDecoder;
 import org.eclipse.jetty.io.ByteBufferPool;
+import org.eclipse.jetty.io.RetainableByteBuffer;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.NanoTime;
 import org.junit.jupiter.api.Test;
@@ -56,7 +57,7 @@ public class DataGenerateParseTest
         DataFrame input = new DataFrame(ByteBuffer.wrap(inputBytes), true);
 
         ByteBufferPool bufferPool = ByteBufferPool.NON_POOLING;
-        ByteBufferPool.Accumulator accumulator = new ByteBufferPool.Accumulator(); // TODO remove
+        RetainableByteBuffer.Mutable accumulator = new RetainableByteBuffer.DynamicCapacity(bufferPool, true, -1, 0, 0);
         new MessageGenerator(bufferPool, null, true).generate(accumulator, 0, input, null);
 
         List<DataFrame> frames = new ArrayList<>();
@@ -71,11 +72,8 @@ public class DataGenerateParseTest
             }
         }, decoder, 13);
         parser.init(UnaryOperator.identity());
-        for (ByteBuffer buffer : accumulator.getByteBuffers())
-        {
-            parser.parse(buffer, false);
-            assertFalse(buffer.hasRemaining());
-        }
+        parser.parse(accumulator.getByteBuffer(), false);
+        assertFalse(accumulator.hasRemaining());
 
         assertEquals(1, frames.size());
         DataFrame output = frames.get(0);

--- a/jetty-core/jetty-http3/jetty-http3-common/src/test/java/org/eclipse/jetty/http3/internal/GoAwayGenerateParseTest.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/test/java/org/eclipse/jetty/http3/internal/GoAwayGenerateParseTest.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.http3.internal;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,6 +21,7 @@ import org.eclipse.jetty.http3.generator.ControlGenerator;
 import org.eclipse.jetty.http3.parser.ControlParser;
 import org.eclipse.jetty.http3.parser.ParserListener;
 import org.eclipse.jetty.io.ByteBufferPool;
+import org.eclipse.jetty.io.RetainableByteBuffer;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -35,7 +35,7 @@ public class GoAwayGenerateParseTest
         GoAwayFrame input = GoAwayFrame.CLIENT_GRACEFUL;
 
         ByteBufferPool bufferPool = ByteBufferPool.NON_POOLING;
-        ByteBufferPool.Accumulator accumulator = new ByteBufferPool.Accumulator(); // TODO remove
+        RetainableByteBuffer.Mutable accumulator = new RetainableByteBuffer.DynamicCapacity(bufferPool, true, -1, 0, 0);
         new ControlGenerator(bufferPool, true).generate(accumulator, 0, input, null);
 
         List<GoAwayFrame> frames = new ArrayList<>();
@@ -47,11 +47,8 @@ public class GoAwayGenerateParseTest
                 frames.add(frame);
             }
         });
-        for (ByteBuffer buffer : accumulator.getByteBuffers())
-        {
-            parser.parse(buffer);
-            assertFalse(buffer.hasRemaining());
-        }
+        parser.parse(accumulator.getByteBuffer());
+        assertFalse(accumulator.hasRemaining());
 
         assertEquals(1, frames.size());
         GoAwayFrame output = frames.get(0);

--- a/jetty-core/jetty-http3/jetty-http3-common/src/test/java/org/eclipse/jetty/http3/internal/HeadersGenerateParseTest.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/test/java/org/eclipse/jetty/http3/internal/HeadersGenerateParseTest.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.http3.internal;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.UnaryOperator;
@@ -30,6 +29,7 @@ import org.eclipse.jetty.http3.parser.ParserListener;
 import org.eclipse.jetty.http3.qpack.QpackDecoder;
 import org.eclipse.jetty.http3.qpack.QpackEncoder;
 import org.eclipse.jetty.io.ByteBufferPool;
+import org.eclipse.jetty.io.RetainableByteBuffer;
 import org.eclipse.jetty.util.NanoTime;
 import org.junit.jupiter.api.Test;
 
@@ -50,7 +50,7 @@ public class HeadersGenerateParseTest
         QpackEncoder encoder = new QpackEncoder(instructions -> {});
         encoder.setMaxHeadersSize(4 * 1024);
         ByteBufferPool bufferPool = ByteBufferPool.NON_POOLING;
-        ByteBufferPool.Accumulator accumulator = new ByteBufferPool.Accumulator(); // TODO remove
+        RetainableByteBuffer.Mutable accumulator = new RetainableByteBuffer.DynamicCapacity(bufferPool, true, -1, 0, 0);
         new MessageGenerator(bufferPool, encoder, true).generate(accumulator, 0, input, null);
 
         QpackDecoder decoder = new QpackDecoder(instructions -> {});
@@ -66,11 +66,8 @@ public class HeadersGenerateParseTest
             }
         }, decoder, 13);
         parser.init(UnaryOperator.identity());
-        for (ByteBuffer buffer : accumulator.getByteBuffers())
-        {
-            parser.parse(buffer, false);
-            assertFalse(buffer.hasRemaining());
-        }
+        parser.parse(accumulator.getByteBuffer(), false);
+        assertFalse(accumulator.hasRemaining());
 
         assertEquals(1, frames.size());
         HeadersFrame output = frames.get(0);

--- a/jetty-core/jetty-http3/jetty-http3-common/src/test/java/org/eclipse/jetty/http3/internal/SettingsGenerateParseTest.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/test/java/org/eclipse/jetty/http3/internal/SettingsGenerateParseTest.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.http3.internal;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -23,6 +22,7 @@ import org.eclipse.jetty.http3.generator.ControlGenerator;
 import org.eclipse.jetty.http3.parser.ControlParser;
 import org.eclipse.jetty.http3.parser.ParserListener;
 import org.eclipse.jetty.io.ByteBufferPool;
+import org.eclipse.jetty.io.RetainableByteBuffer;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -47,7 +47,7 @@ public class SettingsGenerateParseTest
         SettingsFrame input = new SettingsFrame(settings);
 
         ByteBufferPool bufferPool = ByteBufferPool.NON_POOLING;
-        ByteBufferPool.Accumulator accumulator = new ByteBufferPool.Accumulator(); // TODO
+        RetainableByteBuffer.Mutable accumulator = new RetainableByteBuffer.DynamicCapacity(bufferPool, true, -1, 0, 0);
         new ControlGenerator(bufferPool, true).generate(accumulator, 0, input, null);
 
         List<SettingsFrame> frames = new ArrayList<>();
@@ -59,11 +59,8 @@ public class SettingsGenerateParseTest
                 frames.add(frame);
             }
         });
-        for (ByteBuffer buffer : accumulator.getByteBuffers())
-        {
-            parser.parse(buffer);
-            assertFalse(buffer.hasRemaining());
-        }
+        parser.parse(accumulator.getByteBuffer());
+        assertFalse(accumulator.hasRemaining());
 
         assertEquals(1, frames.size());
         SettingsFrame output = frames.get(0);

--- a/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HttpStreamOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HttpStreamOverHTTP3.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.http3.server.internal;
 
 import java.io.EOFException;
 import java.nio.ByteBuffer;
+import java.util.Objects;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
@@ -250,11 +251,11 @@ public class HttpStreamOverHTTP3 implements HttpStream
     @Override
     public void send(MetaData.Request request, MetaData.Response response, boolean last, ByteBuffer byteBuffer, Callback callback)
     {
-        ByteBuffer content = byteBuffer != null ? byteBuffer : BufferUtil.EMPTY_BUFFER;
-        if (response != null)
+        ByteBuffer content = Objects.requireNonNullElse(byteBuffer, BufferUtil.EMPTY_BUFFER);
+        if (responseMetaData == null)
             sendHeaders(request, response, content, last, callback);
         else
-            sendContent(request, content, last, callback);
+            sendContent(request, response, content, last, callback);
     }
 
     @Override
@@ -283,7 +284,7 @@ public class HttpStreamOverHTTP3 implements HttpStream
 
     private void sendHeaders(MetaData.Request request, MetaData.Response response, ByteBuffer content, boolean lastContent, Callback callback)
     {
-        this.responseMetaData = response;
+        responseMetaData = response;
 
         HeadersFrame headersFrame;
         DataFrame dataFrame = null;
@@ -294,13 +295,11 @@ public class HttpStreamOverHTTP3 implements HttpStream
         if (HttpStatus.isInterim(response.getStatus()))
         {
             // Must not commit interim responses.
-
             if (hasContent)
             {
                 callback.failed(new IllegalStateException("Interim response cannot have content"));
                 return;
             }
-
             headersFrame = new HeadersFrame(response, false);
         }
         else
@@ -312,7 +311,7 @@ public class HttpStreamOverHTTP3 implements HttpStream
                 long contentLength = response.getContentLength();
                 if (contentLength < 0)
                 {
-                    this.responseMetaData = new MetaData.Response(
+                    responseMetaData = new MetaData.Response(
                         response.getStatus(), response.getReason(), response.getHttpVersion(),
                         response.getHttpFields(),
                         realContentLength,
@@ -406,11 +405,11 @@ public class HttpStreamOverHTTP3 implements HttpStream
         }, callback::failed));
     }
 
-    private void sendContent(MetaData.Request request, ByteBuffer content, boolean lastContent, Callback callback)
+    private void sendContent(MetaData.Request request, MetaData.Response response, ByteBuffer content, boolean lastContent, Callback callback)
     {
         boolean isHeadRequest = HttpMethod.HEAD.is(request.getMethod());
         boolean hasContent = BufferUtil.hasContent(content) && !isHeadRequest;
-        if (hasContent || (lastContent && !isTunnel(request, responseMetaData)))
+        if (hasContent || (lastContent && !isTunnel(request, response)))
         {
             if (!hasContent)
                 content = BufferUtil.EMPTY_BUFFER;

--- a/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HttpStreamOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/HttpStreamOverHTTP3.java
@@ -252,10 +252,10 @@ public class HttpStreamOverHTTP3 implements HttpStream
     public void send(MetaData.Request request, MetaData.Response response, boolean last, ByteBuffer byteBuffer, Callback callback)
     {
         ByteBuffer content = Objects.requireNonNullElse(byteBuffer, BufferUtil.EMPTY_BUFFER);
-        if (responseMetaData == null)
+        if (response != null)
             sendHeaders(request, response, content, last, callback);
         else
-            sendContent(request, response, content, last, callback);
+            sendContent(request, responseMetaData, content, last, callback);
     }
 
     @Override

--- a/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/ServerHTTP3Session.java
+++ b/jetty-core/jetty-http3/jetty-http3-server/src/main/java/org/eclipse/jetty/http3/server/internal/ServerHTTP3Session.java
@@ -54,7 +54,9 @@ public class ServerHTTP3Session extends ServerProtocolSession
 
     private final HTTP3Configuration configuration;
     private final HTTP3SessionServer session;
+    private final InstructionFlusher encoderFlusher;
     private final QpackEncoder encoder;
+    private final InstructionFlusher decoderFlusher;
     private final QpackDecoder decoder;
     private final ControlFlusher controlFlusher;
     private final MessageFlusher messageFlusher;
@@ -74,8 +76,8 @@ public class ServerHTTP3Session extends ServerProtocolSession
 
         long encoderStreamId = quicSession.newStreamId(false);
         StreamEndPoint encoderEndPoint = openInstructionEndPoint(encoderStreamId);
-        InstructionFlusher encoderInstructionFlusher = new InstructionFlusher(byteBufferPool, encoderEndPoint, StreamType.ENCODER_STREAM);
-        encoder = new QpackEncoder(new InstructionHandler(encoderInstructionFlusher));
+        encoderFlusher = new InstructionFlusher(byteBufferPool, encoderEndPoint, StreamType.ENCODER_STREAM);
+        encoder = new QpackEncoder(new InstructionHandler(encoderFlusher));
         encoder.setMaxHeadersSize(configuration.getMaxResponseHeadersSize());
         installBean(encoder);
         if (LOG.isDebugEnabled())
@@ -83,8 +85,8 @@ public class ServerHTTP3Session extends ServerProtocolSession
 
         long decoderStreamId = quicSession.newStreamId(false);
         StreamEndPoint decoderEndPoint = openInstructionEndPoint(decoderStreamId);
-        InstructionFlusher decoderInstructionFlusher = new InstructionFlusher(byteBufferPool, decoderEndPoint, StreamType.DECODER_STREAM);
-        decoder = new QpackDecoder(new InstructionHandler(decoderInstructionFlusher));
+        decoderFlusher = new InstructionFlusher(byteBufferPool, decoderEndPoint, StreamType.DECODER_STREAM);
+        decoder = new QpackDecoder(new InstructionHandler(decoderFlusher));
         installBean(decoder);
         if (LOG.isDebugEnabled())
             LOG.debug("created decoder stream #{} on {}", decoderStreamId, decoderEndPoint);
@@ -169,6 +171,15 @@ public class ServerHTTP3Session extends ServerProtocolSession
         SettingsFrame frame = new SettingsFrame(settings);
         if (controlFlusher.offer(frame, Callback.from(Invocable.InvocationType.NON_BLOCKING, session::onOpen, this::failControlStream)))
             controlFlusher.iterate();
+    }
+
+    @Override
+    protected void onStop()
+    {
+        messageFlusher.close();
+        controlFlusher.close();
+        decoderFlusher.close();
+        encoderFlusher.close();
     }
 
     @Override

--- a/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/AbstractClientServerTest.java
+++ b/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/AbstractClientServerTest.java
@@ -36,6 +36,7 @@ import org.eclipse.jetty.http3.server.HTTP3ServerConnectionFactory;
 import org.eclipse.jetty.http3.server.HTTP3ServerQuicConfiguration;
 import org.eclipse.jetty.http3.server.RawHTTP3ServerConnectionFactory;
 import org.eclipse.jetty.io.ArrayByteBufferPool;
+import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.ClientConnector;
 import org.eclipse.jetty.io.Transport;
 import org.eclipse.jetty.jmx.MBeanContainer;
@@ -107,7 +108,7 @@ public class AbstractClientServerTest
     {
         QueuedThreadPool serverThreads = new QueuedThreadPool();
         serverThreads.setName("server");
-        ArrayByteBufferPool.Tracking byteBufferPool = new ArrayByteBufferPool.Tracking();
+        ByteBufferPool byteBufferPool = new ArrayByteBufferPool.Tracking();
         server = new Server(serverThreads, null, byteBufferPool);
 
         serverSslContextFactory = new SslContextFactory.Server();
@@ -140,7 +141,7 @@ public class AbstractClientServerTest
         QueuedThreadPool clientThreads = new QueuedThreadPool();
         clientThreads.setName("client");
         clientConnector.setExecutor(clientThreads);
-        ArrayByteBufferPool.Tracking byteBufferPool = new ArrayByteBufferPool.Tracking();
+        ByteBufferPool byteBufferPool = new ArrayByteBufferPool.Tracking();
         clientConnector.setByteBufferPool(byteBufferPool);
         clientConnector.setSslContextFactory(new SslContextFactory.Client(true));
 
@@ -188,21 +189,23 @@ public class AbstractClientServerTest
     }
 
     @AfterEach
-    public void dispose() throws Exception
+    public void dispose()
     {
         LifeCycle.stop(http3Client);
         LifeCycle.stop(httpClient);
 
         if (http3Client != null)
         {
-            ArrayByteBufferPool.Tracking clientByteBufferPool = (ArrayByteBufferPool.Tracking)http3Client.getClientConnector().getByteBufferPool();
-            await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertThat("client leaks: " + clientByteBufferPool.dumpLeaks(), clientByteBufferPool.getLeaks().size(), is(0)));
+            ByteBufferPool clientByteBufferPool = http3Client.getClientConnector().getByteBufferPool();
+            if (clientByteBufferPool instanceof ArrayByteBufferPool.Tracking tracking)
+                await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertThat("client leaks: " + tracking.dumpLeaks(), tracking.getLeaks().size(), is(0)));
         }
 
         if (server != null)
         {
-            ArrayByteBufferPool.Tracking serverByteBufferPool = (ArrayByteBufferPool.Tracking)server.getByteBufferPool();
-            await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertThat("server leaks: " + serverByteBufferPool.dumpLeaks(), serverByteBufferPool.getLeaks().size(), is(0)));
+            ByteBufferPool serverByteBufferPool = server.getByteBufferPool();
+            if (serverByteBufferPool instanceof ArrayByteBufferPool.Tracking tracking)
+            await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertThat("server leaks: " + tracking.dumpLeaks(), tracking.getLeaks().size(), is(0)));
         }
 
         LifeCycle.stop(server);

--- a/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/AbstractClientServerTest.java
+++ b/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/AbstractClientServerTest.java
@@ -35,6 +35,7 @@ import org.eclipse.jetty.http3.client.transport.HttpClientTransportOverHTTP3;
 import org.eclipse.jetty.http3.server.HTTP3ServerConnectionFactory;
 import org.eclipse.jetty.http3.server.HTTP3ServerQuicConfiguration;
 import org.eclipse.jetty.http3.server.RawHTTP3ServerConnectionFactory;
+import org.eclipse.jetty.io.ArrayByteBufferPool;
 import org.eclipse.jetty.io.ClientConnector;
 import org.eclipse.jetty.io.Transport;
 import org.eclipse.jetty.jmx.MBeanContainer;
@@ -57,6 +58,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 @ExtendWith(WorkDirExtension.class)
 public class AbstractClientServerTest
@@ -102,7 +107,8 @@ public class AbstractClientServerTest
     {
         QueuedThreadPool serverThreads = new QueuedThreadPool();
         serverThreads.setName("server");
-        server = new Server(serverThreads);
+        ArrayByteBufferPool.Tracking byteBufferPool = new ArrayByteBufferPool.Tracking();
+        server = new Server(serverThreads, null, byteBufferPool);
 
         serverSslContextFactory = new SslContextFactory.Server();
         serverSslContextFactory.setKeyStorePath("src/test/resources/keystore.p12");
@@ -134,6 +140,8 @@ public class AbstractClientServerTest
         QueuedThreadPool clientThreads = new QueuedThreadPool();
         clientThreads.setName("client");
         clientConnector.setExecutor(clientThreads);
+        ArrayByteBufferPool.Tracking byteBufferPool = new ArrayByteBufferPool.Tracking();
+        clientConnector.setByteBufferPool(byteBufferPool);
         clientConnector.setSslContextFactory(new SslContextFactory.Client(true));
 
         ClientQuicConfiguration clientQuicConfig = HTTP3ClientQuicConfiguration.configure(switch (transportType)
@@ -180,10 +188,23 @@ public class AbstractClientServerTest
     }
 
     @AfterEach
-    public void dispose()
+    public void dispose() throws Exception
     {
         LifeCycle.stop(http3Client);
         LifeCycle.stop(httpClient);
+
+        if (http3Client != null)
+        {
+            ArrayByteBufferPool.Tracking clientByteBufferPool = (ArrayByteBufferPool.Tracking)http3Client.getClientConnector().getByteBufferPool();
+            await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertThat("client leaks: " + clientByteBufferPool.dumpLeaks(), clientByteBufferPool.getLeaks().size(), is(0)));
+        }
+
+        if (server != null)
+        {
+            ArrayByteBufferPool.Tracking serverByteBufferPool = (ArrayByteBufferPool.Tracking)server.getByteBufferPool();
+            await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertThat("server leaks: " + serverByteBufferPool.dumpLeaks(), serverByteBufferPool.getLeaks().size(), is(0)));
+        }
+
         LifeCycle.stop(server);
     }
 

--- a/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/AbstractClientServerTest.java
+++ b/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/AbstractClientServerTest.java
@@ -196,15 +196,13 @@ public class AbstractClientServerTest
 
         if (http3Client != null)
         {
-            ByteBufferPool clientByteBufferPool = http3Client.getClientConnector().getByteBufferPool();
-            if (clientByteBufferPool instanceof ArrayByteBufferPool.Tracking tracking)
-                await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertThat("client leaks: " + tracking.dumpLeaks(), tracking.getLeaks().size(), is(0)));
+            ArrayByteBufferPool.Tracking tracking = (ArrayByteBufferPool.Tracking)http3Client.getClientConnector().getByteBufferPool();
+            await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertThat("client leaks: " + tracking.dumpLeaks(), tracking.getLeaks().size(), is(0)));
         }
 
         if (server != null)
         {
-            ByteBufferPool serverByteBufferPool = server.getByteBufferPool();
-            if (serverByteBufferPool instanceof ArrayByteBufferPool.Tracking tracking)
+            ArrayByteBufferPool.Tracking tracking = (ArrayByteBufferPool.Tracking)server.getByteBufferPool();
             await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertThat("server leaks: " + tracking.dumpLeaks(), tracking.getLeaks().size(), is(0)));
         }
 

--- a/jetty-core/jetty-http3/jetty-http3-tests/src/test/resources/jetty-logging.properties
+++ b/jetty-core/jetty-http3/jetty-http3-tests/src/test/resources/jetty-logging.properties
@@ -10,3 +10,4 @@ org.eclipse.jetty.server.Server.LEVEL=WARN
 org.eclipse.jetty.server.AbstractConnector.LEVEL=WARN
 org.eclipse.jetty.server.handler.ContextHandler.LEVEL=WARN
 org.eclipse.jetty.util.ssl.SslContextFactory.LEVEL=WARN
+#org.eclipse.jetty.io.ArrayByteBufferPool$Tracking.LEVEL=DEBUG

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Content.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/Content.java
@@ -1080,7 +1080,7 @@ public class Content
             {
                 if (retainable.canRetain())
                 {
-                    return new ByteBufferChunk.WithRetainable(byteBuffer, last, Objects.requireNonNull(retainable));
+                    return new ByteBufferChunk.WithRetainable(byteBuffer, last, retainable);
                 }
                 else
                 {

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/RetainableByteBuffer.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/RetainableByteBuffer.java
@@ -2046,10 +2046,15 @@ public interface RetainableByteBuffer extends Retainable
             checkNotReleased();
             if (_buffers.isEmpty())
                 return;
-            _aggregate = null;
             for (RetainableByteBuffer rbb : _buffers)
-                rbb.release();
+            {
+                if (rbb instanceof DynamicCapacity dynamic)
+                    dynamic.clear();
+                else
+                    rbb.release();
+            }
             _buffers.clear();
+            _aggregate = null;
         }
 
         @Override
@@ -2399,7 +2404,7 @@ public interface RetainableByteBuffer extends Retainable
                 case 1 ->
                 {
                     RetainableByteBuffer buffer = _buffers.get(0);
-                    buffer.writeTo(sink, last, Callback.from(this::clear, callback));
+                    buffer.writeTo(sink, last, callback);
                 }
                 default ->
                 {
@@ -2410,53 +2415,24 @@ public interface RetainableByteBuffer extends Retainable
                         int i = 0;
                         for (RetainableByteBuffer rbb : _buffers)
                             buffers[i++] = rbb.getByteBuffer();
-                        endPoint.write(Callback.from(this::clear, callback), buffers);
+                        endPoint.write(callback, buffers);
                         return;
                     }
 
-                    // write buffer by buffer
+                    // Write buffer by buffer.
                     new IteratingNestedCallback(callback)
                     {
-                        int _index;
-                        RetainableByteBuffer _buffer;
-                        boolean _lastWritten;
+                        private int _index;
 
                         @Override
                         protected Action process()
                         {
-                            // write next buffer
-                            if (_index < _buffers.size())
-                            {
-                                _buffer = _buffers.get(_index++);
-                                _lastWritten = last && (_index == _buffers.size());
-                                _buffer.writeTo(sink, _lastWritten, this);
-                                return Action.SCHEDULED;
-                            }
-
-                            // All buffers written
-                            if (last && !_lastWritten)
-                            {
-                                _buffer = null;
-                                _lastWritten = true;
-                                sink.write(true, BufferUtil.EMPTY_BUFFER, this);
-                                return Action.SCHEDULED;
-                            }
-                            _buffers.clear();
-                            return Action.SUCCEEDED;
-                        }
-
-                        @Override
-                        protected void onSuccess()
-                        {
-                            // release the last buffer written
-                            _buffer = Retainable.release(_buffer);
-                        }
-
-                        @Override
-                        protected void onCompleteFailure(Throwable x)
-                        {
-                            // release the last buffer written
-                            _buffer = Retainable.release(_buffer);
+                            if (_index == _buffers.size())
+                                return Action.SUCCEEDED;
+                            RetainableByteBuffer buffer = _buffers.get(_index++);
+                            boolean lastWritten = last && (_index == _buffers.size());
+                            buffer.writeTo(sink, lastWritten, this);
+                            return Action.SCHEDULED;
                         }
                     }.iterate();
                 }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/RetainableByteBuffer.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/RetainableByteBuffer.java
@@ -2404,7 +2404,7 @@ public interface RetainableByteBuffer extends Retainable
                 case 1 ->
                 {
                     RetainableByteBuffer buffer = _buffers.get(0);
-                    buffer.writeTo(sink, last, callback);
+                    buffer.writeTo(sink, last, Callback.from(this::clear, callback));
                 }
                 default ->
                 {
@@ -2415,7 +2415,7 @@ public interface RetainableByteBuffer extends Retainable
                         int i = 0;
                         for (RetainableByteBuffer rbb : _buffers)
                             buffers[i++] = rbb.getByteBuffer();
-                        endPoint.write(callback, buffers);
+                        endPoint.write(Callback.from(this::clear, callback), buffers);
                         return;
                     }
 
@@ -2428,7 +2428,10 @@ public interface RetainableByteBuffer extends Retainable
                         protected Action process()
                         {
                             if (_index == _buffers.size())
+                            {
+                                clear();
                                 return Action.SUCCEEDED;
+                            }
                             RetainableByteBuffer buffer = _buffers.get(_index++);
                             boolean lastWritten = last && (_index == _buffers.size());
                             buffer.writeTo(sink, lastWritten, this);

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/RetainableByteBuffer.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/RetainableByteBuffer.java
@@ -2428,10 +2428,7 @@ public interface RetainableByteBuffer extends Retainable
                         protected Action process()
                         {
                             if (_index == _buffers.size())
-                            {
-                                clear();
                                 return Action.SUCCEEDED;
-                            }
                             RetainableByteBuffer buffer = _buffers.get(_index++);
                             boolean lastWritten = last && (_index == _buffers.size());
                             buffer.writeTo(sink, lastWritten, this);

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/RetainableByteBuffer.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/RetainableByteBuffer.java
@@ -2051,8 +2051,7 @@ public interface RetainableByteBuffer extends Retainable
             {
                 if (rbb instanceof DynamicCapacity dynamic)
                     dynamic.clear();
-                else
-                    rbb.release();
+                rbb.release();
             }
             _buffers.clear();
             _aggregate = null;

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/RetainableByteBuffer.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/RetainableByteBuffer.java
@@ -2437,6 +2437,13 @@ public interface RetainableByteBuffer extends Retainable
                             buffer.writeTo(sink, lastWritten, this);
                             return Action.SCHEDULED;
                         }
+
+                        @Override
+                        protected void onCompleted(Throwable causeOrNull)
+                        {
+                            clear();
+                            super.onCompleted(causeOrNull);
+                        }
                     }.iterate();
                 }
             }

--- a/jetty-core/jetty-quic/jetty-quic-common/src/main/java/org/eclipse/jetty/quic/common/StreamEndPoint.java
+++ b/jetty-core/jetty-quic/jetty-quic-common/src/main/java/org/eclipse/jetty/quic/common/StreamEndPoint.java
@@ -428,12 +428,8 @@ public class StreamEndPoint implements EndPoint
     public void write(boolean last, List<ByteBuffer> buffers, Callback callback)
     {
         if (LOG.isDebugEnabled())
-            LOG.debug("writing {} on {}", BufferUtil.toDetailString(buffers.toArray(ByteBuffer[]::new)), this);
-        if (buffers == null || buffers.isEmpty() || remaining(buffers) == 0)
-        {
-            callback.succeeded();
-        }
-        else
+            LOG.debug("writing last={} {} on {}", last, BufferUtil.toDetailString(buffers.toArray(ByteBuffer[]::new)), this);
+        if (last || remaining(buffers) > 0)
         {
             while (true)
             {
@@ -466,6 +462,10 @@ public class StreamEndPoint implements EndPoint
                 }
                 return;
             }
+        }
+        else
+        {
+            callback.succeeded();
         }
     }
 

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-common/src/main/java/org/eclipse/jetty/quic/quiche/QuicheStream.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-common/src/main/java/org/eclipse/jetty/quic/quiche/QuicheStream.java
@@ -213,13 +213,12 @@ public class QuicheStream extends AbstractStream
                 buffer = null;
             }
         }
-        if (buffer == null)
-        {
-            buffer = getSession().getByteBufferPool().acquire(quicConfiguration.getInputBufferSize(), quicConfiguration.isUseInputDirectByteBuffers());
-            if (LOG.isDebugEnabled())
-                LOG.debug("acquired {} on {}", buffer, this);
-        }
-        return buffer;
+        RetainableByteBuffer candidate = buffer;
+        if (candidate == null)
+            candidate = getSession().getByteBufferPool().acquire(quicConfiguration.getInputBufferSize(), quicConfiguration.isUseInputDirectByteBuffers());
+        if (LOG.isDebugEnabled())
+            LOG.debug("acquired {} {} on {}", buffer == null ? "fresh" : "stored", candidate, this);
+        return candidate;
     }
 
     private void tryStoreInputBuffer(RetainableByteBuffer buffer)

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-common/src/main/java/org/eclipse/jetty/quic/quiche/QuicheStream.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-common/src/main/java/org/eclipse/jetty/quic/quiche/QuicheStream.java
@@ -137,14 +137,23 @@ public class QuicheStream extends AbstractStream
             ByteBuffer byteBuffer = inputBuffer.getByteBuffer();
             int position = byteBuffer.position();
             byteBuffer.limit(byteBuffer.capacity());
+
+            boolean finished = session.isFinished(this);
+            if (LOG.isDebugEnabled())
+                LOG.debug("finished={} on {}", finished, this);
+            if (finished)
+            {
+                updateCloseState(CloseState.REMOTELY_CLOSED);
+                tryReleaseInputBuffer(inputBuffer);
+                return Content.Chunk.EOF;
+            }
+
             boolean[] outLast = new boolean[1];
             int filled = session.read(this, byteBuffer, outLast);
             BufferUtil.flipToFlush(byteBuffer, position);
             boolean last = outLast[0];
-
             if (LOG.isDebugEnabled())
                 LOG.debug("read {} bytes last={} on {}", filled, last, this);
-
             if (last)
                 updateCloseState(CloseState.REMOTELY_CLOSED);
 
@@ -152,9 +161,9 @@ public class QuicheStream extends AbstractStream
             {
                 ByteBuffer slice = byteBuffer.slice();
                 byteBuffer.position(byteBuffer.limit());
+                // Retain because multiple chunks can be read from the same inputBuffer.
+                inputBuffer.retain();
                 Content.Chunk chunk = Content.Chunk.asChunk(slice, last, inputBuffer);
-                // Retain because multiple data can be read with the same inputBuffer.
-                chunk.retain();
                 if (last)
                     tryReleaseInputBuffer(inputBuffer);
                 else
@@ -173,7 +182,6 @@ public class QuicheStream extends AbstractStream
             }
 
             tryReleaseInputBuffer(inputBuffer);
-
             return Content.Chunk.EOF;
         }
         catch (Throwable x)


### PR DESCRIPTION
* Updated HTTP/3 code to use RetainableByteBuffer.Mutable.
* Fixed retain of buffers/chunks, now done _before_ calling Chunk.asChunk() to avoid the buffers/chunks are released Chunk.asChunk() when they are empty.
* Fixed detection of finished streams in QuicheStream: must call `session.isFinished(this)` _before_ calling `session.read()` to avoid Quiche throwing when the stream is no longer available.