### PR TITLE
Respect setSyncFlush in GzipEncoderSink

### DIFF
--- a/jetty-core/jetty-compression/jetty-compression-gzip/src/main/java/org/eclipse/jetty/compression/gzip/internal/GzipEncoderSink.java
+++ b/jetty-core/jetty-compression/jetty-compression-gzip/src/main/java/org/eclipse/jetty/compression/gzip/internal/GzipEncoderSink.java
@@ -83,6 +83,7 @@ public class GzipEncoderSink extends EncoderSink
     private final RetainableByteBuffer inputBuffer;
     private final ByteBuffer input;
     private final int bufferSize;
+    private final boolean syncFlush;
     private final CRC32 crc = new CRC32();
     private final AtomicReference<State> state = new AtomicReference<>(State.HEADERS);
     private boolean released;
@@ -94,6 +95,7 @@ public class GzipEncoderSink extends EncoderSink
         this.deflaterEntry = compression.getDeflaterPool().acquire();
         this.deflater = deflaterEntry.get();
         this.bufferSize = config.getBufferSize();
+        this.syncFlush = config.isSyncFlush();
         this.inputBuffer = compression.acquireByteBuffer(bufferSize);
         this.input = this.inputBuffer.getByteBuffer();
         this.input.position(this.input.limit()); // set to totally consume at first
@@ -102,6 +104,11 @@ public class GzipEncoderSink extends EncoderSink
         this.deflater.setStrategy(config.getStrategy());
         this.deflater.setLevel(config.getCompressionLevel());
         this.crc.reset();
+    }
+
+    private int getFlushMode()
+    {
+        return syncFlush ? Deflater.SYNC_FLUSH : Deflater.NO_FLUSH;
     }
 
     protected void addInput(ByteBuffer content)
@@ -228,7 +235,7 @@ public class GzipEncoderSink extends EncoderSink
             addInput(content);
 
         BufferUtil.clearToFill(output);
-        int len = deflater.deflate(output);
+        int len = deflater.deflate(output, getFlushMode());
         BufferUtil.flipToFlush(output, 0);
         return (len > 0);
     }

--- a/jetty-core/jetty-compression/jetty-compression-gzip/src/test/java/org/eclipse/jetty/compression/gzip/GzipEncoderSinkTest.java
+++ b/jetty-core/jetty-compression/jetty-compression-gzip/src/test/java/org/eclipse/jetty/compression/gzip/GzipEncoderSinkTest.java
@@ -17,6 +17,8 @@ import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.zip.Deflater;
 
@@ -35,6 +37,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.WRITE;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -176,6 +179,45 @@ public class GzipEncoderSinkTest extends AbstractGzipTest
 
         String result = new String(decompress(compressed), UTF_8);
         assertThat(result, is("Hello World!"));
+    }
+
+    @Test
+    public void testSyncFlushProducesIntermediateOutput() throws Exception
+    {
+        startGzip();
+        ((GzipEncoderConfig)gzip.getDefaultEncoderConfig()).setSyncFlush(true);
+
+        List<Integer> writeLengths = new ArrayList<>();
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream())
+        {
+            Content.Sink captureSink = (last, byteBuffer, callback) ->
+            {
+                writeLengths.add(byteBuffer.remaining());
+                byte[] bytes = BufferUtil.toArray(byteBuffer);
+                baos.write(bytes, 0, bytes.length);
+                callback.succeeded();
+            };
+            Content.Sink encoderSink = gzip.newEncoderSink(captureSink);
+
+            // Write content without last=true to test intermediate flushing
+            Callback.Completable callback = new Callback.Completable();
+            encoderSink.write(false, ByteBuffer.wrap("Hello World!".getBytes(UTF_8)), callback);
+            callback.get();
+
+            // With syncFlush=true, the deflater must flush pending data even on non-final writes.
+            // We expect at least two writes: the gzip header and at least one body write with content.
+            assertThat("expected writes for header and body", writeLengths.size(), greaterThan(1));
+            int bodyBytes = writeLengths.stream().skip(1).mapToInt(Integer::intValue).sum();
+            assertThat("body write must contain compressed bytes", bodyBytes, greaterThan(0));
+
+            // Finish the stream and verify round-trip
+            Callback.Completable done = new Callback.Completable();
+            encoderSink.write(true, ByteBuffer.wrap("".getBytes(UTF_8)), done);
+            done.get();
+
+            String result = new String(decompress(baos.toByteArray()), UTF_8);
+            assertThat(result, is("Hello World!"));
+        }
     }
 
     private static class WriteLoggerSink implements Content.Sink


### PR DESCRIPTION
GzipEncoderSink was ignoring the sync flush setting from the configuration. The flag was read in the constructor but never actually used when calling deflate(). Fixed by storing it as a field and passing it to the deflate() call. Closes #14566