### PR TITLE
Issue #14436 - Fix NPE in HttpFields.from() quality CSV parsing

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -178,6 +178,8 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
     /**
      * <p>Returns an immutable {@link HttpFields} instance containing the given
      * {@link HttpField}s.</p>
+     * <p>The returned instance uses default HTTP compliance behavior (no explicit
+     * compliance mode and no-op compliance violation listener supplier).</p>
      *
      * @param fields the {@link HttpField}s to be contained in the returned instance
      * @return a new immutable {@link HttpFields} instance with the given {@link HttpField}s

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/ImmutableHttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/ImmutableHttpFields.java
@@ -43,13 +43,13 @@ class ImmutableHttpFields implements HttpFields
 
     protected ImmutableHttpFields(HttpField[] fields, int size)
     {
-        this(null, () -> null, fields, size);
+        this(null, null, fields, size);
     }
 
     ImmutableHttpFields(HttpCompliance httpCompliance, Supplier<ComplianceViolation.Listener> listenerSupplier, HttpField[] fields, int size)
     {
         _httpCompliance = httpCompliance;
-        _listenerSupplier = listenerSupplier;
+        _listenerSupplier = Objects.requireNonNullElse(listenerSupplier, () -> null);
         _fields = fields;
         _size = size;
     }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/ImmutableHttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/ImmutableHttpFields.java
@@ -43,7 +43,7 @@ class ImmutableHttpFields implements HttpFields
 
     protected ImmutableHttpFields(HttpField[] fields, int size)
     {
-        this(null, null, fields, size);
+        this(null, () -> null, fields, size);
     }
 
     ImmutableHttpFields(HttpCompliance httpCompliance, Supplier<ComplianceViolation.Listener> listenerSupplier, HttpField[] fields, int size)

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
@@ -44,6 +44,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -830,6 +831,24 @@ public class HttpFieldsTest
         assertEquals(HttpField.getValueParameters(list.get(3), null), "two");
         assertEquals(HttpField.getValueParameters(list.get(4), null), "three");
         assertEquals(HttpField.getValueParameters(list.get(5), null), "four");
+    }
+
+    private static Stream<Arguments> immutableFieldsForQualityCSV()
+    {
+        String value = "en-US;q=0.8,en;q=0.6";
+        return Stream.of(
+            Arguments.of("from", HttpFields.from(new HttpField(HttpHeader.ACCEPT_LANGUAGE, value))),
+            Arguments.of("buildAsImmutable", HttpFields.build().add(HttpHeader.ACCEPT_LANGUAGE, value).asImmutable())
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("immutableFieldsForQualityCSV")
+    public void testImmutableGetQualityCSV(String scenario, HttpFields fields)
+    {
+        List<String> list = assertDoesNotThrow(() -> fields.getQualityCSV(HttpHeader.ACCEPT_LANGUAGE), scenario);
+        assertEquals(HttpField.getValueParameters(list.get(0), null), "en-US");
+        assertEquals(HttpField.getValueParameters(list.get(1), null), "en");
     }
 
     @Test

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpFieldsTest.java
@@ -833,20 +833,11 @@ public class HttpFieldsTest
         assertEquals(HttpField.getValueParameters(list.get(5), null), "four");
     }
 
-    private static Stream<Arguments> immutableFieldsForQualityCSV()
+    @Test
+    public void testFromGetQualityCSV()
     {
-        String value = "en-US;q=0.8,en;q=0.6";
-        return Stream.of(
-            Arguments.of("from", HttpFields.from(new HttpField(HttpHeader.ACCEPT_LANGUAGE, value))),
-            Arguments.of("buildAsImmutable", HttpFields.build().add(HttpHeader.ACCEPT_LANGUAGE, value).asImmutable())
-        );
-    }
-
-    @ParameterizedTest
-    @MethodSource("immutableFieldsForQualityCSV")
-    public void testImmutableGetQualityCSV(String scenario, HttpFields fields)
-    {
-        List<String> list = assertDoesNotThrow(() -> fields.getQualityCSV(HttpHeader.ACCEPT_LANGUAGE), scenario);
+        HttpFields fields = HttpFields.from(new HttpField(HttpHeader.ACCEPT_LANGUAGE, "en-US;q=0.8,en;q=0.6"));
+        List<String> list = assertDoesNotThrow(() -> fields.getQualityCSV(HttpHeader.ACCEPT_LANGUAGE));
         assertEquals(HttpField.getValueParameters(list.get(0), null), "en-US");
         assertEquals(HttpField.getValueParameters(list.get(1), null), "en");
     }


### PR DESCRIPTION
Fixes #14436

`HttpFields.from(HttpField...)` creates `ImmutableHttpFields` through a constructor path that left `_listenerSupplier` as `null`, so `getQualityCSV(...)` could throw `NullPointerException` when `newQuotedQualityCSV(...)` calls `_listenerSupplier.get()`.

This is a regression introduced by #14400 which added listener-based CSV creation in `ImmutableHttpFields` but did not initialize the default supplier in the `from(...)` constructor path.

Changes in this PR:

- Add regression test `HttpFieldsTest.testFromGetQualityCSV()` reproducing the NPE via `HttpFields.from(...)`
- Guard against null `listenerSupplier` in the main `ImmutableHttpFields` constructor via `Objects.requireNonNullElse()`
- Clarify `HttpFields.from(...)` Javadoc to document default compliance/listener behavior

Verification:

- Before fix: `mvn -Dmimir.enabled=false -pl jetty-core/jetty-http -Dtest=HttpFieldsTest#testFromGetQualityCSV test` fails with NPE
- After fix: same command passes
