### PR TITLE
Modify `HttpContent` caching such as it does not apply to content with unknown length

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/CachingHttpContentFactory.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/CachingHttpContentFactory.java
@@ -218,6 +218,10 @@ public class CachingHttpContentFactory implements HttpContent.Factory
         if (httpContent.getResource().isDirectory())
             return false;
 
+        // Content with unknown length is not cacheable.
+        if (httpContent.getContentLengthValue() < 0L)
+            return false;
+
         if (_maxCachedFiles <= 0)
             return false;
 
@@ -243,21 +247,12 @@ public class CachingHttpContentFactory implements HttpContent.Factory
         if (!isCacheable(httpContent))
             return httpContent;
 
-        AtomicBoolean added = new AtomicBoolean();
         cachingHttpContent = _cache.computeIfAbsent(path, key ->
         {
             try
             {
                 CachingHttpContent cachingContent = (httpContent == null) ? newNotFoundContent(key) : newCachedContent(key, httpContent);
-                long contentLengthValue = cachingContent.getContentLengthValue();
-                if (contentLengthValue < 0L)
-                {
-                    if (LOG.isDebugEnabled())
-                        LOG.debug("Content at path '{}' with unknown length is not cacheable: {}", path, httpContent);
-                    return null;
-                }
-                added.set(true);
-                _cachedSize.addAndGet(contentLengthValue);
+                _cachedSize.addAndGet(cachingContent.getContentLengthValue());
                 return cachingContent;
             }
             catch (Throwable x)
@@ -268,13 +263,16 @@ public class CachingHttpContentFactory implements HttpContent.Factory
             }
         });
 
-        if (added.get())
+        if (cachingHttpContent != null)
         {
             // We want to shrink cache only if we have just added an entry.
             shrinkCache();
+            return (cachingHttpContent instanceof NotFoundHttpContent) ? null : cachingHttpContent;
         }
-
-        return (cachingHttpContent instanceof NotFoundHttpContent) ? null : cachingHttpContent;
+        else
+        {
+            return httpContent;
+        }
     }
 
     protected CachingHttpContent newCachedContent(String p, HttpContent httpContent)

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/CachingHttpContentFactory.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/content/CachingHttpContentFactory.java
@@ -247,11 +247,13 @@ public class CachingHttpContentFactory implements HttpContent.Factory
         if (!isCacheable(httpContent))
             return httpContent;
 
+        AtomicBoolean added = new AtomicBoolean();
         cachingHttpContent = _cache.computeIfAbsent(path, key ->
         {
             try
             {
                 CachingHttpContent cachingContent = (httpContent == null) ? newNotFoundContent(key) : newCachedContent(key, httpContent);
+                added.set(true);
                 _cachedSize.addAndGet(cachingContent.getContentLengthValue());
                 return cachingContent;
             }
@@ -263,16 +265,15 @@ public class CachingHttpContentFactory implements HttpContent.Factory
             }
         });
 
-        if (cachingHttpContent != null)
+        if (added.get())
         {
             // We want to shrink cache only if we have just added an entry.
             shrinkCache();
-            return (cachingHttpContent instanceof NotFoundHttpContent) ? null : cachingHttpContent;
         }
-        else
-        {
-            return httpContent;
-        }
+
+        if (cachingHttpContent instanceof NotFoundHttpContent)
+            return null;
+        return cachingHttpContent != null ? cachingHttpContent : httpContent;
     }
 
     protected CachingHttpContent newCachedContent(String p, HttpContent httpContent)

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/content/CachingHttpContentFactoryTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/content/CachingHttpContentFactoryTest.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.http.content;
 
 import java.io.ByteArrayOutputStream;
 import java.net.URI;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -59,10 +60,9 @@ public class CachingHttpContentFactoryTest
     }
 
     @Test
-    public void testUnknownLength() throws Exception
+    public void testUnknownLengthIsNotCached() throws Exception
     {
-        ResourceHttpContent content = new ResourceHttpContent(new MemoryResource(URI.create("file://test"), new byte[] {(byte)0xAA}), "text/html");
-        HttpContent.Factory delegate = path -> new HttpContent.Wrapper(content)
+        HttpContent.Factory authority = path -> new HttpContent.Wrapper(new ResourceHttpContent(new MemoryResource(URI.create("file://test"), new byte[] {'a', 'b', 'c'}), "text/html", sizedPool))
         {
             @Override
             public long getContentLengthValue()
@@ -71,15 +71,19 @@ public class CachingHttpContentFactoryTest
             }
         };
 
-        CachingHttpContentFactory cache = new CachingHttpContentFactory(delegate, sizedPool);
+        CachingHttpContentFactory cachingHttpContentFactory = new CachingHttpContentFactory(authority, sizedPool);
 
-        HttpContent httpContent = cache.getContent("/something");
+        HttpContent httpContent = cachingHttpContentFactory.getContent("path");
+        assertThat(cachingHttpContentFactory.getCachedFiles(), is(0));
         assertThat(httpContent.getResource().getURI(), is(URI.create("file://test")));
         RetainableByteBuffer rbb = IOResources.toRetainableByteBuffer(httpContent.getResource(), sizedPool);
         try
         {
-            assertThat(rbb.getByteBuffer().remaining(), is(1));
-            assertThat(rbb.getByteBuffer().get(), is((byte)0xAA));
+            ByteBuffer byteBuffer = rbb.getByteBuffer();
+            assertThat(byteBuffer.remaining(), is(3));
+            assertThat(byteBuffer.get(), is((byte)'a'));
+            assertThat(byteBuffer.get(), is((byte)'b'));
+            assertThat(byteBuffer.get(), is((byte)'c'));
         }
         finally
         {
@@ -95,9 +99,11 @@ public class CachingHttpContentFactoryTest
         CachingHttpContentFactory cachingHttpContentFactory = new CachingHttpContentFactory(resourceHttpContentFactory, sizedPool);
 
         HttpContent content = cachingHttpContentFactory.getContent("file.txt");
+        assertThat(cachingHttpContentFactory.getCachedFiles(), is(1));
 
         // Empty the cache so 'content' gets released.
         cachingHttpContentFactory.flushCache();
+        assertThat(cachingHttpContentFactory.getCachedFiles(), is(0));
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (Blocker.Callback cb = Blocker.callback())

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/content/CachingHttpContentFactoryTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/content/CachingHttpContentFactoryTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.http.content;
 
 import java.io.ByteArrayOutputStream;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -22,9 +23,12 @@ import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.io.ArrayByteBufferPool;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.io.IOResources;
+import org.eclipse.jetty.io.RetainableByteBuffer;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.Blocker;
+import org.eclipse.jetty.util.resource.MemoryResource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,6 +56,35 @@ public class CachingHttpContentFactoryTest
     public void tearDown()
     {
         assertThat("Leaks: " + trackingPool.dumpLeaks(), trackingPool.getLeaks().size(), is(0));
+    }
+
+    @Test
+    public void testUnknownLength() throws Exception
+    {
+        ResourceHttpContent content = new ResourceHttpContent(new MemoryResource(URI.create("file://test"), new byte[] {(byte)0xAA}), "text/html");
+        HttpContent.Factory delegate = path -> new HttpContent.Wrapper(content)
+        {
+            @Override
+            public long getContentLengthValue()
+            {
+                return -1;
+            }
+        };
+
+        CachingHttpContentFactory cache = new CachingHttpContentFactory(delegate, sizedPool);
+
+        HttpContent httpContent = cache.getContent("/something");
+        assertThat(httpContent.getResource().getURI(), is(URI.create("file://test")));
+        RetainableByteBuffer rbb = IOResources.toRetainableByteBuffer(httpContent.getResource(), sizedPool);
+        try
+        {
+            assertThat(rbb.getByteBuffer().remaining(), is(1));
+            assertThat(rbb.getByteBuffer().get(), is((byte)0xAA));
+        }
+        finally
+        {
+            rbb.release();
+        }
     }
 
     @Test


### PR DESCRIPTION
Fixes #14685