### PR TITLE
Fixes #14651 - Retain negative Max-Age cookie attribute.

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java
@@ -561,7 +561,7 @@ public interface HttpCookie
             if (name == null)
                 return this;
             // Sanity checks on the values, expensive but necessary to avoid to store garbage.
-            switch (name.toLowerCase(Locale.ENGLISH))
+            switch (name.toLowerCase(Locale.ROOT))
             {
                 case "expires" -> expires(StringUtil.isBlank(value) ? null : parseExpires(value));
                 case "httponly" -> httpOnly(asBoolean("httponly", value));
@@ -608,10 +608,7 @@ public interface HttpCookie
 
         public Builder maxAge(long maxAge)
         {
-            if (maxAge >= 0)
-                _attributes = lazyAttributePut(_attributes, MAX_AGE_ATTRIBUTE, Long.toString(maxAge));
-            else
-                _attributes = lazyAttributeRemove(_attributes, MAX_AGE_ATTRIBUTE);
+            _attributes = lazyAttributePut(_attributes, MAX_AGE_ATTRIBUTE, Long.toString(maxAge));
             return this;
         }
 
@@ -834,7 +831,7 @@ public interface HttpCookie
     {
         String domain = httpCookie.getDomain();
         if (domain != null)
-            domain = domain.toLowerCase(Locale.ENGLISH);
+            domain = domain.toLowerCase(Locale.ROOT);
         return Objects.hash(httpCookie.getName(), domain, httpCookie.getPath());
     }
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookieStore.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookieStore.java
@@ -120,6 +120,16 @@ public interface HttpCookieStore
 
     /**
      * <p>A default implementation of {@link HttpCookieStore}.</p>
+     * <p>RFC 6265, section 5.2.2, states that negative values of the
+     * {@code Max-Age} attribute should be treated like `0`, which
+     * indicates that the cookie is expired.
+     * However, the de-facto standard for implementations (browsers
+     * and {@link java.net.http.HttpClient}) is that negative values
+     * are treated as "session cookie": a cookie that is not expired,
+     * but won't be persisted and will be removed when the browser
+     * or client is closed or stopped.
+     * This is in line with the javadocs of {@link java.net.HttpCookie}
+     * as well as {@code jakarta.servlet.http.Cookie}.
      */
     class Default implements HttpCookieStore
     {

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookieStore.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookieStore.java
@@ -124,11 +124,11 @@ public interface HttpCookieStore
      * {@code Max-Age} attribute should be treated like `0`, which
      * indicates that the cookie is expired.
      * However, the de-facto standard for implementations (browsers
-     * and {@link java.net.http.HttpClient}) is that negative values
+     * and {@code java.net.http.HttpClient}) is that negative values
      * are treated as "session cookie": a cookie that is not expired,
      * but won't be persisted and will be removed when the browser
      * or client is closed or stopped.
-     * This is in line with the javadocs of {@link java.net.HttpCookie}
+     * This is in line with the javadocs of {@code java.net.HttpCookie}
      * as well as {@code jakarta.servlet.http.Cookie}.
      */
     class Default implements HttpCookieStore

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpCookieTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpCookieTest.java
@@ -55,6 +55,10 @@ public class HttpCookieTest
             Arguments.of("A=B; a=", HttpCookie.build("A", "B").attribute("a", "").build()),
             Arguments.of("A=B; a=v", HttpCookie.build("A", "B").attribute("a", "v").build()),
             Arguments.of("A=B; Secure; Path=/", HttpCookie.build("A", "B").secure(true).path("/").build()),
+            Arguments.of("A=B; Max-Age=-2", HttpCookie.build("A", "B").maxAge(-2).build()),
+            Arguments.of("A=B; Max-Age=-1", HttpCookie.build("A", "B").maxAge(-1).build()),
+            Arguments.of("A=B; Max-Age=0", HttpCookie.build("A", "B").maxAge(0).build()),
+            Arguments.of("A=B; Max-Age=1", HttpCookie.build("A", "B").maxAge(1).build()),
             // Quoted cookie.
             Arguments.of("A=\"1\"", HttpCookie.build("A", "1").build()),
             Arguments.of("A=\"1\"; HttpOnly", HttpCookie.build("A", "1").httpOnly(true).build()),
@@ -156,5 +160,17 @@ public class HttpCookieTest
         assertThat(noAttributes.getSameSite(), nullValue());
         assertThat(noAttributes.isSecure(), is(false));
         assertThat(noAttributes.isPartitioned(), is(false));
+    }
+
+    @Test
+    public void testNegativeMaxAge()
+    {
+        HttpCookie cookie = HttpCookie.build("A", "B").maxAge(-1).build();
+        assertThat(cookie.getAttributes().size(), is(1));
+        assertThat(cookie.getMaxAge(), is(-1L));
+
+        cookie = HttpCookie.build("A", "B").attribute("max-age", "-2").build();
+        assertThat(cookie.getAttributes().size(), is(1));
+        assertThat(cookie.getMaxAge(), is(-2L));
     }
 }

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpCookieTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpCookieTest.java
@@ -295,7 +295,6 @@ public class HttpCookieTest
             .comment(null)
             .domain(null)
             .httpOnly(false)
-            .maxAge(-1)
             .secure(false)
             .path(null)
             .build();


### PR DESCRIPTION
* Retaining the `Max-Age` attribute when negative.
* Clarified javadocs.