### PR TITLE
Fix build with jdk25.0.2

### DIFF
--- a/jetty-core/jetty-jmx/src/test/java/org/eclipse/jetty/jmx/ConnectorServerTest.java
+++ b/jetty-core/jetty-jmx/src/test/java/org/eclipse/jetty/jmx/ConnectorServerTest.java
@@ -246,19 +246,31 @@ public class ConnectorServerTest
         // needs these system properties.
         System.setProperty("javax.net.ssl.trustStore", keyStorePath);
         System.setProperty("javax.net.ssl.trustStorePassword", keyStorePassword);
+        System.setProperty("jdk.tls.allowCommonNameMatching", "true");
+        System.setProperty("java.rmi.server.hostname", "localhost");
 
-        connectorServer = new ConnectorServer(new JMXServiceURL("rmi", null, 0, "/jndi/rmi://localhost:1100/jmxrmi"), null, objectName, sslContextFactory);
-        connectorServer.start();
-
-        // The client needs to talk TLS to the RMI registry to download
-        // the RMI server stub, and this is independent from JMX.
-        // The RMI server stub then contains the SslRMIClientSocketFactory
-        // needed to talk to the RMI server.
-        Map<String, Object> clientEnv = new HashMap<>();
-        clientEnv.put(ConnectorServer.RMI_REGISTRY_CLIENT_SOCKET_FACTORY_ATTRIBUTE, new SslRMIClientSocketFactory());
-        try (JMXConnector client = JMXConnectorFactory.connect(connectorServer.getAddress(), clientEnv))
+        try
         {
-            client.getMBeanServerConnection().queryNames(null, null);
+            connectorServer = new ConnectorServer(new JMXServiceURL("rmi", "localhost", 0, "/jndi/rmi://localhost:1100/jmxrmi"), null, objectName, sslContextFactory);
+            connectorServer.start();
+
+            // The client needs to talk TLS to the RMI registry to download
+            // the RMI server stub, and this is independent from JMX.
+            // The RMI server stub then contains the SslRMIClientSocketFactory
+            // needed to talk to the RMI server.
+            Map<String, Object> clientEnv = new HashMap<>();
+            clientEnv.put(ConnectorServer.RMI_REGISTRY_CLIENT_SOCKET_FACTORY_ATTRIBUTE, new SslRMIClientSocketFactory());
+            try (JMXConnector client = JMXConnectorFactory.connect(connectorServer.getAddress(), clientEnv))
+            {
+                client.getMBeanServerConnection().queryNames(null, null);
+            }
+        }
+        finally
+        {
+            System.clearProperty("javax.net.ssl.trustStore");
+            System.clearProperty("javax.net.ssl.trustStorePassword");
+            System.clearProperty("jdk.tls.allowCommonNameMatching");
+            System.clearProperty("java.rmi.server.hostname");
         }
     }
 }


### PR DESCRIPTION

Local failure with jdk25 

```
[ERROR] org.eclipse.jetty.jmx.ConnectorServerTest.testJMXOverTLS -- Time elapsed: 0.053 s <<< ERROR!
java.rmi.ConnectIOException:
error during JRMP connection establishment; nested exception is:
	javax.net.ssl.SSLHandshakeException: (certificate_unknown) No subject alternative names present
	at java.rmi/sun.rmi.transport.tcp.TCPChannel.createConnection(TCPChannel.java:241)
	at java.rmi/sun.rmi.transport.tcp.TCPChannel.newConnection(TCPChannel.java:137)
	at java.rmi/sun.rmi.server.UnicastRef.invoke(UnicastRef.java:130)
	at java.management.rmi/javax.management.remote.rmi.RMIServerImpl_Stub.newClient(RMIServerImpl_Stub.java:85)
	at java.management.rmi/javax.management.remote.rmi.RMIConnector.getConnection(RMIConnector.java:2058)
	at java.management.rmi/javax.management.remote.rmi.RMIConnector.connect(RMIConnector.java:317)
	at java.management/javax.management.remote.JMXConnectorFactory.connect(JMXConnectorFactory.java:266)
	at org.eclipse.jetty.jmx@12.1.7-SNAPSHOT/org.eclipse.jetty.jmx.ConnectorServerTest.testJMXOverTLS(ConnectorServerTest.java:259)
Caused by: javax.net.ssl.SSLHandshakeException: (certificate_unknown) No subject alternative names present
	at java.base/sun.security.ssl.Alert.createSSLException(Alert.java:130)
	at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:376)
	at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:319)
	at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:314)
	at java.base/sun.security.ssl.CertificateMessage$T13CertificateConsumer.checkServerCerts(CertificateMessage.java:1295)
	at java.base/sun.security.ssl.CertificateMessage$T13CertificateConsumer.onConsumeCertificate(CertificateMessage.java:1172)
	at java.base/sun.security.ssl.CertificateMessage$T13CertificateConsumer.consume(CertificateMessage.java:1115)
	at java.base/sun.security.ssl.SSLHandshake.consume(SSLHandshake.java:421)
	at java.base/sun.security.ssl.HandshakeContext.dispatch(HandshakeContext.java:477)
	at java.base/sun.security.ssl.HandshakeContext.dispatch(HandshakeContext.java:448)
	at java.base/sun.security.ssl.TransportContext.dispatch(TransportContext.java:199)
	at java.base/sun.security.ssl.SSLTransport.decode(SSLTransport.java:172)
	at java.base/sun.security.ssl.SSLSocketImpl.decode(SSLSocketImpl.java:1506)
	at java.base/sun.security.ssl.SSLSocketImpl.readHandshakeRecord(SSLSocketImpl.java:1421)
	at java.base/sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:455)
	at java.base/sun.security.ssl.SSLSocketImpl.ensureNegotiated(SSLSocketImpl.java:924)
	at java.base/sun.security.ssl.SSLSocketImpl$AppOutputStream.write(SSLSocketImpl.java:1293)
	at java.base/java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:123)
	at java.base/java.io.BufferedOutputStream.flush(BufferedOutputStream.java:203)
	at java.base/java.io.DataOutputStream.flush(DataOutputStream.java:142)
	at java.rmi/sun.rmi.transport.tcp.TCPChannel.createConnection(TCPChannel.java:176)
	... 7 more
Caused by: java.security.cert.CertificateException: No subject alternative names present
	at java.base/sun.security.util.HostnameChecker.matchIP(HostnameChecker.java:138)
	at java.base/sun.security.util.HostnameChecker.match(HostnameChecker.java:101)
	at java.base/sun.security.ssl.X509TrustManagerImpl.checkIdentity(X509TrustManagerImpl.java:466)
	at java.base/sun.security.ssl.X509TrustManagerImpl.checkIdentity(X509TrustManagerImpl.java:432)
	at java.base/sun.security.ssl.X509TrustManagerImpl.checkTrusted(X509TrustManagerImpl.java:237)
	at java.base/sun.security.ssl.X509TrustManagerImpl.checkServerTrusted(X509TrustManagerImpl.java:132)
	at java.base/sun.security.ssl.CertificateMessage$T13CertificateConsumer.checkServerCerts(CertificateMessage.java:1279)
	... 23 more
```