### PR TITLE
Fixes #14752 - Jetty 12.1 Violation of RFC9113 with Host and :authority headers

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpConnection.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpConnection.java
@@ -31,6 +31,7 @@ import org.eclipse.jetty.http.HttpCookieStore;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.io.CyclicTimeouts;
 import org.eclipse.jetty.util.Attachable;
 import org.eclipse.jetty.util.NanoTime;
@@ -67,6 +68,16 @@ public abstract class HttpConnection implements IConnection, Attachable
     public HttpDestination getHttpDestination()
     {
         return destination;
+    }
+
+    protected HttpVersion getHttpVersion()
+    {
+        return null;
+    }
+
+    protected boolean requiresHostHeader()
+    {
+        return false;
     }
 
     protected abstract Iterator<HttpChannel> getHttpChannels();
@@ -152,8 +163,6 @@ public abstract class HttpConnection implements IConnection, Attachable
             request.path(path);
         }
 
-        boolean http1 = request.getVersion().getVersion() <= 11;
-
         boolean applyProxyAuthentication = false;
         ProxyConfiguration.Proxy proxy = destination.getProxy();
         if (proxy instanceof HttpProxy httpProxy)
@@ -163,7 +172,7 @@ public abstract class HttpConnection implements IConnection, Attachable
             // RFC 9112, section 3.2.2: when making a request to a proxy other than CONNECT,
             // the client must send the target URI in absolute-form as the request target.
             // In practice, this is only valid for HTTP/1.1 requests that are not tunnelled.
-            if (http1 && !tunnelled)
+            if (getHttpVersion() == HttpVersion.HTTP_1_1 && !tunnelled)
             {
                 URI uri = request.getURI();
                 if (uri != null)
@@ -177,7 +186,7 @@ public abstract class HttpConnection implements IConnection, Attachable
 
         // If we are HTTP 1.1, add the Host header.
         HttpFields headers = request.getHeaders();
-        if (http1)
+        if (requiresHostHeader())
         {
             if (!headers.contains(HttpHeader.HOST.asString()))
             {

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpConnection.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpConnection.java
@@ -70,15 +70,9 @@ public abstract class HttpConnection implements IConnection, Attachable
         return destination;
     }
 
-    protected HttpVersion getHttpVersion()
-    {
-        return null;
-    }
+    protected abstract HttpVersion getHttpVersion();
 
-    protected boolean requiresHostHeader()
-    {
-        return false;
-    }
+    protected abstract boolean requiresHostHeader();
 
     protected abstract Iterator<HttpChannel> getHttpChannels();
 

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpConnectionOverHTTP.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/HttpConnectionOverHTTP.java
@@ -372,6 +372,18 @@ public class HttpConnectionOverHTTP extends AbstractConnection implements IConne
         }
 
         @Override
+        protected HttpVersion getHttpVersion()
+        {
+            return HttpVersion.HTTP_1_1;
+        }
+
+        @Override
+        protected boolean requiresHostHeader()
+        {
+            return true;
+        }
+
+        @Override
         protected Iterator<HttpChannel> getHttpChannels()
         {
             return Collections.<HttpChannel>singleton(channel).iterator();

--- a/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpConnectionOverFCGI.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpConnectionOverFCGI.java
@@ -41,6 +41,7 @@ import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpHeaderValue;
+import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.io.AbstractConnection;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.Content;
@@ -404,6 +405,12 @@ public class HttpConnectionOverFCGI extends AbstractConnection implements IConne
         private Delegate(Destination destination)
         {
             super((HttpDestination)destination);
+        }
+
+        @Override
+        protected HttpVersion getHttpVersion()
+        {
+            return null;
         }
 
         @Override

--- a/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpConnectionOverFCGI.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-client/src/main/java/org/eclipse/jetty/fcgi/client/transport/internal/HttpConnectionOverFCGI.java
@@ -407,6 +407,12 @@ public class HttpConnectionOverFCGI extends AbstractConnection implements IConne
         }
 
         @Override
+        protected boolean requiresHostHeader()
+        {
+            return true;
+        }
+
+        @Override
         protected Iterator<HttpChannel> getHttpChannels()
         {
             return Collections.<HttpChannel>singleton(channel).iterator();

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpConnectionOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpConnectionOverHTTP2.java
@@ -136,6 +136,12 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
     }
 
     @Override
+    protected HttpVersion getHttpVersion()
+    {
+        return HttpVersion.HTTP_2;
+    }
+
+    @Override
     protected Iterator<HttpChannel> getHttpChannels()
     {
         Set<HttpChannel> channels;

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpConnectionOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpConnectionOverHTTP2.java
@@ -142,6 +142,12 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
     }
 
     @Override
+    protected boolean requiresHostHeader()
+    {
+        return false;
+    }
+
+    @Override
     protected Iterator<HttpChannel> getHttpChannels()
     {
         Set<HttpChannel> channels;
@@ -224,23 +230,14 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
     @Override
     protected void normalizeRequest(HttpRequest request)
     {
-        super.normalizeRequest(request);
-        // Do not set the HTTP version explicitly using Request.version(),
-        // in case the request needs to be retried with a different version.
-        request.useVersion(HttpVersion.HTTP_2);
-
+        boolean canUpgrade = false;
+        // Check whether the client-side supports upgrading to a different protocol.
         HttpUpgrader.Factory upgraderFactory = (HttpUpgrader.Factory)request.getAttributes().get(HttpUpgrader.Factory.class.getName());
         if (upgraderFactory != null)
         {
             // Check whether the server-side support CONNECT with :protocol pseudo-header.
-            boolean connect = ((HTTP2Session)session).isConnectProtocolEnabled();
-            if (connect)
-            {
-                HttpUpgrader upgrader = upgraderFactory.newHttpUpgrader(HttpVersion.HTTP_2);
-                request.getConversation().setAttribute(HttpUpgrader.class.getName(), upgrader);
-                upgrader.prepare(request);
-            }
-            else
+            canUpgrade = ((HTTP2Session)session).isConnectProtocolEnabled();
+            if (!canUpgrade)
             {
                 // Check whether we can fall back to another HttpClientTransport.
                 boolean dynamic = getHttpDestination().getHttpClient().getHttpClientTransport() instanceof HttpClientTransportDynamic;
@@ -259,6 +256,16 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
                 attribute.addAll(List.of("h2c", "h2"));
                 throw new RetryableRequestException("Could not upgrade from protocols " + attribute);
             }
+        }
+
+        super.normalizeRequest(request);
+        request.useVersion(HttpVersion.HTTP_2);
+
+        if (canUpgrade)
+        {
+            HttpUpgrader upgrader = upgraderFactory.newHttpUpgrader(HttpVersion.HTTP_2);
+            request.getConversation().setAttribute(HttpUpgrader.class.getName(), upgrader);
+            upgrader.prepare(request);
         }
     }
 

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
@@ -250,6 +250,30 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
     }
 
     @Test
+    public void testRequestDoesNotContainHostHeader() throws Exception
+    {
+        start(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
+            {
+                callback.succeeded();
+                return true;
+            }
+        });
+
+        ContentResponse response = httpClient.newRequest("localhost", connector.getLocalPort())
+            .onRequestBegin(request ->
+            {
+                if (request.getHeaders().contains(HttpHeader.HOST))
+                    request.abort(new Exception("Host header should not be present"));
+            })
+            .send();
+
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+    }
+
+    @Test
     public void testDelayDemandAfterHeaders() throws Exception
     {
         start(new Handler.Abstract()

--- a/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpConnectionOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpConnectionOverHTTP3.java
@@ -107,6 +107,12 @@ public class HttpConnectionOverHTTP3 extends HttpConnection implements Connectio
     }
 
     @Override
+    protected boolean requiresHostHeader()
+    {
+        return false;
+    }
+
+    @Override
     protected Iterator<HttpChannel> getHttpChannels()
     {
         return activeChannels.iterator();

--- a/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpConnectionOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpConnectionOverHTTP3.java
@@ -101,6 +101,12 @@ public class HttpConnectionOverHTTP3 extends HttpConnection implements Connectio
     }
 
     @Override
+    protected HttpVersion getHttpVersion()
+    {
+        return HttpVersion.HTTP_3;
+    }
+
+    @Override
     protected Iterator<HttpChannel> getHttpChannels()
     {
         return activeChannels.iterator();

--- a/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/HttpClientTransportOverHTTP3Test.java
+++ b/jetty-core/jetty-http3/jetty-http3-tests/src/test/java/org/eclipse/jetty/http3/tests/HttpClientTransportOverHTTP3Test.java
@@ -25,6 +25,7 @@ import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.Response;
 import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpVersion;
@@ -118,6 +119,32 @@ public class HttpClientTransportOverHTTP3Test extends AbstractClientServerTest
             })
             .transport(transport)
             .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+    }
+
+    @ParameterizedTest
+    @MethodSource("transports")
+    public void testRequestDoesNotContainHostHeader(TransportType transportType) throws Exception
+    {
+        start(transportType, new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
+            {
+                callback.succeeded();
+                return true;
+            }
+        });
+
+        ContentResponse response = httpClient.newRequest("localhost", connector.getLocalPort())
+            .scheme(HttpScheme.HTTPS.asString())
+            .onRequestBegin(request ->
+            {
+                if (request.getHeaders().contains(HttpHeader.HOST))
+                    request.abort(new Exception("Host header should not be present"));
+            })
             .send();
 
         assertEquals(HttpStatus.OK_200, response.getStatus());


### PR DESCRIPTION
* Do not add the `Host` header in client requests for HTTP protocol versions for which must not be sent.
* Improved logic in `HttpConnection.normalizeRequest()`.