### PR TITLE
Clarify 400 error related to HTTP/2

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -1608,7 +1608,7 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
             @SuppressWarnings("ReferenceEquality")
             boolean isPriorKnowledgeH2C = _upgrade == PREAMBLE_UPGRADE_H2C;
             if (!isPriorKnowledgeH2C  && !_connectionUpgrade)
-                throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400);
+                throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Unexpected Upgrade header");
 
             // Find the upgrade factory.
             ConnectionFactory.Upgrading factory = getConnector().getConnectionFactories().stream()

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -1608,7 +1608,7 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
             @SuppressWarnings("ReferenceEquality")
             boolean isPriorKnowledgeH2C = _upgrade == PREAMBLE_UPGRADE_H2C;
             if (!isPriorKnowledgeH2C  && !_connectionUpgrade)
-                throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Unexpected Upgrade header");
+                throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, "Invalid H2C upgrade headers");
 
             // Find the upgrade factory.
             ConnectionFactory.Upgrading factory = getConnector().getConnectionFactories().stream()


### PR DESCRIPTION
In some Jenkins-related code I ran into an obstacle that a request made by a `java.net.http` client directly to the Jenkins controller worked fine, but when the same request was run through an Undertow reverse proxy it would fail. The symptom was that Jetty would respond with a 400 error page with no explanation (and no server-side log messages).

Earlier I had seen a similar symptom specific to ALB on AWS which I suspect had the same root cause, but unconfirmed; worked around at that time by switching to the `java.net` client, something I just hit upon by accident.

https://github.com/jenkinsci/winstone/pull/532 looked like it might help in the newer (Undertow) case, but it did not.

After

```diff
diff --git jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
index 82dcc63e4f8..68825b1ba8d 100644
--- jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
+++ jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/Response.java
@@ -588,6 +588,7 @@ public interface Response extends Content.Sink
         {
             status = httpException.getCode();
             message = httpException.getReason();
+            cause.printStackTrace();
         }
         writeError(request, response, callback, status, message, cause);
     }
diff --git jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ErrorHandler.java jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ErrorHandler.java
index f694767d37e..03dead4314c 100644
--- jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ErrorHandler.java
+++ jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ErrorHandler.java
@@ -359,6 +359,7 @@ public class ErrorHandler implements Request.Handler
 
     protected void writeErrorHtmlMessage(Request request, Writer writer, int code, String message, Throwable cause, String uri) throws IOException
     {
+        Thread.dumpStack();
         writer.write("<h2>HTTP ERROR ");
         String status = Integer.toString(code);
         writer.write(status);
```

I was able to determine that the error was coming from the line of code patched here, introduced in d1e6c772c6f0c0e1758d5733f86ddf5cca644f42 and retained in #8685. While I do not exactly understand the issue, configuring the client to avoid HTTP/2

```java
builder.version(HttpClient.Version.HTTP_1_1)
```

solved the problem.

The error page could perhaps include _somewhat_ more information, but I wanted to err on the side of caution when disclosing information to a client; this should be just enough to clue you in that something related to HTTP/2 is involved. Otherwise a 400 error could point to any of a vast array of mistakes.
