### PR TITLE
Optimize `ThreadIdPool`

### DIFF
--- a/jetty-core/jetty-util/src/main/java/module-info.java
+++ b/jetty-core/jetty-util/src/main/java/module-info.java
@@ -23,8 +23,8 @@ module org.eclipse.jetty.util
     requires static java.desktop;
     // Only required if using DriverManagerLeakPreventer.
     requires static java.sql;
-    // Required by MemoryUtils to figure out if oops are compressed.
-    requires java.management;
+    // Used by MemoryUtils when available to figure out if oops are compressed.
+    requires static java.management;
 
     exports org.eclipse.jetty.util;
     exports org.eclipse.jetty.util.annotation;

--- a/jetty-core/jetty-util/src/main/java/module-info.java
+++ b/jetty-core/jetty-util/src/main/java/module-info.java
@@ -23,6 +23,8 @@ module org.eclipse.jetty.util
     requires static java.desktop;
     // Only required if using DriverManagerLeakPreventer.
     requires static java.sql;
+    // Required by MemoryUtils to figure out if oops are compressed.
+    requires java.management;
 
     exports org.eclipse.jetty.util;
     exports org.eclipse.jetty.util.annotation;

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/MemoryUtils.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/MemoryUtils.java
@@ -13,12 +13,18 @@
 
 package org.eclipse.jetty.util;
 
+import java.lang.management.ManagementFactory;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import javax.management.openmbean.CompositeData;
+
 /**
  * MemoryUtils provides an abstraction over memory properties and operations.
  */
 public class MemoryUtils
 {
-    private static final int cacheLineBytes;
+    private static final int CACHE_LINE_BYTES;
+    private static final int REFERENCE_PER_CACHE_LINE;
 
     static
     {
@@ -31,7 +37,25 @@ public class MemoryUtils
         catch (Exception ignored)
         {
         }
-        cacheLineBytes = value;
+        CACHE_LINE_BYTES = value;
+
+        // Use pessimistic default: assume oops are compressed.
+        int referencePerCacheLine = getIntegersPerCacheLine();
+        try
+        {
+            MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+            ObjectName beanName = ObjectName.getInstance("com.sun.management:type=HotSpotDiagnostic");
+            Object vmOption = server.invoke(beanName, "getVMOption",
+                new Object[]{"UseCompressedOops"},
+                new String[]{"java.lang.String"});
+            String v = (String)((CompositeData)vmOption).get("value");
+            if (!Boolean.parseBoolean(v))
+                referencePerCacheLine = getLongsPerCacheLine();
+        }
+        catch (Exception ignored)
+        {
+        }
+        REFERENCE_PER_CACHE_LINE = referencePerCacheLine;
     }
 
     private MemoryUtils()
@@ -40,7 +64,7 @@ public class MemoryUtils
 
     public static int getCacheLineBytes()
     {
-        return cacheLineBytes;
+        return CACHE_LINE_BYTES;
     }
 
     public static int getIntegersPerCacheLine()
@@ -55,8 +79,6 @@ public class MemoryUtils
 
     public static int getReferencesPerCacheLine()
     {
-        // Use getIntegersPerCacheLine() instead of getLongsPerCacheLine() b/c refs (oops) could be
-        // compressed down to 32-bit; maybe this could be detected?
-        return getIntegersPerCacheLine();
+        return REFERENCE_PER_CACHE_LINE;
     }
 }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/MemoryUtils.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/MemoryUtils.java
@@ -18,44 +18,71 @@ import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import javax.management.openmbean.CompositeData;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * MemoryUtils provides an abstraction over memory properties and operations.
  */
 public class MemoryUtils
 {
+    private static final Logger LOG = LoggerFactory.getLogger(MemoryUtils.class);
     private static final int CACHE_LINE_BYTES;
-    private static final int REFERENCE_PER_CACHE_LINE;
+    private static final int REFERENCES_PER_CACHE_LINE;
 
     static
     {
-        int defaultValue = 64;
-        int value = defaultValue;
+        int cacheLineBytes = 64;
         try
         {
-            value = Integer.parseInt(System.getProperty("org.eclipse.jetty.util.cacheLineBytes", String.valueOf(defaultValue)));
+            cacheLineBytes = Integer.parseInt(System.getProperty("org.eclipse.jetty.util.cacheLineBytes", String.valueOf(cacheLineBytes)));
         }
-        catch (Exception ignored)
+        catch (Exception e)
         {
+            if (LOG.isTraceEnabled())
+                LOG.trace("", e);
         }
-        CACHE_LINE_BYTES = value;
+        CACHE_LINE_BYTES = cacheLineBytes;
 
-        // Use pessimistic default: assume oops are compressed.
-        int referencePerCacheLine = getIntegersPerCacheLine();
+        int referencesPerCacheLine = -1;
         try
         {
-            MBeanServer server = ManagementFactory.getPlatformMBeanServer();
-            ObjectName beanName = ObjectName.getInstance("com.sun.management:type=HotSpotDiagnostic");
-            Object vmOption = server.invoke(beanName, "getVMOption",
-                new Object[]{"UseCompressedOops"},
-                new String[]{"java.lang.String"});
-            String v = (String)((CompositeData)vmOption).get("value");
-            if (!Boolean.parseBoolean(v))
-                referencePerCacheLine = getLongsPerCacheLine();
+            String property = System.getProperty("org.eclipse.jetty.util.referencesPerCacheLine");
+            if (property != null)
+            {
+                referencesPerCacheLine = Integer.parseInt(property);
+                if (referencesPerCacheLine < 1)
+                    referencesPerCacheLine = -1;
+            }
         }
-        catch (Exception ignored)
+        catch (Exception e)
         {
+            if (LOG.isTraceEnabled())
+                LOG.trace("", e);
         }
-        REFERENCE_PER_CACHE_LINE = referencePerCacheLine;
+        if (referencesPerCacheLine == -1)
+        {
+            try
+            {
+                MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+                ObjectName beanName = ObjectName.getInstance("com.sun.management:type=HotSpotDiagnostic");
+                Object vmOption = server.invoke(beanName, "getVMOption",
+                    new Object[]{"UseCompressedOops"},
+                    new String[]{"java.lang.String"});
+                String v = (String)((CompositeData)vmOption).get("value");
+                if (!Boolean.parseBoolean(v))
+                    referencesPerCacheLine = getLongsPerCacheLine();
+            }
+            catch (Throwable x)
+            {
+                if (LOG.isTraceEnabled())
+                    LOG.trace("", x);
+            }
+        }
+        // Use pessimistic default: assume oops are compressed to 32-bit.
+        if (referencesPerCacheLine == -1)
+            referencesPerCacheLine = getIntegersPerCacheLine();
+        REFERENCES_PER_CACHE_LINE = referencesPerCacheLine;
     }
 
     private MemoryUtils()
@@ -79,6 +106,6 @@ public class MemoryUtils
 
     public static int getReferencesPerCacheLine()
     {
-        return REFERENCE_PER_CACHE_LINE;
+        return REFERENCES_PER_CACHE_LINE;
     }
 }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ThreadIdPool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ThreadIdPool.java
@@ -22,7 +22,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.eclipse.jetty.util.MathUtils;
-import org.eclipse.jetty.util.MemoryUtils;
 import org.eclipse.jetty.util.ProcessorUtils;
 import org.eclipse.jetty.util.TypeUtil;
 import org.eclipse.jetty.util.component.Dumpable;
@@ -43,9 +42,6 @@ public class ThreadIdPool<E> implements Dumpable
 {
     private static final Logger LOG = LoggerFactory.getLogger(ThreadIdPool.class);
 
-    // How far the entries in the AtomicReferenceArray are spread apart to avoid false sharing.
-    private static final int SPREAD_FACTOR = MemoryUtils.getReferencesPerCacheLine();
-
     private final int _capacity;
     private final AtomicReferenceArray<E> _items;
 
@@ -57,7 +53,7 @@ public class ThreadIdPool<E> implements Dumpable
     public ThreadIdPool(int capacity)
     {
         _capacity = calcCapacity(capacity);
-        _items = new AtomicReferenceArray<>((_capacity + 1) * SPREAD_FACTOR);
+        _items = new AtomicReferenceArray<>(_capacity);
         if (LOG.isDebugEnabled())
             LOG.debug("{}", this);
     }
@@ -67,11 +63,6 @@ public class ThreadIdPool<E> implements Dumpable
         if (capacity >= 0)
             return capacity;
         return 2 * MathUtils.ceilToNextPowerOfTwo(ProcessorUtils.availableProcessors());
-    }
-
-    private static int toSlot(int index)
-    {
-        return (index + 1) * SPREAD_FACTOR;
     }
 
     /**
@@ -90,7 +81,7 @@ public class ThreadIdPool<E> implements Dumpable
         int available = 0;
         for (int i = 0; i < capacity(); i++)
         {
-            if (_items.getPlain(toSlot(i)) != null)
+            if (_items.getPlain(i) != null)
                 available++;
         }
         return available;
@@ -100,7 +91,7 @@ public class ThreadIdPool<E> implements Dumpable
      * Offer an item to the pool.
      * @param e The item to offer
      * @return The index the item was added at or -1, if it was not added
-     * @see #remove(Object, int)
+     * @see #remove(Object, int) 
      */
     public int offer(E e)
     {
@@ -110,7 +101,7 @@ public class ThreadIdPool<E> implements Dumpable
             int index = (int)(Thread.currentThread().getId() % capacity);
             for (int i = 0; i < capacity; i++)
             {
-                if (_items.compareAndSet(toSlot(index), null, e))
+                if (_items.compareAndSet(index, null, e))
                     return index;
                 if (++index == capacity)
                     index = 0;
@@ -131,10 +122,7 @@ public class ThreadIdPool<E> implements Dumpable
         int index = (int)(Thread.currentThread().getId() % capacity);
         for (int i = 0; i < capacity; i++)
         {
-            // Use getAndUpdate instead of getAndSet as the former
-            // uses weak CAS that turns out to be cheaper when
-            // there is heavy contention.
-            E e = _items.getAndUpdate(toSlot(index), v -> null);
+            E e = _items.getAndSet(index, null);
             if (e != null)
                 return e;
             if (++index == capacity)
@@ -144,7 +132,7 @@ public class ThreadIdPool<E> implements Dumpable
     }
 
     /**
-     * Remove a specific item from the pool from a specific index
+     * Remove a specific item from the pool from a specific index 
      * @param e The item to remove
      * @param index The index the item was given to, as returned by {@link #offer(Object)}
      * @return {@code True} if the item was in the pool and was able to be removed.
@@ -153,7 +141,7 @@ public class ThreadIdPool<E> implements Dumpable
     {
         if (index < 0)
             throw new IndexOutOfBoundsException();
-        return _items.compareAndSet(toSlot(index), e, null);
+        return _items.compareAndSet(index, e, null);
     }
 
     /**
@@ -166,7 +154,7 @@ public class ThreadIdPool<E> implements Dumpable
         List<E> all = new ArrayList<>(capacity);
         for (int i = 0; i < capacity; i++)
         {
-            E e = _items.getAndSet(toSlot(i), null);
+            E e = _items.getAndSet(i, null);
             if (e != null)
                 all.add(e);
         }
@@ -240,7 +228,7 @@ public class ThreadIdPool<E> implements Dumpable
         List<Object> slots = new ArrayList<>(capacity);
         for (int i = 0; i < capacity; i++)
         {
-            E slot = _items.get(toSlot(i));
+            E slot = _items.get(i);
             if (slot != null)
                 slots.add(Dumpable.named(Integer.toString(i), slot));
         }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ThreadIdPool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ThreadIdPool.java
@@ -22,6 +22,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.eclipse.jetty.util.MathUtils;
+import org.eclipse.jetty.util.MemoryUtils;
 import org.eclipse.jetty.util.ProcessorUtils;
 import org.eclipse.jetty.util.TypeUtil;
 import org.eclipse.jetty.util.component.Dumpable;
@@ -42,6 +43,9 @@ public class ThreadIdPool<E> implements Dumpable
 {
     private static final Logger LOG = LoggerFactory.getLogger(ThreadIdPool.class);
 
+    // How far the entries in the AtomicReferenceArray are spread apart to avoid false sharing.
+    private static final int SPREAD_FACTOR = MemoryUtils.getReferencesPerCacheLine();
+
     private final int _capacity;
     private final AtomicReferenceArray<E> _items;
 
@@ -53,7 +57,7 @@ public class ThreadIdPool<E> implements Dumpable
     public ThreadIdPool(int capacity)
     {
         _capacity = calcCapacity(capacity);
-        _items = new AtomicReferenceArray<>(_capacity);
+        _items = new AtomicReferenceArray<>((_capacity + 1) * SPREAD_FACTOR);
         if (LOG.isDebugEnabled())
             LOG.debug("{}", this);
     }
@@ -63,6 +67,11 @@ public class ThreadIdPool<E> implements Dumpable
         if (capacity >= 0)
             return capacity;
         return 2 * MathUtils.ceilToNextPowerOfTwo(ProcessorUtils.availableProcessors());
+    }
+
+    private static int toSlot(int index)
+    {
+        return (index + 1) * SPREAD_FACTOR;
     }
 
     /**
@@ -81,7 +90,7 @@ public class ThreadIdPool<E> implements Dumpable
         int available = 0;
         for (int i = 0; i < capacity(); i++)
         {
-            if (_items.getPlain(i) != null)
+            if (_items.getPlain(toSlot(i)) != null)
                 available++;
         }
         return available;
@@ -91,7 +100,7 @@ public class ThreadIdPool<E> implements Dumpable
      * Offer an item to the pool.
      * @param e The item to offer
      * @return The index the item was added at or -1, if it was not added
-     * @see #remove(Object, int) 
+     * @see #remove(Object, int)
      */
     public int offer(E e)
     {
@@ -101,7 +110,7 @@ public class ThreadIdPool<E> implements Dumpable
             int index = (int)(Thread.currentThread().getId() % capacity);
             for (int i = 0; i < capacity; i++)
             {
-                if (_items.compareAndSet(index, null, e))
+                if (_items.compareAndSet(toSlot(index), null, e))
                     return index;
                 if (++index == capacity)
                     index = 0;
@@ -122,7 +131,10 @@ public class ThreadIdPool<E> implements Dumpable
         int index = (int)(Thread.currentThread().getId() % capacity);
         for (int i = 0; i < capacity; i++)
         {
-            E e = _items.getAndSet(index, null);
+            // Use getAndUpdate instead of getAndSet as the former
+            // uses weak CAS that turns out to be cheaper when
+            // there is heavy contention.
+            E e = _items.getAndUpdate(toSlot(index), v -> null);
             if (e != null)
                 return e;
             if (++index == capacity)
@@ -132,7 +144,7 @@ public class ThreadIdPool<E> implements Dumpable
     }
 
     /**
-     * Remove a specific item from the pool from a specific index 
+     * Remove a specific item from the pool from a specific index
      * @param e The item to remove
      * @param index The index the item was given to, as returned by {@link #offer(Object)}
      * @return {@code True} if the item was in the pool and was able to be removed.
@@ -141,7 +153,7 @@ public class ThreadIdPool<E> implements Dumpable
     {
         if (index < 0)
             throw new IndexOutOfBoundsException();
-        return _items.compareAndSet(index, e, null);
+        return _items.compareAndSet(toSlot(index), e, null);
     }
 
     /**
@@ -154,7 +166,7 @@ public class ThreadIdPool<E> implements Dumpable
         List<E> all = new ArrayList<>(capacity);
         for (int i = 0; i < capacity; i++)
         {
-            E e = _items.getAndSet(i, null);
+            E e = _items.getAndSet(toSlot(i), null);
             if (e != null)
                 all.add(e);
         }
@@ -228,7 +240,7 @@ public class ThreadIdPool<E> implements Dumpable
         List<Object> slots = new ArrayList<>(capacity);
         for (int i = 0; i < capacity; i++)
         {
-            E slot = _items.get(i);
+            E slot = _items.get(toSlot(i));
             if (slot != null)
                 slots.add(Dumpable.named(Integer.toString(i), slot));
         }

--- a/tests/jetty-jmh/pom.xml
+++ b/tests/jetty-jmh/pom.xml
@@ -95,6 +95,19 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.openjdk.jmh</groupId>
+              <artifactId>jmh-generator-annprocess</artifactId>
+              <version>${jmh.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <executions>
           <execution>

--- a/tests/jetty-jmh/src/main/java/org/eclipse/jetty/util/thread/jmh/ThreadIdPoolBenchmark.java
+++ b/tests/jetty-jmh/src/main/java/org/eclipse/jetty/util/thread/jmh/ThreadIdPoolBenchmark.java
@@ -54,7 +54,7 @@ public class ThreadIdPoolBenchmark
     public static void main(String[] args) throws RunnerException
     {
         // Measure false-sharing with:
-        //   perf c2c record -- java -jar target/benchmark.jar ThreadIdPoolBenchmark
+        //   perf c2c record -- java -jar target/benchmarks.jar ThreadIdPoolBenchmark
         // then print report with:
         //   perf c2c report --stdio
         Options opt = new OptionsBuilder()

--- a/tests/jetty-jmh/src/main/java/org/eclipse/jetty/util/thread/jmh/ThreadIdPoolBenchmark.java
+++ b/tests/jetty-jmh/src/main/java/org/eclipse/jetty/util/thread/jmh/ThreadIdPoolBenchmark.java
@@ -1,0 +1,68 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.util.thread.jmh;
+
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.util.thread.ThreadIdPool;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State(Scope.Benchmark)
+@Warmup(iterations = 4, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 4, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(1)
+@Threads(200)
+public class ThreadIdPoolBenchmark
+{
+    private final ThreadIdPool<String> threadIdPool = new ThreadIdPool<>(32);
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public void test()
+    {
+        String s = threadIdPool.take();
+
+        Blackhole.consumeCPU(100);
+
+        threadIdPool.offer(s);
+    }
+
+    public static void main(String[] args) throws RunnerException
+    {
+        // Measure false-sharing with:
+        //   perf c2c record -- java -jar target/benchmark.jar ThreadIdPoolBenchmark
+        // then print report with:
+        //   perf c2c report --stdio
+        Options opt = new OptionsBuilder()
+            .include(ThreadIdPoolBenchmark.class.getSimpleName())
+            // .addProfiler(LinuxPerfNormProfiler.class)
+            // .addProfiler(LinuxPerfAsmProfiler.class)
+            .build();
+
+        new Runner(opt).run();
+    }
+}


### PR DESCRIPTION
WIP related to https://github.com/jetty/jetty.project/issues/14689

The previous analysis concluded that the spreading done in `ThreadIdPool` resulted in a too large array that was too costly in cache real estate, thus being overall detrimental to performance despite false-sharing occurrences.

A week of nightly performance runs later and it turns out the above wasn't the complete truth: false-sharing has more impact than previously understood, but the savings in cache real estate are real, meaning the performance is sometimes better and sometimes worse.

These changes are an attempt at getting a finer understanding of what's going on and being more precise in our implementation to try to squeeze out as much perf as possible.