### PR TITLE
Issue #14566 - Use GzipEncoderConfig syncFlush in CompressionHandler as well

### DIFF
--- a/jetty-core/jetty-compression/jetty-compression-gzip/src/main/java/org/eclipse/jetty/compression/gzip/internal/GzipEncoderSink.java
+++ b/jetty-core/jetty-compression/jetty-compression-gzip/src/main/java/org/eclipse/jetty/compression/gzip/internal/GzipEncoderSink.java
@@ -230,7 +230,7 @@ public class GzipEncoderSink extends EncoderSink
             addInput(content);
 
         BufferUtil.clearToFill(output);
-        int len = deflater.deflate(output, Deflater.SYNC_FLUSH);
+        int len = deflater.deflate(output, flushMode);
         BufferUtil.flipToFlush(output, 0);
         return (len > 0);
     }
@@ -247,7 +247,7 @@ public class GzipEncoderSink extends EncoderSink
         BufferUtil.flipToFill(output);
         while (!deflater.finished())
         {
-            int len = deflater.deflate(output, Deflater.FULL_FLUSH);
+            int len = deflater.deflate(output, flushMode);
             if (len > 0)
             {
                 BufferUtil.flipToFlush(output, pos);

--- a/jetty-core/jetty-compression/jetty-compression-gzip/src/main/java/org/eclipse/jetty/compression/gzip/internal/GzipEncoderSink.java
+++ b/jetty-core/jetty-compression/jetty-compression-gzip/src/main/java/org/eclipse/jetty/compression/gzip/internal/GzipEncoderSink.java
@@ -83,6 +83,7 @@ public class GzipEncoderSink extends EncoderSink
     private final RetainableByteBuffer inputBuffer;
     private final ByteBuffer input;
     private final int bufferSize;
+    private final int flushMode;
     private final CRC32 crc = new CRC32();
     private final AtomicReference<State> state = new AtomicReference<>(State.HEADERS);
     private boolean released;
@@ -101,6 +102,7 @@ public class GzipEncoderSink extends EncoderSink
         this.deflater.setInput(input);
         this.deflater.setStrategy(config.getStrategy());
         this.deflater.setLevel(config.getCompressionLevel());
+        this.flushMode = config.isSyncFlush() ? Deflater.SYNC_FLUSH : Deflater.NO_FLUSH;
         this.crc.reset();
     }
 
@@ -123,7 +125,7 @@ public class GzipEncoderSink extends EncoderSink
     protected WriteRecord encode(boolean last, ByteBuffer content)
     {
         if (LOG.isDebugEnabled())
-            LOG.debug("encode() last={}, content={}", last, BufferUtil.toDetailString(content));
+            LOG.debug("encode() state={}, last={}, content={}", state, last, BufferUtil.toDetailString(content));
 
         if (released)
             throw new IllegalStateException("Already released");
@@ -228,7 +230,7 @@ public class GzipEncoderSink extends EncoderSink
             addInput(content);
 
         BufferUtil.clearToFill(output);
-        int len = deflater.deflate(output);
+        int len = deflater.deflate(output, Deflater.SYNC_FLUSH);
         BufferUtil.flipToFlush(output, 0);
         return (len > 0);
     }

--- a/jetty-core/jetty-compression/jetty-compression-tests/src/test/java/org/eclipse/jetty/compression/CompressionHandlerTest.java
+++ b/jetty-core/jetty-compression/jetty-compression-tests/src/test/java/org/eclipse/jetty/compression/CompressionHandlerTest.java
@@ -13,20 +13,29 @@
 
 package org.eclipse.jetty.compression;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.PrintStream;
+import java.net.Socket;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.zip.GZIPInputStream;
 
 import org.eclipse.jetty.client.BytesRequestContent;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.compression.brotli.BrotliCompression;
 import org.eclipse.jetty.compression.gzip.GzipCompression;
+import org.eclipse.jetty.compression.gzip.GzipEncoderConfig;
 import org.eclipse.jetty.compression.server.CompressionConfig;
 import org.eclipse.jetty.compression.server.CompressionHandler;
 import org.eclipse.jetty.compression.zstandard.ZstandardCompression;
@@ -34,6 +43,7 @@ import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.io.ArrayByteBufferPool;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.server.Handler;
@@ -42,7 +52,9 @@ import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
+import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.junit.jupiter.api.AfterEach;
@@ -1082,6 +1094,95 @@ public class CompressionHandlerTest extends AbstractCompressionTest
         etagField = response.getHeaders().getField(HttpHeader.ETAG);
         assertNotNull(etagField);
         assertEquals(etag, etagField.getValue());
+    }
+
+    @Test
+    public void testSyncFlush() throws Exception
+    {
+        pool = new ArrayByteBufferPool.Tracking();
+        GzipCompression gzipCompression = new GzipCompression();
+        GzipEncoderConfig gzipEncoderConfig = new GzipEncoderConfig();
+        gzipEncoderConfig.setSyncFlush(true);
+        gzipCompression.setDefaultEncoderConfig(gzipEncoderConfig);
+        gzipCompression.setByteBufferPool(pool);
+
+        CompressionHandler compressionHandler = new CompressionHandler();
+        compressionHandler.putCompression(gzipCompression);
+
+        CompressionConfig config = CompressionConfig.builder()
+            .build();
+
+        CountDownLatch latch = new CountDownLatch(1);
+
+        compressionHandler.putConfiguration("/", config);
+        compressionHandler.setHandler(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) throws IOException
+            {
+                response.getHeaders().put(HttpHeader.CONTENT_TYPE, "text/plain");
+                try (OutputStream outputStream = Content.Sink.asOutputStream(response);
+                    PrintStream writer = new PrintStream(outputStream))
+                {
+                    writer.print("This line should be flushed\n");
+                    assertTrue(latch.await(5, TimeUnit.SECONDS), "Post-Flush Latch timed out");
+                    writer.print("This line should be seen afterwards\n");
+                    // trigger "last" write to allow Gzip to finish and write its trailers.
+                    response.write(true, BufferUtil.EMPTY_BUFFER, callback);
+                }
+                catch (InterruptedException e)
+                {
+                    callback.failed(e);
+                }
+                return true;
+            }
+        });
+
+        startServer(compressionHandler);
+
+        client.getContentDecoderFactories().clear();
+
+        URI serverURI = server.getURI();
+        try (Socket socket = new Socket(serverURI.getHost(), serverURI.getPort());
+              OutputStream out = socket.getOutputStream();
+              InputStream in = socket.getInputStream())
+        {
+            String rawRequest = """
+                GET /test HTTP/1.1\r
+                Accept-Encoding: gzip\r
+                Host: %s\r
+                Connection: close\r
+                \r
+                """.formatted(serverURI.getAuthority());
+            out.write(rawRequest.getBytes(UTF_8));
+            out.flush();
+            HttpTester.Response response;
+            try (ByteArrayOutputStream baos = new ByteArrayOutputStream())
+            {
+                byte[] rawRespBytes = new byte[20];
+                int readCount = in.read(rawRespBytes, 0, 17); // we should see the response headers at least, indicating a flush occurred.
+                assertThat(readCount, is(17)); // oops we didn't get the whole line (did the network split it?)
+                String respLine = new String(rawRespBytes, 0, 17, UTF_8);
+                // proof that flush occurred.
+                assertThat(respLine, is("HTTP/1.1 200 OK\r\n"));
+                baos.write(rawRespBytes, 0, 17);
+                // let servlet write again
+                latch.countDown();
+                // collect the rest of the body
+                IO.copy(in, baos);
+                response = HttpTester.parseResponse(ByteBuffer.wrap(baos.toByteArray()));
+            }
+
+            byte[] rawResponseBodyBytes = response.getContentBytes();
+
+            try (
+                InputStream encodedIn = new ByteArrayInputStream(rawResponseBodyBytes);
+                GZIPInputStream gzipIn = new GZIPInputStream(encodedIn))
+            {
+                String decoded = IO.toString(gzipIn, UTF_8);
+                assertThat(decoded, is("This line should be flushed\nThis line should be seen afterwards\n"));
+            }
+        }
     }
 
     private void dumpResponse(org.eclipse.jetty.client.Response response)


### PR DESCRIPTION
The previous code was only using `GzipEncoderConfig` `syncFlush` for `GzipCompression.newEncoderOutputStream` use cases, this PR also allows `syncFlush` for `GzipEncoderSink`, which in turn allows it for use in `CompressionHandler` as well.

Resolves #14566