### PR TITLE
Fix `ScannerTest` flakyness

### DIFF
--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/ScannerTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/ScannerTest.java
@@ -744,7 +744,7 @@ public class ScannerTest
 
     private static void touch(Path file) throws IOException
     {
-        touch(file, (ft) -> System.currentTimeMillis());
+        touch(file, (ft) -> ft + 1L);
     }
 
     private static void touch(Path file, Function<Long, Long> fileTimeDelta) throws IOException


### PR DESCRIPTION
The `touch()` helper is fundamentally broken as if it is called multiple times in the same wall-clock millisecond, it does not have any effect.

Fixes https://github.com/jetty/jetty.project/issues/14529