### PR TITLE
Fix `HttpDestination` sweep race condition

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
@@ -279,7 +279,6 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
         }
 
         // Create the connection.
-        Pool<Connection> pool = this.pool;
         Pool.Entry<Connection> entry = pool.reserve();
         if (entry == null)
         {
@@ -300,9 +299,6 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
     {
         if (!(connection instanceof Attachable attachable))
             throw new IllegalArgumentException("Invalid connection object: " + connection);
-        Pool<Connection> pool = this.pool;
-        if (pool == null)
-            return false;
         Pool.Entry<Connection> entry = pool.reserve();
         if (entry == null)
             return false;
@@ -323,7 +319,6 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
     {
         while (true)
         {
-            Pool<Connection> pool = this.pool;
             Pool.Entry<Connection> entry = pool.acquire();
             if (entry != null)
             {
@@ -469,7 +464,7 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
 
     Collection<Connection> getIdleConnections()
     {
-        return pool == null ? List.of() : pool.stream()
+        return pool.stream()
             .filter(Pool.Entry::isIdle)
             .filter(entry -> !entry.isTerminated())
             .map(Pool.Entry::getPooled)
@@ -478,7 +473,7 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
 
     Collection<Connection> getActiveConnections()
     {
-        return pool == null ? List.of() : pool.stream()
+        return pool.stream()
             .filter(entry -> !entry.isIdle())
             .filter(entry -> !entry.isTerminated())
             .map(Pool.Entry::getPooled)

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
@@ -88,6 +88,9 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
         List<CompletableFuture<?>> futures = new ArrayList<>();
         for (int i = 0; i < connectionCount; i++)
         {
+            Pool<Connection> pool = this.pool;
+            if (pool == null)
+                break;
             Pool.Entry<Connection> entry = pool.reserve();
             if (entry == null)
                 break;
@@ -279,6 +282,9 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
         }
 
         // Create the connection.
+        Pool<Connection> pool = this.pool;
+        if (pool == null)
+            return;
         Pool.Entry<Connection> entry = pool.reserve();
         if (entry == null)
         {
@@ -299,6 +305,9 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
     {
         if (!(connection instanceof Attachable attachable))
             throw new IllegalArgumentException("Invalid connection object: " + connection);
+        Pool<Connection> pool = this.pool;
+        if (pool == null)
+            return false;
         Pool.Entry<Connection> entry = pool.reserve();
         if (entry == null)
             return false;
@@ -319,6 +328,9 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
     {
         while (true)
         {
+            Pool<Connection> pool = this.pool;
+            if (pool == null)
+                return null;
             Pool.Entry<Connection> entry = pool.acquire();
             if (entry != null)
             {
@@ -464,7 +476,7 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
 
     Collection<Connection> getIdleConnections()
     {
-        return pool.stream()
+        return pool == null ? List.of() : pool.stream()
             .filter(Pool.Entry::isIdle)
             .filter(entry -> !entry.isTerminated())
             .map(Pool.Entry::getPooled)
@@ -473,7 +485,7 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
 
     Collection<Connection> getActiveConnections()
     {
-        return pool.stream()
+        return pool == null ? List.of() : pool.stream()
             .filter(entry -> !entry.isIdle())
             .filter(entry -> !entry.isTerminated())
             .map(Pool.Entry::getPooled)

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
@@ -76,7 +76,6 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
         super.doStop();
         removeBean(pool);
         pool.terminate().forEach(this::close);
-        pool = null;
     }
 
     @Override
@@ -89,8 +88,6 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
         for (int i = 0; i < connectionCount; i++)
         {
             Pool<Connection> pool = this.pool;
-            if (pool == null)
-                break;
             Pool.Entry<Connection> entry = pool.reserve();
             if (entry == null)
                 break;
@@ -283,8 +280,6 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
 
         // Create the connection.
         Pool<Connection> pool = this.pool;
-        if (pool == null)
-            return;
         Pool.Entry<Connection> entry = pool.reserve();
         if (entry == null)
         {
@@ -329,8 +324,6 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
         while (true)
         {
             Pool<Connection> pool = this.pool;
-            if (pool == null)
-                return null;
             Pool.Entry<Connection> entry = pool.acquire();
             if (entry != null)
             {

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractConnectionPool.java
@@ -87,7 +87,6 @@ public abstract class AbstractConnectionPool extends ContainerLifeCycle implemen
         List<CompletableFuture<?>> futures = new ArrayList<>();
         for (int i = 0; i < connectionCount; i++)
         {
-            Pool<Connection> pool = this.pool;
             Pool.Entry<Connection> entry = pool.reserve();
             if (entry == null)
                 break;

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpDestination.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpDestination.java
@@ -154,6 +154,7 @@ public class HttpDestination extends ContainerLifeCycle implements Destination, 
     {
         this.connectionPool = newConnectionPool(client);
         addBean(connectionPool, true);
+        this.activeNanoTime = NanoTime.now();
         super.doStart();
         Sweeper connectionPoolSweeper = client.getBean(Sweeper.class);
         if (connectionPoolSweeper != null && connectionPool instanceof Sweeper.Sweepable)
@@ -364,7 +365,22 @@ public class HttpDestination extends ContainerLifeCycle implements Destination, 
         {
             Connection connection = connectionPool.acquire(create);
             if (connection == null)
+            {
+                if (!isRunning())
+                {
+                    // This instance is being used after becoming stale: the sweeper stops the destination in such case
+                    // which itself stops the connection pool; the latter only returns null for two reasons: the pool
+                    // being empty or stopped, so we differentiate between the two by checking the running state.
+                    while (true)
+                    {
+                        HttpExchange httpExchange = exchanges.poll();
+                        if (httpExchange == null)
+                            break;
+                        httpExchange.abort(new RejectedExecutionException(this + " is stale"), Promise.noop());
+                    }
+                }
                 break;
+            }
             boolean proceed = process(connection);
             if (proceed)
                 create = false;

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpDestination.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpDestination.java
@@ -304,15 +304,15 @@ public class HttpDestination extends ContainerLifeCycle implements Destination, 
     public void send(HttpExchange exchange)
     {
         HttpRequest request = exchange.getRequest();
-        if (client.isRunning())
+        if (isRunning())
         {
             if (enqueue(exchanges, exchange))
             {
                 request.sent();
                 requestTimeouts.schedule(exchange);
-                if (!client.isRunning() && exchanges.remove(exchange))
+                if (!isRunning() && exchanges.remove(exchange))
                 {
-                    request.abort(new RejectedExecutionException(client + " is stopping"));
+                    request.abort(new RejectedExecutionException(this + " is stopping"));
                 }
                 else
                 {
@@ -332,7 +332,7 @@ public class HttpDestination extends ContainerLifeCycle implements Destination, 
         }
         else
         {
-            request.abort(new RejectedExecutionException(client + " is stopped"));
+            request.abort(new RejectedExecutionException(this + " is stopped"));
         }
     }
 
@@ -365,22 +365,7 @@ public class HttpDestination extends ContainerLifeCycle implements Destination, 
         {
             Connection connection = connectionPool.acquire(create);
             if (connection == null)
-            {
-                if (!isRunning())
-                {
-                    // This instance is being used after becoming stale: the sweeper stops the destination in such case
-                    // which itself stops the connection pool; the latter only returns null for two reasons: the pool
-                    // being empty or stopped, so we differentiate between the two by checking the running state.
-                    while (true)
-                    {
-                        HttpExchange httpExchange = exchanges.poll();
-                        if (httpExchange == null)
-                            break;
-                        httpExchange.abort(new RejectedExecutionException(this + " is stale"), Promise.noop());
-                    }
-                }
                 break;
-            }
             boolean proceed = process(connection);
             if (proceed)
                 create = false;

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/ConnectionPoolTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/ConnectionPoolTest.java
@@ -15,7 +15,6 @@ package org.eclipse.jetty.client;
 
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -29,12 +28,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import org.eclipse.jetty.client.transport.HttpChannel;
 import org.eclipse.jetty.client.transport.HttpClientTransportOverHTTP;
-import org.eclipse.jetty.client.transport.HttpConnection;
 import org.eclipse.jetty.client.transport.HttpDestination;
-import org.eclipse.jetty.client.transport.HttpExchange;
-import org.eclipse.jetty.client.transport.SendFailure;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpHeaderValue;
 import org.eclipse.jetty.http.HttpMethod;

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/ConnectionPoolTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/ConnectionPoolTest.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.client;
 
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -28,8 +29,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import org.eclipse.jetty.client.transport.HttpChannel;
 import org.eclipse.jetty.client.transport.HttpClientTransportOverHTTP;
+import org.eclipse.jetty.client.transport.HttpConnection;
 import org.eclipse.jetty.client.transport.HttpDestination;
+import org.eclipse.jetty.client.transport.HttpExchange;
+import org.eclipse.jetty.client.transport.SendFailure;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpHeaderValue;
 import org.eclipse.jetty.http.HttpMethod;
@@ -668,7 +673,7 @@ public class ConnectionPoolTest
 
     @ParameterizedTest
     @MethodSource("pools")
-    public void testCountersSweepToStringThroughLifecycle(ConnectionPoolFactory factory) throws Exception
+    public void testNullSafeAndCountersSweepToStringThroughLifecycle(ConnectionPoolFactory factory) throws Exception
     {
         startClient(destination ->
         {
@@ -677,7 +682,34 @@ public class ConnectionPoolTest
             return connectionPool;
         });
 
-        AbstractConnectionPool connectionPool = (AbstractConnectionPool)factory.factory.newConnectionPool(new HttpDestination(client, new Origin("", "", 0)));
+        HttpDestination destination = new HttpDestination(client, new Origin("", "", 0));
+        Connection connection = new HttpConnection(destination)
+        {
+            @Override
+            protected Iterator<HttpChannel> getHttpChannels()
+            {
+                return null;
+            }
+
+            @Override
+            public SendFailure send(HttpExchange exchange)
+            {
+                return null;
+            }
+
+            @Override
+            public void close()
+            {
+            }
+
+            @Override
+            public boolean isClosed()
+            {
+                return false;
+            }
+        };
+
+        AbstractConnectionPool connectionPool = (AbstractConnectionPool)factory.factory.newConnectionPool(destination);
         assertThat(connectionPool.getConnectionCount(), is(0));
         assertThat(connectionPool.getActiveConnectionCount(), is(0));
         assertThat(connectionPool.getIdleConnectionCount(), is(0));
@@ -685,6 +717,11 @@ public class ConnectionPoolTest
         assertThat(connectionPool.isEmpty(), is(true));
         assertThat(connectionPool.sweep(), is(false));
         assertThat(connectionPool.toString(), not(nullValue()));
+        assertThat(connectionPool.preCreateConnections(1).get(), nullValue());
+        assertThat(connectionPool.acquire(true), nullValue());
+        assertThat(connectionPool.accept(connection), is(false));
+        assertThat(connectionPool.getIdleConnections().size(), is(0));
+        assertThat(connectionPool.getActiveConnections().size(), is(0));
 
         LifeCycle.start(connectionPool);
         assertThat(connectionPool.getConnectionCount(), is(0));
@@ -703,6 +740,11 @@ public class ConnectionPoolTest
         assertThat(connectionPool.isEmpty(), is(true));
         assertThat(connectionPool.sweep(), is(false));
         assertThat(connectionPool.toString(), not(nullValue()));
+        assertThat(connectionPool.preCreateConnections(1).get(), nullValue());
+        assertThat(connectionPool.acquire(true), nullValue());
+        assertThat(connectionPool.accept(connection), is(false));
+        assertThat(connectionPool.getIdleConnections().size(), is(0));
+        assertThat(connectionPool.getActiveConnections().size(), is(0));
     }
 
     public static class ConnectionPoolFactory

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/ConnectionPoolTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/ConnectionPoolTest.java
@@ -682,34 +682,7 @@ public class ConnectionPoolTest
             return connectionPool;
         });
 
-        HttpDestination destination = new HttpDestination(client, new Origin("", "", 0));
-        Connection connection = new HttpConnection(destination)
-        {
-            @Override
-            protected Iterator<HttpChannel> getHttpChannels()
-            {
-                return null;
-            }
-
-            @Override
-            public SendFailure send(HttpExchange exchange)
-            {
-                return null;
-            }
-
-            @Override
-            public void close()
-            {
-            }
-
-            @Override
-            public boolean isClosed()
-            {
-                return false;
-            }
-        };
-
-        AbstractConnectionPool connectionPool = (AbstractConnectionPool)factory.factory.newConnectionPool(destination);
+        AbstractConnectionPool connectionPool = (AbstractConnectionPool)factory.factory.newConnectionPool(new HttpDestination(client, new Origin("", "", 0)));
         assertThat(connectionPool.getConnectionCount(), is(0));
         assertThat(connectionPool.getActiveConnectionCount(), is(0));
         assertThat(connectionPool.getIdleConnectionCount(), is(0));
@@ -717,11 +690,6 @@ public class ConnectionPoolTest
         assertThat(connectionPool.isEmpty(), is(true));
         assertThat(connectionPool.sweep(), is(false));
         assertThat(connectionPool.toString(), not(nullValue()));
-        assertThat(connectionPool.preCreateConnections(1).get(), nullValue());
-        assertThat(connectionPool.acquire(true), nullValue());
-        assertThat(connectionPool.accept(connection), is(false));
-        assertThat(connectionPool.getIdleConnections().size(), is(0));
-        assertThat(connectionPool.getActiveConnections().size(), is(0));
 
         LifeCycle.start(connectionPool);
         assertThat(connectionPool.getConnectionCount(), is(0));
@@ -736,13 +704,12 @@ public class ConnectionPoolTest
         assertThat(connectionPool.getConnectionCount(), is(0));
         assertThat(connectionPool.getActiveConnectionCount(), is(0));
         assertThat(connectionPool.getIdleConnectionCount(), is(0));
-        assertThat(connectionPool.getMaxConnectionCount(), is(0));
+        assertThat(connectionPool.getMaxConnectionCount(), is(64));
         assertThat(connectionPool.isEmpty(), is(true));
         assertThat(connectionPool.sweep(), is(false));
         assertThat(connectionPool.toString(), not(nullValue()));
         assertThat(connectionPool.preCreateConnections(1).get(), nullValue());
         assertThat(connectionPool.acquire(true), nullValue());
-        assertThat(connectionPool.accept(connection), is(false));
         assertThat(connectionPool.getIdleConnections().size(), is(0));
         assertThat(connectionPool.getActiveConnections().size(), is(0));
     }

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/DuplexHttpDestinationTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/DuplexHttpDestinationTest.java
@@ -18,8 +18,8 @@ import java.util.Iterator;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
-
 import java.util.concurrent.atomic.AtomicReference;
+
 import org.eclipse.jetty.client.transport.HttpDestination;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpHeaderValue;

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/DuplexHttpDestinationTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/DuplexHttpDestinationTest.java
@@ -19,6 +19,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import java.util.concurrent.atomic.AtomicReference;
 import org.eclipse.jetty.client.transport.HttpDestination;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpHeaderValue;
@@ -31,6 +32,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -40,6 +42,29 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DuplexHttpDestinationTest extends AbstractHttpClientServerTest
 {
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testUseDestinationAfterSweep(Scenario scenario) throws Exception
+    {
+        startClient(scenario, client -> client.setDestinationIdleTimeout(1));
+
+        // The port does not matter as the request should fail before leaving the client.
+        Request request = client.newRequest("localhost", 0)
+            .scheme(scenario.getScheme());
+        Destination destination = client.resolveDestination(request);
+        assertFalse(((HttpDestination)destination).stale());
+
+        // Wait for the sweeper to mark the destination as stale.
+        Thread.sleep(1500);
+        assertTrue(((HttpDestination)destination).stale());
+
+        AtomicReference<Result> resultRef = new AtomicReference<>();
+        destination.send(request, resultRef::set);
+
+        Result result = await().atMost(5, TimeUnit.SECONDS).until(resultRef::get, notNullValue());
+        assertInstanceOf(RejectedExecutionException.class, result.getResponseFailure());
+    }
+
     @ParameterizedTest
     @ArgumentsSource(ScenarioProvider.class)
     public void testAcquireWithEmptyQueue(Scenario scenario) throws Exception


### PR DESCRIPTION
A `HttpDestination` can be swept between it being resolved and an exchange being enqueued in it, which would hit a NPE while trying a get a connection from a stopped pool.

This is an attempt at fixing that by disabling sweeping between the resolving and the enqueuing of the exchange.

Fixes https://github.com/jetty/jetty.project/issues/14533