### PR TITLE
Issue #14435 - Bump OSGi min version for slf4j imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -327,7 +327,7 @@
     <osgi-util-version>3.7.400</osgi-util-version>
     <osgi-util-xml-version>1.0.2</osgi-util-xml-version>
     <osgi-version>3.24.0</osgi-version>
-    <osgi.slf4j.import.packages>org.slf4j;version="[1.7,3.0)", org.slf4j.event;version="[1.7,3.0)", org.slf4j.helpers;version="[1.7,3.0)", org.slf4j.spi;version="[1.7,3.0)"</osgi.slf4j.import.packages>
+    <osgi.slf4j.import.packages>org.slf4j;version="[2.0,3.0)", org.slf4j.event;version="[2.0,3.0)", org.slf4j.helpers;version="[2.0,3.0)", org.slf4j.spi;version="[2.0,3.0)"</osgi.slf4j.import.packages>
     <pax.exam.version>4.14.0</pax.exam.version>
     <pax.url.version>3.0.2</pax.url.version>
     <plexus-classworlds.version>2.9.0</plexus-classworlds.version>


### PR DESCRIPTION
Bump the version range of slf4j in OSGi from `1.7 ... 3.0` to `2.0 ... 3.0`

We can no longer support slf4j-api 1.7.x, since we started using the `Logger.atInfo()` and `Logger.atDebug()` APIs as part of issue #13884

We've been using slf4j 2.x since Jetty 10.0.0.
Thing is, we started by using slf4j 2.0.0.alpha releases, due it having a proper JPMS declaration / support.
This use of an alpha version of 2.0.0 was a problem for OSGI back in 2021.

See:

* #6354

Since there's been several non-alpha releases of slf4j 2.0.x so far, this PR is undoing the down-versioning from that past issue.

Resolves: #14435