### PR TITLE
ResourceFactory.newResource(String) strip out CR and LF 

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
@@ -202,6 +202,9 @@ public interface ResourceFactory
      */
     default Resource newClassLoaderResource(String resource, boolean searchSystemClassLoader)
     {
+        if (resource != null)
+            // Facilitates XML configurations.
+            resource = resource.replaceAll("[\\r\\n]+", "");
         if (StringUtil.isBlank(resource))
             throw new IllegalArgumentException("Resource String is invalid: " + resource);
 
@@ -332,6 +335,9 @@ public interface ResourceFactory
      */
     default Resource newResource(String resource)
     {
+        if (resource != null)
+            // Facilitates XML configurations.
+            resource = resource.replaceAll("[\\r\\n]+", "");
         if (StringUtil.isBlank(resource))
             throw new IllegalArgumentException("Resource String is invalid: " + resource);
 


### PR DESCRIPTION
`ResourceFactory.newResource(String)` and `newClassLoaderResource(String, boolean)` now strip out CR and LF to simplify XML configurations.

This allows nicer auto-formatting from the XML POV. Without this PR, the following would fail due to CR and/or LF within the path:
```xml
<New class="org.eclipse.jetty.util.ssl.SslContextFactory$Server">
    <Set name="keyStorePath">
        <!-- Without this PR, you MUST not have SystemProperty elements on separate lines or the resulting path will have EOLs in it and fail loading. -->
        <SystemProperty default="./" name="my.app.home.dir.system.property" />
        <SystemProperty default="../security/keystore" name="my.app.system.property.keyStorePath" />
    </Set>
...

The property names above are for illustrative purposes (ours are just as long but include internal name parts).