### PR TITLE
Move debug log after stream completion

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -720,11 +720,12 @@ public class HttpChannelState implements HttpChannel, Components
             listener.onRequestEnd(_request);
 
             // This is THE ONLY PLACE the stream is succeeded or failed.
-            LOG.atDebug().setCause(failure).log("completing the stream of {}", this);
             if (failure == null)
                 stream.succeeded();
             else
                 stream.failed(failure);
+            if (LOG.isDebugEnabled())
+                LOG.atDebug().setCause(failure).log("completing the stream of {}", this);
         }
     }
 


### PR DESCRIPTION
Move the debug log to after stream.succeeded()/failed() and guard it with isDebugEnabled(). This avoids unnecessary logging overhead when debug isn't enabled and ensures stream operations complete cleanly. Fixes #14567.