### PR TITLE
Set the exception cause of a failing XML configuration

### DIFF
--- a/jetty-core/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
+++ b/jetty-core/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
@@ -530,7 +530,7 @@ public class XmlConfiguration
                 }
                 catch (NoSuchMethodException x)
                 {
-                    throw new IllegalStateException("No matching constructor " + oClass);
+                    throw new IllegalStateException("No matching constructor " + oClass, x);
                 }
             }
             else


### PR DESCRIPTION
Without a cause, this exception is impossible to diagnose for a user debugging XML issues.
CC @olamy , @sbordet 