### PR TITLE
Add guards for debug and trace logging

### DIFF
--- a/jetty-core/jetty-ee/jetty-ee-webapp/src/main/java/org/eclipse/jetty/ee/webapp/WebAppClassLoader.java
+++ b/jetty-core/jetty-ee/jetty-ee-webapp/src/main/java/org/eclipse/jetty/ee/webapp/WebAppClassLoader.java
@@ -651,7 +651,8 @@ public class WebAppClassLoader extends URLClassLoader implements ClassVisibility
             }
             catch (Throwable t)
             {
-                LOG.trace("could not read manifest of {}", url, t);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("could not read manifest of {}", url, t);
             }
 
             definePackage(packageName, null, null, null, null, null, null, null);

--- a/jetty-core/jetty-http-spi/src/main/java/org/eclipse/jetty/http/spi/HttpSpiContextHandler.java
+++ b/jetty-core/jetty-http-spi/src/main/java/org/eclipse/jetty/http/spi/HttpSpiContextHandler.java
@@ -67,7 +67,8 @@ public class HttpSpiContextHandler extends ContextHandler
                 }
                 catch (Throwable t)
                 {
-                    LOG.atDebug().setCause(t).log("Failed to handle");
+                    if (LOG.isDebugEnabled())
+                        LOG.atDebug().setCause(t).log("Failed to handle");
                     Response.writeError(request, response, callback, 500, null, t);
                 }
                 return true;

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CookieCutter.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/CookieCutter.java
@@ -240,7 +240,8 @@ public class CookieCutter implements CookieParser
                                 }
                                 catch (Exception e)
                                 {
-                                    LOG.debug("Unable to process Cookie", e);
+                                    if (LOG.isDebugEnabled())
+                                        LOG.debug("Unable to process Cookie", e);
                                 }
 
                                 name = null;

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpGenerator.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpGenerator.java
@@ -247,7 +247,8 @@ public class HttpGenerator
                 }
                 catch (BufferOverflowException e)
                 {
-                    LOG.trace("IGNORED", e);
+                    if (LOG.isTraceEnabled())
+                        LOG.trace("IGNORED", e);
                     return Result.HEADER_OVERFLOW;
                 }
                 catch (Exception e)
@@ -433,7 +434,8 @@ public class HttpGenerator
                 }
                 catch (BufferOverflowException e)
                 {
-                    LOG.trace("IGNORED", e);
+                    if (LOG.isTraceEnabled())
+                        LOG.trace("IGNORED", e);
                     return Result.HEADER_OVERFLOW;
                 }
                 catch (Exception e)

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -2321,9 +2321,11 @@ public class HttpParser
                 default -> null;
             };
             if (info == null)
-                LOG.debug("{} --> {}", _state, state);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("{} --> {}", _state, state);
             else
-                LOG.debug("{} --> {}({})", _state, state, info);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("{} --> {}({})", _state, state, info);
         }
         _state = state;
     }
@@ -2333,9 +2335,11 @@ public class HttpParser
         if (debugEnabled)
         {
             if (state != FieldState.FIELD)
-                LOG.debug("{}:{} --> {}", _state, _fieldState, state);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("{}:{} --> {}", _state, _fieldState, state);
             else
-                LOG.debug("{}:{} --> {}({}: {})", _state, _fieldState, state, _field != null ? _field : _headerString, _valueString);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("{}:{} --> {}({}: {})", _state, _fieldState, state, _field != null ? _field : _headerString, _valueString);
         }
         _fieldState = state;
     }
@@ -2343,7 +2347,8 @@ public class HttpParser
     private void setChunkSizeState(ChunkSizeState state)
     {
         if (debugEnabled)
-            LOG.debug("{}:{} --> {}", _state, _chunkSizeState, state);
+            if (LOG.isDebugEnabled())
+                LOG.debug("{}:{} --> {}", _state, _chunkSizeState, state);
         _chunkSizeState = state;
     }
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -2321,11 +2321,9 @@ public class HttpParser
                 default -> null;
             };
             if (info == null)
-                if (LOG.isDebugEnabled())
-                    LOG.debug("{} --> {}", _state, state);
+                LOG.debug("{} --> {}", _state, state);
             else
-                if (LOG.isDebugEnabled())
-                    LOG.debug("{} --> {}({})", _state, state, info);
+                LOG.debug("{} --> {}({})", _state, state, info);
         }
         _state = state;
     }
@@ -2335,11 +2333,9 @@ public class HttpParser
         if (debugEnabled)
         {
             if (state != FieldState.FIELD)
-                if (LOG.isDebugEnabled())
-                    LOG.debug("{}:{} --> {}", _state, _fieldState, state);
+                LOG.debug("{}:{} --> {}", _state, _fieldState, state);
             else
-                if (LOG.isDebugEnabled())
-                    LOG.debug("{}:{} --> {}({}: {})", _state, _fieldState, state, _field != null ? _field : _headerString, _valueString);
+                LOG.debug("{}:{} --> {}({}: {})", _state, _fieldState, state, _field != null ? _field : _headerString, _valueString);
         }
         _fieldState = state;
     }
@@ -2347,8 +2343,7 @@ public class HttpParser
     private void setChunkSizeState(ChunkSizeState state)
     {
         if (debugEnabled)
-            if (LOG.isDebugEnabled())
-                LOG.debug("{}:{} --> {}", _state, _chunkSizeState, state);
+            LOG.debug("{}:{} --> {}", _state, _chunkSizeState, state);
         _chunkSizeState = state;
     }
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/QuotedQualityCSV.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/QuotedQualityCSV.java
@@ -200,7 +200,8 @@ public class QuotedQualityCSV extends QuotedCSV implements Iterable<String>
             }
             catch (Exception e)
             {
-                LOG.trace("IGNORED", e);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", e);
                 q = 0.0D;
             }
             buffer.setLength(Math.max(0, paramName - 1));

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/ServerParser.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/parser/ServerParser.java
@@ -130,7 +130,8 @@ public class ServerParser extends Parser
         }
         catch (Throwable x)
         {
-            LOG.atDebug().setCause(x).log("Parse error");
+            if (LOG.isDebugEnabled())
+                LOG.atDebug().setCause(x).log("Parse error");
             BufferUtil.clear(buffer);
             notifyConnectionFailure(ErrorCode.PROTOCOL_ERROR.code, "parser_error");
         }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ManagedSelector.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ManagedSelector.java
@@ -431,7 +431,8 @@ public class ManagedSelector extends ContainerLifeCycle implements Dumpable
         }
         catch (Throwable x)
         {
-            LOG.trace("IGNORED", x);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", x);
             return -1;
         }
     }
@@ -444,7 +445,8 @@ public class ManagedSelector extends ContainerLifeCycle implements Dumpable
         }
         catch (Throwable x)
         {
-            LOG.trace("IGNORED", x);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", x);
             return -1;
         }
     }
@@ -780,7 +782,8 @@ public class ManagedSelector extends ContainerLifeCycle implements Dumpable
             }
             catch (InterruptedException x)
             {
-                LOG.trace("IGNORED", x);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", x);
             }
             return keys;
         }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/NegotiatingClientConnection.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/NegotiatingClientConnection.java
@@ -115,7 +115,8 @@ public abstract class NegotiatingClientConnection extends AbstractConnection.Non
 
         if (failure != null)
         {
-            LOG.atDebug().setCause(failure).log("Unable to fill from endpoint");
+            if (LOG.isDebugEnabled())
+                LOG.atDebug().setCause(failure).log("Unable to fill from endpoint");
             close();
             failConnectionPromise(failure);
         }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/SelectableChannelEndPoint.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/SelectableChannelEndPoint.java
@@ -138,7 +138,8 @@ public abstract class SelectableChannelEndPoint extends AbstractEndPoint impleme
         }
         catch (Throwable x)
         {
-            LOG.trace("Could not retrieve local socket address", x);
+            if (LOG.isTraceEnabled())
+                LOG.trace("Could not retrieve local socket address", x);
             return null;
         }
     }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/SelectorManager.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/SelectorManager.java
@@ -345,7 +345,10 @@ public abstract class SelectorManager extends ContainerLifeCycle implements Dump
             if (isRunning())
                 LOG.warn("Exception while notifying connection {}", connection, x);
             else
-                LOG.atDebug().setCause(x).log("Exception while notifying connection {}", connection);
+            {
+                if (LOG.isDebugEnabled())
+                    LOG.atDebug().setCause(x).log("Exception while notifying connection {}", connection);
+            }
             throw x;
         }
     }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/WriteFlusher.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/WriteFlusher.java
@@ -527,7 +527,8 @@ public abstract class WriteFlusher
                     if (LOG.isDebugEnabled())
                     {
                         LOG.debug("ignored: {} {}", cause, this);
-                        LOG.trace("IGNORED", cause);
+                        if (LOG.isTraceEnabled())
+                            LOG.trace("IGNORED", cause);
                     }
                     return false;
 

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
@@ -1032,7 +1032,8 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
             }
             catch (Throwable x)
             {
-                LOG.trace("IGNORED", x);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", x);
             }
         }
 
@@ -1048,12 +1049,14 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
             {
                 if (handshakeStatus == HandshakeStatus.NOT_HANDSHAKING && isRequireCloseMessage())
                     throw x;
-                LOG.trace("IGNORED", x);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", x);
                 return x;
             }
             catch (Throwable x)
             {
-                LOG.trace("IGNORED", x);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", x);
                 return x;
             }
         }
@@ -1474,7 +1477,8 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
             }
             catch (Throwable x)
             {
-                LOG.trace("IGNORED", x);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", x);
                 return true;
             }
         }
@@ -1518,7 +1522,8 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
             }
             catch (Throwable x)
             {
-                LOG.trace("IGNORED", x);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", x);
                 return true;
             }
         }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java
@@ -1319,7 +1319,8 @@ public class SslConnection extends AbstractConnection implements Connection.Upgr
                                 }
                                 catch (IOException e)
                                 {
-                                    LOG.debug("Incomplete flush?", e);
+                                    if (LOG.isDebugEnabled())
+                                        LOG.debug("Incomplete flush?", e);
                                     close(e);
                                     write = BufferUtil.EMPTY_BUFFER;
                                     _flushState = FlushState.WRITING;

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/SslConnectionTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/SslConnectionTest.java
@@ -250,7 +250,8 @@ public class SslConnectionTest
             }
             catch (InterruptedException | EofException e)
             {
-                LOG.trace("IGNORED", e);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", e);
             }
             catch (Exception e)
             {

--- a/jetty-core/jetty-jmx/src/main/java/org/eclipse/jetty/jmx/ConnectorServer.java
+++ b/jetty-core/jetty-jmx/src/main/java/org/eclipse/jetty/jmx/ConnectorServer.java
@@ -245,7 +245,8 @@ public class ConnectorServer extends AbstractLifeCycle
         }
         catch (Throwable ex)
         {
-            LOG.trace("IGNORED", ex);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", ex);
         }
 
         RMIClientSocketFactory csf = _sslContextFactory == null ? null : new SslRMIClientSocketFactory();
@@ -270,7 +271,8 @@ public class ConnectorServer extends AbstractLifeCycle
             }
             catch (Exception ex)
             {
-                LOG.trace("IGNORED", ex);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", ex);
             }
             finally
             {

--- a/jetty-core/jetty-jmx/src/main/java/org/eclipse/jetty/jmx/MBeanContainer.java
+++ b/jetty-core/jetty-jmx/src/main/java/org/eclipse/jetty/jmx/MBeanContainer.java
@@ -475,7 +475,8 @@ public class MBeanContainer implements Container.InheritedListener, Dumpable, De
         }
         catch (MBeanRegistrationException | InstanceNotFoundException x)
         {
-            LOG.trace("IGNORED", x);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", x);
         }
         catch (Throwable x)
         {

--- a/jetty-core/jetty-jndi/src/test/java/org/eclipse/jetty/jndi/java/TestJNDI.java
+++ b/jetty-core/jetty-jndi/src/test/java/org/eclipse/jetty/jndi/java/TestJNDI.java
@@ -270,11 +270,13 @@ public class TestJNDI
             NamingContext ncontext = (NamingContext)sub0;
 
             Name nn = ncontext.toCanonicalName(ncontext.getNameParser("").parse("/yellow/blue/"));
-            LOG.debug(nn.toString());
+            if (LOG.isDebugEnabled())
+                LOG.debug(nn.toString());
             assertEquals(2, nn.size());
 
             nn = ncontext.toCanonicalName(ncontext.getNameParser("").parse("/yellow/blue"));
-            LOG.debug(nn.toString());
+            if (LOG.isDebugEnabled())
+                LOG.debug(nn.toString());
             assertEquals(2, nn.size());
 
             nn = ncontext.toCanonicalName(ncontext.getNameParser("").parse("/"));
@@ -284,7 +286,8 @@ public class TestJNDI
             assertEquals(1, nn.size());
 
             nn = ncontext.toCanonicalName(ncontext.getNameParser("").parse(""));
-            LOG.debug(nn.toString());
+            if (LOG.isDebugEnabled())
+                LOG.debug(nn.toString());
             assertEquals(0, nn.size());
 
             Context fee = ncontext.createSubcontext("fee");

--- a/jetty-core/jetty-maven/src/main/java/org/eclipse/jetty/maven/SelectiveJarResource.java
+++ b/jetty-core/jetty-maven/src/main/java/org/eclipse/jetty/maven/SelectiveJarResource.java
@@ -202,8 +202,8 @@ public class SelectiveJarResource extends Resource
             while ((entry = jin.getNextJarEntry()) != null)
             {
                 String entryName = entry.getName();
-
-                LOG.debug("Looking at {}", entryName);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Looking at {}", entryName);
                 // make sure no access out of the root entry is present
                 if (URIUtil.isNotNormalWithinSelf(entryName))
                 {
@@ -224,10 +224,12 @@ public class SelectiveJarResource extends Resource
                                 Files.createDirectories(file);
                         }
                         else
-                            LOG.debug("{} dir is excluded", entryName);
+                            if (LOG.isDebugEnabled())
+                                LOG.debug("{} dir is excluded", entryName);
                     }
                     else
-                        LOG.debug("{} dir is NOT included", entryName);
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("{} dir is NOT included", entryName);
                 }
                 else
                 {
@@ -252,10 +254,12 @@ public class SelectiveJarResource extends Resource
                                 Files.setLastModifiedTime(file, FileTime.fromMillis(entry.getTime()));
                         }
                         else
-                            LOG.debug("{} file is excluded", entryName);
+                            if (LOG.isDebugEnabled())
+                                LOG.debug("{} file is excluded", entryName);
                     }
                     else
-                        LOG.debug("{} file is NOT included", entryName);
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("{} file is NOT included", entryName);
                 }
             }
 

--- a/jetty-core/jetty-osgi/src/main/java/org/eclipse/jetty/osgi/JettyServerFactory.java
+++ b/jetty-core/jetty-osgi/src/main/java/org/eclipse/jetty/osgi/JettyServerFactory.java
@@ -188,7 +188,8 @@ public class JettyServerFactory
                 }
                 catch (Exception x)
                 {
-                    LOG.trace("IGNORED", x);
+                    if (LOG.isTraceEnabled())
+                        LOG.trace("IGNORED", x);
                 }
             }
             throw e;

--- a/jetty-core/jetty-osgi/src/main/java/org/eclipse/jetty/osgi/util/BundleClassLoaderHelperFactory.java
+++ b/jetty-core/jetty-osgi/src/main/java/org/eclipse/jetty/osgi/util/BundleClassLoaderHelperFactory.java
@@ -46,7 +46,8 @@ public class BundleClassLoaderHelperFactory
         }
         catch (Throwable t)
         {
-            LOG.trace("IGNORED", t);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", t);
         }
 
         return helper;

--- a/jetty-core/jetty-osgi/src/main/java/org/eclipse/jetty/osgi/util/BundleFileLocatorHelperFactory.java
+++ b/jetty-core/jetty-osgi/src/main/java/org/eclipse/jetty/osgi/util/BundleFileLocatorHelperFactory.java
@@ -45,7 +45,8 @@ public class BundleFileLocatorHelperFactory
         }
         catch (Throwable t)
         {
-            LOG.trace("IGNORED", t);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", t);
         }
         return helper;
     }

--- a/jetty-core/jetty-osgi/src/main/java/org/eclipse/jetty/osgi/util/Util.java
+++ b/jetty-core/jetty-osgi/src/main/java/org/eclipse/jetty/osgi/util/Util.java
@@ -334,7 +334,8 @@ public class Util
         catch (InvalidPathException x)
         {
             //ignore and try via the jetty bundle instead
-            LOG.trace("IGNORED", x);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", x);
         }
 
         //relative location

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/main/java/org/eclipse/jetty/quic/quiche/foreign/quiche_h.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/main/java/org/eclipse/jetty/quic/quiche/foreign/quiche_h.java
@@ -59,7 +59,8 @@ public class quiche_h
 
         public void log(MemorySegment msg, MemorySegment argp)
         {
-            LOG.debug(msg.getString(0L, StandardCharsets.UTF_8));
+            if (LOG.isDebugEnabled())
+                LOG.debug(msg.getString(0L, StandardCharsets.UTF_8));
         }
     }
 

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/JnaQuicheConnection.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/JnaQuicheConnection.java
@@ -66,8 +66,8 @@ public class JnaQuicheConnection extends Quiche
 
         byte[] token = new byte[Quiche.TokenMinter.MAX_TOKEN_LENGTH];
         size_t_pointer tokenLen = new size_t_pointer(token.length);
-
-        LOG.debug("getting header info (fromPacket)...");
+        if (LOG.isDebugEnabled())
+            LOG.debug("getting header info (fromPacket)...");
         int rc = LibQuiche.INSTANCE.quiche_header_info(packet, new size_t(packet.remaining()), new size_t(QUICHE_MAX_CONN_ID_LEN),
             version, type,
             scid, scidLen,
@@ -234,8 +234,8 @@ public class JnaQuicheConnection extends Quiche
 
         byte[] token = new byte[TokenMinter.MAX_TOKEN_LENGTH];
         size_t_pointer token_len = new size_t_pointer(token.length);
-
-        LOG.debug("getting header info (packetType)...");
+        if (LOG.isDebugEnabled())
+            LOG.debug("getting header info (packetType)...");
         int rc = LibQuiche.INSTANCE.quiche_header_info(packet, new size_t(packet.remaining()), new size_t(QUICHE_MAX_CONN_ID_LEN),
             version, type,
             scid, scid_len,
@@ -267,8 +267,8 @@ public class JnaQuicheConnection extends Quiche
 
         byte[] token = new byte[TokenMinter.MAX_TOKEN_LENGTH];
         size_t_pointer token_len = new size_t_pointer(token.length);
-
-        LOG.debug("getting header info (negotiate)...");
+        if (LOG.isDebugEnabled())
+            LOG.debug("getting header info (negotiate)...");
         int rc = LibQuiche.INSTANCE.quiche_header_info(packetRead, new size_t(packetRead.remaining()), new size_t(QUICHE_MAX_CONN_ID_LEN),
             version, type,
             scid, scid_len,
@@ -277,16 +277,19 @@ public class JnaQuicheConnection extends Quiche
         if (rc < 0)
             throw new IOException("failed to parse header: " + quiche_error.errToString(rc));
         packetRead.position(packetRead.limit());
-
-        LOG.debug("version: {}", version);
-        LOG.debug("type: {}", type);
-        LOG.debug("scid len: {}", scid_len);
-        LOG.debug("dcid len: {}", dcid_len);
-        LOG.debug("token len: {}", token_len);
+        if (LOG.isDebugEnabled())
+        {
+            LOG.debug("version: {}", version);
+            LOG.debug("type: {}", type);
+            LOG.debug("scid len: {}", scid_len);
+            LOG.debug("dcid len: {}", dcid_len);
+            LOG.debug("token len: {}", token_len);
+        }
 
         if (LibQuiche.INSTANCE.quiche_version_is_supported(version.getPointee()).isFalse())
         {
-            LOG.debug("version negotiation");
+            if (LOG.isDebugEnabled())
+                LOG.debug("version negotiation");
 
             ssize_t generated = LibQuiche.INSTANCE.quiche_negotiate_version(scid, scid_len.getPointee(), dcid, dcid_len.getPointee(), packetToSend, new size_t(packetToSend.remaining()));
             packetToSend.position(packetToSend.position() + generated.intValue());
@@ -297,7 +300,8 @@ public class JnaQuicheConnection extends Quiche
 
         if (token_len.getValue() == 0)
         {
-            LOG.debug("stateless retry");
+            if (LOG.isDebugEnabled())
+                LOG.debug("stateless retry");
 
             token = tokenMinter.mint(dcid, (int)dcid_len.getValue());
 
@@ -339,8 +343,8 @@ public class JnaQuicheConnection extends Quiche
 
         byte[] token = new byte[TokenMinter.MAX_TOKEN_LENGTH];
         size_t_pointer token_len = new size_t_pointer(token.length);
-
-        LOG.debug("getting header info (tryAccept)...");
+        if (LOG.isDebugEnabled())
+            LOG.debug("getting header info (tryAccept)...");
         int rc = LibQuiche.INSTANCE.quiche_header_info(packetRead, new size_t(packetRead.remaining()), new size_t(QUICHE_MAX_CONN_ID_LEN),
             version, type,
             scid, scid_len,
@@ -348,33 +352,40 @@ public class JnaQuicheConnection extends Quiche
             token, token_len);
         if (rc < 0)
             throw new IOException("failed to parse header: " + quiche_error.errToString(rc));
-
-        LOG.debug("version: {}", version);
-        LOG.debug("type: {}", type);
-        LOG.debug("scid len: {}", scid_len);
-        LOG.debug("dcid len: {}", dcid_len);
-        LOG.debug("token len: {}", token_len);
+        if (LOG.isDebugEnabled())
+        {
+            LOG.debug("version: {}", version);
+            LOG.debug("type: {}", type);
+            LOG.debug("scid len: {}", scid_len);
+            LOG.debug("dcid len: {}", dcid_len);
+            LOG.debug("token len: {}", token_len);
+        }
 
         if (LibQuiche.INSTANCE.quiche_version_is_supported(version.getPointee()).isFalse())
         {
-            LOG.debug("need version negotiation");
+            if (LOG.isDebugEnabled())
+                LOG.debug("need version negotiation");
             return null;
         }
 
         if (token_len.getValue() == 0)
         {
-            LOG.debug("need stateless retry");
+            if (LOG.isDebugEnabled())
+                LOG.debug("need stateless retry");
             return null;
         }
-
-        LOG.debug("token validation...");
+        if (LOG.isDebugEnabled())
+            LOG.debug("token validation...");
         // Original Destination Connection ID
         byte[] odcid = tokenValidator.validate(token, (int)token_len.getValue());
         if (odcid == null)
             throw new TokenValidationException("invalid address validation token");
-        LOG.debug("validated token");
+        if (LOG.isDebugEnabled())
+        {
+            LOG.debug("validated token");
+            LOG.debug("connection creation...");
+        }
 
-        LOG.debug("connection creation...");
         LibQuiche.quiche_config libQuicheConfig = buildConfig(quicheConfig);
 
         SizedStructure<sockaddr> localSockaddr = sockaddr.convert(local);
@@ -386,10 +397,11 @@ public class JnaQuicheConnection extends Quiche
             LibQuiche.INSTANCE.quiche_config_free(libQuicheConfig);
             throw new IOException("failed to create connection");
         }
-
-        LOG.debug("connection created");
+        if (LOG.isDebugEnabled())
+            LOG.debug("connection created");
         JnaQuicheConnection quicheConnection = new JnaQuicheConnection(quicheConn, libQuicheConfig);
-        LOG.debug("accepted, immediately receiving the same packet - remaining in buffer: {}", packetRead.remaining());
+        if (LOG.isDebugEnabled())
+            LOG.debug("accepted, immediately receiving the same packet - remaining in buffer: {}", packetRead.remaining());
         while (packetRead.hasRemaining())
         {
             quicheConnection.feedCipherBytes(packetRead, local, peer);

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/JDBCLoginService.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/JDBCLoginService.java
@@ -251,7 +251,8 @@ public class JDBCLoginService extends AbstractLoginService
             }
             catch (Exception e)
             {
-                LOG.trace("IGNORED", e);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", e);
             }
         }
         _con = null;

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/DigestAuthenticator.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/DigestAuthenticator.java
@@ -259,7 +259,8 @@ public class DigestAuthenticator extends LoginAuthenticator
         }
         catch (Exception e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
         }
         return -1;
     }

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/SessionAuthentication.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/SessionAuthentication.java
@@ -90,7 +90,8 @@ public class SessionAuthentication extends LoginAuthenticator.UserAuthentication
         }
 
         _userIdentity = loginService.login(_name, _credentials, null, null);
-        LOG.debug("Deserialized and relogged in {}", this);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Deserialized and relogged in {}", this);
     }
 
     @Override

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/internal/DeferredAuthenticationState.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/internal/DeferredAuthenticationState.java
@@ -69,7 +69,8 @@ public class DeferredAuthenticationState implements AuthenticationState.Deferred
         }
         catch (ServerAuthException e)
         {
-            LOG.debug("Unable to authenticate {}", request, e);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Unable to authenticate {}", request, e);
         }
 
         return null;
@@ -97,7 +98,8 @@ public class DeferredAuthenticationState implements AuthenticationState.Deferred
         }
         catch (ServerAuthException e)
         {
-            LOG.debug("Unable to authenticate {}", request, e);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Unable to authenticate {}", request, e);
         }
         return null;
     }

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/jaas/spi/LdapLoginModule.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/jaas/spi/LdapLoginModule.java
@@ -296,7 +296,8 @@ public class LdapLoginModule extends AbstractLoginModule
             }
             catch (NamingException e)
             {
-                LOG.debug("no password available under attribute: {}", _userPasswordAttribute);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("no password available under attribute: {}", _userPasswordAttribute);
             }
         }
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractConnector.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractConnector.java
@@ -644,13 +644,15 @@ public abstract class AbstractConnector extends ContainerLifeCycle implements Co
             }
             catch (Throwable x)
             {
-                LOG.trace("IGNORED", x);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", x);
             }
             return false;
         }
         else
         {
-            LOG.trace("IGNORED", ex);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", ex);
             return false;
         }
     }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractNetworkConnector.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractNetworkConnector.java
@@ -135,7 +135,8 @@ public abstract class AbstractNetworkConnector extends AbstractConnector impleme
     {
         if (isOpen())
             return super.handleAcceptFailure(ex);
-        LOG.trace("IGNORED", ex);
+        if (LOG.isTraceEnabled())
+            LOG.trace("IGNORED", ex);
         return false;
     }
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/AsyncRequestLogWriter.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/AsyncRequestLogWriter.java
@@ -76,7 +76,8 @@ public class AsyncRequestLogWriter extends RequestLogWriter
                 }
                 catch (InterruptedException e)
                 {
-                    LOG.trace("IGNORED", e);
+                    if (LOG.isTraceEnabled())
+                        LOG.trace("IGNORED", e);
                 }
                 catch (Throwable t)
                 {

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HomeBaseWarning.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HomeBaseWarning.java
@@ -54,7 +54,8 @@ public class HomeBaseWarning
         }
         catch (IOException e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
             // Can't definitively determine this state
             return;
         }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/NegotiatingServerConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/NegotiatingServerConnection.java
@@ -148,7 +148,8 @@ public abstract class NegotiatingServerConnection extends AbstractConnection.Non
         }
         catch (IOException x)
         {
-            LOG.atDebug().setCause(x).log("Unable to fill from endpoint {}", getEndPoint());
+            if (LOG.isDebugEnabled())
+                LOG.atDebug().setCause(x).log("Unable to fill from endpoint {}", getEndPoint());
             close();
             return -1;
         }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/RequestLogWriter.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/RequestLogWriter.java
@@ -227,7 +227,8 @@ public class RequestLogWriter extends AbstractLifeCycle implements RequestLog.Wr
             }
             catch (IOException e)
             {
-                LOG.trace("IGNORED", e);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", e);
             }
             if (_out != null && _closeOut)
             {
@@ -237,7 +238,8 @@ public class RequestLogWriter extends AbstractLifeCycle implements RequestLog.Wr
                 }
                 catch (IOException e)
                 {
-                    LOG.trace("IGNORED", e);
+                    if (LOG.isTraceEnabled())
+                        LOG.trace("IGNORED", e);
                 }
             }
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ServerConnector.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ServerConnector.java
@@ -411,7 +411,8 @@ public class ServerConnector extends AbstractNetworkConnector
         }
         catch (SocketException e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
         }
     }
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ShutdownService.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ShutdownService.java
@@ -354,7 +354,8 @@ public class ShutdownService
                                 stopComponents(exitVm);
 
                                 // Reply to client
-                                LOG.debug("Informing client that we are stopped");
+                                if (LOG.isDebugEnabled())
+                                    LOG.debug("Informing client that we are stopped");
                                 flush(out, "Stopped\r\n");
 
                                 processCommands = false;
@@ -371,7 +372,8 @@ public class ShutdownService
                                 stopComponents(true);
 
                                 // Reply to client
-                                LOG.debug("Informing client that we are stopped");
+                                if (LOG.isDebugEnabled())
+                                    LOG.debug("Informing client that we are stopped");
                                 flush(out, "Stopped\r\n");
 
                                 processCommands = false;
@@ -406,7 +408,8 @@ public class ShutdownService
             }
             catch (Throwable x)
             {
-                LOG.atDebug().setCause(x).log("Failed ServerSocket");
+                if (LOG.isDebugEnabled())
+                    LOG.atDebug().setCause(x).log("Failed ServerSocket");
             }
             finally
             {
@@ -448,7 +451,8 @@ public class ShutdownService
                 }
                 catch (Throwable x)
                 {
-                    LOG.atDebug().setCause(x).log("Unable to stop component: {}", component);
+                    if (LOG.isDebugEnabled())
+                        LOG.atDebug().setCause(x).log("Unable to stop component: {}", component);
                 }
             }
         }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ConnectHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ConnectHandler.java
@@ -497,8 +497,8 @@ public class ConnectHandler extends Handler.Wrapper
         @Override
         public Connection newConnection(SelectableChannel channel, EndPoint endpoint, Object attachment) throws IOException
         {
-            if (ConnectHandler.LOG.isDebugEnabled())
-                ConnectHandler.LOG.debug("Connected to {}", ((SocketChannel)channel).getRemoteAddress());
+            if (LOG.isDebugEnabled())
+                LOG.debug("Connected to {}", ((SocketChannel)channel).getRemoteAddress());
             ConnectContext connectContext = (ConnectContext)attachment;
             UpstreamConnection connection = newUpstreamConnection(endpoint, connectContext);
             connection.setInputBufferSize(getBufferSize());

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ConnectHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ConnectHandler.java
@@ -305,7 +305,8 @@ public class ConnectHandler extends Handler.Wrapper
         }
         catch (Throwable x)
         {
-            LOG.trace("IGNORED", x);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", x);
         }
     }
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -757,9 +757,13 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
             catch (Throwable x)
             {
                 // Log as warning the first time it happens.
-                (_enterScopeSetClassloaderFailed.compareAndSet(false, true) ? LOG.atWarn() : LOG.atDebug())
-                    .setCause(x)
-                    .log("Error setting a context classloader on thread {}", Thread.currentThread());
+                if (_enterScopeSetClassloaderFailed.compareAndSet(false, true))
+                    LOG.warn("Error setting a context classloader on thread {}", Thread.currentThread(), x);
+                else
+                {
+                    if (LOG.isDebugEnabled())
+                        LOG.atDebug().setCause(x).log("Error setting a context classloader on thread {}", Thread.currentThread());
+                }
             }
         }
         notifyEnterScope(contextRequest);

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -720,7 +720,8 @@ public class HttpChannelState implements HttpChannel, Components
             listener.onRequestEnd(_request);
 
             // This is THE ONLY PLACE the stream is succeeded or failed.
-            LOG.atDebug().setCause(failure).log("completing the stream of {}", this);
+            if (LOG.isDebugEnabled())
+                LOG.atDebug().setCause(failure).log("completing the stream of {}", this);
             if (failure == null)
                 stream.succeeded();
             else

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ComplianceViolationListenerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ComplianceViolationListenerTest.java
@@ -479,7 +479,8 @@ public class ComplianceViolationListenerTest
         protected void event(String format, Object... args)
         {
             String str = format.formatted(args);
-            LOG.debug(str);
+            if (LOG.isDebugEnabled())
+                LOG.debug(str);
             events.add(str);
         }
     }

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ConnectorTimeoutTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ConnectorTimeoutTest.java
@@ -316,7 +316,8 @@ public abstract class ConnectorTimeoutTest extends HttpServerTestFixture
             }
             catch (SSLHandshakeException e)
             {
-                LOG.debug("Legit possible SSL result", e);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Legit possible SSL result", e);
             }
             catch (IOException e)
             {

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/GracefulHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/GracefulHandlerTest.java
@@ -78,7 +78,8 @@ public class GracefulHandlerTest
     {
         URI serverURI = server.getURI();
         Socket socket = new Socket(serverURI.getHost(), serverURI.getPort());
-        LOG.debug("{} : l={},r={}", id, socket.getLocalSocketAddress(), socket.getRemoteSocketAddress());
+        if (LOG.isDebugEnabled())
+            LOG.debug("{} : l={},r={}", id, socket.getLocalSocketAddress(), socket.getRemoteSocketAddress());
         return socket;
     }
 
@@ -552,7 +553,8 @@ public class GracefulHandlerTest
             {
                 try (Blocker.Callback block = Blocker.callback())
                 {
-                    LOG.debug("Response commit (early): {}", request.getHttpURI());
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("Response commit (early): {}", request.getHttpURI());
                     Content.Sink.write(response, false, "", block);
                     block.block();
                 }
@@ -759,7 +761,8 @@ public class GracefulHandlerTest
         @Override
         public boolean handle(Request request, Response response, Callback callback) throws Exception
         {
-            LOG.debug("process: request={}", request);
+            if (LOG.isDebugEnabled())
+                LOG.debug("process: request={}", request);
             request.addHttpStreamWrapper(s -> new HttpStream.Wrapper(s)
             {
                 @Override
@@ -794,7 +797,8 @@ public class GracefulHandlerTest
         @Override
         public boolean handle(Request request, Response response, Callback callback) throws Exception
         {
-            LOG.debug("process: request={}", request);
+            if (LOG.isDebugEnabled())
+                LOG.debug("process: request={}", request);
             onBeforeRead(request, response);
             // Read request content (completely)
             int bytesRead = 0;
@@ -814,7 +818,8 @@ public class GracefulHandlerTest
                             continue;
                         }
                     }
-                    LOG.debug("chunk = {}", chunk);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("chunk = {}", chunk);
                     if (Content.Chunk.isFailure(chunk))
                     {
                         Response.writeError(request, response, callback, chunk.getFailure());
@@ -828,7 +833,8 @@ public class GracefulHandlerTest
             }
 
             String responseBody = "(Read:%d) (Content-Length:%d)".formatted(bytesRead, contentLength);
-            LOG.debug("Content.Sink.Write: {}", responseBody);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Content.Sink.Write: {}", responseBody);
             Content.Sink.write(response, true, responseBody, callback);
             return true;
         }

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/LargeHeaderTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/LargeHeaderTest.java
@@ -89,7 +89,8 @@ public class LargeHeaderTest
             public boolean handle(Request request, Response response, Callback callback)
             {
                 String idCount = request.getHeaders().get("X-Count");
-                LOG.debug("X-Count: {} [handle]", idCount);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("X-Count: {} [handle]", idCount);
 
                 response.getHeaders().put(HttpHeader.CONTENT_TYPE.toString(), MimeTypes.Type.TEXT_HTML.toString());
                 response.getHeaders().put("LongStr", largeHeaderValue);
@@ -101,19 +102,22 @@ public class LargeHeaderTest
                     @Override
                     public void succeeded()
                     {
-                        LOG.debug("X-Count: {} [callback.succeeded]", idCount);
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("X-Count: {} [callback.succeeded]", idCount);
                         callback.succeeded();
                     }
 
                     @Override
                     public void failed(Throwable x)
                     {
-                        LOG.debug("X-Count: {} [callback.failed] {}", idCount, this);
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("X-Count: {} [callback.failed] {}", idCount, this);
                         callback.failed(x);
                     }
                 };
                 response.write(true, BufferUtil.toBuffer(responseBody, UTF_8), topCallback);
-                LOG.debug("X-Count: {} [handle-completed]", idCount);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("X-Count: {} [handle-completed]", idCount);
                 return true;
             }
         });
@@ -194,7 +198,8 @@ public class LargeHeaderTest
                      OutputStream output = client.getOutputStream();
                      InputStream input = client.getInputStream())
                 {
-                    LOG.debug("X-Count: {} - Send Request - {}->{}", count, client.getLocalAddress(), client.getRemoteSocketAddress());
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("X-Count: {} - Send Request - {}->{}", count, client.getLocalAddress(), client.getRemoteSocketAddress());
 
                     output.write(rawRequest.formatted(count).getBytes(UTF_8));
                     output.flush();

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ResponseCompleteTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ResponseCompleteTest.java
@@ -149,7 +149,8 @@ public class ResponseCompleteTest
                                     {
                                         handleLatch.countDown();
                                         failureLatch.await();
-                                        LOG.debug("consumeAvailable allowed to continue");
+                                        if (LOG.isDebugEnabled())
+                                            LOG.debug("consumeAvailable allowed to continue");
                                         return super.consumeAvailable();
                                     }
                                     catch (InterruptedException e)
@@ -172,7 +173,8 @@ public class ResponseCompleteTest
                     response.setStatus(200);
                     getServer().getThreadPool().execute(() ->
                     {
-                        LOG.debug("handle.threadPool.execute() -> callback.failed() being called");
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("handle.threadPool.execute() -> callback.failed() being called");
                         callback.failed(new Exception("Test-Threaded"));
                     });
                     handleLatch.await();
@@ -192,8 +194,8 @@ public class ResponseCompleteTest
 
             Thread.sleep(1000); // ensure we are fully out of the HandlerInvoker.run()
             failureLatch.countDown();
-
-            LOG.debug("Reading response");
+            if (LOG.isDebugEnabled())
+                LOG.debug("Reading response");
             String rawResponse = IO.toString(input, UTF_8);
             assertThat("Raw Response Length", rawResponse.length(), greaterThan(0));
             HttpTester.Response response = HttpTester.parseResponse(rawResponse);

--- a/jetty-core/jetty-session/src/main/java/org/eclipse/jetty/session/DefaultSessionCache.java
+++ b/jetty-core/jetty-session/src/main/java/org/eclipse/jetty/session/DefaultSessionCache.java
@@ -153,7 +153,8 @@ public class DefaultSessionCache extends AbstractSessionCache
                     }
                     catch (Exception e)
                     {
-                        LOG.trace("IGNORED", e);
+                        if (LOG.isTraceEnabled())
+                            LOG.trace("IGNORED", e);
                     }
                 }
                 else

--- a/jetty-core/jetty-util-ajax/src/main/java/org/eclipse/jetty/util/ajax/JSONPojoConvertor.java
+++ b/jetty-core/jetty-util-ajax/src/main/java/org/eclipse/jetty/util/ajax/JSONPojoConvertor.java
@@ -339,7 +339,8 @@ public class JSONPojoConvertor implements JSON.Convertor
                     catch (Exception e)
                     {
                         // Unusual array with multiple types.
-                        LOG.trace("IGNORED", e);
+                        if (LOG.isTraceEnabled())
+                            LOG.trace("IGNORED", e);
                         _setter.invoke(obj, value);
                     }
                 }
@@ -358,7 +359,8 @@ public class JSONPojoConvertor implements JSON.Convertor
                     catch (Exception e)
                     {
                         // unusual array with multiple types
-                        LOG.trace("IGNORED", e);
+                        if (LOG.isTraceEnabled())
+                            LOG.trace("IGNORED", e);
                         _setter.invoke(obj, value);
                     }
                 }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/BufferUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/BufferUtil.java
@@ -1445,7 +1445,8 @@ public class BufferUtil
         }
         catch (Throwable x)
         {
-            LOG.trace("IGNORED", x);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", x);
             buf.append("!!concurrent mod!!");
         }
         finally

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ConcurrentPool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ConcurrentPool.java
@@ -212,7 +212,8 @@ public class ConcurrentPool<P> implements Pool<P>, Dumpable
             }
             catch (IndexOutOfBoundsException e)
             {
-                LOG.trace("IGNORED", e);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", e);
                 size = entries.size();
                 // Size can be 0 when the pool is in the middle of
                 // acquiring a connection while another thread

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/DecoratedObjectFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/DecoratedObjectFactory.java
@@ -62,13 +62,15 @@ public class DecoratedObjectFactory implements Iterable<Decorator>, Decorator
 
     public void addDecorator(Decorator decorator)
     {
-        LOG.debug("Adding Decorator: {}", decorator);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Adding Decorator: {}", decorator);
         decorators.add(decorator);
     }
 
     public boolean removeDecorator(Decorator decorator)
     {
-        LOG.debug("Remove Decorator: {}", decorator);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Remove Decorator: {}", decorator);
         return decorators.remove(decorator);
     }
 

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/DeprecationWarning.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/DeprecationWarning.java
@@ -40,7 +40,8 @@ public class DeprecationWarning implements Decorator
         }
         catch (Throwable t)
         {
-            LOG.trace("IGNORED", t);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", t);
         }
 
         verifyIndirectTypes(clazz.getSuperclass(), clazz, "Class");
@@ -70,7 +71,8 @@ public class DeprecationWarning implements Decorator
         }
         catch (Throwable t)
         {
-            LOG.trace("IGNORED", t);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", t);
         }
     }
 

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/IO.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/IO.java
@@ -624,7 +624,8 @@ public class IO
         }
         catch (Exception x)
         {
-            LOG.trace("IGNORED", x);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", x);
         }
     }
 
@@ -771,7 +772,8 @@ public class IO
                     // 2) The input string has unencoded characters that are not allowed in a url (like spaces)
                     //    Eg: "C:\path\to dir with spaces\"
                     // We ignore this and continue with normal path processing instead.
-                    LOG.trace("ignored", e);
+                    if (LOG.isTraceEnabled())
+                        LOG.trace("ignored", e);
                 }
             }
 

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Jetty.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Jetty.java
@@ -47,7 +47,8 @@ public class Jetty
         }
         catch (Exception e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
         }
 
         String gitHash = __buildProperties.getProperty("buildNumber", "unknown");
@@ -87,7 +88,8 @@ public class Jetty
         }
         catch (NumberFormatException e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
             return "unknown";
         }
     }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Scanner.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Scanner.java
@@ -956,7 +956,8 @@ public class Scanner extends ContainerLifeCycle
 
         if (startFailures != null)
         {
-            LOG.debug("scan failures {}", startFailures);
+            if (LOG.isDebugEnabled())
+                LOG.debug("scan failures {}", startFailures);
             startFailures.ifExceptionThrowRuntime();
         }
     }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/SharedBlockingCallback.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/SharedBlockingCallback.java
@@ -179,16 +179,15 @@ public class SharedBlockingCallback
                     // Failure arrived late, block() already
                     // modified the state, nothing more to do.
                     if (LOG.isDebugEnabled())
-                        LOG.debug("Failed after {}", _state);
+                        LOG.atDebug().setCause(_state).log("Failed after");
                 }
                 else
                 {
-                    String msg = String.format("Failed after %s: %s", _state, cause);
-                    LOG.warn(msg);
+                    LOG.warn("Failed after {}: {}", _state, cause.toString());
                     if (LOG.isDebugEnabled())
                     {
-                        LOG.debug(msg, _state);
-                        LOG.atDebug().setCause(cause).log(msg);
+                        LOG.atDebug().setCause(_state).log();
+                        LOG.atDebug().setCause(cause).log();
                     }
                 }
             }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/SharedBlockingCallback.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/SharedBlockingCallback.java
@@ -183,11 +183,12 @@ public class SharedBlockingCallback
                 }
                 else
                 {
-                    LOG.warn("Failed after {}: {}", _state, cause.toString());
+                    String msg = String.format("Failed after %s: %s", _state, cause);
+                    LOG.warn(msg);
                     if (LOG.isDebugEnabled())
                     {
-                        LOG.atDebug().setCause(_state).log();
-                        LOG.atDebug().setCause(cause).log();
+                        LOG.atDebug().setCause(_state).log(msg);
+                        LOG.atDebug().setCause(cause).log(msg);
                     }
                 }
             }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java
@@ -314,13 +314,15 @@ public class TypeUtil
         }
         catch (NoSuchMethodException | IllegalAccessException | InstantiationException x)
         {
-            LOG.trace("IGNORED", x);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", x);
         }
         catch (InvocationTargetException x)
         {
             if (x.getTargetException() instanceof Error)
                 throw (Error)x.getTargetException();
-            LOG.trace("IGNORED", x);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", x);
         }
         return null;
     }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java
@@ -1952,7 +1952,8 @@ public final class URIUtil
         }
         catch (URISyntaxException e)
         {
-            LOG.trace("IGNORED: Invalid as URI Reference: {}", reference, e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED: Invalid as URI Reference: {}", reference, e);
         }
 
         try
@@ -1963,7 +1964,8 @@ public final class URIUtil
         catch (InvalidPathException e)
         {
             // Not a path reference.
-            LOG.trace("IGNORED: Invalid as Path Reference: {}", reference, e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED: Invalid as Path Reference: {}", reference, e);
         }
 
         // If we reached this here, that means the input string cannot be used as

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/AttributeNormalizer.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/AttributeNormalizer.java
@@ -365,7 +365,8 @@ public class AttributeNormalizer
             }
             catch (IOException x)
             {
-                LOG.trace("IGNORED", x);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", x);
             }
 
             if (path.startsWith(a.path))

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/GraalIssue5720PathResource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/GraalIssue5720PathResource.java
@@ -84,7 +84,8 @@ final class GraalIssue5720PathResource extends PathResource
                 }
                 catch (FileSystemAlreadyExistsException e2)
                 {
-                    LOG.debug("Race condition upon calling FileSystems.newFileSystem for: {}", uri, e);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("Race condition upon calling FileSystems.newFileSystem for: {}", uri, e);
                 }
                 uri = Path.of(uri).toUri();
             }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
@@ -240,11 +240,13 @@ public class PathResource extends Resource
         }
         catch (DirectoryIteratorException e)
         {
-            LOG.debug("Directory list failure", e);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Directory list failure", e);
         }
         catch (IOException e)
         {
-            LOG.debug("Directory list access failure", e);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Directory list access failure", e);
         }
         return List.of(); // empty
     }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
@@ -335,7 +335,8 @@ public class PathResource extends Resource
         }
         catch (IOException e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
             return Instant.EPOCH;
         }
     }
@@ -457,7 +458,8 @@ public class PathResource extends Resource
             catch (Exception e)
             {
                 if (e instanceof IOException)
-                    LOG.trace("IGNORED", e);
+                    if (LOG.isTraceEnabled())
+                        LOG.trace("IGNORED", e);
                 else
                     LOG.warn("bad alias ({} {}) for {}", e.getClass().getName(), e.getMessage(), path);
                 // Not possible to serve this resource.

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
@@ -458,8 +458,10 @@ public class PathResource extends Resource
             catch (Exception e)
             {
                 if (e instanceof IOException)
+                {
                     if (LOG.isTraceEnabled())
                         LOG.trace("IGNORED", e);
+                }
                 else
                     LOG.warn("bad alias ({} {}) for {}", e.getClass().getName(), e.getMessage(), path);
                 // Not possible to serve this resource.

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
@@ -350,7 +350,8 @@ public interface ResourceFactory
             {
                 // We have an input string that has what looks like a scheme, but isn't a URI.
                 // Eg: "C:\path\to\resource.txt"
-                LOG.trace("ignored", x);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("ignored", x);
             }
         }
 
@@ -364,7 +365,8 @@ public interface ResourceFactory
         }
         catch (InvalidPathException | URISyntaxException x)
         {
-            LOG.trace("ignored", x);
+            if (LOG.isTraceEnabled())
+                LOG.trace("ignored", x);
         }
 
         // If we reached this here, that means the input string cannot be used as

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/URLResourceFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/URLResourceFactory.java
@@ -141,7 +141,8 @@ public class URLResourceFactory implements ResourceFactory
                     }
                     catch (IOException e)
                     {
-                        LOG.trace("IGNORED", e);
+                        if (LOG.isTraceEnabled())
+                            LOG.trace("IGNORED", e);
                     }
                 }
                 return connection != null;
@@ -228,7 +229,8 @@ public class URLResourceFactory implements ResourceFactory
             }
             catch (IOException e)
             {
-                LOG.trace("IGNORED", e);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", e);
             }
             return false;
         }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/security/CertificateValidator.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/security/CertificateValidator.java
@@ -134,7 +134,8 @@ public class CertificateValidator
             }
             catch (KeyStoreException kse)
             {
-                LOG.debug("Unable to validate alias: {}", keyAlias, kse);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Unable to validate alias: {}", keyAlias, kse);
                 throw new CertificateException("Unable to validate certificate" +
                     " for alias [" + keyAlias + "]: " + kse.getMessage(), kse);
             }
@@ -182,7 +183,8 @@ public class CertificateValidator
             }
             catch (KeyStoreException kse)
             {
-                LOG.debug("Unable to validate certificate", kse);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Unable to validate certificate", kse);
                 throw new CertificateException("Unable to validate certificate" +
                     (certAlias == null ? "" : " for alias [" + certAlias + "]") + ": " + kse.getMessage(), kse);
             }
@@ -252,7 +254,8 @@ public class CertificateValidator
         }
         catch (GeneralSecurityException gse)
         {
-            LOG.debug("Unable to validate certificate chain", gse);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Unable to validate certificate chain", gse);
             throw new CertificateException("Unable to validate certificate: " + gse.getMessage(), gse);
         }
     }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/SslContextFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/SslContextFactory.java
@@ -408,7 +408,8 @@ public abstract class SslContextFactory extends ContainerLifeCycle implements Du
         }
         catch (NoSuchAlgorithmException x)
         {
-            LOG.trace("IGNORED", x);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", x);
         }
     }
 

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/X509.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/ssl/X509.java
@@ -149,7 +149,8 @@ public class X509
         }
         catch (Throwable x)
         {
-            LOG.trace("IGNORED", x);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", x);
             return null;
         }
     }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java
@@ -1211,7 +1211,8 @@ public class QueuedThreadPool extends ContainerLifeCycle implements ThreadFactor
                     }
                     catch (InterruptedException e)
                     {
-                        LOG.trace("IGNORED", e);
+                        if (LOG.isTraceEnabled())
+                            LOG.trace("IGNORED", e);
                     }
                 }
             }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ShutdownThread.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ShutdownThread.java
@@ -57,7 +57,8 @@ public class ShutdownThread extends Thread
         }
         catch (Exception e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
             LOG.info("shutdown already commenced");
         }
     }
@@ -71,7 +72,8 @@ public class ShutdownThread extends Thread
         }
         catch (Exception e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
             if (LOG.isDebugEnabled())
                 LOG.debug("shutdown already commenced");
         }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ShutdownThread.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ShutdownThread.java
@@ -72,7 +72,8 @@ public class ShutdownThread extends Thread
         catch (Exception e)
         {
             LOG.trace("IGNORED", e);
-            LOG.debug("shutdown already commenced");
+            if (LOG.isDebugEnabled())
+                LOG.debug("shutdown already commenced");
         }
     }
 
@@ -134,18 +135,21 @@ public class ShutdownThread extends Thread
                 if (lifeCycle.isStarted())
                 {
                     lifeCycle.stop();
-                    LOG.debug("Stopped {}", lifeCycle);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("Stopped {}", lifeCycle);
                 }
 
                 if (lifeCycle instanceof Destroyable)
                 {
                     ((Destroyable)lifeCycle).destroy();
-                    LOG.debug("Destroyed {}", lifeCycle);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("Destroyed {}", lifeCycle);
                 }
             }
             catch (Exception ex)
             {
-                LOG.debug("Unable to stop", ex);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Unable to stop", ex);
             }
         }
     }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/strategy/AdaptiveExecutionStrategy.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/strategy/AdaptiveExecutionStrategy.java
@@ -532,7 +532,10 @@ public class AdaptiveExecutionStrategy extends ContainerLifeCycle implements Exe
             if (isRunning())
                 LOG.warn("Execute failed", e);
             else
-                LOG.trace("IGNORED", e);
+            {
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", e);
+            }
 
             if (task instanceof Closeable)
                 IO.close((Closeable)task);

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/ScannerTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/ScannerTest.java
@@ -772,21 +772,24 @@ public class ScannerTest
         @Override
         public void fileRemoved(String filename)
         {
-            LOG.debug("fileRemoved: {}", filename);
+            if (LOG.isDebugEnabled())
+                LOG.debug("fileRemoved: {}", filename);
             this.add(new Event(filename, Notification.REMOVED));
         }
 
         @Override
         public void fileChanged(String filename)
         {
-            LOG.debug("fileChanged: {}", filename);
+            if (LOG.isDebugEnabled())
+                LOG.debug("fileChanged: {}", filename);
             this.add(new Event(filename, Notification.CHANGED));
         }
 
         @Override
         public void fileAdded(String filename)
         {
-            LOG.debug("fileAdded: {}", filename);
+            if (LOG.isDebugEnabled())
+                LOG.debug("fileAdded: {}", filename);
             this.add(new Event(filename, Notification.ADDED));
         }
     }
@@ -800,7 +803,8 @@ public class ScannerTest
         @Override
         public void pathsChanged(Set<Path> paths)
         {
-            LOG.debug("pathsChanged: {}", paths);
+            if (LOG.isDebugEnabled())
+                LOG.debug("pathsChanged: {}", paths);
             add(paths);
         }
 
@@ -820,7 +824,8 @@ public class ScannerTest
         @Override
         public void filesChanged(Set<String> filenames)
         {
-            LOG.debug("filesChanged: {}", filenames);
+            if (LOG.isDebugEnabled())
+                LOG.debug("filesChanged: {}", filenames);
             add(filenames);
         }
     }
@@ -832,7 +837,8 @@ public class ScannerTest
         @Override
         public void pathsChanged(Map<Path, Notification> pathsChanged)
         {
-            LOG.atDebug().addArgument(pathsChanged).log("pathsChanged: {}");
+            if (LOG.isDebugEnabled())
+                LOG.atDebug().addArgument(pathsChanged).log("pathsChanged: {}");
             add(pathsChanged);
         }
 

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
@@ -431,7 +431,8 @@ public class PathResourceTest
             }
             catch (InvalidPathException e)
             {
-                LOG.debug("IGNORE", e);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("IGNORE", e);
             }
         }
 
@@ -517,7 +518,8 @@ public class PathResourceTest
         }
         catch (InvalidPathException e)
         {
-            LOG.debug("IGNORE", e);
+            if (LOG.isDebugEnabled())
+                LOG.debug("IGNORE", e);
             assumeTrue(false, "FileSystem does not support null character");
         }
 
@@ -625,7 +627,8 @@ public class PathResourceTest
         }
         catch (InvalidPathException e)
         {
-            LOG.debug("IGNORE", e);
+            if (LOG.isDebugEnabled())
+                LOG.debug("IGNORE", e);
             assumeTrue(false, "FileSystem does not support null character");
         }
 

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
@@ -569,7 +569,8 @@ public class PathResourceTest
         catch (InvalidPathException e)
         {
             // this file system does allow null char ending filenames
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
         }
     }
 
@@ -661,7 +662,8 @@ public class PathResourceTest
         catch (InvalidPathException e)
         {
             // this file system does allow null char ending filenames
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
         }
     }
 

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceAliasTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceAliasTest.java
@@ -181,7 +181,8 @@ public class ResourceAliasTest
         catch (InvalidPathException e)
         {
             // this file system does allow null char ending filenames
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
         }
     }
 }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/thread/QueuedThreadPoolTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/thread/QueuedThreadPoolTest.java
@@ -188,7 +188,8 @@ public class QueuedThreadPoolTest extends AbstractThreadPoolTest
             }
             catch (Exception e)
             {
-                LOG.debug("RunningJob failed", e);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("RunningJob failed", e);
             }
             finally
             {

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/PerMessageDeflateExtension.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/internal/PerMessageDeflateExtension.java
@@ -145,7 +145,8 @@ public class PerMessageDeflateExtension extends AbstractExtension implements Dem
         }
 
         configNegotiated = new ExtensionConfig(config.getName(), paramsNegotiated);
-        LOG.debug("config: outgoingContextTakover={}, incomingContextTakeover={} : {}", outgoingContextTakeover, incomingContextTakeover, this);
+        if (LOG.isDebugEnabled())
+            LOG.debug("config: outgoingContextTakover={}, incomingContextTakeover={} : {}", outgoingContextTakeover, incomingContextTakeover, this);
 
         super.init(configNegotiated, components);
     }
@@ -234,7 +235,8 @@ public class PerMessageDeflateExtension extends AbstractExtension implements Dem
     {
         if (frame.isFin() && !incomingContextTakeover)
         {
-            LOG.debug("Incoming Context Reset");
+            if (LOG.isDebugEnabled())
+                LOG.debug("Incoming Context Reset");
             releaseInflater();
         }
         super.nextIncomingFrame(frame, callback);
@@ -245,7 +247,8 @@ public class PerMessageDeflateExtension extends AbstractExtension implements Dem
     {
         if (entry.getFrame().isFin() && !outgoingContextTakeover)
         {
-            LOG.debug("Outgoing Context Reset");
+            if (LOG.isDebugEnabled())
+                LOG.debug("Outgoing Context Reset");
             releaseDeflater();
         }
         super.nextOutgoingFrame(entry);

--- a/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/GeneratorTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/GeneratorTest.java
@@ -1144,7 +1144,8 @@ public class GeneratorTest
         // but only a few bytes in the middle are made available for the payload.
         // we are testing that masking works as intended, even if the provided
         // payload does not start at position 0.
-        LOG.debug("Payload = {}", BufferUtil.toDetailString(payload));
+        if (LOG.isDebugEnabled())
+            LOG.debug("Payload = {}", BufferUtil.toDetailString(payload));
         Frame frame = new Frame(OpCode.TEXT).setPayload(payload);
         byte[] maskingKey = Hex.asByteArray("11223344");
         frame.setMask(maskingKey);

--- a/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/WebSocketCloseTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/WebSocketCloseTest.java
@@ -544,7 +544,8 @@ public class WebSocketCloseTest extends WebSocketTester
         @Override
         public void onOpen(CoreSession coreSession, Callback callback)
         {
-            LOG.debug("onOpen {}", coreSession);
+            if (LOG.isDebugEnabled())
+                LOG.debug("onOpen {}", coreSession);
             this.coreSession = coreSession;
             state = this.coreSession.toString();
             callback.succeeded();
@@ -554,7 +555,8 @@ public class WebSocketCloseTest extends WebSocketTester
         @Override
         public void onFrame(Frame frame, Callback callback)
         {
-            LOG.debug("onFrame: " + BufferUtil.toDetailString(frame.getPayload()));
+            if (LOG.isDebugEnabled())
+                LOG.debug("onFrame: " + BufferUtil.toDetailString(frame.getPayload()));
             state = coreSession.toString();
             receivedCallback.offer(callback);
             receivedFrames.offer(Frame.copy(frame));
@@ -568,7 +570,8 @@ public class WebSocketCloseTest extends WebSocketTester
         @Override
         public void onClosed(CloseStatus closeStatus, Callback callback)
         {
-            LOG.debug("onClosed {}", closeStatus);
+            if (LOG.isDebugEnabled())
+                LOG.debug("onClosed {}", closeStatus);
             state = coreSession.toString();
             this.closeStatus = closeStatus;
             closed.countDown();
@@ -578,7 +581,8 @@ public class WebSocketCloseTest extends WebSocketTester
         @Override
         public void onError(Throwable cause, Callback callback)
         {
-            LOG.atDebug().setCause(cause).log("onError");
+            if (LOG.isDebugEnabled())
+                LOG.atDebug().setCause(cause).log("onError");
             error = cause;
             state = coreSession.toString();
             callback.succeeded();

--- a/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/chat/ChatWebSocketClient.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/chat/ChatWebSocketClient.java
@@ -77,7 +77,8 @@ public class ChatWebSocketClient
                             value = value.trim();
                             handler.sendText("[" + value + ": changed name from " + name + "]", Callback.NOOP, false);
                             name = value;
-                            LOG.debug("name changed: " + name);
+                            if (LOG.isDebugEnabled())
+                                LOG.debug("name changed: " + name);
                         }
                         break;
 
@@ -95,9 +96,14 @@ public class ChatWebSocketClient
                 return;
             }
         }
-        LOG.debug("sending {}...", line);
+        if (LOG.isDebugEnabled())
+            LOG.debug("sending {}...", line);
 
-        handler.sendText(Callback.from(() -> LOG.debug("message sent"), (cause) -> LOG.warn("message send failure", cause)), false, name, ": ", line);
+        handler.sendText(Callback.from(() ->
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("message sent");
+        }, (cause) -> LOG.warn("message send failure", cause)), false, name, ": ", line);
     }
 
     public static void main(String[] args)

--- a/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/chat/ChatWebSocketServer.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/chat/ChatWebSocketServer.java
@@ -67,7 +67,8 @@ public class ChatWebSocketServer
             @Override
             public void onOpen(CoreSession coreSession, Callback callback)
             {
-                LOG.debug("onOpen {}", coreSession);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("onOpen {}", coreSession);
                 coreSession.setMaxTextMessageSize(2 * 1024);
                 super.onOpen(coreSession, Callback.from(() ->
                 {
@@ -83,7 +84,8 @@ public class ChatWebSocketServer
                 {
                     if (handler == this)
                         continue;
-                    LOG.debug("Sending Message{} to {}", message, handler);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("Sending Message{} to {}", message, handler);
                     handler.sendText(message, NOOP, false);
                 }
 
@@ -93,7 +95,8 @@ public class ChatWebSocketServer
             @Override
             public void onClosed(CloseStatus closeStatus, Callback callback)
             {
-                LOG.debug("onClosed {}", closeStatus);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("onClosed {}", closeStatus);
                 super.onClosed(closeStatus, Callback.from(() -> members.remove(this), callback));
                 members.remove(this);
             }

--- a/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/extensions/ExtensionStackTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-tests/src/test/java/org/eclipse/jetty/websocket/core/extensions/ExtensionStackTest.java
@@ -71,7 +71,8 @@ public class ExtensionStackTest
         stack.initialize(session, connection, null);
 
         // Dump
-        LOG.debug("{}", stack.dump());
+        if (LOG.isDebugEnabled())
+            LOG.debug("{}", stack.dump());
 
         // Should be no change to handlers
         Extension actualIncomingExtension = assertIsExtension("Incoming", stack.getNextIncoming(), IdentityExtension.class);
@@ -94,7 +95,8 @@ public class ExtensionStackTest
         stack.initialize(session, connection, null);
 
         // Dump
-        LOG.debug("{}", stack.dump());
+        if (LOG.isDebugEnabled())
+            LOG.debug("{}", stack.dump());
 
         // Should be no change to handlers
         IdentityExtension actualIncomingExtension = assertIsExtension("Incoming", stack.getNextIncoming(), IdentityExtension.class);
@@ -108,7 +110,8 @@ public class ExtensionStackTest
     public void testToString()
     {
         // Shouldn't cause a NPE.
-        LOG.debug("Shouldn't cause a NPE: {}", stack.toString());
+        if (LOG.isDebugEnabled())
+            LOG.debug("Shouldn't cause a NPE: {}", stack.toString());
     }
 
     @Test
@@ -122,6 +125,7 @@ public class ExtensionStackTest
         String response = ExtensionConfig.toHeaderValue(negotiated);
 
         assertThat("Negotiated Extensions", response, is("permessage-deflate"));
-        LOG.debug("Shouldn't cause a NPE: {}", stack.toString());
+        if (LOG.isDebugEnabled())
+            LOG.debug("Shouldn't cause a NPE: {}", stack.toString());
     }
 }

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/test/java/org/eclipse/jetty/websocket/common/MessageOutputStreamTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/test/java/org/eclipse/jetty/websocket/common/MessageOutputStreamTest.java
@@ -110,7 +110,8 @@ public class MessageOutputStreamTest
     {
         int bufsize = (int)(OUTPUT_BUFFER_SIZE * 2.5);
         byte[] buf = new byte[bufsize];
-        LOG.debug("Buffer sizes: max:{}, test:{}", OUTPUT_BUFFER_SIZE, bufsize);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Buffer sizes: max:{}, test:{}", OUTPUT_BUFFER_SIZE, bufsize);
         Arrays.fill(buf, (byte)'x');
         buf[bufsize - 1] = (byte)'o'; // mark last entry for debugging
 

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/test/java/org/eclipse/jetty/websocket/common/OutgoingMessageCapture.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-common/src/test/java/org/eclipse/jetty/websocket/common/OutgoingMessageCapture.java
@@ -77,28 +77,32 @@ public class OutgoingMessageCapture extends CoreSession.Empty implements CoreSes
             {
                 CloseStatus closeStatus = new CloseStatus(payload);
                 String event = String.format("CLOSE:%s:%s", CloseStatus.codeString(closeStatus.getCode()), closeStatus.getReason());
-                LOG.debug(event);
+                if (LOG.isDebugEnabled())
+                    LOG.debug(event);
                 events.add(event);
                 break;
             }
             case OpCode.PING:
             {
                 String event = String.format("PING:%s", dataHint(payload));
-                LOG.debug(event);
+                if (LOG.isDebugEnabled())
+                    LOG.debug(event);
                 events.add(event);
                 break;
             }
             case OpCode.PONG:
             {
                 String event = String.format("PONG:%s", dataHint(payload));
-                LOG.debug(event);
+                if (LOG.isDebugEnabled())
+                    LOG.debug(event);
                 events.add(event);
                 break;
             }
             case OpCode.TEXT:
             {
                 String event = String.format("TEXT:fin=%b:len=%d", frame.isFin(), frame.getPayloadLength());
-                LOG.debug(event);
+                if (LOG.isDebugEnabled())
+                    LOG.debug(event);
                 events.add(event);
                 messageSink = new StringMessageSink(this, MethodHolder.from(wholeTextHandle), true);
                 break;
@@ -106,7 +110,8 @@ public class OutgoingMessageCapture extends CoreSession.Empty implements CoreSes
             case OpCode.BINARY:
             {
                 String event = String.format("BINARY:fin=%b:len=%d", frame.isFin(), frame.getPayloadLength());
-                LOG.debug(event);
+                if (LOG.isDebugEnabled())
+                    LOG.debug(event);
                 events.add(event);
                 messageSink = new ByteBufferMessageSink(this, MethodHolder.from(wholeBinaryHandle), true);
                 break;
@@ -114,7 +119,8 @@ public class OutgoingMessageCapture extends CoreSession.Empty implements CoreSes
             case OpCode.CONTINUATION:
             {
                 String event = String.format("CONTINUATION:fin=%b:len=%d", frame.isFin(), frame.getPayloadLength());
-                LOG.debug(event);
+                if (LOG.isDebugEnabled())
+                    LOG.debug(event);
                 events.add(event);
                 break;
             }

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/CloseTrackingEndpoint.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/CloseTrackingEndpoint.java
@@ -81,7 +81,8 @@ public class CloseTrackingEndpoint extends Session.Listener.AbstractAutoDemandin
     @Override
     public void onWebSocketClose(int statusCode, String reason)
     {
-        LOG.debug("onWebSocketClose({},{})", statusCode, reason);
+        if (LOG.isDebugEnabled())
+            LOG.debug("onWebSocketClose({},{})", statusCode, reason);
         super.onWebSocketClose(statusCode, reason);
         closeCount.incrementAndGet();
         closeCode = statusCode;
@@ -93,14 +94,16 @@ public class CloseTrackingEndpoint extends Session.Listener.AbstractAutoDemandin
     public void onWebSocketOpen(Session session)
     {
         super.onWebSocketOpen(session);
-        LOG.debug("onWebSocketOpen({})", session);
+        if (LOG.isDebugEnabled())
+            LOG.debug("onWebSocketOpen({})", session);
         openLatch.countDown();
     }
 
     @Override
     public void onWebSocketError(Throwable cause)
     {
-        LOG.atDebug().setCause(cause).log("onWebSocketError");
+        if (LOG.isDebugEnabled())
+            LOG.atDebug().setCause(cause).log("onWebSocketError");
         assertThat("Unique Error Event", error.compareAndSet(null, cause), is(true));
         errorLatch.countDown();
     }
@@ -108,14 +111,16 @@ public class CloseTrackingEndpoint extends Session.Listener.AbstractAutoDemandin
     @Override
     public void onWebSocketText(String message)
     {
-        LOG.debug("onWebSocketText({})", message);
+        if (LOG.isDebugEnabled())
+            LOG.debug("onWebSocketText({})", message);
         messageQueue.offer(message);
     }
 
     @Override
     public void onWebSocketBinary(ByteBuffer payload, Callback callback)
     {
-        LOG.debug("onWebSocketBinary({})", payload.remaining());
+        if (LOG.isDebugEnabled())
+            LOG.debug("onWebSocketBinary({})", payload.remaining());
         binaryMessageQueue.offer(BufferUtil.copy(payload));
         callback.succeed();
     }

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientCloseTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientCloseTest.java
@@ -441,9 +441,11 @@ public class ClientCloseTest
                 }
                 else if (message.equals("block"))
                 {
-                    LOG.debug("blocking");
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("blocking");
                     assertTrue(block.await(5, TimeUnit.MINUTES));
-                    LOG.debug("unblocked");
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("unblocked");
                 }
                 else
                 {
@@ -453,7 +455,8 @@ public class ClientCloseTest
             }
             catch (Throwable t)
             {
-                LOG.atDebug().setCause(t).log("send text failure");
+                if (LOG.isDebugEnabled())
+                    LOG.atDebug().setCause(t).log("send text failure");
                 throw new RuntimeException(t);
             }
         }
@@ -482,7 +485,8 @@ public class ClientCloseTest
                     }
                     catch (Throwable x)
                     {
-                        LOG.atDebug().setCause(x).log("OOPS");
+                        if (LOG.isDebugEnabled())
+                            LOG.atDebug().setCause(x).log("OOPS");
                     }
                 }
                 else if (reason.equals("abort"))

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientCloseTest.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientCloseTest.java
@@ -499,7 +499,8 @@ public class ClientCloseTest
                     }
                     catch (Throwable x)
                     {
-                        LOG.trace("IGNORED", x);
+                        if (LOG.isTraceEnabled())
+                            LOG.trace("IGNORED", x);
                     }
                 }
                 else if (reason.startsWith("sleep|"))
@@ -513,7 +514,8 @@ public class ClientCloseTest
                     }
                     catch (InterruptedException x)
                     {
-                        LOG.trace("IGNORED", x);
+                        if (LOG.isTraceEnabled())
+                            LOG.trace("IGNORED", x);
                     }
                 }
                 else

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientWriteThread.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-tests/src/test/java/org/eclipse/jetty/websocket/tests/client/ClientWriteThread.java
@@ -56,8 +56,11 @@ public class ClientWriteThread extends Thread
 
         try
         {
-            LOG.debug("Writing {} messages to {}", messageCount, session);
-            LOG.debug("Artificial Slowness {} ms", slowness);
+            if (LOG.isDebugEnabled())
+            {
+                LOG.debug("Writing {} messages to {}", messageCount, session);
+                LOG.debug("Artificial Slowness {} ms", slowness);
+            }
             FutureCallback lastMessage = null;
             while (m.get() < messageCount)
             {

--- a/jetty-core/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
+++ b/jetty-core/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java
@@ -703,7 +703,8 @@ public class XmlConfiguration
                 }
                 catch (IllegalArgumentException | IllegalAccessException | NoSuchMethodException e)
                 {
-                    LOG.trace("IGNORED", e);
+                    if (LOG.isTraceEnabled())
+                        LOG.trace("IGNORED", e);
                     errors.add(e);
                 }
 
@@ -718,7 +719,8 @@ public class XmlConfiguration
                 }
                 catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException | NoSuchMethodException e)
                 {
-                    LOG.trace("IGNORED", e);
+                    if (LOG.isTraceEnabled())
+                        LOG.trace("IGNORED", e);
                     errors.add(e);
                 }
 
@@ -734,7 +736,8 @@ public class XmlConfiguration
                 }
                 catch (IllegalArgumentException | IllegalAccessException | NoSuchMethodException e)
                 {
-                    LOG.trace("IGNORED", e);
+                    if (LOG.isTraceEnabled())
+                        LOG.trace("IGNORED", e);
                     errors.add(e);
                 }
 
@@ -752,7 +755,8 @@ public class XmlConfiguration
                 }
                 catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException | NoSuchMethodException e)
                 {
-                    LOG.trace("IGNORED", e);
+                    if (LOG.isTraceEnabled())
+                        LOG.trace("IGNORED", e);
                     errors.add(e);
                 }
 
@@ -789,7 +793,8 @@ public class XmlConfiguration
                 }
                 catch (NoSuchFieldException e)
                 {
-                    LOG.trace("IGNORED", e);
+                    if (LOG.isTraceEnabled())
+                        LOG.trace("IGNORED", e);
                     errors.add(e);
                 }
 
@@ -813,7 +818,8 @@ public class XmlConfiguration
                         }
                         catch (IllegalArgumentException | IllegalAccessException e)
                         {
-                            LOG.trace("IGNORED", e);
+                            if (LOG.isTraceEnabled())
+                                LOG.trace("IGNORED", e);
                             errors.add(e);
                         }
 
@@ -831,7 +837,8 @@ public class XmlConfiguration
                         }
                         catch (IllegalAccessException e)
                         {
-                            LOG.trace("IGNORED", e);
+                            if (LOG.isTraceEnabled())
+                                LOG.trace("IGNORED", e);
                             errors.add(e);
                         }
                     }
@@ -863,7 +870,8 @@ public class XmlConfiguration
                     }
                     catch (NoSuchMethodException | IllegalAccessException | InstantiationException e)
                     {
-                        LOG.trace("IGNORED", e);
+                        if (LOG.isTraceEnabled())
+                            LOG.trace("IGNORED", e);
                         errors.add(e);
                     }
                 }
@@ -1106,7 +1114,8 @@ public class XmlConfiguration
                 }
                 catch (IllegalAccessException | IllegalArgumentException e)
                 {
-                    LOG.trace("IGNORED", e);
+                    if (LOG.isTraceEnabled())
+                        LOG.trace("IGNORED", e);
                 }
             }
 
@@ -1166,7 +1175,8 @@ public class XmlConfiguration
                 }
                 catch (InstantiationException | IllegalAccessException | IllegalArgumentException e)
                 {
-                    LOG.trace("IGNORED", e);
+                    if (LOG.isTraceEnabled())
+                        LOG.trace("IGNORED", e);
                 }
             }
             throw new NoSuchMethodException("<init>");

--- a/jetty-core/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlParser.java
+++ b/jetty-core/jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlParser.java
@@ -165,7 +165,8 @@ public class XmlParser
                 if (validating)
                     LOG.warn("Schema validation may not be supported: ", e);
                 else
-                    LOG.trace("IGNORED", e);
+                    if (LOG.isTraceEnabled())
+                        LOG.trace("IGNORED", e);
             }
 
             _parser.getXMLReader().setFeature("http://xml.org/sax/features/validation", validating);
@@ -360,7 +361,8 @@ public class XmlParser
             }
             catch (IOException | SAXException e)
             {
-                LOG.trace("IGNORE EntityResolver exception for (pid=%s, sid=%s)".formatted(pid, sid), e);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORE EntityResolver exception for (pid=%s, sid=%s)".formatted(pid, sid), e);
             }
         }
 

--- a/jetty-demos/jetty-core-demos/jetty-core-demo-handler/src/main/java/org/eclipse/jetty/demo/JettyDemos.java
+++ b/jetty-demos/jetty-core-demos/jetty-core-demo-handler/src/main/java/org/eclipse/jetty/demo/JettyDemos.java
@@ -133,7 +133,8 @@ public class JettyDemos
         }
         catch (Exception e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
         }
         return null;
     }

--- a/jetty-demos/jetty-core-demos/jetty-core-demo-handler/src/main/java/org/eclipse/jetty/demo/JettyDemos.java
+++ b/jetty-demos/jetty-core-demos/jetty-core-demo-handler/src/main/java/org/eclipse/jetty/demo/JettyDemos.java
@@ -39,11 +39,13 @@ public class JettyDemos
     static
     {
         Path demosDir = asDirectory(System.getProperty("jetty.demos"));
-        LOG.debug("JettyDemos(prop(jetty.demos)) = {}", demosDir);
+        if (LOG.isDebugEnabled())
+            LOG.debug("JettyDemos(prop(jetty.demos)) = {}", demosDir);
         if (demosDir == null)
         {
             demosDir = asDirectory(System.getenv().get("JETTY_DEMOS"));
-            LOG.debug("JettyDemos(env(JETTY_DEMOS)) = {}", demosDir);
+            if (LOG.isDebugEnabled())
+                LOG.debug("JettyDemos(env(JETTY_DEMOS)) = {}", demosDir);
         }
 
         if (demosDir == null || !Files.exists(demosDir.resolve("pom.xml")))
@@ -52,7 +54,8 @@ public class JettyDemos
             {
                 Path working = Paths.get(System.getProperty("user.dir"));
                 Path dir = null;
-                LOG.debug("JettyDemos(prop(user.dir)) = {}", working);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("JettyDemos(prop(user.dir)) = {}", working);
                 while (dir == null && working != null)
                 {
                     dir = asDirectory(working.resolve("jetty-ee11-demos").toString());
@@ -105,24 +108,27 @@ public class JettyDemos
 
             if (StringUtil.isBlank(path))
             {
-                LOG.debug("asDirectory {} is blank", path);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("asDirectory {} is blank", path);
                 return null;
             }
 
             Path dir = Paths.get(path);
             if (!Files.exists(dir))
             {
-                LOG.debug("asDirectory {} does not exist", path);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("asDirectory {} does not exist", path);
                 return null;
             }
 
             if (!Files.isDirectory(dir))
             {
-                LOG.debug("asDirectory {} is not a directory", path);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("asDirectory {} is not a directory", path);
                 return null;
             }
-
-            LOG.debug("asDirectory {}", dir);
+            if (LOG.isDebugEnabled())
+                LOG.debug("asDirectory {}", dir);
             return dir.toAbsolutePath();
         }
         catch (Exception e)

--- a/jetty-demos/jetty-servlet6-demos/jetty-servlet6-demo-embedded/src/main/java/org/eclipse/jetty/servlet6/embedded/JettyDemos.java
+++ b/jetty-demos/jetty-servlet6-demos/jetty-servlet6-demo-embedded/src/main/java/org/eclipse/jetty/servlet6/embedded/JettyDemos.java
@@ -133,7 +133,8 @@ public class JettyDemos
         }
         catch (Exception e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
         }
         return null;
     }

--- a/jetty-demos/jetty-servlet6-demos/jetty-servlet6-demo-embedded/src/main/java/org/eclipse/jetty/servlet6/embedded/JettyDemos.java
+++ b/jetty-demos/jetty-servlet6-demos/jetty-servlet6-demo-embedded/src/main/java/org/eclipse/jetty/servlet6/embedded/JettyDemos.java
@@ -39,11 +39,13 @@ public class JettyDemos
     static
     {
         Path demosDir = asDirectory(System.getProperty("jetty.demos"));
-        LOG.debug("JettyDemos(prop(jetty.demos)) = {}", demosDir);
+        if (LOG.isDebugEnabled())
+            LOG.debug("JettyDemos(prop(jetty.demos)) = {}", demosDir);
         if (demosDir == null)
         {
             demosDir = asDirectory(System.getenv().get("JETTY_DEMOS"));
-            LOG.debug("JettyDemos(env(JETTY_DEMOS)) = {}", demosDir);
+            if (LOG.isDebugEnabled())
+                LOG.debug("JettyDemos(env(JETTY_DEMOS)) = {}", demosDir);
         }
 
         if (demosDir == null || !Files.exists(demosDir.resolve("pom.xml")))
@@ -52,7 +54,8 @@ public class JettyDemos
             {
                 Path working = Paths.get(System.getProperty("user.dir"));
                 Path dir = null;
-                LOG.debug("JettyDemos(prop(user.dir)) = {}", working);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("JettyDemos(prop(user.dir)) = {}", working);
                 while (dir == null && working != null)
                 {
                     dir = asDirectory(working.resolve("jetty-demos/jetty-servlet6-demos").toString());
@@ -105,24 +108,27 @@ public class JettyDemos
 
             if (StringUtil.isBlank(path))
             {
-                LOG.debug("asDirectory {} is blank", path);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("asDirectory {} is blank", path);
                 return null;
             }
 
             Path dir = Paths.get(path);
             if (!Files.exists(dir))
             {
-                LOG.debug("asDirectory {} does not exist", path);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("asDirectory {} does not exist", path);
                 return null;
             }
 
             if (!Files.isDirectory(dir))
             {
-                LOG.debug("asDirectory {} is not a directory", path);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("asDirectory {} is not a directory", path);
                 return null;
             }
-
-            LOG.debug("asDirectory {}", dir);
+            if (LOG.isDebugEnabled())
+                LOG.debug("asDirectory {}", dir);
             return dir.toAbsolutePath();
         }
         catch (Exception e)

--- a/jetty-demos/jetty-servlet6-demos/jetty-servlet6-demo-embedded/src/test/java/org/eclipse/jetty/servlet6/embedded/WebSocketServerTest.java
+++ b/jetty-demos/jetty-servlet6-demos/jetty-servlet6-demo-embedded/src/test/java/org/eclipse/jetty/servlet6/embedded/WebSocketServerTest.java
@@ -101,7 +101,8 @@ public class WebSocketServerTest
         @OnWebSocketClose
         public void onClose(int statusCode, String reason)
         {
-            LOG.debug("Closed({}, {})", statusCode, reason);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Closed({}, {})", statusCode, reason);
         }
     }
 }

--- a/jetty-demos/jetty-servlet6-demos/jetty-servlet6-demo-simple-webapp/src/test/java/org/eclipse/jetty/demo/servlet6/JettyDemos.java
+++ b/jetty-demos/jetty-servlet6-demos/jetty-servlet6-demo-simple-webapp/src/test/java/org/eclipse/jetty/demo/servlet6/JettyDemos.java
@@ -39,11 +39,13 @@ public class JettyDemos
     static
     {
         Path demosDir = asDirectory(System.getProperty("jetty.demos"));
-        LOG.debug("JettyDemos(prop(jetty.demos)) = {}", demosDir);
+        if (LOG.isDebugEnabled())
+            LOG.debug("JettyDemos(prop(jetty.demos)) = {}", demosDir);
         if (demosDir == null)
         {
             demosDir = asDirectory(System.getenv().get("JETTY_DEMOS"));
-            LOG.debug("JettyDemos(env(JETTY_DEMOS)) = {}", demosDir);
+            if (LOG.isDebugEnabled())
+                LOG.debug("JettyDemos(env(JETTY_DEMOS)) = {}", demosDir);
         }
 
         if (demosDir == null || !Files.exists(demosDir.resolve("pom.xml")))
@@ -52,7 +54,8 @@ public class JettyDemos
             {
                 Path working = Paths.get(System.getProperty("user.dir"));
                 Path dir = null;
-                LOG.debug("JettyDemos(prop(user.dir)) = {}", working);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("JettyDemos(prop(user.dir)) = {}", working);
                 while (dir == null && working != null)
                 {
                     dir = asDirectory(working.resolve("jetty-demos/jetty-servlet6-demos/jetty-servlet6-demo-simple-webapp").toString());
@@ -105,24 +108,27 @@ public class JettyDemos
 
             if (StringUtil.isBlank(path))
             {
-                LOG.debug("asDirectory {} is blank", path);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("asDirectory {} is blank", path);
                 return null;
             }
 
             Path dir = Paths.get(path);
             if (!Files.exists(dir))
             {
-                LOG.debug("asDirectory {} does not exist", path);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("asDirectory {} does not exist", path);
                 return null;
             }
 
             if (!Files.isDirectory(dir))
             {
-                LOG.debug("asDirectory {} is not a directory", path);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("asDirectory {} is not a directory", path);
                 return null;
             }
-
-            LOG.debug("asDirectory {}", dir);
+            if (LOG.isDebugEnabled())
+                LOG.debug("asDirectory {}", dir);
             return dir.toAbsolutePath();
         }
         catch (Exception e)

--- a/jetty-demos/jetty-servlet6-demos/jetty-servlet6-demo-simple-webapp/src/test/java/org/eclipse/jetty/demo/servlet6/JettyDemos.java
+++ b/jetty-demos/jetty-servlet6-demos/jetty-servlet6-demo-simple-webapp/src/test/java/org/eclipse/jetty/demo/servlet6/JettyDemos.java
@@ -133,7 +133,8 @@ public class JettyDemos
         }
         catch (Exception e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
         }
         return null;
     }

--- a/jetty-demos/jetty-servlet6-demos/jetty-servlet6-demo-spec-6-1-webapp/src/test/java/org/eclipse/jetty/demo/servlet6/JettyDemos.java
+++ b/jetty-demos/jetty-servlet6-demos/jetty-servlet6-demo-spec-6-1-webapp/src/test/java/org/eclipse/jetty/demo/servlet6/JettyDemos.java
@@ -39,11 +39,13 @@ public class JettyDemos
     static
     {
         Path demosDir = asDirectory(System.getProperty("jetty.demos"));
-        LOG.debug("JettyDemos(prop(jetty.demos)) = {}", demosDir);
+        if (LOG.isDebugEnabled())
+            LOG.debug("JettyDemos(prop(jetty.demos)) = {}", demosDir);
         if (demosDir == null)
         {
             demosDir = asDirectory(System.getenv().get("JETTY_DEMOS"));
-            LOG.debug("JettyDemos(env(JETTY_DEMOS)) = {}", demosDir);
+            if (LOG.isDebugEnabled())
+                LOG.debug("JettyDemos(env(JETTY_DEMOS)) = {}", demosDir);
         }
 
         if (demosDir == null || !Files.exists(demosDir.resolve("pom.xml")))
@@ -52,7 +54,8 @@ public class JettyDemos
             {
                 Path working = Paths.get(System.getProperty("user.dir"));
                 Path dir = null;
-                LOG.debug("JettyDemos(prop(user.dir)) = {}", working);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("JettyDemos(prop(user.dir)) = {}", working);
                 while (dir == null && working != null)
                 {
                     dir = asDirectory(working.resolve("jetty-demos/jetty-servlet6-demos/jetty-servlet6-demo-simple-webapp").toString());
@@ -105,24 +108,27 @@ public class JettyDemos
 
             if (StringUtil.isBlank(path))
             {
-                LOG.debug("asDirectory {} is blank", path);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("asDirectory {} is blank", path);
                 return null;
             }
 
             Path dir = Paths.get(path);
             if (!Files.exists(dir))
             {
-                LOG.debug("asDirectory {} does not exist", path);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("asDirectory {} does not exist", path);
                 return null;
             }
 
             if (!Files.isDirectory(dir))
             {
-                LOG.debug("asDirectory {} is not a directory", path);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("asDirectory {} is not a directory", path);
                 return null;
             }
-
-            LOG.debug("asDirectory {}", dir);
+            if (LOG.isDebugEnabled())
+                LOG.debug("asDirectory {}", dir);
             return dir.toAbsolutePath();
         }
         catch (Exception e)

--- a/jetty-demos/jetty-servlet6-demos/jetty-servlet6-demo-spec-6-1-webapp/src/test/java/org/eclipse/jetty/demo/servlet6/JettyDemos.java
+++ b/jetty-demos/jetty-servlet6-demos/jetty-servlet6-demo-spec-6-1-webapp/src/test/java/org/eclipse/jetty/demo/servlet6/JettyDemos.java
@@ -133,7 +133,8 @@ public class JettyDemos
         }
         catch (Exception e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
         }
         return null;
     }

--- a/jetty-ee10/jetty-ee10-annotations/src/main/java/org/eclipse/jetty/ee10/annotations/ResourceAnnotationHandler.java
+++ b/jetty-ee10/jetty-ee10-annotations/src/main/java/org/eclipse/jetty/ee10/annotations/ResourceAnnotationHandler.java
@@ -190,7 +190,8 @@ public class ResourceAnnotationHandler extends AbstractIntrospectableAnnotationH
                     //Check there is a JNDI entry for this annotation
                     if (bound)
                     {
-                        LOG.debug("Bound {} as {}", (mappedName == null ? name : mappedName), name);
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("Bound {} as {}", (mappedName == null ? name : mappedName), name);
                         //   Make the Injection for it if the binding succeeded
                         injection = new Injection(clazz, field, type, name, mappedName);
                         injections.add(injection);
@@ -348,7 +349,8 @@ public class ResourceAnnotationHandler extends AbstractIntrospectableAnnotationH
 
                     if (bound)
                     {
-                        LOG.debug("Bound {} as {}", (mappedName == null ? name : mappedName), name);
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("Bound {} as {}", (mappedName == null ? name : mappedName), name);
                         //   Make the Injection for it
                         injection = new Injection(clazz, method, paramType, resourceType, name, mappedName);
                         injections.add(injection);

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/MavenMetaInfConfiguration.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/MavenMetaInfConfiguration.java
@@ -64,7 +64,8 @@ public class MavenMetaInfConfiguration extends MetaInfConfiguration
                 {
                     try
                     {
-                        LOG.debug(" add  resource to resources to examine {}", file);
+                        if (LOG.isDebugEnabled())
+                            LOG.debug(" add  resource to resources to examine {}", file);
                         list.add(context.getResourceFactory().newResource(file.toURI()));
                     }
                     catch (Exception e)

--- a/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/MavenWebAppContext.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/main/java/org/eclipse/jetty/ee10/maven/plugin/MavenWebAppContext.java
@@ -492,7 +492,8 @@ public class MavenWebAppContext extends WebAppContext
         }
         catch (ClassNotFoundException e)
         {
-            LOG.debug("o.e.j.cdi.servlet.JettyWeldInitializer not found, no cdi integration available");
+            if (LOG.isDebugEnabled())
+                LOG.debug("o.e.j.cdi.servlet.JettyWeldInitializer not found, no cdi integration available");
         }
         catch (NoSuchMethodException e)
         {

--- a/jetty-ee10/jetty-ee10-plus/src/main/java/org/eclipse/jetty/ee10/plus/webapp/EnvConfiguration.java
+++ b/jetty-ee10/jetty-ee10-plus/src/main/java/org/eclipse/jetty/ee10/plus/webapp/EnvConfiguration.java
@@ -170,11 +170,13 @@ public class EnvConfiguration extends AbstractConfiguration
         catch (NameNotFoundException e)
         {
             LOG.trace("IGNORED", e);
-            LOG.debug("No jndi entries scoped to webapp {}", context);
+            if (LOG.isDebugEnabled())
+                LOG.debug("No jndi entries scoped to webapp {}", context);
         }
         catch (NamingException e)
         {
-            LOG.debug("Error unbinding jndi entries scoped to webapp {}", context, e);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Error unbinding jndi entries scoped to webapp {}", context, e);
         }
     }
 
@@ -192,17 +194,17 @@ public class EnvConfiguration extends AbstractConfiguration
     {
         InitialContext ic = new InitialContext();
         Context envCtx = (Context)ic.lookup("java:comp/env");
-
-        LOG.debug("Binding env entries from the jvm scope");
+        if (LOG.isDebugEnabled())
+            LOG.debug("Binding env entries from the jvm scope");
         doBindings(envCtx, null);
-
-        LOG.debug("Binding env entries from the server scope");
+        if (LOG.isDebugEnabled())
+            LOG.debug("Binding env entries from the server scope");
         doBindings(envCtx, context.getServer());
-
-        LOG.debug("Binding env entries from environment {} scope", ServletContextHandler.ENVIRONMENT.getName());
+        if (LOG.isDebugEnabled())
+            LOG.debug("Binding env entries from environment {} scope", ServletContextHandler.ENVIRONMENT.getName());
         doBindings(envCtx, ServletContextHandler.ENVIRONMENT.getName());
-
-        LOG.debug("Binding env entries from the context scope");
+        if (LOG.isDebugEnabled())
+            LOG.debug("Binding env entries from the context scope");
         doBindings(envCtx, context);
     }
 

--- a/jetty-ee10/jetty-ee10-plus/src/main/java/org/eclipse/jetty/ee10/plus/webapp/EnvConfiguration.java
+++ b/jetty-ee10/jetty-ee10-plus/src/main/java/org/eclipse/jetty/ee10/plus/webapp/EnvConfiguration.java
@@ -169,7 +169,8 @@ public class EnvConfiguration extends AbstractConfiguration
         }
         catch (NameNotFoundException e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
             if (LOG.isDebugEnabled())
                 LOG.debug("No jndi entries scoped to webapp {}", context);
         }

--- a/jetty-ee10/jetty-ee10-plus/src/main/java/org/eclipse/jetty/ee10/plus/webapp/PlusConfiguration.java
+++ b/jetty-ee10/jetty-ee10-plus/src/main/java/org/eclipse/jetty/ee10/plus/webapp/PlusConfiguration.java
@@ -93,7 +93,8 @@ public class PlusConfiguration extends AbstractConfiguration
             }
             catch (NameNotFoundException x)
             {
-                LOG.debug("No Transaction manager found - if your webapp requires one, please configure one.");
+                if (LOG.isDebugEnabled())
+                    LOG.debug("No Transaction manager found - if your webapp requires one, please configure one.");
             }
         }
     }

--- a/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/AfterContentTransformer.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/AfterContentTransformer.java
@@ -286,7 +286,8 @@ public abstract class AfterContentTransformer implements AsyncMiddleManServlet.C
         }
         catch (IOException x)
         {
-            LOG.trace("IGNORED", x);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", x);
         }
     }
 

--- a/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/AsyncMiddleManServletTest.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/AsyncMiddleManServletTest.java
@@ -1823,7 +1823,8 @@ public class AsyncMiddleManServletTest
             protected String transform(String value)
             {
                 String result = PREFIX + URLEncoder.encode(value, StandardCharsets.UTF_8);
-                LOG.debug("{} -> {}", value, result);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("{} -> {}", value, result);
                 return result;
             }
         }
@@ -1834,7 +1835,8 @@ public class AsyncMiddleManServletTest
             protected String transform(String value)
             {
                 String result = URLDecoder.decode(value.substring(PREFIX.length()), StandardCharsets.UTF_8);
-                LOG.debug("{} <- {}", value, result);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("{} <- {}", value, result);
                 return result;
             }
         }

--- a/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/ProxyServletLoadTest.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/ProxyServletLoadTest.java
@@ -193,7 +193,8 @@ public class ProxyServletLoadTest
         public void run()
         {
             String threadName = Thread.currentThread().getName();
-            LOG.debug("Starting thread {}", threadName);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Starting thread {}", threadName);
             try
             {
                 while (success.get())
@@ -225,7 +226,8 @@ public class ProxyServletLoadTest
             }
             finally
             {
-                LOG.debug("Shutting down thread {}", threadName);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Shutting down thread {}", threadName);
                 active.countDown();
             }
         }

--- a/jetty-ee10/jetty-ee10-quickstart/src/main/java/org/eclipse/jetty/ee10/quickstart/ExtraXmlDescriptorProcessor.java
+++ b/jetty-ee10/jetty-ee10-quickstart/src/main/java/org/eclipse/jetty/ee10/quickstart/ExtraXmlDescriptorProcessor.java
@@ -52,7 +52,8 @@ public class ExtraXmlDescriptorProcessor extends IterativeDescriptorProcessor
     @Override
     public void start(WebAppContext context, Descriptor descriptor)
     {
-        LOG.debug("process {}", descriptor);
+        if (LOG.isDebugEnabled())
+            LOG.debug("process {}", descriptor);
         _origin = (StringUtil.isBlank(_originAttribute) ? null : "  <!-- " + descriptor + " -->\n");
     }
 
@@ -72,7 +73,8 @@ public class ExtraXmlDescriptorProcessor extends IterativeDescriptorProcessor
         //Note: we have to output the origin as a comment field instead of
         //as an attribute like the other other elements because
         //we are copying these elements _verbatim_ from the descriptor
-        LOG.debug("save {}", node.getTag());
+        if (LOG.isDebugEnabled())
+            LOG.debug("save {}", node.getTag());
         if (_origin != null)
             _buffer.append(_origin);
         _buffer.append("  ").append(node.toString()).append("\n");

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/CrossContextServletContext.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/CrossContextServletContext.java
@@ -162,7 +162,8 @@ class CrossContextServletContext implements ServletContext
         }
         catch (Exception e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
         }
         return null;
     }

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/Invoker.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/Invoker.java
@@ -179,7 +179,8 @@ public class Invoker extends HttpServlet
                     }
                     catch (Exception e)
                     {
-                        LOG.debug("Unable to start {}", holder, e);
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("Unable to start {}", holder, e);
                         throw new UnavailableException(e.toString());
                     }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/Invoker.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/Invoker.java
@@ -198,7 +198,8 @@ public class Invoker extends HttpServlet
                             }
                             catch (Exception e)
                             {
-                                LOG.trace("IGNORED", e);
+                                if (LOG.isTraceEnabled())
+                                    LOG.trace("IGNORED", e);
                             }
 
                             LOG.warn("Dynamic servlet {} not loaded from context {}", s, request.getContextPath());

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ResourceServlet.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ResourceServlet.java
@@ -823,7 +823,7 @@ public class ResourceServlet extends HttpServlet
         protected void writeHttpError(Request coreRequest, Response coreResponse, Callback callback, Throwable cause)
         {
             if (LOG.isDebugEnabled())
-                LOG.atDebug().setCause(cause).log("writeHttpError(coreRequest={}, coreResponse={}, callback={}, cause={})", coreRequest, coreResponse, callback, cause);
+                LOG.atDebug().setCause(cause).log("writeHttpError(coreRequest={}, coreResponse={}, callback={})", coreRequest, coreResponse, callback);
 
             int statusCode = HttpStatus.INTERNAL_SERVER_ERROR_500;
             String reason = null;
@@ -839,7 +839,7 @@ public class ResourceServlet extends HttpServlet
         protected void writeHttpError(Request coreRequest, Response coreResponse, Callback callback, int statusCode, String reason, Throwable cause)
         {
             if (LOG.isDebugEnabled())
-                LOG.atDebug().setCause(cause).log("writeHttpError(coreRequest={}, coreResponse={}, callback={}, statusCode={}, reason={}, cause={})", coreRequest, coreResponse, callback, statusCode, reason, cause);
+                LOG.atDebug().setCause(cause).log("writeHttpError(coreRequest={}, coreResponse={}, callback={}, statusCode={}, reason={})", coreRequest, coreResponse, callback, statusCode, reason);
             HttpServletRequest request = getServletRequest(coreRequest);
             HttpServletResponse response = getServletResponse(coreResponse);
             try

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java
@@ -614,7 +614,10 @@ public class ServletChannel
             catch (Throwable failure)
             {
                 if ("org.eclipse.jetty.continuation.ContinuationThrowable".equals(failure.getClass().getName()))
-                    LOG.trace("IGNORED", failure);
+                {
+                    if (LOG.isTraceEnabled())
+                        LOG.trace("IGNORED", failure);
+                }
                 else
                     handleException(failure);
             }

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannelState.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannelState.java
@@ -984,7 +984,10 @@ public class ServletChannelState
             else if (_requestState != RequestState.COMPLETE)
             {
                 if (QuietException.isQuiet(th))
-                    LOG.debug("unhandled in state {}", _requestState, th);
+                {
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("unhandled in state {}", _requestState, th);
+                }
                 else
                     LOG.warn("unhandled in state {}", _requestState, new IllegalStateException(th));
             }

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
@@ -785,7 +785,8 @@ public class ServletContextHandler extends ContextHandler
         }
         catch (Exception e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
         }
 
         return null;
@@ -847,7 +848,8 @@ public class ServletContextHandler extends ContextHandler
         }
         catch (Exception e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
         }
         return Collections.emptySet();
     }
@@ -2824,7 +2826,8 @@ public class ServletContextHandler extends ContextHandler
             }
             catch (Exception e)
             {
-                LOG.trace("IGNORED", e);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", e);
             }
             return null;
         }
@@ -2870,7 +2873,8 @@ public class ServletContextHandler extends ContextHandler
             }
             catch (Exception e)
             {
-                LOG.trace("IGNORED", e);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", e);
             }
 
             return null;
@@ -2934,7 +2938,8 @@ public class ServletContextHandler extends ContextHandler
             catch (Throwable e)
             {
                 // catch RuntimeException and things like java.nio.fileInvalidPathException here.
-                LOG.trace("IGNORED", e);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", e);
                 return null;
             }
         }

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletHandler.java
@@ -562,12 +562,14 @@ public class ServletHandler extends Handler.Wrapper
             if (_maxFilterChainsCacheSize > 0 && cache.size() >= _maxFilterChainsCacheSize)
             {
                 // flush the cache
-                LOG.debug("{} flushed filter chain cache for {}", this, dispatcherType);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("{} flushed filter chain cache for {}", this, dispatcherType);
                 cache.clear();
             }
             chain = chain == null ? new ChainEnd(servletHolder) : chain;
             // flush the cache
-            LOG.debug("{} cached filter chain for {}: {}", this, dispatcherType, chain);
+            if (LOG.isDebugEnabled())
+                LOG.debug("{} cached filter chain for {}: {}", this, dispatcherType, chain);
             cache.put(key, chain);
         }
         return chain;

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletHolder.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletHolder.java
@@ -385,7 +385,8 @@ public class ServletHolder extends Holder<Servlet> implements Comparable<Servlet
             makeUnavailable(ex);
             if (getServletHandler().isStartWithUnavailable())
             {
-                LOG.trace("IGNORED", ex);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", ex);
                 return;
             }
             else
@@ -402,7 +403,8 @@ public class ServletHolder extends Holder<Servlet> implements Comparable<Servlet
             makeUnavailable(ex);
             if (getServletHandler().isStartWithUnavailable())
             {
-                LOG.trace("IGNORED", ex);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", ex);
                 return;
             }
             else

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncServletIOTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/AsyncServletIOTest.java
@@ -215,14 +215,16 @@ public class AsyncServletIOTest
 
             // response line
             String line = in.readLine();
-            LOG.debug("response-line: " + line);
+            if (LOG.isDebugEnabled())
+                LOG.debug("response-line: " + line);
             assertThat(line, startsWith("HTTP/1.1 200 OK"));
 
             // Skip headers
             while (line != null)
             {
                 line = in.readLine();
-                LOG.debug("header-line: " + line);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("header-line: " + line);
                 if (line.length() == 0)
                     break;
             }
@@ -231,7 +233,8 @@ public class AsyncServletIOTest
             while (true)
             {
                 line = in.readLine();
-                LOG.debug("body: " + line);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("body: " + line);
                 if (line == null)
                     break;
                 list.add(line);
@@ -291,21 +294,24 @@ public class AsyncServletIOTest
 
             // response line
             String line = in.readLine();
-            LOG.debug("response-line: " + line);
+            if (LOG.isDebugEnabled())
+                LOG.debug("response-line: " + line);
             assertThat(line, startsWith("HTTP/1.1 200 OK"));
 
             // Skip headers
             while (line != null)
             {
                 line = in.readLine();
-                LOG.debug("header-line: " + line);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("header-line: " + line);
                 if (line.length() == 0)
                     break;
             }
 
             // Get body
             line = in.readLine();
-            LOG.debug("body: " + line);
+            if (LOG.isDebugEnabled())
+                LOG.debug("body: " + line);
             assertEquals("DONE", line);
 
             // The connection should be aborted
@@ -334,7 +340,8 @@ public class AsyncServletIOTest
             request.append(s).append("w=").append(w);
             s = '&';
         }
-        LOG.debug("process {} {}", request.toString(), BufferUtil.toDetailString(BufferUtil.toBuffer(content)));
+        if (LOG.isDebugEnabled())
+            LOG.debug("process {} {}", request.toString(), BufferUtil.toDetailString(BufferUtil.toBuffer(content)));
 
         request.append(" HTTP/1.1\r\n")
             .append("Host: localhost\r\n")
@@ -369,14 +376,16 @@ public class AsyncServletIOTest
 
             // response line
             String line = in.readLine();
-            LOG.debug("response-line: " + line);
+            if (LOG.isDebugEnabled())
+                LOG.debug("response-line: " + line);
             assertThat(line, startsWith("HTTP/1.1 200 OK"));
 
             // Skip headers
             while (line != null)
             {
                 line = in.readLine();
-                LOG.debug("header-line:  " + line);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("header-line:  " + line);
                 if (line.length() == 0)
                     break;
             }
@@ -387,7 +396,8 @@ public class AsyncServletIOTest
                 line = in.readLine();
                 if (line == null)
                     break;
-                LOG.debug("body:  " + brief(line));
+                if (LOG.isDebugEnabled())
+                    LOG.debug("body:  " + brief(line));
                 list.add(line);
                 Thread.sleep(50);
             }
@@ -397,7 +407,8 @@ public class AsyncServletIOTest
         int w = 0;
         for (String line : list)
         {
-            LOG.debug("line:  " + brief(line));
+            if (LOG.isDebugEnabled())
+                LOG.debug("line:  " + brief(line));
             if ("-".equals(line))
                 continue;
             assertEquals(writes[w], line.length(), "Line Length");
@@ -500,7 +511,8 @@ public class AsyncServletIOTest
                 @Override
                 public void onWritePossible() throws IOException
                 {
-                    LOG.debug("OWP");
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("OWP");
                     _owp.incrementAndGet();
 
                     while (writes != null && _w < writes.length)
@@ -676,7 +688,8 @@ public class AsyncServletIOTest
 
             // response line
             String line = in.readLine();
-            LOG.debug("response-line: " + line);
+            if (LOG.isDebugEnabled())
+                LOG.debug("response-line: " + line);
             assertThat(line, startsWith("HTTP/1.1 200 OK"));
 
             boolean chunked = false;
@@ -684,7 +697,8 @@ public class AsyncServletIOTest
             while (line != null)
             {
                 line = in.readLine();
-                LOG.debug("header-line: " + line);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("header-line: " + line);
                 chunked |= "Transfer-Encoding: chunked".equals(line);
                 if (line.length() == 0)
                     break;
@@ -701,7 +715,8 @@ public class AsyncServletIOTest
                     last = line;
                     //Thread.sleep(1000);
                     line = in.readLine();
-                    LOG.debug("body: " + line);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("body: " + line);
                     if (line == null)
                         break;
                     list.add(line);
@@ -711,8 +726,8 @@ public class AsyncServletIOTest
             {
                 // ignored
             }
-
-            LOG.debug("last: " + last);
+            if (LOG.isDebugEnabled())
+                LOG.debug("last: " + last);
 
             // last non empty line should not contain end chunk
             assertThat(last, notNullValue());

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ErrorPageTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ErrorPageTest.java
@@ -516,7 +516,8 @@ public class ErrorPageTest
                 }
                 catch (Throwable ignore)
                 {
-                    LOG.trace("IGNORED", ignore);
+                    if (LOG.isTraceEnabled())
+                        LOG.trace("IGNORED", ignore);
                 }
             }
         };
@@ -1479,7 +1480,8 @@ public class ErrorPageTest
                             }
                             catch (IllegalStateException e)
                             {
-                                LOG.trace("IGNORED", e);
+                                if (LOG.isTraceEnabled())
+                                    LOG.trace("IGNORED", e);
                             }
                             finally
                             {

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/RequestTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/RequestTest.java
@@ -574,7 +574,8 @@ public class RequestTest
         }
         catch (UnknownHostException e)
         {
-            LOG.debug("Unable to obtain InetAddress.LocalHost", e);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Unable to obtain InetAddress.LocalHost", e);
         }
         return hostHeader.stream().map(Arguments::of);
     }

--- a/jetty-ee10/jetty-ee10-servlets/src/main/java/org/eclipse/jetty/ee10/servlets/CrossOriginFilter.java
+++ b/jetty-ee10/jetty-ee10-servlets/src/main/java/org/eclipse/jetty/ee10/servlets/CrossOriginFilter.java
@@ -281,21 +281,25 @@ public class CrossOriginFilter implements Filter
             {
                 if (isSimpleRequest(request))
                 {
-                    LOG.debug("Cross-origin request to {} is a simple cross-origin request", request.getRequestURI());
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("Cross-origin request to {} is a simple cross-origin request", request.getRequestURI());
                     handleSimpleResponse(request, response, origin);
                 }
                 else if (isPreflightRequest(request))
                 {
-                    LOG.debug("Cross-origin request to {} is a preflight cross-origin request", request.getRequestURI());
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("Cross-origin request to {} is a preflight cross-origin request", request.getRequestURI());
                     handlePreflightResponse(request, response, origin);
                     if (chainPreflight)
-                        LOG.debug("Preflight cross-origin request to {} forwarded to application", request.getRequestURI());
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("Preflight cross-origin request to {} forwarded to application", request.getRequestURI());
                     else
                         return;
                 }
                 else
                 {
-                    LOG.debug("Cross-origin request to {} is a non-simple cross-origin request", request.getRequestURI());
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("Cross-origin request to {} is a non-simple cross-origin request", request.getRequestURI());
                     handleSimpleResponse(request, response, origin);
                 }
 
@@ -422,18 +426,21 @@ public class CrossOriginFilter implements Filter
     private boolean isMethodAllowed(HttpServletRequest request)
     {
         String accessControlRequestMethod = request.getHeader(ACCESS_CONTROL_REQUEST_METHOD_HEADER);
-        LOG.debug("{} is {}", ACCESS_CONTROL_REQUEST_METHOD_HEADER, accessControlRequestMethod);
+        if (LOG.isDebugEnabled())
+            LOG.debug("{} is {}", ACCESS_CONTROL_REQUEST_METHOD_HEADER, accessControlRequestMethod);
         boolean result = false;
         if (accessControlRequestMethod != null)
             result = allowedMethods.contains(accessControlRequestMethod);
-        LOG.debug("Method {} is" + (result ? "" : " not") + " among allowed methods {}", accessControlRequestMethod, allowedMethods);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Method {} is" + (result ? "" : " not") + " among allowed methods {}", accessControlRequestMethod, allowedMethods);
         return result;
     }
 
     private List<String> getAccessControlRequestHeaders(HttpServletRequest request)
     {
         String accessControlRequestHeaders = request.getHeader(ACCESS_CONTROL_REQUEST_HEADERS_HEADER);
-        LOG.debug("{} is {}", ACCESS_CONTROL_REQUEST_HEADERS_HEADER, accessControlRequestHeaders);
+        if (LOG.isDebugEnabled())
+            LOG.debug("{} is {}", ACCESS_CONTROL_REQUEST_HEADERS_HEADER, accessControlRequestHeaders);
         if (accessControlRequestHeaders == null)
             return Collections.emptyList();
 
@@ -452,7 +459,8 @@ public class CrossOriginFilter implements Filter
     {
         if (anyHeadersAllowed)
         {
-            LOG.debug("Any header is allowed");
+            if (LOG.isDebugEnabled())
+                LOG.debug("Any header is allowed");
             return true;
         }
 
@@ -474,7 +482,8 @@ public class CrossOriginFilter implements Filter
                 break;
             }
         }
-        LOG.debug("Headers [{}] are" + (result ? "" : " not") + " among allowed headers {}", requestedHeaders, allowedHeaders);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Headers [{}] are" + (result ? "" : " not") + " among allowed headers {}", requestedHeaders, allowedHeaders);
         return result;
     }
 

--- a/jetty-ee10/jetty-ee10-servlets/src/main/java/org/eclipse/jetty/ee10/servlets/CrossOriginFilter.java
+++ b/jetty-ee10/jetty-ee10-servlets/src/main/java/org/eclipse/jetty/ee10/servlets/CrossOriginFilter.java
@@ -291,8 +291,10 @@ public class CrossOriginFilter implements Filter
                         LOG.debug("Cross-origin request to {} is a preflight cross-origin request", request.getRequestURI());
                     handlePreflightResponse(request, response, origin);
                     if (chainPreflight)
+                    {
                         if (LOG.isDebugEnabled())
                             LOG.debug("Preflight cross-origin request to {} forwarded to application", request.getRequestURI());
+                    }
                     else
                         return;
                 }

--- a/jetty-ee10/jetty-ee10-servlets/src/main/java/org/eclipse/jetty/ee10/servlets/DoSFilter.java
+++ b/jetty-ee10/jetty-ee10-servlets/src/main/java/org/eclipse/jetty/ee10/servlets/DoSFilter.java
@@ -422,7 +422,8 @@ public class DoSFilter implements Filter
         }
         catch (InterruptedException e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
             response.sendError(getTooManyCode());
         }
         finally
@@ -489,7 +490,8 @@ public class DoSFilter implements Filter
             }
             catch (IllegalStateException ise)
             {
-                LOG.trace("IGNORED", ise);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", ise);
                 // abort instead
                 response.sendError(-1);
             }
@@ -705,7 +707,8 @@ public class DoSFilter implements Filter
         }
         catch (Exception x)
         {
-            LOG.trace("IGNORED", x);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", x);
         }
     }
 

--- a/jetty-ee10/jetty-ee10-servlets/src/main/java/org/eclipse/jetty/ee10/servlets/DoSFilter.java
+++ b/jetty-ee10/jetty-ee10-servlets/src/main/java/org/eclipse/jetty/ee10/servlets/DoSFilter.java
@@ -690,7 +690,8 @@ public class DoSFilter implements Filter
     @Override
     public void destroy()
     {
-        LOG.debug("Destroy {}", this);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Destroy {}", this);
         stopScheduler();
         _rateTrackers.clear();
         _whitelist.clear();
@@ -1037,7 +1038,8 @@ public class DoSFilter implements Filter
         }
         clearWhitelist();
         _whitelist.addAll(result);
-        LOG.debug("Whitelisted IP addresses: {}", result);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Whitelisted IP addresses: {}", result);
     }
 
     /**

--- a/jetty-ee10/jetty-ee10-servlets/src/main/java/org/eclipse/jetty/ee10/servlets/IncludeExcludeBasedFilter.java
+++ b/jetty-ee10/jetty-ee10-servlets/src/main/java/org/eclipse/jetty/ee10/servlets/IncludeExcludeBasedFilter.java
@@ -109,19 +109,22 @@ public abstract class IncludeExcludeBasedFilter implements Filter
     protected String guessMimeType(HttpServletRequest httpRequest, HttpServletResponse httpResponse)
     {
         String contentType = httpResponse.getContentType();
-        LOG.debug("Content Type is: {}", contentType);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Content Type is: {}", contentType);
 
         String mimeType;
         if (contentType != null)
         {
             mimeType = MimeTypes.getContentTypeWithoutCharset(contentType);
-            LOG.debug("Mime Type is: {}", mimeType);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Mime Type is: {}", mimeType);
         }
         else
         {
             String requestUrl = httpRequest.getPathInfo();
             mimeType = Objects.requireNonNullElse(httpRequest.getServletContext().getMimeType(requestUrl), "");
-            LOG.debug("Guessed mime type is {}", mimeType);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Guessed mime type is {}", mimeType);
         }
 
         return mimeType;
@@ -130,10 +133,12 @@ public abstract class IncludeExcludeBasedFilter implements Filter
     protected boolean shouldFilter(HttpServletRequest httpRequest, HttpServletResponse httpResponse)
     {
         String httpMethod = httpRequest.getMethod();
-        LOG.debug("HTTP method is: {}", httpMethod);
+        if (LOG.isDebugEnabled())
+            LOG.debug("HTTP method is: {}", httpMethod);
         if (!_httpMethods.test(httpMethod))
         {
-            LOG.debug("should not apply filter because HTTP method does not match");
+            if (LOG.isDebugEnabled())
+                LOG.debug("should not apply filter because HTTP method does not match");
             return false;
         }
 
@@ -141,16 +146,19 @@ public abstract class IncludeExcludeBasedFilter implements Filter
 
         if (!_mimeTypes.test(mimeType))
         {
-            LOG.debug("should not apply filter because mime type does not match");
+            if (LOG.isDebugEnabled())
+                LOG.debug("should not apply filter because mime type does not match");
             return false;
         }
 
         ServletContext context = httpRequest.getServletContext();
         String path = context == null ? httpRequest.getRequestURI() : URIUtil.addPaths(httpRequest.getServletPath(), httpRequest.getPathInfo());
-        LOG.debug("Path is: {}", path);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Path is: {}", path);
         if (!_paths.test(path))
         {
-            LOG.debug("should not apply filter because path does not match");
+            if (LOG.isDebugEnabled())
+                LOG.debug("should not apply filter because path does not match");
             return false;
         }
 

--- a/jetty-ee10/jetty-ee10-servlets/src/test/java/org/eclipse/jetty/ee10/servlets/AsyncManipFilter.java
+++ b/jetty-ee10/jetty-ee10-servlets/src/test/java/org/eclipse/jetty/ee10/servlets/AsyncManipFilter.java
@@ -46,21 +46,25 @@ public class AsyncManipFilter implements Filter, AsyncListener
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException
     {
-        LOG.debug("doFilter() - {}", chain);
+        if (LOG.isDebugEnabled())
+            LOG.debug("doFilter() - {}", chain);
         AsyncContext ctx = (AsyncContext)request.getAttribute(MANIP_KEY);
         if (ctx == null)
         {
-            LOG.debug("Initial pass through: {}", chain);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Initial pass through: {}", chain);
             ctx = request.startAsync();
             ctx.addListener(this);
             ctx.setTimeout(1000);
-            LOG.debug("AsyncContext: {}", ctx);
+            if (LOG.isDebugEnabled())
+                LOG.debug("AsyncContext: {}", ctx);
             request.setAttribute(MANIP_KEY, ctx);
             return;
         }
         else
         {
-            LOG.debug("Second pass through: {}", chain);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Second pass through: {}", chain);
             chain.doFilter(request, response);
         }
     }
@@ -73,25 +77,29 @@ public class AsyncManipFilter implements Filter, AsyncListener
     @Override
     public void onComplete(AsyncEvent event) throws IOException
     {
-        LOG.debug("onComplete() {}", event);
+        if (LOG.isDebugEnabled())
+            LOG.debug("onComplete() {}", event);
     }
 
     @Override
     public void onTimeout(AsyncEvent event) throws IOException
     {
-        LOG.debug("onTimeout() {}", event.getAsyncContext());
+        if (LOG.isDebugEnabled())
+            LOG.debug("onTimeout() {}", event.getAsyncContext());
         event.getAsyncContext().dispatch();
     }
 
     @Override
     public void onError(AsyncEvent event) throws IOException
     {
-        LOG.debug("onError()", event.getThrowable());
+        if (LOG.isDebugEnabled())
+            LOG.debug("onError()", event.getThrowable());
     }
 
     @Override
     public void onStartAsync(AsyncEvent event) throws IOException
     {
-        LOG.debug("onTimeout() {}", event);
+        if (LOG.isDebugEnabled())
+            LOG.debug("onTimeout() {}", event);
     }
 }

--- a/jetty-ee10/jetty-ee10-servlets/src/test/java/org/eclipse/jetty/ee10/servlets/QoSFilterTest.java
+++ b/jetty-ee10/jetty-ee10-servlets/src/test/java/org/eclipse/jetty/ee10/servlets/QoSFilterTest.java
@@ -214,7 +214,8 @@ public class QoSFilterTest
             }
             catch (Exception e)
             {
-                LOG.debug("Request " + url + " failed", e);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Request " + url + " failed", e);
             }
             finally
             {

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/FailedSelectorTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/FailedSelectorTest.java
@@ -377,7 +377,8 @@ public class FailedSelectorTest
                 {
                     CustomManagedSelector customManagedSelector = (CustomManagedSelector)managedSelector;
                     Selector selector = customManagedSelector.getSelector();
-                    LOG.debug("Closing selector {}}", selector);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("Closing selector {}}", selector);
                     IO.close(selector);
                 }
             }

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/FailedSelectorTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/FailedSelectorTest.java
@@ -378,7 +378,7 @@ public class FailedSelectorTest
                     CustomManagedSelector customManagedSelector = (CustomManagedSelector)managedSelector;
                     Selector selector = customManagedSelector.getSelector();
                     if (LOG.isDebugEnabled())
-                        LOG.debug("Closing selector {}}", selector);
+                        LOG.debug("Closing selector {}", selector);
                     IO.close(selector);
                 }
             }

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/websocket/JakartaSimpleEchoSocket.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/websocket/JakartaSimpleEchoSocket.java
@@ -46,21 +46,24 @@ public class JakartaSimpleEchoSocket
     @OnClose
     public void onClose(CloseReason close)
     {
-        LOG.debug("Closed: {}, {}", close.getCloseCode().getCode(), close.getReasonPhrase());
+        if (LOG.isDebugEnabled())
+            LOG.debug("Closed: {}, {}", close.getCloseCode().getCode(), close.getReasonPhrase());
         closeLatch.countDown();
     }
 
     @OnMessage
     public void onMessage(String message)
     {
-        LOG.debug("Received: {}", message);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Received: {}", message);
         messageLatch.countDown();
     }
 
     @OnOpen
     public void onOpen(Session session)
     {
-        LOG.debug("Opened");
+        if (LOG.isDebugEnabled())
+            LOG.debug("Opened");
         this.session = session;
     }
 }

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/websocket/JettySimpleEchoSocket.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/websocket/JettySimpleEchoSocket.java
@@ -50,7 +50,8 @@ public class JettySimpleEchoSocket
     @OnWebSocketClose
     public void onClose(int statusCode, String reason)
     {
-        LOG.debug("Connection closed: {} - {}", statusCode, reason);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Connection closed: {} - {}", statusCode, reason);
         this.session = null;
         this.closeLatch.countDown(); // trigger latch
     }
@@ -58,7 +59,8 @@ public class JettySimpleEchoSocket
     @OnWebSocketOpen
     public void onOpen(Session session)
     {
-        LOG.debug("Open: {}", session);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Open: {}", session);
         this.session = session;
         session.setMaxTextMessageSize(64 * 1024);
         try
@@ -75,6 +77,7 @@ public class JettySimpleEchoSocket
     @OnWebSocketMessage
     public void onMessage(String msg)
     {
-        LOG.debug("Got msg: {}", msg);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Got msg: {}", msg);
     }
 }

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jersey/src/test/java/org/eclipse/jetty/ee10/jersey/tests/HungBlockingThreadsTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-jersey/src/test/java/org/eclipse/jetty/ee10/jersey/tests/HungBlockingThreadsTest.java
@@ -161,14 +161,17 @@ public class HungBlockingThreadsTest
             });
         }
 
-        LOG.debug("Awaiting for client to block on all threads");
+        if (LOG.isDebugEnabled())
+            LOG.debug("Awaiting for client to block on all threads");
         assertTrue(latch.await(15, TimeUnit.SECONDS));
 
-        LOG.debug("Shutting down client");
+        if (LOG.isDebugEnabled())
+            LOG.debug("Shutting down client");
         // While the server is hanging in InputStream read, close the client's connections.
         httpClient.stop();
 
-        LOG.debug("Waiting for hung threads");
+        if (LOG.isDebugEnabled())
+            LOG.debug("Waiting for hung threads");
         await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertThat(threadDump(), not(containsString(Blocker.Shared.class.getName()))));
     }
 

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/Configurations.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/Configurations.java
@@ -201,7 +201,8 @@ public class Configurations extends AbstractList<Configuration> implements Dumpa
             else
             {
                 Object attr = server.getAttribute(SERVER_DEFAULT_ATTR);
-                LOG.debug("{} attr({})= {}", server, SERVER_DEFAULT_ATTR, attr);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("{} attr({})= {}", server, SERVER_DEFAULT_ATTR, attr);
                 if (attr instanceof Configurations)
                     configurations = new Configurations((Configurations)attr);
                 else if (attr instanceof String[])
@@ -483,7 +484,8 @@ public class Configurations extends AbstractList<Configuration> implements Dumpa
         for (int i = 0; i < _configurations.size(); i++)
         {
             Configuration configuration = _configurations.get(i);
-            LOG.debug("preConfigure with {}", configuration);
+            if (LOG.isDebugEnabled())
+                LOG.debug("preConfigure with {}", configuration);
             configuration.preConfigure(webapp);
 
             if (_configurations.get(i) != configuration)
@@ -501,7 +503,8 @@ public class Configurations extends AbstractList<Configuration> implements Dumpa
         // Configure webapp
         for (Configuration configuration : _configurations)
         {
-            LOG.debug("configure {}", configuration);
+            if (LOG.isDebugEnabled())
+                LOG.debug("configure {}", configuration);
             configuration.configure(webapp);
             if (configuration.abort(webapp))
                 return false;
@@ -514,7 +517,8 @@ public class Configurations extends AbstractList<Configuration> implements Dumpa
         // Configure webapp
         for (Configuration configuration : _configurations)
         {
-            LOG.debug("postConfigure {}", configuration);
+            if (LOG.isDebugEnabled())
+                LOG.debug("postConfigure {}", configuration);
             configuration.postConfigure(webapp);
         }
     }

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/JaasConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/JaasConfiguration.java
@@ -46,7 +46,8 @@ public class JaasConfiguration extends AbstractConfiguration
         }
         catch (Throwable e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
             return false;
         }
     }

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/JaspiConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/JaspiConfiguration.java
@@ -43,7 +43,8 @@ public class JaspiConfiguration extends AbstractConfiguration
         }
         catch (Throwable e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
             return false;
         }
     }

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/JmxConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/JmxConfiguration.java
@@ -44,7 +44,8 @@ public class JmxConfiguration extends AbstractConfiguration
         }
         catch (Throwable e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
             return false;
         }
     }

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/JndiConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/JndiConfiguration.java
@@ -46,7 +46,8 @@ public class JndiConfiguration extends AbstractConfiguration
         }
         catch (Throwable e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
             return false;
         }
     }

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/JspConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/JspConfiguration.java
@@ -48,7 +48,8 @@ public class JspConfiguration extends AbstractConfiguration
         }
         catch (Throwable e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
             return false;
         }
     }

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/ServletsConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/ServletsConfiguration.java
@@ -45,7 +45,8 @@ public class ServletsConfiguration extends AbstractConfiguration
         }
         catch (Throwable e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
             return false;
         }
     }

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/StandardDescriptorProcessor.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/StandardDescriptorProcessor.java
@@ -352,7 +352,8 @@ public class StandardDescriptorProcessor extends IterativeDescriptorProcessor
                 catch (Exception e)
                 {
                     LOG.warn("Cannot parse load-on-startup {}. Please use integer", s);
-                    LOG.trace("IGNORED", e);
+                    if (LOG.isTraceEnabled())
+                        LOG.trace("IGNORED", e);
                 }
             }
 

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
@@ -383,7 +383,8 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
             }
             catch (MalformedURLException e)
             {
-                LOG.trace("IGNORED", e);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", e);
                 if (mue == null)
                     mue = e;
             }

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
@@ -1305,7 +1305,8 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
 
     public void resolveMetaData() throws Exception
     {
-        LOG.debug("metadata resolve {}", this);
+        if (LOG.isDebugEnabled())
+            LOG.debug("metadata resolve {}", this);
 
         //Ensure origins is fresh
         _metadata._origins.clear();
@@ -1338,7 +1339,8 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
             p.process(this, _metadata.getWebDescriptor());
             for (WebDescriptor wd : _metadata.getOverrideDescriptors())
             {
-                LOG.debug("process {} {} {}", this, p, wd);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("process {} {} {}", this, p, wd);
                 p.process(this, wd);
             }
         }
@@ -1359,7 +1361,8 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
             {
                 for (DescriptorProcessor p : _metadata._descriptorProcessors)
                 {
-                    LOG.debug("process {} {}", this, fd);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("process {} {}", this, fd);
                     p.process(this, fd);
                 }
             }
@@ -1372,7 +1375,8 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
             {
                 for (DiscoveredAnnotation a : annotations)
                 {
-                    LOG.debug("apply {}", a);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("apply {}", a);
                     a.apply();
                 }
             }

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-common/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/common/JakartaWebSocketSession.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-common/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/common/JakartaWebSocketSession.java
@@ -193,7 +193,8 @@ public class JakartaWebSocketSession implements jakarta.websocket.Session
         }
         catch (Throwable t)
         {
-            LOG.trace("IGNORED", t);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", t);
         }
     }
 

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/coders/QuotesDecoder.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/coders/QuotesDecoder.java
@@ -38,7 +38,8 @@ public class QuotesDecoder implements Decoder.TextStream<Quotes>
             String line;
             while ((line = buf.readLine()) != null)
             {
-                LOG.debug("decode() line = {}", line);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("decode() line = {}", line);
                 switch (line.charAt(0))
                 {
                     case 'a':
@@ -49,7 +50,8 @@ public class QuotesDecoder implements Decoder.TextStream<Quotes>
                         break;
                 }
             }
-            LOG.debug("decode() complete");
+            if (LOG.isDebugEnabled())
+                LOG.debug("decode() complete");
         }
         return quotes;
     }

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/coders/QuotesDecoder.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/coders/QuotesDecoder.java
@@ -33,7 +33,8 @@ public class QuotesDecoder implements Decoder.TextStream<Quotes>
         Quotes quotes = new Quotes();
         try (BufferedReader buf = new BufferedReader(reader))
         {
-            LOG.debug("decode() begin");
+            if (LOG.isDebugEnabled())
+                LOG.debug("decode() begin");
             String line;
             while ((line = buf.readLine()) != null)
             {

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/quotes/QuotesDecoder.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/quotes/QuotesDecoder.java
@@ -34,11 +34,13 @@ public class QuotesDecoder implements Decoder.TextStream<Quotes>
         Quotes quotes = new Quotes();
         try (BufferedReader buf = new BufferedReader(reader))
         {
-            LOG.debug("decode() begin");
+            if (LOG.isDebugEnabled())
+                LOG.debug("decode() begin");
             String line;
             while ((line = buf.readLine()) != null)
             {
-                LOG.debug("decode() line = {}", line);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("decode() line = {}", line);
                 switch (line.charAt(0))
                 {
                     case 'a':
@@ -49,7 +51,8 @@ public class QuotesDecoder implements Decoder.TextStream<Quotes>
                         break;
                 }
             }
-            LOG.debug("decode() complete");
+            if (LOG.isDebugEnabled())
+                LOG.debug("decode() complete");
         }
         return quotes;
     }

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/quotes/QuotesDecoderTest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/quotes/QuotesDecoderTest.java
@@ -65,7 +65,8 @@ public class QuotesDecoderTest
         public void onOpenResource(String filename)
         {
             super.onWsText(filename);
-            QuotesDecoderTest.LOG.debug("onOpenResource({})", filename);
+            if (LOG.isDebugEnabled())
+                LOG.debug("onOpenResource({})", filename);
             try
             {
                 RemoteEndpoint.Basic remote = session.getBasicRemote();

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/server/ConfiguratorTest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/server/ConfiguratorTest.java
@@ -199,7 +199,8 @@ public class ConfiguratorTest
         public void modifyHandshake(ServerEndpointConfig sec, HandshakeRequest request, HandshakeResponse response)
         {
             int upgradeNum = upgradeCount.addAndGet(1);
-            LOG.debug("Upgrade Num: {}", upgradeNum);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Upgrade Num: {}", upgradeNum);
             sec.getUserProperties().put("upgradeNum", Integer.toString(upgradeNum));
             switch (upgradeNum)
             {

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/server/EndpointViaConfigTest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/server/EndpointViaConfigTest.java
@@ -84,13 +84,15 @@ public class EndpointViaConfigTest
             finally
             {
                 client.stop();
-                LOG.debug("Stopped - " + client);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Stopped - " + client);
             }
         }
         finally
         {
             wsb.stop();
-            LOG.debug("Stopped - " + wsb);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Stopped - " + wsb);
         }
     }
 }

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/server/TextStreamTest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/server/TextStreamTest.java
@@ -286,8 +286,8 @@ public class TextStreamTest
                     totalRead += read;
                     output.write(buffer, 0, read);
                 }
-
-                LOG.debug("{} total bytes read/write", totalRead);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("{} total bytes read/write", totalRead);
             }
         }
     }

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/server/examples/WebSocketServerExamplesTest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/server/examples/WebSocketServerExamplesTest.java
@@ -61,27 +61,31 @@ public class WebSocketServerExamplesTest
         @OnOpen
         public void onOpen(Session sess)
         {
-            LOG.debug("ClientSocket Connected: " + sess);
+            if (LOG.isDebugEnabled())
+                LOG.debug("ClientSocket Connected: {}", sess);
         }
 
         @OnMessage
         public void onMessage(String message)
         {
             messageQueue.offer(message);
-            LOG.debug("Received TEXT message: " + message);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Received TEXT message: {}", message);
         }
 
         @OnClose
         public void onClose(CloseReason closeReason)
         {
-            LOG.debug("ClientSocket Closed: " + closeReason);
+            if (LOG.isDebugEnabled())
+                LOG.debug("ClientSocket Closed: {}", closeReason);
             closed.countDown();
         }
 
         @OnError
         public void onError(Throwable cause)
         {
-            LOG.atDebug().setCause(cause).log("ClientSocket error");
+            if (LOG.isDebugEnabled())
+                LOG.atDebug().setCause(cause).log("ClientSocket error");
         }
     }
 

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/test/java/org/eclipse/jetty/ee10/websocket/server/browser/BrowserDebugTool.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/test/java/org/eclipse/jetty/ee10/websocket/server/browser/BrowserDebugTool.java
@@ -136,7 +136,8 @@ public class BrowserDebugTool
         @Override
         public void configure(JettyWebSocketServletFactory factory)
         {
-            LOG.debug("Configuring WebSocketServerFactory ...");
+            if (LOG.isDebugEnabled())
+                LOG.debug("Configuring WebSocketServerFactory ...");
 
             // Setup the desired Socket to use for all incoming upgrade requests
             factory.addMapping("/", new BrowserSocketCreator());
@@ -160,7 +161,8 @@ public class BrowserDebugTool
         @Override
         public Object createWebSocket(JettyServerUpgradeRequest req, JettyServerUpgradeResponse resp)
         {
-            LOG.debug("Creating BrowserSocket");
+            if (LOG.isDebugEnabled())
+                LOG.debug("Creating BrowserSocket");
 
             if (req.getSubProtocols() != null)
             {
@@ -190,12 +192,13 @@ public class BrowserDebugTool
             }
 
             resp.setExtensions(negotiated);
-
-            LOG.debug("User-Agent: {}", ua);
-            LOG.debug("Sec-WebSocket-Extensions (Request) : {}", rexts);
-            LOG.debug("Sec-WebSocket-Protocol (Request): {}", req.getHeader("Sec-WebSocket-Protocol"));
-            LOG.debug("Sec-WebSocket-Protocol (Response): {}", resp.getAcceptedSubProtocol());
-
+            if (LOG.isDebugEnabled())
+            {
+                LOG.debug("User-Agent: {}", ua);
+                LOG.debug("Sec-WebSocket-Extensions (Request) : {}", rexts);
+                LOG.debug("Sec-WebSocket-Protocol (Request): {}", req.getHeader("Sec-WebSocket-Protocol"));
+                LOG.debug("Sec-WebSocket-Protocol (Response): {}", resp.getAcceptedSubProtocol());
+            }
             req.getExtensions();
             return new BrowserSocket(ua, rexts);
         }

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/test/java/org/eclipse/jetty/ee10/websocket/server/browser/BrowserSocket.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server/src/test/java/org/eclipse/jetty/ee10/websocket/server/browser/BrowserSocket.java
@@ -273,13 +273,15 @@ public class BrowserSocket
     {
         if (this.session == null)
         {
-            LOG.debug("Not connected");
+            if (LOG.isDebugEnabled())
+                LOG.debug("Not connected");
             return;
         }
 
         if (!session.isOpen())
         {
-            LOG.debug("Not open");
+            if (LOG.isDebugEnabled())
+                LOG.debug("Not open");
             return;
         }
 

--- a/jetty-ee11/jetty-ee11-annotations/src/main/java/org/eclipse/jetty/ee11/annotations/ResourceAnnotationHandler.java
+++ b/jetty-ee11/jetty-ee11-annotations/src/main/java/org/eclipse/jetty/ee11/annotations/ResourceAnnotationHandler.java
@@ -190,7 +190,8 @@ public class ResourceAnnotationHandler extends AbstractIntrospectableAnnotationH
                     //Check there is a JNDI entry for this annotation
                     if (bound)
                     {
-                        LOG.debug("Bound {} as {}", (mappedName == null ? name : mappedName), name);
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("Bound {} as {}", (mappedName == null ? name : mappedName), name);
                         //   Make the Injection for it if the binding succeeded
                         injection = new Injection(clazz, field, type, name, mappedName);
                         injections.add(injection);
@@ -348,7 +349,8 @@ public class ResourceAnnotationHandler extends AbstractIntrospectableAnnotationH
 
                     if (bound)
                     {
-                        LOG.debug("Bound {} as {}", (mappedName == null ? name : mappedName), name);
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("Bound {} as {}", (mappedName == null ? name : mappedName), name);
                         //   Make the Injection for it
                         injection = new Injection(clazz, method, paramType, resourceType, name, mappedName);
                         injections.add(injection);

--- a/jetty-ee11/jetty-ee11-maven-plugin/src/main/java/org/eclipse/jetty/ee11/maven/plugin/MavenMetaInfConfiguration.java
+++ b/jetty-ee11/jetty-ee11-maven-plugin/src/main/java/org/eclipse/jetty/ee11/maven/plugin/MavenMetaInfConfiguration.java
@@ -64,7 +64,8 @@ public class MavenMetaInfConfiguration extends MetaInfConfiguration
                 {
                     try
                     {
-                        LOG.debug(" add  resource to resources to examine {}", file);
+                        if (LOG.isDebugEnabled())
+                            LOG.debug(" add  resource to resources to examine {}", file);
                         list.add(context.getResourceFactory().newResource(file.toURI()));
                     }
                     catch (Exception e)

--- a/jetty-ee11/jetty-ee11-maven-plugin/src/main/java/org/eclipse/jetty/ee11/maven/plugin/MavenWebAppContext.java
+++ b/jetty-ee11/jetty-ee11-maven-plugin/src/main/java/org/eclipse/jetty/ee11/maven/plugin/MavenWebAppContext.java
@@ -492,7 +492,8 @@ public class MavenWebAppContext extends WebAppContext
         }
         catch (ClassNotFoundException e)
         {
-            LOG.debug("o.e.j.cdi.servlet.JettyWeldInitializer not found, no cdi integration available");
+            if (LOG.isDebugEnabled())
+                LOG.debug("o.e.j.cdi.servlet.JettyWeldInitializer not found, no cdi integration available");
         }
         catch (NoSuchMethodException e)
         {

--- a/jetty-ee11/jetty-ee11-plus/src/main/java/org/eclipse/jetty/ee11/plus/webapp/EnvConfiguration.java
+++ b/jetty-ee11/jetty-ee11-plus/src/main/java/org/eclipse/jetty/ee11/plus/webapp/EnvConfiguration.java
@@ -169,11 +169,13 @@ public class EnvConfiguration extends AbstractConfiguration
         catch (NameNotFoundException e)
         {
             LOG.trace("IGNORED", e);
-            LOG.debug("No jndi entries scoped to webapp {}", context);
+            if (LOG.isDebugEnabled())
+                LOG.debug("No jndi entries scoped to webapp {}", context);
         }
         catch (NamingException e)
         {
-            LOG.debug("Error unbinding jndi entries scoped to webapp {}", context, e);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Error unbinding jndi entries scoped to webapp {}", context, e);
         }
     }
 
@@ -191,17 +193,17 @@ public class EnvConfiguration extends AbstractConfiguration
     {
         InitialContext ic = new InitialContext();
         Context envCtx = (Context)ic.lookup("java:comp/env");
-
-        LOG.debug("Binding env entries from the jvm scope");
+        if (LOG.isDebugEnabled())
+            LOG.debug("Binding env entries from the jvm scope");
         doBindings(envCtx, null);
-
-        LOG.debug("Binding env entries from the server scope");
+        if (LOG.isDebugEnabled())
+            LOG.debug("Binding env entries from the server scope");
         doBindings(envCtx, context.getServer());
-
-        LOG.debug("Binding env entries from environment {} scope", ServletContextHandler.ENVIRONMENT.getName());
+        if (LOG.isDebugEnabled())
+            LOG.debug("Binding env entries from environment {} scope", ServletContextHandler.ENVIRONMENT.getName());
         doBindings(envCtx, ServletContextHandler.ENVIRONMENT.getName());
-
-        LOG.debug("Binding env entries from the context scope");
+        if (LOG.isDebugEnabled())
+            LOG.debug("Binding env entries from the context scope");
         doBindings(envCtx, context);
     }
 

--- a/jetty-ee11/jetty-ee11-plus/src/main/java/org/eclipse/jetty/ee11/plus/webapp/EnvConfiguration.java
+++ b/jetty-ee11/jetty-ee11-plus/src/main/java/org/eclipse/jetty/ee11/plus/webapp/EnvConfiguration.java
@@ -168,7 +168,8 @@ public class EnvConfiguration extends AbstractConfiguration
         }
         catch (NameNotFoundException e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
             if (LOG.isDebugEnabled())
                 LOG.debug("No jndi entries scoped to webapp {}", context);
         }

--- a/jetty-ee11/jetty-ee11-plus/src/main/java/org/eclipse/jetty/ee11/plus/webapp/PlusConfiguration.java
+++ b/jetty-ee11/jetty-ee11-plus/src/main/java/org/eclipse/jetty/ee11/plus/webapp/PlusConfiguration.java
@@ -93,7 +93,8 @@ public class PlusConfiguration extends AbstractConfiguration
             }
             catch (NameNotFoundException x)
             {
-                LOG.debug("No Transaction manager found - if your webapp requires one, please configure one.");
+                if (LOG.isDebugEnabled())
+                    LOG.debug("No Transaction manager found - if your webapp requires one, please configure one.");
             }
         }
     }

--- a/jetty-ee11/jetty-ee11-proxy/src/main/java/org/eclipse/jetty/ee11/proxy/AfterContentTransformer.java
+++ b/jetty-ee11/jetty-ee11-proxy/src/main/java/org/eclipse/jetty/ee11/proxy/AfterContentTransformer.java
@@ -286,7 +286,8 @@ public abstract class AfterContentTransformer implements AsyncMiddleManServlet.C
         }
         catch (IOException x)
         {
-            LOG.trace("IGNORED", x);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", x);
         }
     }
 

--- a/jetty-ee11/jetty-ee11-proxy/src/test/java/org/eclipse/jetty/ee11/proxy/AsyncMiddleManServletTest.java
+++ b/jetty-ee11/jetty-ee11-proxy/src/test/java/org/eclipse/jetty/ee11/proxy/AsyncMiddleManServletTest.java
@@ -1801,7 +1801,8 @@ public class AsyncMiddleManServletTest
             protected String transform(String value)
             {
                 String result = PREFIX + URLEncoder.encode(value, StandardCharsets.UTF_8);
-                LOG.debug("{} -> {}", value, result);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("{} -> {}", value, result);
                 return result;
             }
         }
@@ -1812,7 +1813,8 @@ public class AsyncMiddleManServletTest
             protected String transform(String value)
             {
                 String result = URLDecoder.decode(value.substring(PREFIX.length()), StandardCharsets.UTF_8);
-                LOG.debug("{} <- {}", value, result);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("{} <- {}", value, result);
                 return result;
             }
         }

--- a/jetty-ee11/jetty-ee11-proxy/src/test/java/org/eclipse/jetty/ee11/proxy/ProxyServletLoadTest.java
+++ b/jetty-ee11/jetty-ee11-proxy/src/test/java/org/eclipse/jetty/ee11/proxy/ProxyServletLoadTest.java
@@ -193,7 +193,8 @@ public class ProxyServletLoadTest
         public void run()
         {
             String threadName = Thread.currentThread().getName();
-            LOG.debug("Starting thread {}", threadName);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Starting thread {}", threadName);
             try
             {
                 while (success.get())
@@ -225,7 +226,8 @@ public class ProxyServletLoadTest
             }
             finally
             {
-                LOG.debug("Shutting down thread {}", threadName);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Shutting down thread {}", threadName);
                 active.countDown();
             }
         }

--- a/jetty-ee11/jetty-ee11-quickstart/src/main/java/org/eclipse/jetty/ee11/quickstart/ExtraXmlDescriptorProcessor.java
+++ b/jetty-ee11/jetty-ee11-quickstart/src/main/java/org/eclipse/jetty/ee11/quickstart/ExtraXmlDescriptorProcessor.java
@@ -51,7 +51,8 @@ public class ExtraXmlDescriptorProcessor extends IterativeDescriptorProcessor
     @Override
     public void start(WebAppContext context, Descriptor descriptor)
     {
-        LOG.debug("process {}", descriptor);
+        if (LOG.isDebugEnabled())
+            LOG.debug("process {}", descriptor);
         _origin = (StringUtil.isBlank(_originAttribute) ? null : "  <!-- " + descriptor + " -->\n");
     }
 
@@ -71,7 +72,8 @@ public class ExtraXmlDescriptorProcessor extends IterativeDescriptorProcessor
         //Note: we have to output the origin as a comment field instead of
         //as an attribute like the other other elements because
         //we are copying these elements _verbatim_ from the descriptor
-        LOG.debug("save {}", node.getTag());
+        if (LOG.isDebugEnabled())
+            LOG.debug("save {}", node.getTag());
         if (_origin != null)
             _buffer.append(_origin);
         _buffer.append("  ").append(node.toString()).append("\n");

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/CrossContextServletContext.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/CrossContextServletContext.java
@@ -150,7 +150,8 @@ class CrossContextServletContext implements ServletContext
         }
         catch (Exception e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
         }
         return null;
     }

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/Invoker.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/Invoker.java
@@ -179,7 +179,8 @@ public class Invoker extends HttpServlet
                     }
                     catch (Exception e)
                     {
-                        LOG.debug("Unable to start {}", holder, e);
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("Unable to start {}", holder, e);
                         throw new UnavailableException(e.toString());
                     }
 

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/Invoker.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/Invoker.java
@@ -198,7 +198,8 @@ public class Invoker extends HttpServlet
                             }
                             catch (Exception e)
                             {
-                                LOG.trace("IGNORED", e);
+                                if (LOG.isTraceEnabled())
+                                    LOG.trace("IGNORED", e);
                             }
 
                             LOG.warn("Dynamic servlet {} not loaded from context {}", s, request.getContextPath());

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ResourceServlet.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ResourceServlet.java
@@ -835,7 +835,7 @@ public class ResourceServlet extends HttpServlet
         protected void writeHttpError(Request coreRequest, Response coreResponse, Callback callback, Throwable cause)
         {
             if (LOG.isDebugEnabled())
-                LOG.atDebug().setCause(cause).log("writeHttpError(coreRequest={}, coreResponse={}, callback={}, cause={})", coreRequest, coreResponse, callback, cause);
+                LOG.atDebug().setCause(cause).log("writeHttpError(coreRequest={}, coreResponse={}, callback={})", coreRequest, coreResponse, callback);
 
             int statusCode = HttpStatus.INTERNAL_SERVER_ERROR_500;
             String reason = null;
@@ -851,7 +851,7 @@ public class ResourceServlet extends HttpServlet
         protected void writeHttpError(Request coreRequest, Response coreResponse, Callback callback, int statusCode, String reason, Throwable cause)
         {
             if (LOG.isDebugEnabled())
-                LOG.atDebug().setCause(cause).log("writeHttpError(coreRequest={}, coreResponse={}, callback={}, statusCode={}, reason={}, cause={})", coreRequest, coreResponse, callback, statusCode, reason, cause);
+                LOG.atDebug().setCause(cause).log("writeHttpError(coreRequest={}, coreResponse={}, callback={}, statusCode={}, reason={})", coreRequest, coreResponse, callback, statusCode, reason);
             HttpServletRequest request = getServletRequest(coreRequest);
             HttpServletResponse response = getServletResponse(coreResponse);
             try

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletChannel.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletChannel.java
@@ -614,7 +614,10 @@ public class ServletChannel
             catch (Throwable failure)
             {
                 if ("org.eclipse.jetty.continuation.ContinuationThrowable".equals(failure.getClass().getName()))
-                    LOG.trace("IGNORED", failure);
+                {
+                    if (LOG.isTraceEnabled())
+                        LOG.trace("IGNORED", failure);
+                }
                 else
                     handleException(failure);
             }

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletChannelState.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletChannelState.java
@@ -983,7 +983,10 @@ public class ServletChannelState
             else if (_requestState != RequestState.COMPLETE)
             {
                 if (QuietException.isQuiet(th))
-                    LOG.debug("unhandled in state {}", _requestState, th);
+                {
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("unhandled in state {}", _requestState, th);
+                }
                 else
                     LOG.warn("unhandled in state {}", _requestState, new IllegalStateException(th));
             }

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextHandler.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextHandler.java
@@ -782,7 +782,8 @@ public class ServletContextHandler extends ContextHandler
         }
         catch (Exception e)
         {
-            LOG.trace("IGNORE", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORE", e);
         }
         return null;
     }
@@ -843,7 +844,8 @@ public class ServletContextHandler extends ContextHandler
         }
         catch (Exception e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
         }
         return Collections.emptySet();
     }
@@ -2767,7 +2769,8 @@ public class ServletContextHandler extends ContextHandler
             }
             catch (Exception e)
             {
-                LOG.trace("IGNORED", e);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", e);
             }
             return null;
         }
@@ -2813,7 +2816,8 @@ public class ServletContextHandler extends ContextHandler
             }
             catch (Exception e)
             {
-                LOG.trace("IGNORED", e);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", e);
             }
 
             return null;
@@ -2864,7 +2868,8 @@ public class ServletContextHandler extends ContextHandler
             }
             catch (Exception e)
             {
-                LOG.trace("IGNORED", e);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", e);
                 return null;
             }
         }

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextHandler.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextHandler.java
@@ -783,7 +783,7 @@ public class ServletContextHandler extends ContextHandler
         catch (Exception e)
         {
             if (LOG.isTraceEnabled())
-                LOG.trace("IGNORE", e);
+                LOG.trace("IGNORED", e);
         }
         return null;
     }

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletHandler.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletHandler.java
@@ -563,12 +563,14 @@ public class ServletHandler extends Handler.Wrapper
             if (_maxFilterChainsCacheSize > 0 && cache.size() >= _maxFilterChainsCacheSize)
             {
                 // flush the cache
-                LOG.debug("{} flushed filter chain cache for {}", this, dispatcherType);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("{} flushed filter chain cache for {}", this, dispatcherType);
                 cache.clear();
             }
             chain = chain == null ? new ChainEnd(servletHolder) : chain;
             // flush the cache
-            LOG.debug("{} cached filter chain for {}: {}", this, dispatcherType, chain);
+            if (LOG.isDebugEnabled())
+                LOG.debug("{} cached filter chain for {}: {}", this, dispatcherType, chain);
             cache.put(key, chain);
         }
         return chain;

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletHolder.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletHolder.java
@@ -385,7 +385,8 @@ public class ServletHolder extends Holder<Servlet> implements Comparable<Servlet
             makeUnavailable(ex);
             if (getServletHandler().isStartWithUnavailable())
             {
-                LOG.trace("IGNORED", ex);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", ex);
                 return;
             }
             else
@@ -402,7 +403,8 @@ public class ServletHolder extends Holder<Servlet> implements Comparable<Servlet
             makeUnavailable(ex);
             if (getServletHandler().isStartWithUnavailable())
             {
-                LOG.trace("IGNORED", ex);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", ex);
                 return;
             }
             else

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/AsyncServletIOTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/AsyncServletIOTest.java
@@ -215,14 +215,16 @@ public class AsyncServletIOTest
 
             // response line
             String line = in.readLine();
-            LOG.debug("response-line: " + line);
+            if (LOG.isDebugEnabled())
+                LOG.debug("response-line: " + line);
             assertThat(line, startsWith("HTTP/1.1 200 OK"));
 
             // Skip headers
             while (line != null)
             {
                 line = in.readLine();
-                LOG.debug("header-line: " + line);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("header-line: " + line);
                 if (line.length() == 0)
                     break;
             }
@@ -231,7 +233,8 @@ public class AsyncServletIOTest
             while (true)
             {
                 line = in.readLine();
-                LOG.debug("body: " + line);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("body: " + line);
                 if (line == null)
                     break;
                 list.add(line);
@@ -291,21 +294,24 @@ public class AsyncServletIOTest
 
             // response line
             String line = in.readLine();
-            LOG.debug("response-line: " + line);
+            if (LOG.isDebugEnabled())
+                LOG.debug("response-line: " + line);
             assertThat(line, startsWith("HTTP/1.1 200 OK"));
 
             // Skip headers
             while (line != null)
             {
                 line = in.readLine();
-                LOG.debug("header-line: " + line);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("header-line: " + line);
                 if (line.length() == 0)
                     break;
             }
 
             // Get body
             line = in.readLine();
-            LOG.debug("body: " + line);
+            if (LOG.isDebugEnabled())
+                LOG.debug("body: " + line);
             assertEquals("DONE", line);
 
             // The connection should be aborted
@@ -334,7 +340,8 @@ public class AsyncServletIOTest
             request.append(s).append("w=").append(w);
             s = '&';
         }
-        LOG.debug("process {} {}", request.toString(), BufferUtil.toDetailString(BufferUtil.toBuffer(content)));
+        if (LOG.isDebugEnabled())
+            LOG.debug("process {} {}", request.toString(), BufferUtil.toDetailString(BufferUtil.toBuffer(content)));
 
         request.append(" HTTP/1.1\r\n")
             .append("Host: localhost\r\n")
@@ -369,14 +376,16 @@ public class AsyncServletIOTest
 
             // response line
             String line = in.readLine();
-            LOG.debug("response-line: " + line);
+            if (LOG.isDebugEnabled())
+                LOG.debug("response-line: " + line);
             assertThat(line, startsWith("HTTP/1.1 200 OK"));
 
             // Skip headers
             while (line != null)
             {
                 line = in.readLine();
-                LOG.debug("header-line:  " + line);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("header-line:  " + line);
                 if (line.length() == 0)
                     break;
             }
@@ -387,7 +396,8 @@ public class AsyncServletIOTest
                 line = in.readLine();
                 if (line == null)
                     break;
-                LOG.debug("body:  " + brief(line));
+                if (LOG.isDebugEnabled())
+                    LOG.debug("body:  " + brief(line));
                 list.add(line);
                 Thread.sleep(50);
             }
@@ -397,7 +407,8 @@ public class AsyncServletIOTest
         int w = 0;
         for (String line : list)
         {
-            LOG.debug("line:  " + brief(line));
+            if (LOG.isDebugEnabled())
+                LOG.debug("line:  " + brief(line));
             if ("-".equals(line))
                 continue;
             assertEquals(writes[w], line.length(), "Line Length");
@@ -500,7 +511,8 @@ public class AsyncServletIOTest
                 @Override
                 public void onWritePossible() throws IOException
                 {
-                    LOG.debug("OWP");
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("OWP");
                     _owp.incrementAndGet();
 
                     while (writes != null && _w < writes.length)
@@ -676,7 +688,8 @@ public class AsyncServletIOTest
 
             // response line
             String line = in.readLine();
-            LOG.debug("response-line: " + line);
+            if (LOG.isDebugEnabled())
+                LOG.debug("response-line: " + line);
             assertThat(line, startsWith("HTTP/1.1 200 OK"));
 
             boolean chunked = false;
@@ -684,7 +697,8 @@ public class AsyncServletIOTest
             while (line != null)
             {
                 line = in.readLine();
-                LOG.debug("header-line: " + line);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("header-line: " + line);
                 chunked |= "Transfer-Encoding: chunked".equals(line);
                 if (line.length() == 0)
                     break;
@@ -701,7 +715,8 @@ public class AsyncServletIOTest
                     last = line;
                     //Thread.sleep(1000);
                     line = in.readLine();
-                    LOG.debug("body: " + line);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("body: " + line);
                     if (line == null)
                         break;
                     list.add(line);
@@ -711,8 +726,8 @@ public class AsyncServletIOTest
             {
                 // ignored
             }
-
-            LOG.debug("last: " + last);
+            if (LOG.isDebugEnabled())
+                LOG.debug("last: " + last);
 
             // last non empty line should not contain end chunk
             assertThat(last, notNullValue());

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/ErrorPageTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/ErrorPageTest.java
@@ -517,7 +517,8 @@ public class ErrorPageTest
                 }
                 catch (Throwable ignore)
                 {
-                    LOG.trace("IGNORED", ignore);
+                    if (LOG.isTraceEnabled())
+                        LOG.trace("IGNORED", ignore);
                 }
             }
         };
@@ -1484,7 +1485,8 @@ public class ErrorPageTest
                             }
                             catch (IllegalStateException e)
                             {
-                                LOG.trace("IGNORED", e);
+                                if (LOG.isTraceEnabled())
+                                    LOG.trace("IGNORED", e);
                             }
                             finally
                             {

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/RequestTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/RequestTest.java
@@ -575,7 +575,8 @@ public class RequestTest
         }
         catch (UnknownHostException e)
         {
-            LOG.debug("Unable to obtain InetAddress.LocalHost", e);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Unable to obtain InetAddress.LocalHost", e);
         }
         return hostHeader.stream().map(Arguments::of);
     }

--- a/jetty-ee11/jetty-ee11-servlets/src/main/java/org/eclipse/jetty/ee11/servlets/CrossOriginFilter.java
+++ b/jetty-ee11/jetty-ee11-servlets/src/main/java/org/eclipse/jetty/ee11/servlets/CrossOriginFilter.java
@@ -281,21 +281,25 @@ public class CrossOriginFilter implements Filter
             {
                 if (isSimpleRequest(request))
                 {
-                    LOG.debug("Cross-origin request to {} is a simple cross-origin request", request.getRequestURI());
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("Cross-origin request to {} is a simple cross-origin request", request.getRequestURI());
                     handleSimpleResponse(request, response, origin);
                 }
                 else if (isPreflightRequest(request))
                 {
-                    LOG.debug("Cross-origin request to {} is a preflight cross-origin request", request.getRequestURI());
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("Cross-origin request to {} is a preflight cross-origin request", request.getRequestURI());
                     handlePreflightResponse(request, response, origin);
                     if (chainPreflight)
-                        LOG.debug("Preflight cross-origin request to {} forwarded to application", request.getRequestURI());
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("Preflight cross-origin request to {} forwarded to application", request.getRequestURI());
                     else
                         return;
                 }
                 else
                 {
-                    LOG.debug("Cross-origin request to {} is a non-simple cross-origin request", request.getRequestURI());
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("Cross-origin request to {} is a non-simple cross-origin request", request.getRequestURI());
                     handleSimpleResponse(request, response, origin);
                 }
 
@@ -422,18 +426,21 @@ public class CrossOriginFilter implements Filter
     private boolean isMethodAllowed(HttpServletRequest request)
     {
         String accessControlRequestMethod = request.getHeader(ACCESS_CONTROL_REQUEST_METHOD_HEADER);
-        LOG.debug("{} is {}", ACCESS_CONTROL_REQUEST_METHOD_HEADER, accessControlRequestMethod);
+        if (LOG.isDebugEnabled())
+            LOG.debug("{} is {}", ACCESS_CONTROL_REQUEST_METHOD_HEADER, accessControlRequestMethod);
         boolean result = false;
         if (accessControlRequestMethod != null)
             result = allowedMethods.contains(accessControlRequestMethod);
-        LOG.debug("Method {} is" + (result ? "" : " not") + " among allowed methods {}", accessControlRequestMethod, allowedMethods);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Method {} is" + (result ? "" : " not") + " among allowed methods {}", accessControlRequestMethod, allowedMethods);
         return result;
     }
 
     private List<String> getAccessControlRequestHeaders(HttpServletRequest request)
     {
         String accessControlRequestHeaders = request.getHeader(ACCESS_CONTROL_REQUEST_HEADERS_HEADER);
-        LOG.debug("{} is {}", ACCESS_CONTROL_REQUEST_HEADERS_HEADER, accessControlRequestHeaders);
+        if (LOG.isDebugEnabled())
+            LOG.debug("{} is {}", ACCESS_CONTROL_REQUEST_HEADERS_HEADER, accessControlRequestHeaders);
         if (accessControlRequestHeaders == null)
             return Collections.emptyList();
 
@@ -452,7 +459,8 @@ public class CrossOriginFilter implements Filter
     {
         if (anyHeadersAllowed)
         {
-            LOG.debug("Any header is allowed");
+            if (LOG.isDebugEnabled())
+                LOG.debug("Any header is allowed");
             return true;
         }
 
@@ -474,7 +482,8 @@ public class CrossOriginFilter implements Filter
                 break;
             }
         }
-        LOG.debug("Headers [{}] are" + (result ? "" : " not") + " among allowed headers {}", requestedHeaders, allowedHeaders);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Headers [{}] are" + (result ? "" : " not") + " among allowed headers {}", requestedHeaders, allowedHeaders);
         return result;
     }
 

--- a/jetty-ee11/jetty-ee11-servlets/src/main/java/org/eclipse/jetty/ee11/servlets/CrossOriginFilter.java
+++ b/jetty-ee11/jetty-ee11-servlets/src/main/java/org/eclipse/jetty/ee11/servlets/CrossOriginFilter.java
@@ -291,8 +291,10 @@ public class CrossOriginFilter implements Filter
                         LOG.debug("Cross-origin request to {} is a preflight cross-origin request", request.getRequestURI());
                     handlePreflightResponse(request, response, origin);
                     if (chainPreflight)
+                    {
                         if (LOG.isDebugEnabled())
                             LOG.debug("Preflight cross-origin request to {} forwarded to application", request.getRequestURI());
+                    }
                     else
                         return;
                 }

--- a/jetty-ee11/jetty-ee11-servlets/src/main/java/org/eclipse/jetty/ee11/servlets/DoSFilter.java
+++ b/jetty-ee11/jetty-ee11-servlets/src/main/java/org/eclipse/jetty/ee11/servlets/DoSFilter.java
@@ -422,7 +422,8 @@ public class DoSFilter implements Filter
         }
         catch (InterruptedException e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
             response.sendError(getTooManyCode());
         }
         finally
@@ -489,7 +490,8 @@ public class DoSFilter implements Filter
             }
             catch (IllegalStateException ise)
             {
-                LOG.trace("IGNORED", ise);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", ise);
                 // abort instead
                 response.sendError(-1);
             }
@@ -705,7 +707,8 @@ public class DoSFilter implements Filter
         }
         catch (Exception x)
         {
-            LOG.trace("IGNORED", x);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", x);
         }
     }
 

--- a/jetty-ee11/jetty-ee11-servlets/src/main/java/org/eclipse/jetty/ee11/servlets/DoSFilter.java
+++ b/jetty-ee11/jetty-ee11-servlets/src/main/java/org/eclipse/jetty/ee11/servlets/DoSFilter.java
@@ -690,7 +690,8 @@ public class DoSFilter implements Filter
     @Override
     public void destroy()
     {
-        LOG.debug("Destroy {}", this);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Destroy {}", this);
         stopScheduler();
         _rateTrackers.clear();
         _whitelist.clear();
@@ -1037,7 +1038,8 @@ public class DoSFilter implements Filter
         }
         clearWhitelist();
         _whitelist.addAll(result);
-        LOG.debug("Whitelisted IP addresses: {}", result);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Whitelisted IP addresses: {}", result);
     }
 
     /**

--- a/jetty-ee11/jetty-ee11-servlets/src/main/java/org/eclipse/jetty/ee11/servlets/IncludeExcludeBasedFilter.java
+++ b/jetty-ee11/jetty-ee11-servlets/src/main/java/org/eclipse/jetty/ee11/servlets/IncludeExcludeBasedFilter.java
@@ -109,19 +109,22 @@ public abstract class IncludeExcludeBasedFilter implements Filter
     protected String guessMimeType(HttpServletRequest httpRequest, HttpServletResponse httpResponse)
     {
         String contentType = httpResponse.getContentType();
-        LOG.debug("Content Type is: {}", contentType);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Content Type is: {}", contentType);
 
         String mimeType;
         if (contentType != null)
         {
             mimeType = MimeTypes.getContentTypeWithoutCharset(contentType);
-            LOG.debug("Mime Type is: {}", mimeType);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Mime Type is: {}", mimeType);
         }
         else
         {
             String requestUrl = httpRequest.getPathInfo();
             mimeType = Objects.requireNonNullElse(httpRequest.getServletContext().getMimeType(requestUrl), "");
-            LOG.debug("Guessed mime type is {}", mimeType);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Guessed mime type is {}", mimeType);
         }
 
         return mimeType;
@@ -130,10 +133,12 @@ public abstract class IncludeExcludeBasedFilter implements Filter
     protected boolean shouldFilter(HttpServletRequest httpRequest, HttpServletResponse httpResponse)
     {
         String httpMethod = httpRequest.getMethod();
-        LOG.debug("HTTP method is: {}", httpMethod);
+        if (LOG.isDebugEnabled())
+            LOG.debug("HTTP method is: {}", httpMethod);
         if (!_httpMethods.test(httpMethod))
         {
-            LOG.debug("should not apply filter because HTTP method does not match");
+            if (LOG.isDebugEnabled())
+                LOG.debug("should not apply filter because HTTP method does not match");
             return false;
         }
 
@@ -141,16 +146,19 @@ public abstract class IncludeExcludeBasedFilter implements Filter
 
         if (!_mimeTypes.test(mimeType))
         {
-            LOG.debug("should not apply filter because mime type does not match");
+            if (LOG.isDebugEnabled())
+                LOG.debug("should not apply filter because mime type does not match");
             return false;
         }
 
         ServletContext context = httpRequest.getServletContext();
         String path = context == null ? httpRequest.getRequestURI() : URIUtil.addPaths(httpRequest.getServletPath(), httpRequest.getPathInfo());
-        LOG.debug("Path is: {}", path);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Path is: {}", path);
         if (!_paths.test(path))
         {
-            LOG.debug("should not apply filter because path does not match");
+            if (LOG.isDebugEnabled())
+                LOG.debug("should not apply filter because path does not match");
             return false;
         }
 

--- a/jetty-ee11/jetty-ee11-servlets/src/test/java/org/eclipse/jetty/ee11/servlets/AsyncManipFilter.java
+++ b/jetty-ee11/jetty-ee11-servlets/src/test/java/org/eclipse/jetty/ee11/servlets/AsyncManipFilter.java
@@ -46,21 +46,25 @@ public class AsyncManipFilter implements Filter, AsyncListener
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException
     {
-        LOG.debug("doFilter() - {}", chain);
+        if (LOG.isDebugEnabled())
+            LOG.debug("doFilter() - {}", chain);
         AsyncContext ctx = (AsyncContext)request.getAttribute(MANIP_KEY);
         if (ctx == null)
         {
-            LOG.debug("Initial pass through: {}", chain);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Initial pass through: {}", chain);
             ctx = request.startAsync();
             ctx.addListener(this);
             ctx.setTimeout(1000);
-            LOG.debug("AsyncContext: {}", ctx);
+            if (LOG.isDebugEnabled())
+                LOG.debug("AsyncContext: {}", ctx);
             request.setAttribute(MANIP_KEY, ctx);
             return;
         }
         else
         {
-            LOG.debug("Second pass through: {}", chain);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Second pass through: {}", chain);
             chain.doFilter(request, response);
         }
     }
@@ -73,25 +77,29 @@ public class AsyncManipFilter implements Filter, AsyncListener
     @Override
     public void onComplete(AsyncEvent event) throws IOException
     {
-        LOG.debug("onComplete() {}", event);
+        if (LOG.isDebugEnabled())
+            LOG.debug("onComplete() {}", event);
     }
 
     @Override
     public void onTimeout(AsyncEvent event) throws IOException
     {
-        LOG.debug("onTimeout() {}", event.getAsyncContext());
+        if (LOG.isDebugEnabled())
+            LOG.debug("onTimeout() {}", event.getAsyncContext());
         event.getAsyncContext().dispatch();
     }
 
     @Override
     public void onError(AsyncEvent event) throws IOException
     {
-        LOG.debug("onError()", event.getThrowable());
+        if (LOG.isDebugEnabled())
+            LOG.debug("onError()", event.getThrowable());
     }
 
     @Override
     public void onStartAsync(AsyncEvent event) throws IOException
     {
-        LOG.debug("onTimeout() {}", event);
+        if (LOG.isDebugEnabled())
+            LOG.debug("onTimeout() {}", event);
     }
 }

--- a/jetty-ee11/jetty-ee11-servlets/src/test/java/org/eclipse/jetty/ee11/servlets/QoSFilterTest.java
+++ b/jetty-ee11/jetty-ee11-servlets/src/test/java/org/eclipse/jetty/ee11/servlets/QoSFilterTest.java
@@ -214,7 +214,8 @@ public class QoSFilterTest
             }
             catch (Exception e)
             {
-                LOG.debug("Request " + url + " failed", e);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Request " + url + " failed", e);
             }
             finally
             {

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/java/org/eclipse/jetty/ee11/test/FailedSelectorTest.java
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/java/org/eclipse/jetty/ee11/test/FailedSelectorTest.java
@@ -377,7 +377,8 @@ public class FailedSelectorTest
                 {
                     CustomManagedSelector customManagedSelector = (CustomManagedSelector)managedSelector;
                     Selector selector = customManagedSelector.getSelector();
-                    LOG.debug("Closing selector {}}", selector);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("Closing selector {}}", selector);
                     IO.close(selector);
                 }
             }

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/java/org/eclipse/jetty/ee11/test/FailedSelectorTest.java
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/java/org/eclipse/jetty/ee11/test/FailedSelectorTest.java
@@ -378,7 +378,7 @@ public class FailedSelectorTest
                     CustomManagedSelector customManagedSelector = (CustomManagedSelector)managedSelector;
                     Selector selector = customManagedSelector.getSelector();
                     if (LOG.isDebugEnabled())
-                        LOG.debug("Closing selector {}}", selector);
+                        LOG.debug("Closing selector {}", selector);
                     IO.close(selector);
                 }
             }

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/java/org/eclipse/jetty/ee11/test/websocket/JakartaSimpleEchoSocket.java
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/java/org/eclipse/jetty/ee11/test/websocket/JakartaSimpleEchoSocket.java
@@ -46,21 +46,24 @@ public class JakartaSimpleEchoSocket
     @OnClose
     public void onClose(CloseReason close)
     {
-        LOG.debug("Closed: {}, {}", close.getCloseCode().getCode(), close.getReasonPhrase());
+        if (LOG.isDebugEnabled())
+            LOG.debug("Closed: {}, {}", close.getCloseCode().getCode(), close.getReasonPhrase());
         closeLatch.countDown();
     }
 
     @OnMessage
     public void onMessage(String message)
     {
-        LOG.debug("Received: {}", message);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Received: {}", message);
         messageLatch.countDown();
     }
 
     @OnOpen
     public void onOpen(Session session)
     {
-        LOG.debug("Opened");
+        if (LOG.isDebugEnabled())
+            LOG.debug("Opened");
         this.session = session;
     }
 }

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/java/org/eclipse/jetty/ee11/test/websocket/JettySimpleEchoSocket.java
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/java/org/eclipse/jetty/ee11/test/websocket/JettySimpleEchoSocket.java
@@ -50,7 +50,8 @@ public class JettySimpleEchoSocket
     @OnWebSocketClose
     public void onClose(int statusCode, String reason)
     {
-        LOG.debug("Connection closed: {} - {}", statusCode, reason);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Connection closed: {} - {}", statusCode, reason);
         this.session = null;
         this.closeLatch.countDown(); // trigger latch
     }
@@ -58,7 +59,8 @@ public class JettySimpleEchoSocket
     @OnWebSocketOpen
     public void onOpen(Session session)
     {
-        LOG.debug("Open: {}", session);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Open: {}", session);
         this.session = session;
         session.setMaxTextMessageSize(64 * 1024);
         try
@@ -75,6 +77,7 @@ public class JettySimpleEchoSocket
     @OnWebSocketMessage
     public void onMessage(String msg)
     {
-        LOG.debug("Got msg: {}", msg);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Got msg: {}", msg);
     }
 }

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-jersey/src/test/java/org/eclipse/jetty/ee11/jersey/tests/HungBlockingThreadsTest.java
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-jersey/src/test/java/org/eclipse/jetty/ee11/jersey/tests/HungBlockingThreadsTest.java
@@ -159,15 +159,15 @@ public class HungBlockingThreadsTest
                     .send(result -> {});
             });
         }
-
-        LOG.debug("Awaiting for client to block on all threads");
+        if (LOG.isDebugEnabled())
+            LOG.debug("Awaiting for client to block on all threads");
         assertTrue(latch.await(15, TimeUnit.SECONDS));
-
-        LOG.debug("Shutting down client");
+        if (LOG.isDebugEnabled())
+            LOG.debug("Shutting down client");
         // While the server is hanging in InputStream read, close the client's connections.
         httpClient.stop();
-
-        LOG.debug("Waiting for hung threads");
+        if (LOG.isDebugEnabled())
+            LOG.debug("Waiting for hung threads");
         await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertThat(threadDump(), not(containsString(Blocker.Shared.class.getName()))));
     }
 

--- a/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/Configurations.java
+++ b/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/Configurations.java
@@ -201,7 +201,8 @@ public class Configurations extends AbstractList<Configuration> implements Dumpa
             else
             {
                 Object attr = server.getAttribute(SERVER_DEFAULT_ATTR);
-                LOG.debug("{} attr({})= {}", server, SERVER_DEFAULT_ATTR, attr);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("{} attr({})= {}", server, SERVER_DEFAULT_ATTR, attr);
                 if (attr instanceof Configurations)
                     configurations = new Configurations((Configurations)attr);
                 else if (attr instanceof String[])
@@ -483,7 +484,8 @@ public class Configurations extends AbstractList<Configuration> implements Dumpa
         for (int i = 0; i < _configurations.size(); i++)
         {
             Configuration configuration = _configurations.get(i);
-            LOG.debug("preConfigure with {}", configuration);
+            if (LOG.isDebugEnabled())
+                LOG.debug("preConfigure with {}", configuration);
             configuration.preConfigure(webapp);
 
             if (_configurations.get(i) != configuration)
@@ -501,7 +503,8 @@ public class Configurations extends AbstractList<Configuration> implements Dumpa
         // Configure webapp
         for (Configuration configuration : _configurations)
         {
-            LOG.debug("configure {}", configuration);
+            if (LOG.isDebugEnabled())
+                LOG.debug("configure {}", configuration);
             configuration.configure(webapp);
             if (configuration.abort(webapp))
                 return false;
@@ -514,7 +517,8 @@ public class Configurations extends AbstractList<Configuration> implements Dumpa
         // Configure webapp
         for (Configuration configuration : _configurations)
         {
-            LOG.debug("postConfigure {}", configuration);
+            if (LOG.isDebugEnabled())
+                LOG.debug("postConfigure {}", configuration);
             configuration.postConfigure(webapp);
         }
     }

--- a/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/JaasConfiguration.java
+++ b/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/JaasConfiguration.java
@@ -47,7 +47,8 @@ public class JaasConfiguration extends AbstractConfiguration
         }
         catch (Throwable e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
             return false;
         }
     }

--- a/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/JaspiConfiguration.java
+++ b/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/JaspiConfiguration.java
@@ -43,7 +43,8 @@ public class JaspiConfiguration extends AbstractConfiguration
         }
         catch (Throwable e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
             return false;
         }
     }

--- a/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/JmxConfiguration.java
+++ b/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/JmxConfiguration.java
@@ -44,7 +44,8 @@ public class JmxConfiguration extends AbstractConfiguration
         }
         catch (Throwable e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
             return false;
         }
     }

--- a/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/JndiConfiguration.java
+++ b/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/JndiConfiguration.java
@@ -46,7 +46,8 @@ public class JndiConfiguration extends AbstractConfiguration
         }
         catch (Throwable e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
             return false;
         }
     }

--- a/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/JspConfiguration.java
+++ b/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/JspConfiguration.java
@@ -48,7 +48,8 @@ public class JspConfiguration extends AbstractConfiguration
         }
         catch (Throwable e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
             return false;
         }
     }

--- a/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/ServletsConfiguration.java
+++ b/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/ServletsConfiguration.java
@@ -45,7 +45,8 @@ public class ServletsConfiguration extends AbstractConfiguration
         }
         catch (Throwable e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
             return false;
         }
     }

--- a/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/StandardDescriptorProcessor.java
+++ b/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/StandardDescriptorProcessor.java
@@ -352,7 +352,8 @@ public class StandardDescriptorProcessor extends IterativeDescriptorProcessor
                 catch (Exception e)
                 {
                     LOG.warn("Cannot parse load-on-startup {}. Please use integer", s);
-                    LOG.trace("IGNORED", e);
+                    if (LOG.isTraceEnabled())
+                        LOG.trace("IGNORED", e);
                 }
             }
 

--- a/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/WebAppContext.java
+++ b/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/WebAppContext.java
@@ -366,7 +366,8 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
             }
             catch (MalformedURLException e)
             {
-                LOG.trace("IGNORED", e);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", e);
                 if (mue == null)
                     mue = e;
             }

--- a/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/WebAppContext.java
+++ b/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/WebAppContext.java
@@ -1190,7 +1190,8 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
 
     public void resolveMetaData() throws Exception
     {
-        LOG.debug("metadata resolve {}", this);
+        if (LOG.isDebugEnabled())
+            LOG.debug("metadata resolve {}", this);
 
         //Ensure origins is fresh
         _metadata._origins.clear();
@@ -1223,7 +1224,8 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
             p.process(this, _metadata.getWebDescriptor());
             for (WebDescriptor wd : _metadata.getOverrideDescriptors())
             {
-                LOG.debug("process {} {} {}", this, p, wd);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("process {} {} {}", this, p, wd);
                 p.process(this, wd);
             }
         }
@@ -1244,7 +1246,8 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
             {
                 for (DescriptorProcessor p : _metadata._descriptorProcessors)
                 {
-                    LOG.debug("process {} {}", this, fd);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("process {} {}", this, fd);
                     p.process(this, fd);
                 }
             }
@@ -1257,7 +1260,8 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
             {
                 for (DiscoveredAnnotation a : annotations)
                 {
-                    LOG.debug("apply {}", a);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("apply {}", a);
                     a.apply();
                 }
             }

--- a/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-common/src/main/java/org/eclipse/jetty/ee11/websocket/jakarta/common/JakartaWebSocketSession.java
+++ b/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-common/src/main/java/org/eclipse/jetty/ee11/websocket/jakarta/common/JakartaWebSocketSession.java
@@ -200,7 +200,8 @@ public class JakartaWebSocketSession implements jakarta.websocket.Session
         }
         catch (Throwable t)
         {
-            LOG.trace("IGNORED", t);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", t);
         }
     }
 

--- a/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee11/websocket/jakarta/tests/coders/QuotesDecoder.java
+++ b/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee11/websocket/jakarta/tests/coders/QuotesDecoder.java
@@ -33,11 +33,13 @@ public class QuotesDecoder implements Decoder.TextStream<Quotes>
         Quotes quotes = new Quotes();
         try (BufferedReader buf = new BufferedReader(reader))
         {
-            LOG.debug("decode() begin");
+            if (LOG.isDebugEnabled())
+                LOG.debug("decode() begin");
             String line;
             while ((line = buf.readLine()) != null)
             {
-                LOG.debug("decode() line = {}", line);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("decode() line = {}", line);
                 switch (line.charAt(0))
                 {
                     case 'a':
@@ -48,7 +50,8 @@ public class QuotesDecoder implements Decoder.TextStream<Quotes>
                         break;
                 }
             }
-            LOG.debug("decode() complete");
+            if (LOG.isDebugEnabled())
+                LOG.debug("decode() complete");
         }
         return quotes;
     }

--- a/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee11/websocket/jakarta/tests/quotes/QuotesDecoder.java
+++ b/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee11/websocket/jakarta/tests/quotes/QuotesDecoder.java
@@ -34,11 +34,13 @@ public class QuotesDecoder implements Decoder.TextStream<Quotes>
         Quotes quotes = new Quotes();
         try (BufferedReader buf = new BufferedReader(reader))
         {
-            LOG.debug("decode() begin");
+            if (LOG.isDebugEnabled())
+                LOG.debug("decode() begin");
             String line;
             while ((line = buf.readLine()) != null)
             {
-                LOG.debug("decode() line = {}", line);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("decode() line = {}", line);
                 switch (line.charAt(0))
                 {
                     case 'a':
@@ -49,7 +51,8 @@ public class QuotesDecoder implements Decoder.TextStream<Quotes>
                         break;
                 }
             }
-            LOG.debug("decode() complete");
+            if (LOG.isDebugEnabled())
+                LOG.debug("decode() complete");
         }
         return quotes;
     }

--- a/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee11/websocket/jakarta/tests/quotes/QuotesDecoderTest.java
+++ b/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee11/websocket/jakarta/tests/quotes/QuotesDecoderTest.java
@@ -65,7 +65,8 @@ public class QuotesDecoderTest
         public void onOpenResource(String filename)
         {
             super.onWsText(filename);
-            QuotesDecoderTest.LOG.debug("onOpenResource({})", filename);
+            if (LOG.isDebugEnabled())
+                LOG.debug("onOpenResource({})", filename);
             try
             {
                 RemoteEndpoint.Basic remote = session.getBasicRemote();

--- a/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee11/websocket/jakarta/tests/server/ConfiguratorTest.java
+++ b/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee11/websocket/jakarta/tests/server/ConfiguratorTest.java
@@ -199,7 +199,8 @@ public class ConfiguratorTest
         public void modifyHandshake(ServerEndpointConfig sec, HandshakeRequest request, HandshakeResponse response)
         {
             int upgradeNum = upgradeCount.addAndGet(1);
-            LOG.debug("Upgrade Num: {}", upgradeNum);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Upgrade Num: {}", upgradeNum);
             sec.getUserProperties().put("upgradeNum", Integer.toString(upgradeNum));
             switch (upgradeNum)
             {

--- a/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee11/websocket/jakarta/tests/server/EndpointViaConfigTest.java
+++ b/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee11/websocket/jakarta/tests/server/EndpointViaConfigTest.java
@@ -84,13 +84,15 @@ public class EndpointViaConfigTest
             finally
             {
                 client.stop();
-                LOG.debug("Stopped - " + client);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Stopped - " + client);
             }
         }
         finally
         {
             wsb.stop();
-            LOG.debug("Stopped - " + wsb);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Stopped - " + wsb);
         }
     }
 }

--- a/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee11/websocket/jakarta/tests/server/TextStreamTest.java
+++ b/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee11/websocket/jakarta/tests/server/TextStreamTest.java
@@ -286,8 +286,8 @@ public class TextStreamTest
                     totalRead += read;
                     output.write(buffer, 0, read);
                 }
-
-                LOG.debug("{} total bytes read/write", totalRead);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("{} total bytes read/write", totalRead);
             }
         }
     }

--- a/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee11/websocket/jakarta/tests/server/examples/WebSocketServerExamplesTest.java
+++ b/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee11/websocket/jakarta/tests/server/examples/WebSocketServerExamplesTest.java
@@ -61,27 +61,31 @@ public class WebSocketServerExamplesTest
         @OnOpen
         public void onOpen(Session sess)
         {
-            LOG.debug("ClientSocket Connected: " + sess);
+            if (LOG.isDebugEnabled())
+                LOG.debug("ClientSocket Connected: {}", sess);
         }
 
         @OnMessage
         public void onMessage(String message)
         {
             messageQueue.offer(message);
-            LOG.debug("Received TEXT message: " + message);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Received TEXT message: {}", message);
         }
 
         @OnClose
         public void onClose(CloseReason closeReason)
         {
-            LOG.debug("ClientSocket Closed: " + closeReason);
+            if (LOG.isDebugEnabled())
+                LOG.debug("ClientSocket Closed: {}", closeReason);
             closed.countDown();
         }
 
         @OnError
         public void onError(Throwable cause)
         {
-            LOG.atDebug().setCause(cause).log("ClientSocket error");
+            if (LOG.isDebugEnabled())
+                LOG.atDebug().setCause(cause).log("ClientSocket error");
         }
     }
 

--- a/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jetty-server/src/test/java/org/eclipse/jetty/ee11/websocket/server/browser/BrowserDebugTool.java
+++ b/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jetty-server/src/test/java/org/eclipse/jetty/ee11/websocket/server/browser/BrowserDebugTool.java
@@ -136,7 +136,8 @@ public class BrowserDebugTool
         @Override
         public void configure(JettyWebSocketServletFactory factory)
         {
-            LOG.debug("Configuring WebSocketServerFactory ...");
+            if (LOG.isDebugEnabled())
+                LOG.debug("Configuring WebSocketServerFactory ...");
 
             // Setup the desired Socket to use for all incoming upgrade requests
             factory.addMapping("/", new BrowserSocketCreator());
@@ -160,7 +161,8 @@ public class BrowserDebugTool
         @Override
         public Object createWebSocket(JettyServerUpgradeRequest req, JettyServerUpgradeResponse resp)
         {
-            LOG.debug("Creating BrowserSocket");
+            if (LOG.isDebugEnabled())
+                LOG.debug("Creating BrowserSocket");
 
             if (req.getSubProtocols() != null)
             {
@@ -190,11 +192,14 @@ public class BrowserDebugTool
             }
 
             resp.setExtensions(negotiated);
-
-            LOG.debug("User-Agent: {}", ua);
-            LOG.debug("Sec-WebSocket-Extensions (Request) : {}", rexts);
-            LOG.debug("Sec-WebSocket-Protocol (Request): {}", req.getHeader("Sec-WebSocket-Protocol"));
-            LOG.debug("Sec-WebSocket-Protocol (Response): {}", resp.getAcceptedSubProtocol());
+            if (LOG.isDebugEnabled())
+                LOG.debug("User-Agent: {}", ua);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Sec-WebSocket-Extensions (Request) : {}", rexts);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Sec-WebSocket-Protocol (Request): {}", req.getHeader("Sec-WebSocket-Protocol"));
+            if (LOG.isDebugEnabled())
+                LOG.debug("Sec-WebSocket-Protocol (Response): {}", resp.getAcceptedSubProtocol());
 
             req.getExtensions();
             return new BrowserSocket(ua, rexts);

--- a/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jetty-server/src/test/java/org/eclipse/jetty/ee11/websocket/server/browser/BrowserSocket.java
+++ b/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jetty-server/src/test/java/org/eclipse/jetty/ee11/websocket/server/browser/BrowserSocket.java
@@ -273,13 +273,15 @@ public class BrowserSocket
     {
         if (this.session == null)
         {
-            LOG.debug("Not connected");
+            if (LOG.isDebugEnabled())
+                LOG.debug("Not connected");
             return;
         }
 
         if (!session.isOpen())
         {
-            LOG.debug("Not open");
+            if (LOG.isDebugEnabled())
+                LOG.debug("Not open");
             return;
         }
 

--- a/jetty-ee9/jetty-ee9-annotations/src/main/java/org/eclipse/jetty/ee9/annotations/ResourceAnnotationHandler.java
+++ b/jetty-ee9/jetty-ee9-annotations/src/main/java/org/eclipse/jetty/ee9/annotations/ResourceAnnotationHandler.java
@@ -178,7 +178,8 @@ public class ResourceAnnotationHandler extends AbstractIntrospectableAnnotationH
                     //Check there is a JNDI entry for this annotation
                     if (bound)
                     {
-                        LOG.debug("Bound {} as {}", (mappedName == null ? name : mappedName), name);
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("Bound {} as {}", (mappedName == null ? name : mappedName), name);
                         //   Make the Injection for it if the binding succeeded
                         injection = new Injection(clazz, field, type, name, mappedName);
                         injections.add(injection);
@@ -335,7 +336,8 @@ public class ResourceAnnotationHandler extends AbstractIntrospectableAnnotationH
 
                     if (bound)
                     {
-                        LOG.debug("Bound {} as {}", (mappedName == null ? name : mappedName), name);
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("Bound {} as {}", (mappedName == null ? name : mappedName), name);
                         //   Make the Injection for it
                         injection = new Injection(clazz, method, paramType, resourceType, name, mappedName);
                         injections.add(injection);

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/MavenMetaInfConfiguration.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/MavenMetaInfConfiguration.java
@@ -64,7 +64,8 @@ public class MavenMetaInfConfiguration extends MetaInfConfiguration
                 {
                     try
                     {
-                        LOG.debug(" add  resource to resources to examine {}", file);
+                        if (LOG.isDebugEnabled())
+                            LOG.debug(" add  resource to resources to examine {}", file);
                         list.add(context.getResourceFactory().newResource(file.toURI()));
                     }
                     catch (Exception e)

--- a/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/MavenWebAppContext.java
+++ b/jetty-ee9/jetty-ee9-maven-plugin/src/main/java/org/eclipse/jetty/ee9/maven/plugin/MavenWebAppContext.java
@@ -491,7 +491,8 @@ public class MavenWebAppContext extends WebAppContext
         }
         catch (ClassNotFoundException e)
         {
-            LOG.debug("o.e.j.cdi.servlet.JettyWeldInitializer not found, no cdi integration available");
+            if (LOG.isDebugEnabled())
+                LOG.debug("o.e.j.cdi.servlet.JettyWeldInitializer not found, no cdi integration available");
         }
         catch (NoSuchMethodException e)
         {

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
@@ -1560,7 +1560,8 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
         }
         catch (Exception e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
         }
 
         return null;
@@ -1652,7 +1653,8 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
         }
         catch (Exception e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
         }
         return Collections.emptySet();
     }
@@ -2007,7 +2009,8 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
             }
             catch (Exception e)
             {
-                LOG.trace("IGNORED", e);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", e);
             }
             return null;
         }
@@ -2053,7 +2056,8 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
             }
             catch (Exception e)
             {
-                LOG.trace("IGNORED", e);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", e);
             }
 
             return null;
@@ -2107,7 +2111,8 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
             catch (Throwable e)
             {
                 // catch IOException, RuntimeException, and things like java.nio.fileInvalidPathException here.
-                LOG.trace("IGNORED", e);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", e);
                 return null;
             }
         }

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Cookies.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Cookies.java
@@ -142,7 +142,8 @@ public class Cookies implements CookieParser.Handler
         }
         catch (Exception e)
         {
-            LOG.debug("Unable to add Cookie name={}, value={}, domain={}, path={}, version={}, comment={}",
+            if (LOG.isDebugEnabled())
+                LOG.debug("Unable to add Cookie name={}, value={}, domain={}, path={}, version={}, comment={}",
                 name, value, domain, path, version, comment, e);
         }
     }

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/CrossContextServletContext.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/CrossContextServletContext.java
@@ -190,7 +190,8 @@ class CrossContextServletContext implements ServletContext
         }
         catch (Exception e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
         }
         return null;
     }

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ErrorHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ErrorHandler.java
@@ -104,7 +104,8 @@ public class ErrorHandler extends AbstractHandler
                 }
                 catch (ServletException e)
                 {
-                    LOG.debug("Unable to call error dispatcher", e);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("Unable to call error dispatcher", e);
                     if (response.isCommitted())
                         return;
                 }

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ErrorHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ErrorHandler.java
@@ -198,7 +198,8 @@ public class ErrorHandler extends AbstractHandler
             }
             catch (Exception e)
             {
-                LOG.trace("IGNORED", e);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", e);
             }
         }
         return null;
@@ -246,7 +247,8 @@ public class ErrorHandler extends AbstractHandler
                 }
                 catch (Exception e)
                 {
-                    LOG.trace("IGNORED", e);
+                    if (LOG.isTraceEnabled())
+                        LOG.trace("IGNORED", e);
                 }
             }
             if (charset == null)

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
@@ -643,7 +643,10 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
             catch (Throwable failure)
             {
                 if ("org.eclipse.jetty.continuation.ContinuationThrowable".equals(failure.getClass().getName()))
-                    LOG.trace("IGNORED", failure);
+                {
+                    if (LOG.isTraceEnabled())
+                        LOG.trace("IGNORED", failure);
+                }
                 else
                     handleException(failure);
             }
@@ -716,7 +719,8 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
         }
         catch (Throwable x)
         {
-            LOG.trace("IGNORED", x);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", x);
             abort(x);
         }
         return false;

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannel.java
@@ -985,7 +985,8 @@ public class HttpChannel implements Runnable, HttpOutput.Interceptor
             }
             catch (Throwable e)
             {
-                LOG.debug("Unable to complete bad message", e);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Unable to complete bad message", e);
                 abort(e);
             }
         }

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannelState.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpChannelState.java
@@ -888,7 +888,10 @@ public class HttpChannelState
             else if (_requestState != RequestState.COMPLETE)
             {
                 if (QuietException.isQuiet(th))
-                    LOG.debug("unhandled in state {}", _requestState, th);
+                {
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("unhandled in state {}", _requestState, th);
+                }
                 else
                     LOG.warn("unhandled in state {}", _requestState, th);
             }

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/InclusiveByteRange.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/InclusiveByteRange.java
@@ -236,7 +236,8 @@ public class InclusiveByteRange
                     {
                         ranges = null;
                         LOG.warn("Bad range format: {}", t);
-                        LOG.trace("IGNORED", e);
+                        if (LOG.isTraceEnabled())
+                            LOG.trace("IGNORED", e);
                     }
                 }
             }
@@ -244,7 +245,8 @@ public class InclusiveByteRange
             {
                 ranges = null;
                 LOG.warn("Bad range format: {}", t);
-                LOG.trace("IGNORED", e);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", e);
             }
         }
 

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/Request.java
@@ -1681,7 +1681,8 @@ public class Request implements HttpServletRequest
             }
             catch (Exception e)
             {
-                LOG.trace("IGNORED", e);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", e);
                 _reader = null;
                 _readerEncoding = null;
             }

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ResourceService.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ResourceService.java
@@ -748,7 +748,10 @@ public class ResourceService
                         {
                             String msg = "Failed to send content";
                             if (x instanceof IOException)
-                                LOG.atDebug().setCause(x).log(msg);
+                            {
+                                if (LOG.isDebugEnabled())
+                                    LOG.atDebug().setCause(x).log(msg);
+                            }
                             else
                                 LOG.warn(msg, x);
                             context.complete();

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ThreadLimitHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ThreadLimitHandler.java
@@ -136,7 +136,8 @@ public class ThreadLimitHandler extends HandlerWrapper
             }
             catch (Exception e)
             {
-                LOG.trace("IGNORED", e);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", e);
             }
         }
         return _threadLimit;

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ThreadLimitHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ThreadLimitHandler.java
@@ -129,7 +129,8 @@ public class ThreadLimitHandler extends HandlerWrapper
             {
                 if (!_includeExcludeSet.test(InetAddress.getByName(ip)))
                 {
-                    LOG.debug("excluded {}", ip);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("excluded {}", ip);
                     return 0;
                 }
             }
@@ -254,7 +255,8 @@ public class ThreadLimitHandler extends HandlerWrapper
             return remote;
 
         String ip = getRemoteIP(baseRequest);
-        LOG.debug("ip={}", ip);
+        if (LOG.isDebugEnabled())
+            LOG.debug("ip={}", ip);
         if (ip == null)
             return null;
 

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/DumpHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/DumpHandler.java
@@ -256,7 +256,8 @@ public class DumpHandler extends AbstractHandler
         }
         catch (Exception e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
         }
     }
 }

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/LocalAsyncContextTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/LocalAsyncContextTest.java
@@ -207,7 +207,8 @@ public class LocalAsyncContextTest
 
     private synchronized String process(String content) throws Exception
     {
-        LOG.debug("TEST process: {}", content);
+        if (LOG.isDebugEnabled())
+            LOG.debug("TEST process: {}", content);
         reset();
         String request = "GET / HTTP/1.1\r\n" +
             "Host: localhost\r\n" +
@@ -281,7 +282,8 @@ public class LocalAsyncContextTest
         @Override
         public void handle(String target, final Request baseRequest, final HttpServletRequest request, final HttpServletResponse response) throws IOException, ServletException
         {
-            LOG.debug("handle {} {}", baseRequest.getDispatcherType(), baseRequest);
+            if (LOG.isDebugEnabled())
+                LOG.debug("handle {} {}", baseRequest.getDispatcherType(), baseRequest);
             if (DispatcherType.REQUEST.equals(baseRequest.getDispatcherType()))
             {
                 if (_read > 0)

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/NcsaRequestLogTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/NcsaRequestLogTest.java
@@ -542,7 +542,8 @@ public class NcsaRequestLogTest
                         }
                         catch (IOException | IllegalStateException th)
                         {
-                            LOG.trace("IGNORED", th);
+                            if (LOG.isTraceEnabled())
+                                LOG.trace("IGNORED", th);
                         }
                         finally
                         {

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/RequestTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/RequestTest.java
@@ -1101,9 +1101,11 @@ public class RequestTest
                 "Connection: close\r\n" +
                 "\r\n" +
                 content;
-            LOG.debug("test l={}", l);
+            if (LOG.isDebugEnabled())
+                LOG.debug("test l={}", l);
             String response = _connector.getResponse(request);
-            LOG.debug(response);
+            if (LOG.isDebugEnabled())
+                LOG.debug(response);
             assertThat(response, containsString(" 200 OK"));
             assertEquals(l, length.get());
             content.append("x");

--- a/jetty-ee9/jetty-ee9-plus/src/main/java/org/eclipse/jetty/ee9/plus/webapp/EnvConfiguration.java
+++ b/jetty-ee9/jetty-ee9-plus/src/main/java/org/eclipse/jetty/ee9/plus/webapp/EnvConfiguration.java
@@ -188,11 +188,13 @@ public class EnvConfiguration extends AbstractConfiguration
         catch (NameNotFoundException e)
         {
             LOG.trace("IGNORED", e);
-            LOG.debug("No jndi entries scoped to webapp {}", context);
+            if (LOG.isDebugEnabled())
+                LOG.debug("No jndi entries scoped to webapp {}", context);
         }
         catch (NamingException e)
         {
-            LOG.debug("Error unbinding jndi entries scoped to webapp {}", context, e);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Error unbinding jndi entries scoped to webapp {}", context, e);
         }
     }
 
@@ -210,17 +212,17 @@ public class EnvConfiguration extends AbstractConfiguration
     {
         InitialContext ic = new InitialContext();
         Context envCtx = (Context)ic.lookup("java:comp/env");
-
-        LOG.debug("Binding env entries from the jvm scope");
+        if (LOG.isDebugEnabled())
+            LOG.debug("Binding env entries from the jvm scope");
         doBindings(envCtx, null);
-
-        LOG.debug("Binding env entries from the server scope");
+        if (LOG.isDebugEnabled())
+            LOG.debug("Binding env entries from the server scope");
         doBindings(envCtx, context.getServer());
-        
-        LOG.debug("Binding env entries from environment {} scope", ContextHandler.ENVIRONMENT.getName());
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Binding env entries from environment {} scope", ContextHandler.ENVIRONMENT.getName());
         doBindings(envCtx, ContextHandler.ENVIRONMENT.getName());
-
-        LOG.debug("Binding env entries from the context scope");
+        if (LOG.isDebugEnabled())
+            LOG.debug("Binding env entries from the context scope");
         doBindings(envCtx, context);
     }
 

--- a/jetty-ee9/jetty-ee9-plus/src/main/java/org/eclipse/jetty/ee9/plus/webapp/EnvConfiguration.java
+++ b/jetty-ee9/jetty-ee9-plus/src/main/java/org/eclipse/jetty/ee9/plus/webapp/EnvConfiguration.java
@@ -219,8 +219,8 @@ public class EnvConfiguration extends AbstractConfiguration
         if (LOG.isDebugEnabled())
             LOG.debug("Binding env entries from the server scope");
         doBindings(envCtx, context.getServer());
-                if (LOG.isDebugEnabled())
-                    LOG.debug("Binding env entries from environment {} scope", ContextHandler.ENVIRONMENT.getName());
+        if (LOG.isDebugEnabled())
+            LOG.debug("Binding env entries from environment {} scope", ContextHandler.ENVIRONMENT.getName());
         doBindings(envCtx, ContextHandler.ENVIRONMENT.getName());
         if (LOG.isDebugEnabled())
             LOG.debug("Binding env entries from the context scope");

--- a/jetty-ee9/jetty-ee9-plus/src/main/java/org/eclipse/jetty/ee9/plus/webapp/EnvConfiguration.java
+++ b/jetty-ee9/jetty-ee9-plus/src/main/java/org/eclipse/jetty/ee9/plus/webapp/EnvConfiguration.java
@@ -187,7 +187,8 @@ public class EnvConfiguration extends AbstractConfiguration
         }
         catch (NameNotFoundException e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
             if (LOG.isDebugEnabled())
                 LOG.debug("No jndi entries scoped to webapp {}", context);
         }

--- a/jetty-ee9/jetty-ee9-plus/src/main/java/org/eclipse/jetty/ee9/plus/webapp/PlusConfiguration.java
+++ b/jetty-ee9/jetty-ee9-plus/src/main/java/org/eclipse/jetty/ee9/plus/webapp/PlusConfiguration.java
@@ -100,7 +100,8 @@ public class PlusConfiguration extends AbstractConfiguration
             }
             catch (NameNotFoundException x)
             {
-                LOG.debug("No Transaction manager found - if your webapp requires one, please configure one.");
+                if (LOG.isDebugEnabled())
+                    LOG.debug("No Transaction manager found - if your webapp requires one, please configure one.");
             }
         }
     }

--- a/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/AfterContentTransformer.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/AfterContentTransformer.java
@@ -286,7 +286,8 @@ public abstract class AfterContentTransformer implements AsyncMiddleManServlet.C
         }
         catch (IOException x)
         {
-            LOG.trace("IGNORED", x);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", x);
         }
     }
 

--- a/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/AsyncMiddleManServletTest.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/AsyncMiddleManServletTest.java
@@ -1829,7 +1829,8 @@ public class AsyncMiddleManServletTest
             protected String transform(String value)
             {
                 String result = PREFIX + URLEncoder.encode(value, StandardCharsets.UTF_8);
-                LOG.debug("{} -> {}", value, result);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("{} -> {}", value, result);
                 return result;
             }
         }
@@ -1840,7 +1841,8 @@ public class AsyncMiddleManServletTest
             protected String transform(String value)
             {
                 String result = URLDecoder.decode(value.substring(PREFIX.length()), StandardCharsets.UTF_8);
-                LOG.debug("{} <- {}", value, result);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("{} <- {}", value, result);
                 return result;
             }
         }

--- a/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/ProxyServletLoadTest.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/ProxyServletLoadTest.java
@@ -189,7 +189,8 @@ public class ProxyServletLoadTest
         public void run()
         {
             String threadName = Thread.currentThread().getName();
-            LOG.debug("Starting thread {}", threadName);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Starting thread {}", threadName);
             try
             {
                 while (success.get())
@@ -221,7 +222,8 @@ public class ProxyServletLoadTest
             }
             finally
             {
-                LOG.debug("Shutting down thread {}", threadName);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Shutting down thread {}", threadName);
                 active.countDown();
             }
         }

--- a/jetty-ee9/jetty-ee9-quickstart/src/main/java/org/eclipse/jetty/ee9/quickstart/ExtraXmlDescriptorProcessor.java
+++ b/jetty-ee9/jetty-ee9-quickstart/src/main/java/org/eclipse/jetty/ee9/quickstart/ExtraXmlDescriptorProcessor.java
@@ -52,7 +52,8 @@ public class ExtraXmlDescriptorProcessor extends IterativeDescriptorProcessor
     @Override
     public void start(WebAppContext context, Descriptor descriptor)
     {
-        LOG.debug("process {}", descriptor);
+        if (LOG.isDebugEnabled())
+            LOG.debug("process {}", descriptor);
         _origin = (StringUtil.isBlank(_originAttribute) ? null : "  <!-- " + descriptor.getURI() + " -->\n");
     }
 
@@ -72,7 +73,8 @@ public class ExtraXmlDescriptorProcessor extends IterativeDescriptorProcessor
         //Note: we have to output the origin as a comment field instead of
         //as an attribute like the other other elements because
         //we are copying these elements _verbatim_ from the descriptor
-        LOG.debug("save {}", node.getTag());
+        if (LOG.isDebugEnabled())
+            LOG.debug("save {}", node.getTag());
         if (_origin != null)
             _buffer.append(_origin);
         _buffer.append("  ").append(node.toString()).append("\n");

--- a/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/DefaultAuthenticatorFactory.java
+++ b/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/DefaultAuthenticatorFactory.java
@@ -81,7 +81,10 @@ public class DefaultAuthenticatorFactory implements Authenticator.Factory
                 if (sslContextFactories.size() > 1)
                     LOG.info("Multiple SslContextFactory.Server instances discovered. Directly configure a SslClientCertAuthenticator to use one.");
                 else
-                    LOG.debug("No SslContextFactory.Server instances discovered. Directly configure a SslClientCertAuthenticator to use one.");
+                {
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("No SslContextFactory.Server instances discovered. Directly configure a SslClientCertAuthenticator to use one.");
+                }
             }
             else
             {

--- a/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/SecurityHandler.java
+++ b/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/SecurityHandler.java
@@ -631,7 +631,8 @@ public abstract class SecurityHandler extends HandlerWrapper implements Authenti
 
     public void logout(Authentication.User user)
     {
-        LOG.debug("logout {}", user);
+        if (LOG.isDebugEnabled())
+            LOG.debug("logout {}", user);
         if (user == null)
             return;
 

--- a/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/DeferredAuthentication.java
+++ b/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/DeferredAuthentication.java
@@ -72,7 +72,8 @@ public class DeferredAuthentication implements Authentication.Deferred
         }
         catch (ServerAuthException e)
         {
-            LOG.debug("Unable to authenticate {}", request, e);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Unable to authenticate {}", request, e);
         }
 
         return this;
@@ -96,7 +97,8 @@ public class DeferredAuthentication implements Authentication.Deferred
         }
         catch (ServerAuthException e)
         {
-            LOG.debug("Unable to authenticate {}", request, e);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Unable to authenticate {}", request, e);
         }
         return this;
     }

--- a/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/DigestAuthenticator.java
+++ b/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/DigestAuthenticator.java
@@ -284,7 +284,8 @@ public class DigestAuthenticator extends LoginAuthenticator
         }
         catch (Exception e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
         }
         return -1;
     }

--- a/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/FormAuthenticator.java
+++ b/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/FormAuthenticator.java
@@ -259,7 +259,8 @@ public class FormAuthenticator extends LoginAuthenticator
                 final String password = request.getParameter(__J_PASSWORD);
 
                 UserIdentity user = login(username, password, request);
-                LOG.debug("jsecuritycheck {} {}", username, user);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("jsecuritycheck {} {}", username, user);
                 HttpSession session = request.getSession(false);
                 if (user != null)
                 {
@@ -278,7 +279,8 @@ public class FormAuthenticator extends LoginAuthenticator
                         }
                         formAuth = new FormAuthentication(getAuthMethod(), user);
                     }
-                    LOG.debug("authenticated {}->{}", formAuth, nuri);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("authenticated {}->{}", formAuth, nuri);
 
                     response.setContentLength(0);
                     baseResponse.sendRedirect(response.encodeRedirectURL(nuri), true);
@@ -290,13 +292,15 @@ public class FormAuthenticator extends LoginAuthenticator
                     LOG.debug("Form authentication FAILED for {}", StringUtil.printable(username));
                 if (_formErrorPage == null)
                 {
-                    LOG.debug("auth failed {}->403", username);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("auth failed {}->403", username);
                     if (response != null)
                         response.sendError(HttpServletResponse.SC_FORBIDDEN);
                 }
                 else if (_dispatch)
                 {
-                    LOG.debug("auth failed {}=={}", username, _formErrorPage);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("auth failed {}=={}", username, _formErrorPage);
                     RequestDispatcher dispatcher = request.getRequestDispatcher(_formErrorPage);
                     response.setHeader(HttpHeader.CACHE_CONTROL.asString(), HttpHeaderValue.NO_CACHE.asString());
                     response.setDateHeader(HttpHeader.EXPIRES.asString(), 1);
@@ -304,7 +308,8 @@ public class FormAuthenticator extends LoginAuthenticator
                 }
                 else
                 {
-                    LOG.debug("auth failed {}->{}", username, _formErrorPage);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("auth failed {}->{}", username, _formErrorPage);
                     baseResponse.sendRedirect(response.encodeRedirectURL(URIUtil.addPaths(request.getContextPath(), _formErrorPage)), true);
                 }
 
@@ -321,7 +326,8 @@ public class FormAuthenticator extends LoginAuthenticator
                     _loginService != null &&
                     !_loginService.validate(((Authentication.User)authentication).getUserIdentity()))
                 {
-                    LOG.debug("auth revoked {}", authentication);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("auth revoked {}", authentication);
                     session.removeAttribute(SessionAuthentication.__J_AUTHENTICATED);
                 }
                 else
@@ -333,7 +339,8 @@ public class FormAuthenticator extends LoginAuthenticator
                         {
                             //check if the request is for the same url as the original and restore
                             //params if it was a post
-                            LOG.debug("auth retry {}->{}", authentication, jUri);
+                            if (LOG.isDebugEnabled())
+                                LOG.debug("auth retry {}->{}", authentication, jUri);
                             StringBuffer buf = request.getRequestURL();
                             if (request.getQueryString() != null)
                                 buf.append("?").append(request.getQueryString());
@@ -343,7 +350,8 @@ public class FormAuthenticator extends LoginAuthenticator
                                 Fields jPost = (Fields)session.getAttribute(__J_POST);
                                 if (jPost != null)
                                 {
-                                    LOG.debug("auth rePOST {}->{}", authentication, jUri);
+                                    if (LOG.isDebugEnabled())
+                                        LOG.debug("auth rePOST {}->{}", authentication, jUri);
                                     baseRequest.setContentFields(jPost);
                                 }
                                 session.removeAttribute(__J_URI);
@@ -352,7 +360,8 @@ public class FormAuthenticator extends LoginAuthenticator
                             }
                         }
                     }
-                    LOG.debug("auth {}", authentication);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("auth {}", authentication);
                     return authentication;
                 }
             }
@@ -360,7 +369,8 @@ public class FormAuthenticator extends LoginAuthenticator
             // if we can't send challenge
             if (DeferredAuthentication.isDeferred(response))
             {
-                LOG.debug("auth deferred {}", session == null ? null : session.getId());
+                if (LOG.isDebugEnabled())
+                    LOG.debug("auth deferred {}", session == null ? null : session.getId());
                 return Authentication.UNAUTHENTICATED;
             }
 
@@ -389,7 +399,8 @@ public class FormAuthenticator extends LoginAuthenticator
             // send the the challenge
             if (_dispatch)
             {
-                LOG.debug("challenge {}=={}", session.getId(), _formLoginPage);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("challenge {}=={}", session.getId(), _formLoginPage);
                 RequestDispatcher dispatcher = request.getRequestDispatcher(_formLoginPage);
                 response.setHeader(HttpHeader.CACHE_CONTROL.asString(), HttpHeaderValue.NO_CACHE.asString());
                 response.setDateHeader(HttpHeader.EXPIRES.asString(), 1);
@@ -397,7 +408,8 @@ public class FormAuthenticator extends LoginAuthenticator
             }
             else
             {
-                LOG.debug("challenge {}->{}", session.getId(), _formLoginPage);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("challenge {}->{}", session.getId(), _formLoginPage);
                 baseResponse.sendRedirect(response.encodeRedirectURL(URIUtil.addPaths(request.getContextPath(), _formLoginPage)), true);
             }
             return Authentication.SEND_CONTINUE;

--- a/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/SessionAuthentication.java
+++ b/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/SessionAuthentication.java
@@ -94,7 +94,8 @@ public class SessionAuthentication extends AbstractUserAuthentication
         }
 
         _userIdentity = loginService.login(_name, _credentials, null, null);
-        LOG.debug("Deserialized and relogged in {}", this);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Deserialized and relogged in {}", this);
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-servlet/src/main/java/org/eclipse/jetty/ee9/servlet/DefaultServlet.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/main/java/org/eclipse/jetty/ee9/servlet/DefaultServlet.java
@@ -540,7 +540,8 @@ public class DefaultServlet extends HttpServlet implements WelcomeFactory
         }
         catch (IOException e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
         }
 
         if (Resources.missing(r) && subUriPath.endsWith("/jetty-dir.css"))

--- a/jetty-ee9/jetty-ee9-servlet/src/main/java/org/eclipse/jetty/ee9/servlet/Invoker.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/main/java/org/eclipse/jetty/ee9/servlet/Invoker.java
@@ -189,7 +189,8 @@ public class Invoker extends HttpServlet
                     }
                     catch (Exception e)
                     {
-                        LOG.debug("Unable to start {}", holder, e);
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("Unable to start {}", holder, e);
                         throw new UnavailableException(e.toString());
                     }
 

--- a/jetty-ee9/jetty-ee9-servlet/src/main/java/org/eclipse/jetty/ee9/servlet/Invoker.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/main/java/org/eclipse/jetty/ee9/servlet/Invoker.java
@@ -208,7 +208,8 @@ public class Invoker extends HttpServlet
                             }
                             catch (Exception e)
                             {
-                                LOG.trace("IGNORED", e);
+                                if (LOG.isTraceEnabled())
+                                    LOG.trace("IGNORED", e);
                             }
 
                             LOG.warn("Dynamic servlet {} not loaded from context {}", s, request.getContextPath());

--- a/jetty-ee9/jetty-ee9-servlet/src/main/java/org/eclipse/jetty/ee9/servlet/ServletHandler.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/main/java/org/eclipse/jetty/ee9/servlet/ServletHandler.java
@@ -622,12 +622,14 @@ public class ServletHandler extends ScopedHandler
             if (_maxFilterChainsCacheSize > 0 && cache.size() >= _maxFilterChainsCacheSize)
             {
                 // flush the cache
-                LOG.debug("{} flushed filter chain cache for {}", this, baseRequest.getDispatcherType());
+                if (LOG.isDebugEnabled())
+                    LOG.debug("{} flushed filter chain cache for {}", this, baseRequest.getDispatcherType());
                 cache.clear();
             }
             chain = chain == null ? new ChainEnd(servletHolder) : chain;
             // flush the cache
-            LOG.debug("{} cached filter chain for {}: {}", this, baseRequest.getDispatcherType(), chain);
+            if (LOG.isDebugEnabled())
+                LOG.debug("{} cached filter chain for {}: {}", this, baseRequest.getDispatcherType(), chain);
             cache.put(key, chain);
         }
         return chain;
@@ -730,7 +732,8 @@ public class ServletHandler extends ScopedHandler
             }
             catch (Throwable e)
             {
-                LOG.debug("Unable to start {}", h, e);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Unable to start {}", h, e);
                 multiException.add(e);
             }
         };

--- a/jetty-ee9/jetty-ee9-servlet/src/main/java/org/eclipse/jetty/ee9/servlet/ServletHolder.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/main/java/org/eclipse/jetty/ee9/servlet/ServletHolder.java
@@ -377,7 +377,8 @@ public class ServletHolder extends Holder<Servlet> implements UserIdentityScope,
             makeUnavailable(ex);
             if (getServletHandler().isStartWithUnavailable())
             {
-                LOG.trace("IGNORED", ex);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", ex);
                 return;
             }
             else
@@ -394,7 +395,8 @@ public class ServletHolder extends Holder<Servlet> implements UserIdentityScope,
             makeUnavailable(ex);
             if (getServletHandler().isStartWithUnavailable())
             {
-                LOG.trace("IGNORED", ex);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", ex);
                 return;
             }
             else

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/AsyncServletIOTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/AsyncServletIOTest.java
@@ -219,14 +219,16 @@ public class AsyncServletIOTest
 
             // response line
             String line = in.readLine();
-            LOG.debug("response-line: " + line);
+            if (LOG.isDebugEnabled())
+                LOG.debug("response-line: " + line);
             assertThat(line, startsWith("HTTP/1.1 200 OK"));
 
             // Skip headers
             while (line != null)
             {
                 line = in.readLine();
-                LOG.debug("header-line: " + line);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("header-line: " + line);
                 if (line.length() == 0)
                     break;
             }
@@ -235,7 +237,8 @@ public class AsyncServletIOTest
             while (true)
             {
                 line = in.readLine();
-                LOG.debug("body: " + line);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("body: " + line);
                 if (line == null)
                     break;
                 list.add(line);
@@ -295,21 +298,24 @@ public class AsyncServletIOTest
 
             // response line
             String line = in.readLine();
-            LOG.debug("response-line: " + line);
+            if (LOG.isDebugEnabled())
+                LOG.debug("response-line: " + line);
             assertThat(line, startsWith("HTTP/1.1 200 OK"));
 
             // Skip headers
             while (line != null)
             {
                 line = in.readLine();
-                LOG.debug("header-line: " + line);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("header-line: " + line);
                 if (line.length() == 0)
                     break;
             }
 
             // Get body
             line = in.readLine();
-            LOG.debug("body: " + line);
+            if (LOG.isDebugEnabled())
+                LOG.debug("body: " + line);
             assertEquals("DONE", line);
 
             // The connection should be aborted
@@ -338,7 +344,8 @@ public class AsyncServletIOTest
             request.append(s).append("w=").append(w);
             s = '&';
         }
-        LOG.debug("process {} {}", request.toString(), BufferUtil.toDetailString(BufferUtil.toBuffer(content)));
+        if (LOG.isDebugEnabled())
+            LOG.debug("process {} {}", request.toString(), BufferUtil.toDetailString(BufferUtil.toBuffer(content)));
 
         request.append(" HTTP/1.1\r\n")
             .append("Host: localhost\r\n")
@@ -373,14 +380,16 @@ public class AsyncServletIOTest
 
             // response line
             String line = in.readLine();
-            LOG.debug("response-line: " + line);
+            if (LOG.isDebugEnabled())
+                LOG.debug("response-line: " + line);
             assertThat(line, startsWith("HTTP/1.1 200 OK"));
 
             // Skip headers
             while (line != null)
             {
                 line = in.readLine();
-                LOG.debug("header-line:  " + line);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("header-line:  " + line);
                 if (line.length() == 0)
                     break;
             }
@@ -391,7 +400,8 @@ public class AsyncServletIOTest
                 line = in.readLine();
                 if (line == null)
                     break;
-                LOG.debug("body:  " + brief(line));
+                if (LOG.isDebugEnabled())
+                    LOG.debug("body:  " + brief(line));
                 list.add(line);
                 Thread.sleep(50);
             }
@@ -401,7 +411,8 @@ public class AsyncServletIOTest
         int w = 0;
         for (String line : list)
         {
-            LOG.debug("line:  " + brief(line));
+            if (LOG.isDebugEnabled())
+                LOG.debug("line:  " + brief(line));
             if ("-".equals(line))
                 continue;
             assertEquals(writes[w], line.length(), "Line Length");
@@ -504,7 +515,8 @@ public class AsyncServletIOTest
                 @Override
                 public void onWritePossible() throws IOException
                 {
-                    LOG.debug("OWP");
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("OWP");
                     _owp.incrementAndGet();
 
                     while (writes != null && _w < writes.length)
@@ -680,7 +692,8 @@ public class AsyncServletIOTest
 
             // response line
             String line = in.readLine();
-            LOG.debug("response-line: " + line);
+            if (LOG.isDebugEnabled())
+                LOG.debug("response-line: " + line);
             assertThat(line, startsWith("HTTP/1.1 200 OK"));
 
             boolean chunked = false;
@@ -688,7 +701,8 @@ public class AsyncServletIOTest
             while (line != null)
             {
                 line = in.readLine();
-                LOG.debug("header-line: " + line);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("header-line: " + line);
                 chunked |= "Transfer-Encoding: chunked".equals(line);
                 if (line.length() == 0)
                     break;
@@ -705,7 +719,8 @@ public class AsyncServletIOTest
                     last = line;
                     //Thread.sleep(1000);
                     line = in.readLine();
-                    LOG.debug("body: " + line);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("body: " + line);
                     if (line == null)
                         break;
                     list.add(line);
@@ -715,8 +730,8 @@ public class AsyncServletIOTest
             {
                 // ignored
             }
-
-            LOG.debug("last: " + last);
+            if (LOG.isDebugEnabled())
+                LOG.debug("last: " + last);
 
             // last non empty line should not contain end chunk
             assertThat(last, notNullValue());
@@ -902,14 +917,16 @@ public class AsyncServletIOTest
 
             // response line
             String line = in.readLine();
-            LOG.debug("response-line: " + line);
+            if (LOG.isDebugEnabled())
+                LOG.debug("response-line: " + line);
             assertThat(line, startsWith("HTTP/1.1 200 OK"));
 
             // Skip headers
             while (line != null)
             {
                 line = in.readLine();
-                LOG.debug("header-line: " + line);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("header-line: " + line);
                 if (line.length() == 0)
                     break;
             }

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ErrorPageTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ErrorPageTest.java
@@ -671,7 +671,8 @@ public class ErrorPageTest
                         }
                         catch (IllegalStateException e)
                         {
-                            LOG.trace("IGNORED", e);
+                            if (LOG.isTraceEnabled())
+                                LOG.trace("IGNORED", e);
                         }
                         finally
                         {
@@ -732,7 +733,8 @@ public class ErrorPageTest
             }
             catch (Throwable ignore)
             {
-                LOG.trace("IGNORED", ignore);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", ignore);
             }
         }
     }

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ErrorPageTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ErrorPageTest.java
@@ -162,7 +162,8 @@ public class ErrorPageTest
         rawRequest.append("\r\n");
 
         String rawResponse = _connector.getResponse(rawRequest.toString());
-        LOG.debug(rawResponse);
+        if (LOG.isDebugEnabled())
+            LOG.debug(rawResponse);
         HttpTester.Response response = HttpTester.parseResponse(rawResponse);
 
         assertThat(response.getStatus(), is(595));

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ServletUpgradeTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ServletUpgradeTest.java
@@ -227,7 +227,8 @@ public class ServletUpgradeTest
         @Override
         public void destroy()
         {
-            LOG.debug("===============destroy");
+            if (LOG.isDebugEnabled())
+                LOG.debug("===============destroy");
         }
 
         @Override
@@ -316,8 +317,8 @@ public class ServletUpgradeTest
             }
 
             int searchIdx = actual.toLowerCase().indexOf(search.toLowerCase(), startIdx);
-
-            LOG.debug("[ServletTestUtil] Scanning response for " + "search string: '" + search + "' starting at index " + "location: " + startIdx);
+            if (LOG.isDebugEnabled())
+                LOG.debug("[ServletTestUtil] Scanning response for " + "search string: '" + search + "' starting at index " + "location: " + startIdx);
             if (searchIdx < 0)
             {
                 found = false;
@@ -329,11 +330,12 @@ public class ServletUpgradeTest
                     "-------------------------------------------\n" +
                     actual +
                     "\n-------------------------------------------\n";
-                LOG.debug(s);
+                if (LOG.isDebugEnabled())
+                    LOG.debug(s);
                 break;
             }
-
-            LOG.debug("[ServletTestUtil] Found search string: '" + search + "' at index '" + searchIdx + "' in the server's " + "response");
+            if (LOG.isDebugEnabled())
+                LOG.debug("[ServletTestUtil] Found search string: '" + search + "' at index '" + searchIdx + "' in the server's " + "response");
             // the new searchIdx is the old index plus the length of the
             // search string.
             startIdx = searchIdx + search.length();

--- a/jetty-ee9/jetty-ee9-servlets/src/main/java/org/eclipse/jetty/ee9/servlets/CloseableDoSFilter.java
+++ b/jetty-ee9/jetty-ee9-servlets/src/main/java/org/eclipse/jetty/ee9/servlets/CloseableDoSFilter.java
@@ -38,7 +38,8 @@ public class CloseableDoSFilter extends DoSFilter
         }
         catch (IOException e)
         {
-            LOG.debug("Unable to trigger channel close", e);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Unable to trigger channel close", e);
         }
     }
 }

--- a/jetty-ee9/jetty-ee9-servlets/src/main/java/org/eclipse/jetty/ee9/servlets/CrossOriginFilter.java
+++ b/jetty-ee9/jetty-ee9-servlets/src/main/java/org/eclipse/jetty/ee9/servlets/CrossOriginFilter.java
@@ -281,21 +281,25 @@ public class CrossOriginFilter implements Filter
             {
                 if (isSimpleRequest(request))
                 {
-                    LOG.debug("Cross-origin request to {} is a simple cross-origin request", request.getRequestURI());
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("Cross-origin request to {} is a simple cross-origin request", request.getRequestURI());
                     handleSimpleResponse(request, response, origin);
                 }
                 else if (isPreflightRequest(request))
                 {
-                    LOG.debug("Cross-origin request to {} is a preflight cross-origin request", request.getRequestURI());
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("Cross-origin request to {} is a preflight cross-origin request", request.getRequestURI());
                     handlePreflightResponse(request, response, origin);
                     if (chainPreflight)
-                        LOG.debug("Preflight cross-origin request to {} forwarded to application", request.getRequestURI());
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("Preflight cross-origin request to {} forwarded to application", request.getRequestURI());
                     else
                         return;
                 }
                 else
                 {
-                    LOG.debug("Cross-origin request to {} is a non-simple cross-origin request", request.getRequestURI());
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("Cross-origin request to {} is a non-simple cross-origin request", request.getRequestURI());
                     handleSimpleResponse(request, response, origin);
                 }
 
@@ -422,18 +426,21 @@ public class CrossOriginFilter implements Filter
     private boolean isMethodAllowed(HttpServletRequest request)
     {
         String accessControlRequestMethod = request.getHeader(ACCESS_CONTROL_REQUEST_METHOD_HEADER);
-        LOG.debug("{} is {}", ACCESS_CONTROL_REQUEST_METHOD_HEADER, accessControlRequestMethod);
+        if (LOG.isDebugEnabled())
+            LOG.debug("{} is {}", ACCESS_CONTROL_REQUEST_METHOD_HEADER, accessControlRequestMethod);
         boolean result = false;
         if (accessControlRequestMethod != null)
             result = allowedMethods.contains(accessControlRequestMethod);
-        LOG.debug("Method {} is" + (result ? "" : " not") + " among allowed methods {}", accessControlRequestMethod, allowedMethods);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Method {} is" + (result ? "" : " not") + " among allowed methods {}", accessControlRequestMethod, allowedMethods);
         return result;
     }
 
     private List<String> getAccessControlRequestHeaders(HttpServletRequest request)
     {
         String accessControlRequestHeaders = request.getHeader(ACCESS_CONTROL_REQUEST_HEADERS_HEADER);
-        LOG.debug("{} is {}", ACCESS_CONTROL_REQUEST_HEADERS_HEADER, accessControlRequestHeaders);
+        if (LOG.isDebugEnabled())
+            LOG.debug("{} is {}", ACCESS_CONTROL_REQUEST_HEADERS_HEADER, accessControlRequestHeaders);
         if (accessControlRequestHeaders == null)
             return Collections.emptyList();
 
@@ -452,7 +459,8 @@ public class CrossOriginFilter implements Filter
     {
         if (anyHeadersAllowed)
         {
-            LOG.debug("Any header is allowed");
+            if (LOG.isDebugEnabled())
+                LOG.debug("Any header is allowed");
             return true;
         }
 
@@ -474,7 +482,8 @@ public class CrossOriginFilter implements Filter
                 break;
             }
         }
-        LOG.debug("Headers [{}] are" + (result ? "" : " not") + " among allowed headers {}", requestedHeaders, allowedHeaders);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Headers [{}] are" + (result ? "" : " not") + " among allowed headers {}", requestedHeaders, allowedHeaders);
         return result;
     }
 

--- a/jetty-ee9/jetty-ee9-servlets/src/main/java/org/eclipse/jetty/ee9/servlets/CrossOriginFilter.java
+++ b/jetty-ee9/jetty-ee9-servlets/src/main/java/org/eclipse/jetty/ee9/servlets/CrossOriginFilter.java
@@ -291,8 +291,10 @@ public class CrossOriginFilter implements Filter
                         LOG.debug("Cross-origin request to {} is a preflight cross-origin request", request.getRequestURI());
                     handlePreflightResponse(request, response, origin);
                     if (chainPreflight)
+                    {
                         if (LOG.isDebugEnabled())
                             LOG.debug("Preflight cross-origin request to {} forwarded to application", request.getRequestURI());
+                    }
                     else
                         return;
                 }

--- a/jetty-ee9/jetty-ee9-servlets/src/main/java/org/eclipse/jetty/ee9/servlets/DoSFilter.java
+++ b/jetty-ee9/jetty-ee9-servlets/src/main/java/org/eclipse/jetty/ee9/servlets/DoSFilter.java
@@ -421,7 +421,8 @@ public class DoSFilter implements Filter
         }
         catch (InterruptedException e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
             response.sendError(getTooManyCode());
         }
         finally
@@ -488,7 +489,8 @@ public class DoSFilter implements Filter
             }
             catch (IllegalStateException ise)
             {
-                LOG.trace("IGNORED", ise);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", ise);
                 // abort instead
                 response.sendError(-1);
             }
@@ -704,7 +706,8 @@ public class DoSFilter implements Filter
         }
         catch (Exception x)
         {
-            LOG.trace("IGNORED", x);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", x);
         }
     }
 

--- a/jetty-ee9/jetty-ee9-servlets/src/main/java/org/eclipse/jetty/ee9/servlets/DoSFilter.java
+++ b/jetty-ee9/jetty-ee9-servlets/src/main/java/org/eclipse/jetty/ee9/servlets/DoSFilter.java
@@ -689,7 +689,8 @@ public class DoSFilter implements Filter
     @Override
     public void destroy()
     {
-        LOG.debug("Destroy {}", this);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Destroy {}", this);
         stopScheduler();
         _rateTrackers.clear();
         _whitelist.clear();
@@ -1036,7 +1037,8 @@ public class DoSFilter implements Filter
         }
         clearWhitelist();
         _whitelist.addAll(result);
-        LOG.debug("Whitelisted IP addresses: {}", result);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Whitelisted IP addresses: {}", result);
     }
 
     /**

--- a/jetty-ee9/jetty-ee9-servlets/src/main/java/org/eclipse/jetty/ee9/servlets/IncludeExcludeBasedFilter.java
+++ b/jetty-ee9/jetty-ee9-servlets/src/main/java/org/eclipse/jetty/ee9/servlets/IncludeExcludeBasedFilter.java
@@ -110,13 +110,15 @@ public abstract class IncludeExcludeBasedFilter implements Filter
     protected String guessMimeType(HttpServletRequest httpRequest, HttpServletResponse httpResponse)
     {
         String contentType = httpResponse.getContentType();
-        LOG.debug("Content Type is: {}", contentType);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Content Type is: {}", contentType);
 
         String mimeType = "";
         if (contentType != null)
         {
             mimeType = MimeTypes.getContentTypeWithoutCharset(contentType);
-            LOG.debug("Mime Type is: {}", mimeType);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Mime Type is: {}", mimeType);
         }
         else
         {
@@ -125,8 +127,8 @@ public abstract class IncludeExcludeBasedFilter implements Filter
             mimeType = Objects.requireNonNullElse(
                 (baseRequest == null ? MimeTypes.DEFAULTS : baseRequest.getCoreRequest().getContext().getMimeTypes())
                 .getMimeByExtension(requestUrl), "");
-
-            LOG.debug("Guessed mime type is {}", mimeType);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Guessed mime type is {}", mimeType);
         }
 
         return mimeType;
@@ -135,10 +137,12 @@ public abstract class IncludeExcludeBasedFilter implements Filter
     protected boolean shouldFilter(HttpServletRequest httpRequest, HttpServletResponse httpResponse)
     {
         String httpMethod = httpRequest.getMethod();
-        LOG.debug("HTTP method is: {}", httpMethod);
+        if (LOG.isDebugEnabled())
+            LOG.debug("HTTP method is: {}", httpMethod);
         if (!_httpMethods.test(httpMethod))
         {
-            LOG.debug("should not apply filter because HTTP method does not match");
+            if (LOG.isDebugEnabled())
+                LOG.debug("should not apply filter because HTTP method does not match");
             return false;
         }
 
@@ -146,16 +150,19 @@ public abstract class IncludeExcludeBasedFilter implements Filter
 
         if (!_mimeTypes.test(mimeType))
         {
-            LOG.debug("should not apply filter because mime type does not match");
+            if (LOG.isDebugEnabled())
+                LOG.debug("should not apply filter because mime type does not match");
             return false;
         }
 
         ServletContext context = httpRequest.getServletContext();
         String path = context == null ? httpRequest.getRequestURI() : URIUtil.addPaths(httpRequest.getServletPath(), httpRequest.getPathInfo());
-        LOG.debug("Path is: {}", path);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Path is: {}", path);
         if (!_paths.test(path))
         {
-            LOG.debug("should not apply filter because path does not match");
+            if (LOG.isDebugEnabled())
+                LOG.debug("should not apply filter because path does not match");
             return false;
         }
 

--- a/jetty-ee9/jetty-ee9-servlets/src/test/java/org/eclipse/jetty/ee9/servlets/AsyncManipFilter.java
+++ b/jetty-ee9/jetty-ee9-servlets/src/test/java/org/eclipse/jetty/ee9/servlets/AsyncManipFilter.java
@@ -46,21 +46,25 @@ public class AsyncManipFilter implements Filter, AsyncListener
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException
     {
-        LOG.debug("doFilter() - {}", chain);
+        if (LOG.isDebugEnabled())
+            LOG.debug("doFilter() - {}", chain);
         AsyncContext ctx = (AsyncContext)request.getAttribute(MANIP_KEY);
         if (ctx == null)
         {
-            LOG.debug("Initial pass through: {}", chain);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Initial pass through: {}", chain);
             ctx = request.startAsync();
             ctx.addListener(this);
             ctx.setTimeout(1000);
-            LOG.debug("AsyncContext: {}", ctx);
+            if (LOG.isDebugEnabled())
+                LOG.debug("AsyncContext: {}", ctx);
             request.setAttribute(MANIP_KEY, ctx);
             return;
         }
         else
         {
-            LOG.debug("Second pass through: {}", chain);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Second pass through: {}", chain);
             chain.doFilter(request, response);
         }
     }
@@ -73,25 +77,29 @@ public class AsyncManipFilter implements Filter, AsyncListener
     @Override
     public void onComplete(AsyncEvent event) throws IOException
     {
-        LOG.debug("onComplete() {}", event);
+        if (LOG.isDebugEnabled())
+            LOG.debug("onComplete() {}", event);
     }
 
     @Override
     public void onTimeout(AsyncEvent event) throws IOException
     {
-        LOG.debug("onTimeout() {}", event.getAsyncContext());
+        if (LOG.isDebugEnabled())
+            LOG.debug("onTimeout() {}", event.getAsyncContext());
         event.getAsyncContext().dispatch();
     }
 
     @Override
     public void onError(AsyncEvent event) throws IOException
     {
-        LOG.debug("onError()", event.getThrowable());
+        if (LOG.isDebugEnabled())
+            LOG.debug("onError()", event.getThrowable());
     }
 
     @Override
     public void onStartAsync(AsyncEvent event) throws IOException
     {
-        LOG.debug("onTimeout() {}", event);
+        if (LOG.isDebugEnabled())
+            LOG.debug("onTimeout() {}", event);
     }
 }

--- a/jetty-ee9/jetty-ee9-servlets/src/test/java/org/eclipse/jetty/ee9/servlets/QoSFilterTest.java
+++ b/jetty-ee9/jetty-ee9-servlets/src/test/java/org/eclipse/jetty/ee9/servlets/QoSFilterTest.java
@@ -213,7 +213,8 @@ public class QoSFilterTest
             }
             catch (Exception e)
             {
-                LOG.debug("Request " + url + " failed", e);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Request " + url + " failed", e);
             }
             finally
             {

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/FailedSelectorTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/FailedSelectorTest.java
@@ -375,7 +375,8 @@ public class FailedSelectorTest
                 {
                     CustomManagedSelector customManagedSelector = (CustomManagedSelector)managedSelector;
                     Selector selector = customManagedSelector.getSelector();
-                    LOG.debug("Closing selector {}}", selector);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("Closing selector {}}", selector);
                     IO.close(selector);
                 }
             }

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/FailedSelectorTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/FailedSelectorTest.java
@@ -376,7 +376,7 @@ public class FailedSelectorTest
                     CustomManagedSelector customManagedSelector = (CustomManagedSelector)managedSelector;
                     Selector selector = customManagedSelector.getSelector();
                     if (LOG.isDebugEnabled())
-                        LOG.debug("Closing selector {}}", selector);
+                        LOG.debug("Closing selector {}", selector);
                     IO.close(selector);
                 }
             }

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/websocket/JakartaSimpleEchoSocket.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/websocket/JakartaSimpleEchoSocket.java
@@ -46,21 +46,24 @@ public class JakartaSimpleEchoSocket
     @OnClose
     public void onClose(CloseReason close)
     {
-        LOG.debug("Closed: {}, {}", close.getCloseCode().getCode(), close.getReasonPhrase());
+        if (LOG.isDebugEnabled())
+            LOG.debug("Closed: {}, {}", close.getCloseCode().getCode(), close.getReasonPhrase());
         closeLatch.countDown();
     }
 
     @OnMessage
     public void onMessage(String message)
     {
-        LOG.debug("Received: {}", message);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Received: {}", message);
         messageLatch.countDown();
     }
 
     @OnOpen
     public void onOpen(Session session)
     {
-        LOG.debug("Opened");
+        if (LOG.isDebugEnabled())
+            LOG.debug("Opened");
         this.session = session;
     }
 }

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/websocket/JettySimpleEchoSocket.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/websocket/JettySimpleEchoSocket.java
@@ -49,7 +49,8 @@ public class JettySimpleEchoSocket
     @OnWebSocketClose
     public void onClose(int statusCode, String reason)
     {
-        LOG.debug("Connection closed: {} - {}", statusCode, reason);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Connection closed: {} - {}", statusCode, reason);
         this.session = null;
         this.closeLatch.countDown(); // trigger latch
     }
@@ -57,7 +58,8 @@ public class JettySimpleEchoSocket
     @OnWebSocketConnect
     public void onConnect(Session session)
     {
-        LOG.debug("Got connect: {}", session);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Got connect: {}", session);
         this.session = session;
         try
         {
@@ -73,6 +75,7 @@ public class JettySimpleEchoSocket
     @OnWebSocketMessage
     public void onMessage(String msg)
     {
-        LOG.debug("Got msg: {}", msg);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Got msg: {}", msg);
     }
 }

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/java/org/eclipse/jetty/ee9/jersey/tests/HungBlockingThreadsTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-jersey/src/test/java/org/eclipse/jetty/ee9/jersey/tests/HungBlockingThreadsTest.java
@@ -160,15 +160,15 @@ public class HungBlockingThreadsTest
                     .send(result -> {});
             });
         }
-
-        LOG.debug("Awaiting for client to block on all threads");
+        if (LOG.isDebugEnabled())
+            LOG.debug("Awaiting for client to block on all threads");
         assertTrue(latch.await(15, TimeUnit.SECONDS));
-
-        LOG.debug("Shutting down client");
+        if (LOG.isDebugEnabled())
+            LOG.debug("Shutting down client");
         // While the server is hanging in InputStream read, close the client's connections.
         httpClient.stop();
-
-        LOG.debug("Waiting for hung threads");
+        if (LOG.isDebugEnabled())
+            LOG.debug("Waiting for hung threads");
         await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertThat(threadDump(), not(containsString(SharedBlockingCallback.class.getName()))));
     }
 

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/Configurations.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/Configurations.java
@@ -201,7 +201,8 @@ public class Configurations extends AbstractList<Configuration> implements Dumpa
             else
             {
                 Object attr = server.getAttribute(Configuration.ATTR);
-                LOG.debug("{} attr({})= {}", server, Configuration.ATTR, attr);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("{} attr({})= {}", server, Configuration.ATTR, attr);
                 if (attr instanceof Configurations)
                     configurations = new Configurations((Configurations)attr);
                 else if (attr instanceof String[])
@@ -492,7 +493,8 @@ public class Configurations extends AbstractList<Configuration> implements Dumpa
         for (int i = 0; i < _configurations.size(); i++)
         {
             Configuration configuration = _configurations.get(i);
-            LOG.debug("preConfigure with {}", configuration);
+            if (LOG.isDebugEnabled())
+                LOG.debug("preConfigure with {}", configuration);
             configuration.preConfigure(webapp);
 
             if (_configurations.get(i) != configuration)
@@ -510,7 +512,8 @@ public class Configurations extends AbstractList<Configuration> implements Dumpa
         // Configure webapp
         for (Configuration configuration : _configurations)
         {
-            LOG.debug("configure {}", configuration);
+            if (LOG.isDebugEnabled())
+                LOG.debug("configure {}", configuration);
             configuration.configure(webapp);
             if (configuration.abort(webapp))
                 return false;
@@ -523,7 +526,8 @@ public class Configurations extends AbstractList<Configuration> implements Dumpa
         // Configure webapp
         for (Configuration configuration : _configurations)
         {
-            LOG.debug("postConfigure {}", configuration);
+            if (LOG.isDebugEnabled())
+                LOG.debug("postConfigure {}", configuration);
             configuration.postConfigure(webapp);
         }
     }

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/JaasConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/JaasConfiguration.java
@@ -45,7 +45,8 @@ public class JaasConfiguration extends AbstractConfiguration
         }
         catch (Throwable e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
             return false;
         }
     }

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/JaspiConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/JaspiConfiguration.java
@@ -43,7 +43,8 @@ public class JaspiConfiguration extends AbstractConfiguration
         }
         catch (Throwable e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
             return false;
         }
     }

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/JmxConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/JmxConfiguration.java
@@ -43,7 +43,8 @@ public class JmxConfiguration extends AbstractConfiguration
         }
         catch (Throwable e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
             return false;
         }
     }

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/JndiConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/JndiConfiguration.java
@@ -45,7 +45,8 @@ public class JndiConfiguration extends AbstractConfiguration
         }
         catch (Throwable e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
             return false;
         }
     }

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/JspConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/JspConfiguration.java
@@ -47,7 +47,8 @@ public class JspConfiguration extends AbstractConfiguration
         }
         catch (Throwable e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
             return false;
         }
     }

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaData.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaData.java
@@ -444,7 +444,8 @@ public class MetaData
     public void resolve(WebAppContext context)
         throws Exception
     {
-        LOG.debug("metadata resolve {}", context);
+        if (LOG.isDebugEnabled())
+            LOG.debug("metadata resolve {}", context);
 
         //Ensure origins is fresh
         _origins.clear();
@@ -477,7 +478,8 @@ public class MetaData
             p.process(context, getWebDescriptor());
             for (WebDescriptor wd : getOverrideDescriptors())
             {
-                LOG.debug("process {} {} {}", context, p, wd);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("process {} {} {}", context, p, wd);
                 p.process(context, wd);
             }
         }
@@ -498,7 +500,8 @@ public class MetaData
             {
                 for (DescriptorProcessor p : _descriptorProcessors)
                 {
-                    LOG.debug("process {} {}", context, fd);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("process {} {}", context, fd);
                     p.process(context, fd);
                 }
             }
@@ -511,7 +514,8 @@ public class MetaData
             {
                 for (DiscoveredAnnotation a : annotations)
                 {
-                    LOG.debug("apply {}", a);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("apply {}", a);
                     a.apply();
                 }
             }

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/ServletsConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/ServletsConfiguration.java
@@ -44,7 +44,8 @@ public class ServletsConfiguration extends AbstractConfiguration
         }
         catch (Throwable e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
             return false;
         }
     }

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/StandardDescriptorProcessor.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/StandardDescriptorProcessor.java
@@ -349,7 +349,8 @@ public class StandardDescriptorProcessor extends IterativeDescriptorProcessor
                 catch (Exception e)
                 {
                     LOG.warn("Cannot parse load-on-startup {}. Please use integer", s);
-                    LOG.trace("IGNORED", e);
+                    if (LOG.isTraceEnabled())
+                        LOG.trace("IGNORED", e);
                 }
             }
 

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebAppContext.java
@@ -457,7 +457,8 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
             }
             catch (MalformedURLException e)
             {
-                LOG.trace("IGNORED", e);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", e);
                 if (mue == null)
                     mue = e;
             }

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-common/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/common/JakartaWebSocketSession.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-common/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/common/JakartaWebSocketSession.java
@@ -193,7 +193,8 @@ public class JakartaWebSocketSession implements jakarta.websocket.Session
         }
         catch (Throwable t)
         {
-            LOG.trace("IGNORED", t);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", t);
         }
     }
 

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/EventSocket.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/EventSocket.java
@@ -55,7 +55,7 @@ public class EventSocket
         this.session = session;
         this.endpointConfig = endpointConfig;
         if (LOG.isDebugEnabled())
-            LOG.debug("{}  onOpen(): {}", toString(), session);
+            LOG.debug("{}  onOpen(): {}", this, session);
         openLatch.countDown();
     }
 
@@ -63,7 +63,7 @@ public class EventSocket
     public void onMessage(String message) throws IOException
     {
         if (LOG.isDebugEnabled())
-            LOG.debug("{}  onMessage(): {}", toString(), message);
+            LOG.debug("{}  onMessage(): {}", this, message);
         textMessages.offer(message);
     }
 
@@ -71,7 +71,7 @@ public class EventSocket
     public void onMessage(ByteBuffer message) throws IOException
     {
         if (LOG.isDebugEnabled())
-            LOG.debug("{}  onMessage(): {}", toString(), message);
+            LOG.debug("{}  onMessage(): {}", this, message);
         binaryMessages.offer(message);
     }
 
@@ -79,7 +79,7 @@ public class EventSocket
     public void onClose(CloseReason reason)
     {
         if (LOG.isDebugEnabled())
-            LOG.debug("{}  onClose(): {}", toString(), reason);
+            LOG.debug("{}  onClose(): {}", this, reason);
 
         closeReason = reason;
         closeLatch.countDown();
@@ -89,7 +89,7 @@ public class EventSocket
     public void onError(Throwable cause)
     {
         if (LOG.isDebugEnabled())
-            LOG.atDebug().setCause(cause).log("{}  onError(): {}", toString());
+            LOG.atDebug().setCause(cause).log("{}  onError()", this);
         error = cause;
         errorLatch.countDown();
     }

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/framehandlers/FrameEcho.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/framehandlers/FrameEcho.java
@@ -54,7 +54,7 @@ public class FrameEcho implements FrameHandler
     public void onError(Throwable cause, Callback callback)
     {
         if (LOG.isDebugEnabled())
-            LOG.atDebug().setCause(cause).log(this + " onError ");
+            LOG.atDebug().setCause(cause).log("{} onError()", this);
         callback.succeeded();
     }
 

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/coders/QuotesDecoder.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/coders/QuotesDecoder.java
@@ -33,11 +33,13 @@ public class QuotesDecoder implements Decoder.TextStream<Quotes>
         Quotes quotes = new Quotes();
         try (BufferedReader buf = new BufferedReader(reader))
         {
-            LOG.debug("decode() begin");
+            if (LOG.isDebugEnabled())
+                LOG.debug("decode() begin");
             String line;
             while ((line = buf.readLine()) != null)
             {
-                LOG.debug("decode() line = {}", line);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("decode() line = {}", line);
                 switch (line.charAt(0))
                 {
                     case 'a':
@@ -48,7 +50,8 @@ public class QuotesDecoder implements Decoder.TextStream<Quotes>
                         break;
                 }
             }
-            LOG.debug("decode() complete");
+            if (LOG.isDebugEnabled())
+                LOG.debug("decode() complete");
         }
         return quotes;
     }

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/quotes/QuotesDecoder.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/quotes/QuotesDecoder.java
@@ -34,11 +34,13 @@ public class QuotesDecoder implements Decoder.TextStream<Quotes>
         Quotes quotes = new Quotes();
         try (BufferedReader buf = new BufferedReader(reader))
         {
-            LOG.debug("decode() begin");
+            if (LOG.isDebugEnabled())
+                LOG.debug("decode() begin");
             String line;
             while ((line = buf.readLine()) != null)
             {
-                LOG.debug("decode() line = {}", line);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("decode() line = {}", line);
                 switch (line.charAt(0))
                 {
                     case 'a':
@@ -49,7 +51,8 @@ public class QuotesDecoder implements Decoder.TextStream<Quotes>
                         break;
                 }
             }
-            LOG.debug("decode() complete");
+            if (LOG.isDebugEnabled())
+                LOG.debug("decode() complete");
         }
         return quotes;
     }

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/quotes/QuotesDecoderTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/quotes/QuotesDecoderTest.java
@@ -65,7 +65,8 @@ public class QuotesDecoderTest
         public void onOpenResource(String filename)
         {
             super.onWsText(filename);
-            QuotesDecoderTest.LOG.debug("onOpenResource({})", filename);
+            if (LOG.isDebugEnabled())
+                LOG.debug("onOpenResource({})", filename);
             try
             {
                 RemoteEndpoint.Basic remote = session.getBasicRemote();

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/server/BinaryStreamTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/server/BinaryStreamTest.java
@@ -274,7 +274,8 @@ public class BinaryStreamTest
                     output.write(buffer, 0, read);
                     readCount += read;
                 }
-                LOG.debug("Read {} bytes", readCount);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Read {} bytes", readCount);
             }
         }
     }

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/server/ConfiguratorTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/server/ConfiguratorTest.java
@@ -199,7 +199,8 @@ public class ConfiguratorTest
         public void modifyHandshake(ServerEndpointConfig sec, HandshakeRequest request, HandshakeResponse response)
         {
             int upgradeNum = upgradeCount.addAndGet(1);
-            LOG.debug("Upgrade Num: {}", upgradeNum);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Upgrade Num: {}", upgradeNum);
             sec.getUserProperties().put("upgradeNum", Integer.toString(upgradeNum));
             switch (upgradeNum)
             {

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/server/EndpointViaConfigTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/server/EndpointViaConfigTest.java
@@ -84,13 +84,15 @@ public class EndpointViaConfigTest
             finally
             {
                 client.stop();
-                LOG.debug("Stopped - " + client);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Stopped - " + client);
             }
         }
         finally
         {
             wsb.stop();
-            LOG.debug("Stopped - " + wsb);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Stopped - " + wsb);
         }
     }
 }

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/server/TextStreamTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/server/TextStreamTest.java
@@ -286,8 +286,8 @@ public class TextStreamTest
                     totalRead += read;
                     output.write(buffer, 0, read);
                 }
-
-                LOG.debug("{} total bytes read/write", totalRead);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("{} total bytes read/write", totalRead);
             }
         }
     }

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/server/examples/WebSocketServerExamplesTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/server/examples/WebSocketServerExamplesTest.java
@@ -61,27 +61,31 @@ public class WebSocketServerExamplesTest
         @OnOpen
         public void onOpen(Session sess)
         {
-            LOG.debug("ClientSocket Connected: " + sess);
+            if (LOG.isDebugEnabled())
+                LOG.debug("ClientSocket Connected: {}", sess);
         }
 
         @OnMessage
         public void onMessage(String message)
         {
             messageQueue.offer(message);
-            LOG.debug("Received TEXT message: " + message);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Received TEXT message: {}", message);
         }
 
         @OnClose
         public void onClose(CloseReason closeReason)
         {
-            LOG.debug("ClientSocket Closed: " + closeReason);
+            if (LOG.isDebugEnabled())
+                LOG.debug("ClientSocket Closed: {}", closeReason);
             closed.countDown();
         }
 
         @OnError
         public void onError(Throwable cause)
         {
-            LOG.atDebug().setCause(cause).log("ClientSocket error");
+            if (LOG.isDebugEnabled())
+                LOG.atDebug().setCause(cause).log("ClientSocket error");
         }
     }
 

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-common/src/test/java/org/eclipse/jetty/ee9/websocket/common/MessageOutputStreamTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-common/src/test/java/org/eclipse/jetty/ee9/websocket/common/MessageOutputStreamTest.java
@@ -110,7 +110,8 @@ public class MessageOutputStreamTest
     {
         int bufsize = (int)(OUTPUT_BUFFER_SIZE * 2.5);
         byte[] buf = new byte[bufsize];
-        LOG.debug("Buffer sizes: max:{}, test:{}", OUTPUT_BUFFER_SIZE, bufsize);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Buffer sizes: max:{}, test:{}", OUTPUT_BUFFER_SIZE, bufsize);
         Arrays.fill(buf, (byte)'x');
         buf[bufsize - 1] = (byte)'o'; // mark last entry for debugging
 

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-common/src/test/java/org/eclipse/jetty/ee9/websocket/common/OutgoingMessageCapture.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-common/src/test/java/org/eclipse/jetty/ee9/websocket/common/OutgoingMessageCapture.java
@@ -77,28 +77,32 @@ public class OutgoingMessageCapture extends CoreSession.Empty implements CoreSes
             {
                 CloseStatus closeStatus = new CloseStatus(frame.getPayload());
                 String event = String.format("CLOSE:%s:%s", CloseStatus.codeString(closeStatus.getCode()), closeStatus.getReason());
-                LOG.debug(event);
+                if (LOG.isDebugEnabled())
+                    LOG.debug(event);
                 events.offer(event);
                 break;
             }
             case OpCode.PING:
             {
                 String event = String.format("PING:%s", dataHint(frame.getPayload()));
-                LOG.debug(event);
+                if (LOG.isDebugEnabled())
+                    LOG.debug(event);
                 events.offer(event);
                 break;
             }
             case OpCode.PONG:
             {
                 String event = String.format("PONG:%s", dataHint(frame.getPayload()));
-                LOG.debug(event);
+                if (LOG.isDebugEnabled())
+                    LOG.debug(event);
                 events.offer(event);
                 break;
             }
             case OpCode.TEXT:
             {
                 String event = String.format("TEXT:fin=%b:len=%d", frame.isFin(), frame.getPayloadLength());
-                LOG.debug(event);
+                if (LOG.isDebugEnabled())
+                    LOG.debug(event);
                 events.offer(event);
                 messageSink = new StringMessageSink(this, MethodHolder.from(wholeTextHandle), true);
                 break;
@@ -106,7 +110,8 @@ public class OutgoingMessageCapture extends CoreSession.Empty implements CoreSes
             case OpCode.BINARY:
             {
                 String event = String.format("BINARY:fin=%b:len=%d", frame.isFin(), frame.getPayloadLength());
-                LOG.debug(event);
+                if (LOG.isDebugEnabled())
+                    LOG.debug(event);
                 events.offer(event);
                 messageSink = new ByteBufferMessageSink(this, MethodHolder.from(wholeBinaryHandle), true);
                 break;
@@ -114,7 +119,8 @@ public class OutgoingMessageCapture extends CoreSession.Empty implements CoreSes
             case OpCode.CONTINUATION:
             {
                 String event = String.format("CONTINUATION:fin=%b:len=%d", frame.isFin(), frame.getPayloadLength());
-                LOG.debug(event);
+                if (LOG.isDebugEnabled())
+                    LOG.debug(event);
                 events.offer(event);
                 break;
             }

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/test/java/org/eclipse/jetty/ee9/websocket/server/browser/BrowserDebugTool.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/test/java/org/eclipse/jetty/ee9/websocket/server/browser/BrowserDebugTool.java
@@ -136,7 +136,8 @@ public class BrowserDebugTool
         @Override
         public void configure(JettyWebSocketServletFactory factory)
         {
-            LOG.debug("Configuring WebSocketServerFactory ...");
+            if (LOG.isDebugEnabled())
+                LOG.debug("Configuring WebSocketServerFactory ...");
 
             // Setup the desired Socket to use for all incoming upgrade requests
             factory.addMapping("/", new BrowserSocketCreator());
@@ -160,7 +161,8 @@ public class BrowserDebugTool
         @Override
         public Object createWebSocket(JettyServerUpgradeRequest req, JettyServerUpgradeResponse resp)
         {
-            LOG.debug("Creating BrowserSocket");
+            if (LOG.isDebugEnabled())
+                LOG.debug("Creating BrowserSocket");
 
             if (req.getSubProtocols() != null)
             {
@@ -190,11 +192,13 @@ public class BrowserDebugTool
             }
 
             resp.setExtensions(negotiated);
-
-            LOG.debug("User-Agent: {}", ua);
-            LOG.debug("Sec-WebSocket-Extensions (Request) : {}", rexts);
-            LOG.debug("Sec-WebSocket-Protocol (Request): {}", req.getHeader("Sec-WebSocket-Protocol"));
-            LOG.debug("Sec-WebSocket-Protocol (Response): {}", resp.getAcceptedSubProtocol());
+            if (LOG.isDebugEnabled())
+            {
+                LOG.debug("User-Agent: {}", ua);
+                LOG.debug("Sec-WebSocket-Extensions (Request) : {}", rexts);
+                LOG.debug("Sec-WebSocket-Protocol (Request): {}", req.getHeader("Sec-WebSocket-Protocol"));
+                LOG.debug("Sec-WebSocket-Protocol (Response): {}", resp.getAcceptedSubProtocol());
+            }
 
             req.getExtensions();
             return new BrowserSocket(ua, rexts);

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/test/java/org/eclipse/jetty/ee9/websocket/server/browser/BrowserSocket.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-server/src/test/java/org/eclipse/jetty/ee9/websocket/server/browser/BrowserSocket.java
@@ -278,13 +278,15 @@ public class BrowserSocket
     {
         if (this.session == null)
         {
-            LOG.debug("Not connected");
+            if (LOG.isDebugEnabled())
+                LOG.debug("Not connected");
             return;
         }
 
         if (!session.isOpen())
         {
-            LOG.debug("Not open");
+            if (LOG.isDebugEnabled())
+                LOG.debug("Not open");
             return;
         }
 

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/CloseTrackingEndpoint.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/CloseTrackingEndpoint.java
@@ -80,7 +80,8 @@ public class CloseTrackingEndpoint extends WebSocketAdapter
     @Override
     public void onWebSocketClose(int statusCode, String reason)
     {
-        LOG.debug("onWebSocketClose({},{})", statusCode, reason);
+        if (LOG.isDebugEnabled())
+            LOG.debug("onWebSocketClose({},{})", statusCode, reason);
         super.onWebSocketClose(statusCode, reason);
         closeCount.incrementAndGet();
         closeCode = statusCode;
@@ -91,7 +92,8 @@ public class CloseTrackingEndpoint extends WebSocketAdapter
     @Override
     public void onWebSocketConnect(Session session)
     {
-        LOG.debug("onWebSocketConnect({})", session);
+        if (LOG.isDebugEnabled())
+            LOG.debug("onWebSocketConnect({})", session);
         super.onWebSocketConnect(session);
         openLatch.countDown();
     }
@@ -99,7 +101,8 @@ public class CloseTrackingEndpoint extends WebSocketAdapter
     @Override
     public void onWebSocketError(Throwable cause)
     {
-        LOG.atDebug().setCause(cause).log("onWebSocketError");
+        if (LOG.isDebugEnabled())
+            LOG.atDebug().setCause(cause).log("onWebSocketError");
         assertThat("Unique Error Event", error.compareAndSet(null, cause), is(true));
         errorLatch.countDown();
     }
@@ -107,14 +110,16 @@ public class CloseTrackingEndpoint extends WebSocketAdapter
     @Override
     public void onWebSocketText(String message)
     {
-        LOG.debug("onWebSocketText({})", message);
+        if (LOG.isDebugEnabled())
+            LOG.debug("onWebSocketText({})", message);
         messageQueue.offer(message);
     }
 
     @Override
     public void onWebSocketBinary(byte[] payload, int offset, int len)
     {
-        LOG.debug("onWebSocketBinary({},{},{})", payload, offset, len);
+        if (LOG.isDebugEnabled())
+            LOG.debug("onWebSocketBinary({},{},{})", payload, offset, len);
         binaryMessageQueue.offer(ByteBuffer.wrap(payload, offset, len));
     }
 

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/client/BadNetworkTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/client/BadNetworkTest.java
@@ -184,9 +184,7 @@ public class BadNetworkTest
         public void onWebSocketError(Throwable cause)
         {
             if (LOG.isDebugEnabled())
-            {
                 LOG.atDebug().setCause(cause).log("ServerEndpoint error");
-            }
         }
     }
 }

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/client/ClientCloseTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/client/ClientCloseTest.java
@@ -440,9 +440,11 @@ public class ClientCloseTest
                 }
                 else if (message.equals("block"))
                 {
-                    LOG.debug("blocking");
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("blocking");
                     assertTrue(block.await(5, TimeUnit.MINUTES));
-                    LOG.debug("unblocked");
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("unblocked");
                 }
                 else
                 {
@@ -452,7 +454,8 @@ public class ClientCloseTest
             }
             catch (Throwable t)
             {
-                LOG.atDebug().setCause(t).log("send text failure");
+                if (LOG.isDebugEnabled())
+                    LOG.atDebug().setCause(t).log("send text failure");
                 throw new RuntimeException(t);
             }
         }
@@ -492,7 +495,8 @@ public class ClientCloseTest
                     }
                     catch (Throwable ignore)
                     {
-                        LOG.debug("OOPS", ignore);
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("OOPS", ignore);
                     }
                 }
                 else if (reason.equals("abort"))

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/client/ClientCloseTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/client/ClientCloseTest.java
@@ -509,7 +509,8 @@ public class ClientCloseTest
                     }
                     catch (Throwable ignore)
                     {
-                        LOG.trace("IGNORED", ignore);
+                        if (LOG.isTraceEnabled())
+                            LOG.trace("IGNORED", ignore);
                     }
                 }
                 else if (reason.startsWith("sleep|"))
@@ -523,7 +524,8 @@ public class ClientCloseTest
                     }
                     catch (InterruptedException ignore)
                     {
-                        LOG.trace("IGNORED", ignore);
+                        if (LOG.isTraceEnabled())
+                            LOG.trace("IGNORED", ignore);
                     }
                 }
             }

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/client/ClientWriteThread.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/client/ClientWriteThread.java
@@ -58,8 +58,12 @@ public class ClientWriteThread extends Thread
 
         try
         {
-            LOG.debug("Writing {} messages to {}", messageCount, session);
-            LOG.debug("Artificial Slowness {} ms", slowness);
+            if (LOG.isDebugEnabled())
+            {
+                LOG.debug("Writing {} messages to {}", messageCount, session);
+                LOG.debug("Artificial Slowness {} ms", slowness);
+            }
+
             FutureWriteCallback lastMessage = null;
             RemoteEndpoint remote = session.getRemote();
             while (m.get() < messageCount)

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/server/SlowServerEndpoint.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee9/websocket/tests/server/SlowServerEndpoint.java
@@ -64,7 +64,8 @@ public class SlowServerEndpoint
             }
             catch (IOException ignore)
             {
-                LOG.trace("IGNORED", ignore);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("IGNORED", ignore);
             }
         }
     }

--- a/jetty-integrations/jetty-gcloud/jetty-gcloud-session-manager/src/main/java/org/eclipse/jetty/gcloud/session/GCloudSessionDataStore.java
+++ b/jetty-integrations/jetty-gcloud/jetty-gcloud-session-manager/src/main/java/org/eclipse/jetty/gcloud/session/GCloudSessionDataStore.java
@@ -1054,7 +1054,8 @@ public class GCloudSessionDataStore extends AbstractSessionDataStore
         }
         catch (DatastoreException e)
         {
-            LOG.trace("IGNORED", e);
+            if (LOG.isTraceEnabled())
+                LOG.trace("IGNORED", e);
         }
         long expiry = entity.getLong(_model.getExpiry());
         long maxInactive = entity.getLong(_model.getMaxInactive());

--- a/tests/jetty-jmh/src/main/java/org/eclipse/jetty/util/thread/jmh/ReservedThreadExecutorExchanger.java
+++ b/tests/jetty-jmh/src/main/java/org/eclipse/jetty/util/thread/jmh/ReservedThreadExecutorExchanger.java
@@ -330,7 +330,8 @@ public class ReservedThreadExecutorExchanger extends ContainerLifeCycle implemen
                 _thread = null;
                 // Clear any interrupted status.
                 if (Thread.interrupted() && LOG.isDebugEnabled())
-                    LOG.debug("interrupted {}", this);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("interrupted {}", this);
             }
         }
 

--- a/tests/jetty-jmh/src/main/java/org/eclipse/jetty/util/thread/jmh/ReservedThreadExecutorExchanger.java
+++ b/tests/jetty-jmh/src/main/java/org/eclipse/jetty/util/thread/jmh/ReservedThreadExecutorExchanger.java
@@ -330,8 +330,7 @@ public class ReservedThreadExecutorExchanger extends ContainerLifeCycle implemen
                 _thread = null;
                 // Clear any interrupted status.
                 if (Thread.interrupted() && LOG.isDebugEnabled())
-                    if (LOG.isDebugEnabled())
-                        LOG.debug("interrupted {}", this);
+                    LOG.debug("interrupted {}", this);
             }
         }
 

--- a/tests/jetty-jmh/src/main/java/org/eclipse/jetty/util/thread/strategy/jmh/TestConnection.java
+++ b/tests/jetty-jmh/src/main/java/org/eclipse/jetty/util/thread/strategy/jmh/TestConnection.java
@@ -123,7 +123,8 @@ public class TestConnection implements Producer
                         }
                         catch (InterruptedException e)
                         {
-                            LOG.trace("IGNORED", e);
+                            if (LOG.isTraceEnabled())
+                                LOG.trace("IGNORED", e);
                         }
                     }
                     else

--- a/tests/jetty-test-session-common/src/main/java/org/eclipse/jetty/session/test/tools/MongoTestHelper.java
+++ b/tests/jetty-test-session-common/src/main/java/org/eclipse/jetty/session/test/tools/MongoTestHelper.java
@@ -143,8 +143,8 @@ public class MongoTestHelper
         Document sessionDocument = collection.find(Filters.eq(MongoSessionDataStore.__ID, data.getId())).first();
         if (sessionDocument == null)
             return false; //doesn't exist
-
-        LOG.debug("{}", sessionDocument);
+        if (LOG.isDebugEnabled())
+            LOG.debug("{}", sessionDocument);
 
         boolean valid = (Boolean)sessionDocument.get(MongoSessionDataStore.__VALID);
 

--- a/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/MavenHelper.java
+++ b/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/MavenHelper.java
@@ -86,13 +86,15 @@ class MavenHelper
         @Override
         public void artifactDownloaded(RepositoryEvent event)
         {
-            LOG.debug("downloaded {}", event.getFile());
+            if (LOG.isDebugEnabled())
+                LOG.debug("downloaded {}", event.getFile());
         }
 
         @Override
         public void artifactResolved(RepositoryEvent event)
         {
-            LOG.debug("artifact resolved {}", event.getFile());
+            if (LOG.isDebugEnabled())
+                LOG.debug("artifact resolved {}", event.getFile());
         }
     }
 }

--- a/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/ProcessWrapper.java
+++ b/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/ProcessWrapper.java
@@ -331,7 +331,8 @@ public class ProcessWrapper implements AutoCloseable
                 String line;
                 while ((line = reader.readLine()) != null)
                 {
-                    LOG.debug(line);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug(line);
                     logs.add(line);
                 }
             }

--- a/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/ProcessWrapper.java
+++ b/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/ProcessWrapper.java
@@ -338,7 +338,8 @@ public class ProcessWrapper implements AutoCloseable
             }
             catch (Throwable x)
             {
-                LOG.trace("", x);
+                if (LOG.isTraceEnabled())
+                    LOG.trace("", x);
             }
             finally
             {

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DemoModulesTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DemoModulesTests.java
@@ -452,8 +452,8 @@ public class DemoModulesTests extends AbstractJettyHomeTest
                         if (cause instanceof EOFException ||
                             cause instanceof AsynchronousCloseException)
                         {
-                            LoggerFactory.getLogger(DemoModulesTests.class).atInfo()
-                                .setCause(e).log("EOF During request to {}{}", baseURI, ambiguous);
+                            LoggerFactory.getLogger(DemoModulesTests.class)
+                                .info("EOF During request to {}{}", baseURI, ambiguous, e);
                             Assumptions.assumeTrue(false, "Jetty Client should not have failed with %s: %s".formatted(cause.getClass().getName(), cause.getMessage()));
                         }
                         else

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionJSPTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionJSPTests.java
@@ -15,8 +15,6 @@ package org.eclipse.jetty.tests.distribution;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jetty.client.ContentResponse;
@@ -211,7 +209,7 @@ public class DistributionJSPTests extends AbstractJettyHomeTest
         {
             assertTrue(run1.awaitForStart());
             assertEquals(0, run1.getExitValue());
-            LOG.atInfo().setMessage(run1.logs().get()).log();
+            LOG.info(run1.logs().get());
             assertTrue(Files.exists(distribution.getJettyBase().resolve("resources/log4j2.xml")));
 
             Path war = distribution.resolveArtifact("org.eclipse.jetty.demos:jetty-servlet5-demo-jsp-webapp:war:" + jettyVersion);

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DistributionTests.java
@@ -1350,7 +1350,8 @@ public class DistributionTests extends AbstractJettyHomeTest
                 }
                 catch (UnknownHostException e)
                 {
-                    LOG.debug("Unable to obtain InetAddress.LocalHost", e);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("Unable to obtain InetAddress.LocalHost", e);
                 }
 
                 for (String hostHeader: hostHeaders)

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/jettysh/JettyShStartTest.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/jettysh/JettyShStartTest.java
@@ -144,7 +144,8 @@ public class JettyShStartTest extends AbstractJettyHomeTest
             startHttpClient();
 
             URI containerUriRoot = URI.create("http://" + genericContainer.getHost() + ":" + genericContainer.getMappedPort(8080) + "/");
-            LOG.debug("Container URI Root: {}", containerUriRoot);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Container URI Root: {}", containerUriRoot);
 
             // System.err.println("== Attempt GET request to service ==");
             ContentResponse response = client.GET(containerUriRoot);
@@ -230,7 +231,8 @@ public class JettyShStartTest extends AbstractJettyHomeTest
             startHttpClient();
 
             URI containerUriRoot = URI.create("http://" + genericContainer.getHost() + ":" + genericContainer.getMappedPort(8080) + "/");
-            LOG.debug("Container URI Root: {}", containerUriRoot);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Container URI Root: {}", containerUriRoot);
 
             // System.err.println("== Attempt GET request to service ==");
             ContentResponse response = client.GET(containerUriRoot);
@@ -318,7 +320,8 @@ public class JettyShStartTest extends AbstractJettyHomeTest
 
     private void createImage(ImageFromDSL image)
     {
-        LOG.debug("Create Image: {}", image.getDockerImageName());
+        if (LOG.isDebugEnabled())
+            LOG.debug("Create Image: {}", image.getDockerImageName());
         try (GenericContainer<?> container = new GenericContainer<>(image))
         {
             container.start();


### PR DESCRIPTION
- add guards for debug logging with `isDebugEnabled()`.
- add guards for trace logging with `isTraceEnabled()`.
- remove usage of `atInfo()` logging methods.
- some other minor fixes.

This should resolve the issue of logging failing with the wrong SLF4J API version, but only when DEBUG logging is not enabled.