### PR TITLE
Issue #14494 - fixes for parsing of partial QPACK instructions

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/compression/HuffmanDecoder.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/compression/HuffmanDecoder.java
@@ -45,7 +45,7 @@ public class HuffmanDecoder
 
     /**
      * @param buffer the buffer containing the Huffman encoded bytes.
-     * @return the decoded String.
+     * @return the decoded String or null if more data is needed.
      * @throws EncodingException if the huffman encoding is invalid.
      */
     public String decode(ByteBuffer buffer) throws EncodingException

--- a/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/QpackDecoder.java
+++ b/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/QpackDecoder.java
@@ -238,10 +238,7 @@ public class QpackDecoder implements Dumpable
         List<MetaDataNotification> metaDataNotifications;
         try (AutoLock ignored = lock.lock())
         {
-            while (BufferUtil.hasContent(buffer))
-            {
-                _parser.parse(buffer);
-            }
+            _parser.parse(buffer);
             instructions = takeInstructions();
             metaDataNotifications = takeMetaDataNotifications();
         }

--- a/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/QpackEncoder.java
+++ b/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/QpackEncoder.java
@@ -328,10 +328,7 @@ public class QpackEncoder implements Dumpable
         List<Instruction> instructions;
         try (AutoLock ignored = lock.lock())
         {
-            while (BufferUtil.hasContent(buffer))
-            {
-                _parser.parse(buffer);
-            }
+            _parser.parse(buffer);
             instructions = takeInstructions();
         }
         catch (QpackException.SessionException e)

--- a/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/parser/DecoderInstructionParser.java
+++ b/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/parser/DecoderInstructionParser.java
@@ -19,6 +19,7 @@ import org.eclipse.jetty.http.compression.EncodingException;
 import org.eclipse.jetty.http.compression.NBitIntegerDecoder;
 import org.eclipse.jetty.http.compression.NBitStringDecoder;
 import org.eclipse.jetty.http3.qpack.QpackException;
+import org.eclipse.jetty.util.BufferUtil;
 
 /**
  * Parses a stream of unframed instructions for the Decoder. These instructions are sent from the remote Encoder.
@@ -70,63 +71,70 @@ public class DecoderInstructionParser
         _integerDecoder = new NBitIntegerDecoder();
     }
 
+    /**
+     * This will parse and fully consume the given {@link ByteBuffer} and notifies
+     * the {@link Handler} supplied in the constructor for any resulting events.
+     * @param buffer the buffer to parse.
+     * @throws QpackException if there was an error parsing the instructions.
+     * @throws EncodingException if the string encoding is invalid.
+     */
     public void parse(ByteBuffer buffer) throws QpackException, EncodingException
     {
-        if (buffer == null || !buffer.hasRemaining())
-            return;
-
-        switch (_state)
+        while (BufferUtil.hasContent(buffer))
         {
-            case PARSING:
-                byte firstByte = buffer.get(buffer.position());
-                if ((firstByte & 0x80) != 0)
-                {
-                    _state = State.REFERENCED_NAME;
-                    parseInsertNameWithReference(buffer);
-                }
-                else if ((firstByte & 0x40) != 0)
-                {
-                    _state = State.LITERAL_NAME;
-                    parseInsertWithLiteralName(buffer);
-                }
-                else if ((firstByte & 0x20) != 0)
-                {
-                    _state = State.SET_CAPACITY;
-                    _integerDecoder.setPrefix(5);
+            switch (_state)
+            {
+                case PARSING:
+                    byte firstByte = buffer.get(buffer.position());
+                    if ((firstByte & 0x80) != 0)
+                    {
+                        _state = State.REFERENCED_NAME;
+                        parseInsertNameWithReference(buffer);
+                    }
+                    else if ((firstByte & 0x40) != 0)
+                    {
+                        _state = State.LITERAL_NAME;
+                        parseInsertWithLiteralName(buffer);
+                    }
+                    else if ((firstByte & 0x20) != 0)
+                    {
+                        _state = State.SET_CAPACITY;
+                        _integerDecoder.setPrefix(5);
+                        parseSetDynamicTableCapacity(buffer);
+                    }
+                    else
+                    {
+                        _state = State.DUPLICATE;
+                        _integerDecoder.setPrefix(5);
+                        parseDuplicate(buffer);
+                    }
+                    break;
+
+                case SET_CAPACITY:
                     parseSetDynamicTableCapacity(buffer);
-                }
-                else
-                {
-                    _state = State.DUPLICATE;
-                    _integerDecoder.setPrefix(5);
+                    break;
+
+                case DUPLICATE:
                     parseDuplicate(buffer);
-                }
-                break;
+                    break;
 
-            case SET_CAPACITY:
-                parseSetDynamicTableCapacity(buffer);
-                break;
+                case LITERAL_NAME:
+                    parseInsertWithLiteralName(buffer);
+                    break;
 
-            case DUPLICATE:
-                parseDuplicate(buffer);
-                break;
+                case REFERENCED_NAME:
+                    parseInsertNameWithReference(buffer);
+                    break;
 
-            case LITERAL_NAME:
-                parseInsertWithLiteralName(buffer);
-                break;
-
-            case REFERENCED_NAME:
-                parseInsertNameWithReference(buffer);
-                break;
-
-            default:
-                throw new IllegalStateException(_state.name());
+                default:
+                    throw new IllegalStateException(_state.name());
+            }
         }
     }
 
     private void parseInsertNameWithReference(ByteBuffer buffer) throws QpackException, EncodingException
     {
-        while (true)
+        while (BufferUtil.hasContent(buffer))
         {
             switch (_operation)
             {
@@ -165,7 +173,7 @@ public class DecoderInstructionParser
 
     private void parseInsertWithLiteralName(ByteBuffer buffer) throws QpackException, EncodingException
     {
-        while (true)
+        while (BufferUtil.hasContent(buffer))
         {
             switch (_operation)
             {

--- a/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/parser/DecoderInstructionParser.java
+++ b/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/parser/DecoderInstructionParser.java
@@ -84,50 +84,34 @@ public class DecoderInstructionParser
         {
             switch (_state)
             {
-                case PARSING:
+                case PARSING ->
+                {
                     byte firstByte = buffer.get(buffer.position());
                     if ((firstByte & 0x80) != 0)
                     {
                         _state = State.REFERENCED_NAME;
-                        parseInsertNameWithReference(buffer);
                     }
                     else if ((firstByte & 0x40) != 0)
                     {
                         _state = State.LITERAL_NAME;
-                        parseInsertWithLiteralName(buffer);
                     }
                     else if ((firstByte & 0x20) != 0)
                     {
                         _state = State.SET_CAPACITY;
                         _integerDecoder.setPrefix(5);
-                        parseSetDynamicTableCapacity(buffer);
                     }
                     else
                     {
                         _state = State.DUPLICATE;
                         _integerDecoder.setPrefix(5);
-                        parseDuplicate(buffer);
                     }
-                    break;
+                }
 
-                case SET_CAPACITY:
-                    parseSetDynamicTableCapacity(buffer);
-                    break;
-
-                case DUPLICATE:
-                    parseDuplicate(buffer);
-                    break;
-
-                case LITERAL_NAME:
-                    parseInsertWithLiteralName(buffer);
-                    break;
-
-                case REFERENCED_NAME:
-                    parseInsertNameWithReference(buffer);
-                    break;
-
-                default:
-                    throw new IllegalStateException(_state.name());
+                case SET_CAPACITY -> parseSetDynamicTableCapacity(buffer);
+                case DUPLICATE -> parseDuplicate(buffer);
+                case LITERAL_NAME -> parseInsertWithLiteralName(buffer);
+                case REFERENCED_NAME -> parseInsertNameWithReference(buffer);
+                default -> throw new IllegalStateException(_state.name());
             }
         }
     }
@@ -138,23 +122,24 @@ public class DecoderInstructionParser
         {
             switch (_operation)
             {
-                case NONE:
+                case NONE ->
+                {
                     byte firstByte = buffer.get(buffer.position());
                     _referenceDynamicTable = (firstByte & 0x40) == 0;
                     _operation = Operation.INDEX;
                     _integerDecoder.setPrefix(6);
-                    continue;
-
-                case INDEX:
+                }
+                case INDEX ->
+                {
                     _index = _integerDecoder.decodeInt(buffer);
                     if (_index < 0)
                         return;
 
                     _operation = Operation.VALUE;
                     _stringDecoder.setPrefix(8);
-                    continue;
-
-                case VALUE:
+                }
+                case VALUE ->
+                {
                     String value = _stringDecoder.decode(buffer);
                     if (value == null)
                         return;
@@ -164,9 +149,9 @@ public class DecoderInstructionParser
                     reset();
                     _handler.onInsertNameWithReference(index, dynamic, value);
                     return;
+                }
 
-                default:
-                    throw new IllegalStateException(_operation.name());
+                default -> throw new IllegalStateException(_operation.name());
             }
         }
     }
@@ -177,21 +162,22 @@ public class DecoderInstructionParser
         {
             switch (_operation)
             {
-                case NONE:
+                case NONE ->
+                {
                     _operation = Operation.NAME;
                     _stringDecoder.setPrefix(6);
-                    continue;
-
-                case NAME:
+                }
+                case NAME ->
+                {
                     _name = _stringDecoder.decode(buffer);
                     if (_name == null)
                         return;
 
                     _operation = Operation.VALUE;
                     _stringDecoder.setPrefix(8);
-                    continue;
-
-                case VALUE:
+                }
+                case VALUE ->
+                {
                     String value = _stringDecoder.decode(buffer);
                     if (value == null)
                         return;
@@ -200,9 +186,8 @@ public class DecoderInstructionParser
                     reset();
                     _handler.onInsertWithLiteralName(name, value);
                     return;
-
-                default:
-                    throw new IllegalStateException(_operation.name());
+                }
+                default -> throw new IllegalStateException(_operation.name());
             }
         }
     }

--- a/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/parser/EncoderInstructionParser.java
+++ b/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/parser/EncoderInstructionParser.java
@@ -67,43 +67,30 @@ public class EncoderInstructionParser
         {
             switch (_state)
             {
-                case IDLE:
+                case IDLE ->
+                {
                     // Get first byte without incrementing the buffers position.
                     byte firstByte = buffer.get(buffer.position());
                     if ((firstByte & 0x80) != 0)
                     {
                         _state = State.SECTION_ACKNOWLEDGEMENT;
                         _integerDecoder.setPrefix(SECTION_ACKNOWLEDGEMENT_PREFIX);
-                        parseSectionAcknowledgment(buffer);
                     }
                     else if ((firstByte & 0x40) != 0)
                     {
                         _state = State.STREAM_CANCELLATION;
                         _integerDecoder.setPrefix(STREAM_CANCELLATION_PREFIX);
-                        parseStreamCancellation(buffer);
                     }
                     else
                     {
                         _state = State.INSERT_COUNT_INCREMENT;
                         _integerDecoder.setPrefix(INSERT_COUNT_INCREMENT_PREFIX);
-                        parseInsertCountIncrement(buffer);
                     }
-                    break;
-
-                case SECTION_ACKNOWLEDGEMENT:
-                    parseSectionAcknowledgment(buffer);
-                    break;
-
-                case STREAM_CANCELLATION:
-                    parseStreamCancellation(buffer);
-                    break;
-
-                case INSERT_COUNT_INCREMENT:
-                    parseInsertCountIncrement(buffer);
-                    break;
-
-                default:
-                    throw new IllegalStateException(_state.name());
+                }
+                case SECTION_ACKNOWLEDGEMENT -> parseSectionAcknowledgment(buffer);
+                case STREAM_CANCELLATION -> parseStreamCancellation(buffer);
+                case INSERT_COUNT_INCREMENT -> parseInsertCountIncrement(buffer);
+                default -> throw new IllegalStateException(_state.name());
             }
         }
     }

--- a/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/parser/EncoderInstructionParser.java
+++ b/jetty-core/jetty-http3/jetty-http3-qpack/src/main/java/org/eclipse/jetty/http3/qpack/internal/parser/EncoderInstructionParser.java
@@ -17,6 +17,7 @@ import java.nio.ByteBuffer;
 
 import org.eclipse.jetty.http.compression.NBitIntegerDecoder;
 import org.eclipse.jetty.http3.qpack.QpackException;
+import org.eclipse.jetty.util.BufferUtil;
 
 /**
  * Parses a stream of unframed instructions for the Encoder. These instructions are sent from the remote Decoder.
@@ -54,50 +55,56 @@ public class EncoderInstructionParser
         _integerDecoder = new NBitIntegerDecoder();
     }
 
+    /**
+     * This will parse and fully consume the given {@link ByteBuffer} and notifies
+     * the {@link Handler} supplied in the constructor for any resulting events.
+     * @param buffer the buffer to parse.
+     * @throws QpackException if there was an error parsing the instructions.
+     */
     public void parse(ByteBuffer buffer) throws QpackException
     {
-        if (buffer == null || !buffer.hasRemaining())
-            return;
-
-        switch (_state)
+        while (BufferUtil.hasContent(buffer))
         {
-            case IDLE:
-                // Get first byte without incrementing the buffers position.
-                byte firstByte = buffer.get(buffer.position());
-                if ((firstByte & 0x80) != 0)
-                {
-                    _state = State.SECTION_ACKNOWLEDGEMENT;
-                    _integerDecoder.setPrefix(SECTION_ACKNOWLEDGEMENT_PREFIX);
+            switch (_state)
+            {
+                case IDLE:
+                    // Get first byte without incrementing the buffers position.
+                    byte firstByte = buffer.get(buffer.position());
+                    if ((firstByte & 0x80) != 0)
+                    {
+                        _state = State.SECTION_ACKNOWLEDGEMENT;
+                        _integerDecoder.setPrefix(SECTION_ACKNOWLEDGEMENT_PREFIX);
+                        parseSectionAcknowledgment(buffer);
+                    }
+                    else if ((firstByte & 0x40) != 0)
+                    {
+                        _state = State.STREAM_CANCELLATION;
+                        _integerDecoder.setPrefix(STREAM_CANCELLATION_PREFIX);
+                        parseStreamCancellation(buffer);
+                    }
+                    else
+                    {
+                        _state = State.INSERT_COUNT_INCREMENT;
+                        _integerDecoder.setPrefix(INSERT_COUNT_INCREMENT_PREFIX);
+                        parseInsertCountIncrement(buffer);
+                    }
+                    break;
+
+                case SECTION_ACKNOWLEDGEMENT:
                     parseSectionAcknowledgment(buffer);
-                }
-                else if ((firstByte & 0x40) != 0)
-                {
-                    _state = State.STREAM_CANCELLATION;
-                    _integerDecoder.setPrefix(STREAM_CANCELLATION_PREFIX);
+                    break;
+
+                case STREAM_CANCELLATION:
                     parseStreamCancellation(buffer);
-                }
-                else
-                {
-                    _state = State.INSERT_COUNT_INCREMENT;
-                    _integerDecoder.setPrefix(INSERT_COUNT_INCREMENT_PREFIX);
+                    break;
+
+                case INSERT_COUNT_INCREMENT:
                     parseInsertCountIncrement(buffer);
-                }
-                break;
+                    break;
 
-            case SECTION_ACKNOWLEDGEMENT:
-                parseSectionAcknowledgment(buffer);
-                break;
-
-            case STREAM_CANCELLATION:
-                parseStreamCancellation(buffer);
-                break;
-
-            case INSERT_COUNT_INCREMENT:
-                parseInsertCountIncrement(buffer);
-                break;
-
-            default:
-                throw new IllegalStateException(_state.name());
+                default:
+                    throw new IllegalStateException(_state.name());
+            }
         }
     }
 

--- a/jetty-core/jetty-http3/jetty-http3-qpack/src/test/java/org/eclipse/jetty/http3/qpack/DecoderInstructionParserTest.java
+++ b/jetty-core/jetty-http3/jetty-http3-qpack/src/test/java/org/eclipse/jetty/http3/qpack/DecoderInstructionParserTest.java
@@ -129,8 +129,7 @@ public class DecoderInstructionParserTest
         // Parse the buffer 1 byte at a time.
         while (buffer.hasRemaining())
         {
-            ByteBuffer oneByte = buffer.slice();
-            oneByte.limit(1);
+            ByteBuffer oneByte = buffer.slice(buffer.position(), 1);
             _instructionParser.parse(oneByte);
             buffer.position(buffer.position() + 1);
         }

--- a/jetty-core/jetty-http3/jetty-http3-qpack/src/test/java/org/eclipse/jetty/http3/qpack/DecoderInstructionParserTest.java
+++ b/jetty-core/jetty-http3/jetty-http3-qpack/src/test/java/org/eclipse/jetty/http3/qpack/DecoderInstructionParserTest.java
@@ -15,8 +15,10 @@ package org.eclipse.jetty.http3.qpack;
 
 import java.nio.ByteBuffer;
 
+import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http3.qpack.internal.instruction.DuplicateInstruction;
 import org.eclipse.jetty.http3.qpack.internal.instruction.IndexedNameEntryInstruction;
+import org.eclipse.jetty.http3.qpack.internal.instruction.LiteralNameEntryInstruction;
 import org.eclipse.jetty.http3.qpack.internal.instruction.SetCapacityInstruction;
 import org.eclipse.jetty.http3.qpack.internal.parser.DecoderInstructionParser;
 import org.eclipse.jetty.io.ByteBufferPool;
@@ -24,6 +26,7 @@ import org.eclipse.jetty.io.RetainableByteBuffer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.eclipse.jetty.http3.qpack.QpackTestUtil.toBuffer;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -106,6 +109,31 @@ public class DecoderInstructionParserTest
         // Insert With Literal Name (custom-key=custom-value).
         ByteBuffer buffer = QpackTestUtil.hexToBuffer("4a63 7573 746f 6d2d 6b65 790c 6375 7374 6f6d 2d76 616c 7565");
         _instructionParser.parse(buffer);
+
+        // We received the instruction correctly.
+        DecoderParserDebugHandler.LiteralEntry entry = _handler.literalNameEntries.poll();
+        assertNotNull(entry);
+        assertThat(entry.name, is("custom-key"));
+        assertThat(entry.value, is("custom-value"));
+
+        // There are no other instructions received.
+        assertTrue(_handler.isEmpty());
+    }
+
+    @Test
+    public void testOneByteAtATime() throws Exception
+    {
+        HttpField httpField = new HttpField("custom-key", "custom-value");
+        ByteBuffer buffer = toBuffer(new LiteralNameEntryInstruction(httpField, true));
+
+        // Parse the buffer 1 byte at a time.
+        while (buffer.hasRemaining())
+        {
+            ByteBuffer oneByte = buffer.slice();
+            oneByte.limit(1);
+            _instructionParser.parse(oneByte);
+            buffer.position(buffer.position() + 1);
+        }
 
         // We received the instruction correctly.
         DecoderParserDebugHandler.LiteralEntry entry = _handler.literalNameEntries.poll();

--- a/jetty-core/jetty-http3/jetty-http3-qpack/src/test/java/org/eclipse/jetty/http3/qpack/EncoderInstructionParserTest.java
+++ b/jetty-core/jetty-http3/jetty-http3-qpack/src/test/java/org/eclipse/jetty/http3/qpack/EncoderInstructionParserTest.java
@@ -77,17 +77,17 @@ public class EncoderInstructionParserTest
 
         // Test with continuation.
         encoded = "FFBA09";
-        byte[] bytes = StringUtil.fromHexString(encoded);
-        for (int i = 0; i < 10; i++)
+        buffer = BufferUtil.toBuffer(StringUtil.fromHexString(encoded));
+        while (buffer.hasRemaining())
         {
-            ByteBuffer buffer1 = BufferUtil.toBuffer(bytes, 0, 2);
-            ByteBuffer buffer2 = BufferUtil.toBuffer(bytes, 2, 1);
-            _instructionParser.parse(buffer1);
-            assertTrue(_handler.isEmpty());
-            _instructionParser.parse(buffer2);
-            assertThat(_handler.sectionAcknowledgements.poll(), is(1337L));
-            assertTrue(_handler.isEmpty());
+            ByteBuffer oneByte = buffer.slice();
+            oneByte.limit(1);
+            _instructionParser.parse(oneByte);
+            buffer.position(buffer.position() + 1);
         }
+
+        assertThat(_handler.sectionAcknowledgements.poll(), is(1337L));
+        assertTrue(_handler.isEmpty());
     }
 
     @Test

--- a/jetty-core/jetty-http3/jetty-http3-qpack/src/test/java/org/eclipse/jetty/http3/qpack/EncoderInstructionParserTest.java
+++ b/jetty-core/jetty-http3/jetty-http3-qpack/src/test/java/org/eclipse/jetty/http3/qpack/EncoderInstructionParserTest.java
@@ -80,8 +80,7 @@ public class EncoderInstructionParserTest
         buffer = BufferUtil.toBuffer(StringUtil.fromHexString(encoded));
         while (buffer.hasRemaining())
         {
-            ByteBuffer oneByte = buffer.slice();
-            oneByte.limit(1);
+            ByteBuffer oneByte = buffer.slice(buffer.position(), 1);
             _instructionParser.parse(oneByte);
             buffer.position(buffer.position() + 1);
         }

--- a/jetty-core/jetty-http3/jetty-http3-qpack/src/test/java/org/eclipse/jetty/http3/qpack/QpackTestUtil.java
+++ b/jetty-core/jetty-http3/jetty-http3-qpack/src/test/java/org/eclipse/jetty/http3/qpack/QpackTestUtil.java
@@ -51,6 +51,11 @@ public class QpackTestUtil
         return org.hamcrest.text.IsEqualIgnoringCase.equalToIgnoringCase(expectedString);
     }
 
+    public static ByteBuffer toBuffer(Instruction instruction)
+    {
+        return toBuffer(List.of(instruction));
+    }
+
     public static ByteBuffer toBuffer(List<Instruction> instructions)
     {
         ByteBufferPool bufferPool = ByteBufferPool.NON_POOLING;


### PR DESCRIPTION
### Issue #14494

When parsing an incomplete QPACK instruction under certain conditions the parser would loop around and try to read from an empty buffer.