### PR TITLE
Fixes for JASPI isMandatory, authType and isAuthenticationRequest params

### DIFF
--- a/jetty-ee10/jetty-ee10-jaspi/src/main/java/org/eclipse/jetty/ee10/security/jaspi/JaspiAuthenticator.java
+++ b/jetty-ee10/jetty-ee10-jaspi/src/main/java/org/eclipse/jetty/ee10/security/jaspi/JaspiAuthenticator.java
@@ -154,10 +154,13 @@ public class JaspiAuthenticator extends LoginAuthenticator
     @Override
     public AuthenticationState validateRequest(Request request, Response response, Callback callback) throws ServerAuthException
     {
-        JaspiMessageInfo info = new JaspiMessageInfo(request, response, callback);
-        request.setAttribute("org.eclipse.jetty.ee10.security.jaspi.info", info);
-
-        return validateRequest(info);
+        boolean isDeferred = AuthenticationState.getAuthenticationState(request) instanceof AuthenticationState.Deferred;
+        boolean isAuthenticationRequest = isDeferred && !AuthenticationState.Deferred.isDeferred(response);
+        boolean isMandatory = !isDeferred || isAuthenticationRequest;
+        JaspiMessageInfo messageInfo = new JaspiMessageInfo(request, response, callback);
+        messageInfo.setMandatory(isMandatory);
+        messageInfo.setAuthenticationRequest(isMandatory);
+        return validateRequest(messageInfo);
     }
 
     public AuthenticationState validateRequest(JaspiMessageInfo messageInfo) throws ServerAuthException
@@ -172,6 +175,7 @@ public class JaspiAuthenticator extends LoginAuthenticator
             ServerAuthContext authContext = authConfig.getAuthContext(authContextId, _serviceSubject, _authProperties);
             Subject clientSubject = new Subject();
 
+            _callbackHandler.clear();
             AuthStatus authStatus = authContext.validateRequest(messageInfo, clientSubject, _serviceSubject);
 
             if (authStatus == AuthStatus.SEND_CONTINUE)
@@ -224,7 +228,10 @@ public class JaspiAuthenticator extends LoginAuthenticator
                 if (cached != null)
                     return cached;
 
-                return new UserAuthenticationSucceeded(getAuthenticationType(), userIdentity);
+                String authType = messageInfo.getAuthenticationType();
+                if (authType == null)
+                    authType = getAuthenticationType();
+                return new UserAuthenticationSucceeded(authType, userIdentity);
             }
             if (authStatus == AuthStatus.SEND_SUCCESS)
             {
@@ -241,6 +248,10 @@ public class JaspiAuthenticator extends LoginAuthenticator
         catch (AuthException e)
         {
             throw new ServerAuthException(e);
+        }
+        finally
+        {
+            _callbackHandler.clear();
         }
     }
 

--- a/jetty-ee10/jetty-ee10-jaspi/src/main/java/org/eclipse/jetty/ee10/security/jaspi/JaspiAuthenticator.java
+++ b/jetty-ee10/jetty-ee10-jaspi/src/main/java/org/eclipse/jetty/ee10/security/jaspi/JaspiAuthenticator.java
@@ -159,7 +159,7 @@ public class JaspiAuthenticator extends LoginAuthenticator
         boolean isMandatory = !isDeferred || isAuthenticationRequest;
         JaspiMessageInfo messageInfo = new JaspiMessageInfo(request, response, callback);
         messageInfo.setMandatory(isMandatory);
-        messageInfo.setAuthenticationRequest(isMandatory);
+        messageInfo.setAuthenticationRequest(isAuthenticationRequest);
         return validateRequest(messageInfo);
     }
 

--- a/jetty-ee10/jetty-ee10-jaspi/src/main/java/org/eclipse/jetty/ee10/security/jaspi/JaspiAuthenticator.java
+++ b/jetty-ee10/jetty-ee10-jaspi/src/main/java/org/eclipse/jetty/ee10/security/jaspi/JaspiAuthenticator.java
@@ -174,9 +174,21 @@ public class JaspiAuthenticator extends LoginAuthenticator
             String authContextId = authConfig.getAuthContextID(messageInfo);
             ServerAuthContext authContext = authConfig.getAuthContext(authContextId, _serviceSubject, _authProperties);
             Subject clientSubject = new Subject();
+            AuthStatus authStatus;
+            CallerPrincipalCallback principalCallback;
+            GroupPrincipalCallback groupPrincipalCallback;
 
-            _callbackHandler.clear();
-            AuthStatus authStatus = authContext.validateRequest(messageInfo, clientSubject, _serviceSubject);
+            try
+            {
+                _callbackHandler.clear();
+                authStatus = authContext.validateRequest(messageInfo, clientSubject, _serviceSubject);
+                principalCallback = _callbackHandler.getThreadCallerPrincipalCallback();
+                groupPrincipalCallback = _callbackHandler.getThreadGroupPrincipalCallback();
+            }
+            finally
+            {
+                _callbackHandler.clear();
+            }
 
             if (authStatus == AuthStatus.SEND_CONTINUE)
                 return AuthenticationState.CHALLENGE;
@@ -187,13 +199,12 @@ public class JaspiAuthenticator extends LoginAuthenticator
             {
                 Set<UserIdentity> ids = clientSubject.getPrivateCredentials(UserIdentity.class);
                 UserIdentity userIdentity;
-                if (ids.size() > 0)
+                if (!ids.isEmpty())
                 {
                     userIdentity = ids.iterator().next();
                 }
                 else
                 {
-                    CallerPrincipalCallback principalCallback = _callbackHandler.getThreadCallerPrincipalCallback();
                     if (principalCallback == null)
                     {
                         return null;
@@ -218,7 +229,6 @@ public class JaspiAuthenticator extends LoginAuthenticator
                             principal = new UserPrincipal(principalName, null);
                         }
                     }
-                    GroupPrincipalCallback groupPrincipalCallback = _callbackHandler.getThreadGroupPrincipalCallback();
                     String[] groups = groupPrincipalCallback == null ? null : groupPrincipalCallback.getGroups();
                     userIdentity = _identityService.newUserIdentity(clientSubject, principal, groups);
                 }
@@ -248,10 +258,6 @@ public class JaspiAuthenticator extends LoginAuthenticator
         catch (AuthException e)
         {
             throw new ServerAuthException(e);
-        }
-        finally
-        {
-            _callbackHandler.clear();
         }
     }
 

--- a/jetty-ee10/jetty-ee10-jaspi/src/main/java/org/eclipse/jetty/ee10/security/jaspi/JaspiMessageInfo.java
+++ b/jetty-ee10/jetty-ee10-jaspi/src/main/java/org/eclipse/jetty/ee10/security/jaspi/JaspiMessageInfo.java
@@ -13,10 +13,8 @@
 
 package org.eclipse.jetty.ee10.security.jaspi;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 import jakarta.security.auth.message.MessageInfo;
 import jakarta.servlet.ServletRequest;
@@ -32,28 +30,28 @@ import org.eclipse.jetty.util.Callback;
  */
 public class JaspiMessageInfo implements MessageInfo
 {
+    public static final String AUTH_REQUEST_KEY = "jakarta.servlet.http.isAuthenticationRequest";
     public static final String AUTHENTICATION_TYPE_KEY = "jakarta.servlet.http.authType";
+    public static final String MANDATORY_KEY = "jakarta.security.auth.message.MessagePolicy.isMandatory";
     private final Callback _callback;
     private Request _request;
     private Response _response;
-    private final MIMap _map;
+    private final Map<String, Object> _map = new HashMap<>();
 
     public JaspiMessageInfo(Request request, Response response, Callback callback)
     {
         _request = request;
         _response = response;
         _callback = callback;
-        //JASPI 3.8.1
-        _map = new MIMap();
     }
-    
+
     public Callback getCallback()
     {
         return _callback;
     }
 
     @Override
-    public Map getMap()
+    public Map<String, Object> getMap()
     {
         return _map;
     }
@@ -62,10 +60,31 @@ public class JaspiMessageInfo implements MessageInfo
     {
         return _request;
     }
-    
+
     public Response getBaseResponse()
     {
         return _response;
+    }
+
+    public String getAuthenticationType()
+    {
+        return (String)_map.get(AUTHENTICATION_TYPE_KEY);
+    }
+
+    public void setMandatory(boolean isMandatory)
+    {
+        if (isMandatory)
+            _map.put(JaspiMessageInfo.MANDATORY_KEY, "true");
+        else
+            _map.remove(JaspiMessageInfo.MANDATORY_KEY);
+    }
+
+    public void setAuthenticationRequest(boolean isAuthenticationRequest)
+    {
+        if (isAuthenticationRequest)
+            _map.put(JaspiMessageInfo.AUTH_REQUEST_KEY, "true");
+        else
+            _map.remove(JaspiMessageInfo.AUTH_REQUEST_KEY);
     }
 
     @Override
@@ -96,141 +115,5 @@ public class JaspiMessageInfo implements MessageInfo
         if (!(response instanceof ServletResponse))
             throw new IllegalStateException("Not a ServletResponse");
         _response = ServletContextResponse.getServletContextResponse((ServletResponse)response);
-    }
-
-    //TODO this has bugs in the view implementations.  Changing them will not affect the hardcoded values.
-    private static class MIMap implements Map
-    {
-        private String authenticationType;
-        private Map delegate;
-
-        private MIMap()
-        {
-        }
-
-        @Override
-        public int size()
-        {
-            return delegate.size();
-        }
-
-        @Override
-        public boolean isEmpty()
-        {
-            return delegate == null || delegate.isEmpty();
-        }
-
-        @Override
-        public boolean containsKey(Object key)
-        {
-            if (AUTHENTICATION_TYPE_KEY.equals(key))
-                return authenticationType != null;
-            return delegate != null && delegate.containsKey(key);
-        }
-
-        @Override
-        public boolean containsValue(Object value)
-        {
-            if (authenticationType == value || (authenticationType != null && authenticationType.equals(value)))
-                return true;
-            return delegate != null && delegate.containsValue(value);
-        }
-
-        @Override
-        public Object get(Object key)
-        {
-            if (AUTHENTICATION_TYPE_KEY.equals(key))
-                return authenticationType;
-            if (delegate == null)
-                return null;
-            return delegate.get(key);
-        }
-
-        @Override
-        public Object put(Object key, Object value)
-        {
-            if (AUTHENTICATION_TYPE_KEY.equals(key))
-            {
-                String authenticationType = this.authenticationType;
-                this.authenticationType = (String)value;
-                if (delegate != null)
-                    delegate.put(AUTHENTICATION_TYPE_KEY, value);
-                return authenticationType;
-            }
-
-            return getDelegate(true).put(key, value);
-        }
-
-        @Override
-        public Object remove(Object key)
-        {
-            if (AUTHENTICATION_TYPE_KEY.equals(key))
-            {
-                String authenticationType = this.authenticationType;
-                this.authenticationType = null;
-                if (delegate != null)
-                    delegate.remove(AUTHENTICATION_TYPE_KEY);
-                return authenticationType;
-            }
-            if (delegate == null)
-                return null;
-            return delegate.remove(key);
-        }
-
-        @Override
-        public void putAll(Map map)
-        {
-            if (map != null)
-            {
-                for (Object o : map.entrySet())
-                {
-                    Map.Entry entry = (Entry)o;
-                    put(entry.getKey(), entry.getValue());
-                }
-            }
-        }
-
-        @Override
-        public void clear()
-        {
-            authenticationType = null;
-            delegate = null;
-        }
-
-        @Override
-        public Set keySet()
-        {
-            return getDelegate(true).keySet();
-        }
-
-        @Override
-        public Collection values()
-        {
-            return getDelegate(true).values();
-        }
-
-        @Override
-        public Set entrySet()
-        {
-            return getDelegate(true).entrySet();
-        }
-
-        private Map getDelegate(boolean create)
-        {
-            if (!create || delegate != null)
-                return delegate;
-            if (create)
-            {
-                delegate = new HashMap();
-                if (authenticationType != null)
-                    delegate.put(AUTHENTICATION_TYPE_KEY, authenticationType);
-            }
-            return delegate;
-        }
-
-        String getAuthenticationType()
-        {
-            return authenticationType;
-        }
     }
 }

--- a/jetty-ee10/jetty-ee10-jaspi/src/main/java/org/eclipse/jetty/ee10/security/jaspi/ServletCallbackHandler.java
+++ b/jetty-ee10/jetty-ee10-jaspi/src/main/java/org/eclipse/jetty/ee10/security/jaspi/ServletCallbackHandler.java
@@ -129,4 +129,10 @@ public class ServletCallbackHandler implements CallbackHandler
         _groupPrincipals.set(null);
         return groupPrincipalCallback;
     }
+
+    public void clear()
+    {
+        _callerPrincipals.remove();
+        _groupPrincipals.remove();
+    }
 }

--- a/jetty-ee11/jetty-ee11-jaspi/src/main/java/org/eclipse/jetty/ee11/security/jaspi/JaspiAuthenticator.java
+++ b/jetty-ee11/jetty-ee11-jaspi/src/main/java/org/eclipse/jetty/ee11/security/jaspi/JaspiAuthenticator.java
@@ -154,10 +154,13 @@ public class JaspiAuthenticator extends LoginAuthenticator
     @Override
     public AuthenticationState validateRequest(Request request, Response response, Callback callback) throws ServerAuthException
     {
-        JaspiMessageInfo info = new JaspiMessageInfo(request, response, callback);
-        request.setAttribute("org.eclipse.jetty.ee11.security.jaspi.info", info);
-
-        return validateRequest(info);
+        boolean isDeferred = AuthenticationState.getAuthenticationState(request) instanceof AuthenticationState.Deferred;
+        boolean isAuthenticationRequest = isDeferred && !AuthenticationState.Deferred.isDeferred(response);
+        boolean isMandatory = !isDeferred || isAuthenticationRequest;
+        JaspiMessageInfo messageInfo = new JaspiMessageInfo(request, response, callback);
+        messageInfo.setMandatory(isMandatory);
+        messageInfo.setAuthenticationRequest(isMandatory);
+        return validateRequest(messageInfo);
     }
 
     public AuthenticationState validateRequest(JaspiMessageInfo messageInfo) throws ServerAuthException
@@ -172,6 +175,7 @@ public class JaspiAuthenticator extends LoginAuthenticator
             ServerAuthContext authContext = authConfig.getAuthContext(authContextId, _serviceSubject, _authProperties);
             Subject clientSubject = new Subject();
 
+            _callbackHandler.clear();
             AuthStatus authStatus = authContext.validateRequest(messageInfo, clientSubject, _serviceSubject);
 
             if (authStatus == AuthStatus.SEND_CONTINUE)
@@ -224,7 +228,10 @@ public class JaspiAuthenticator extends LoginAuthenticator
                 if (cached != null)
                     return cached;
 
-                return new UserAuthenticationSucceeded(getAuthenticationType(), userIdentity);
+                String authType = messageInfo.getAuthenticationType();
+                if (authType == null)
+                    authType = getAuthenticationType();
+                return new UserAuthenticationSucceeded(authType, userIdentity);
             }
             if (authStatus == AuthStatus.SEND_SUCCESS)
             {
@@ -241,6 +248,10 @@ public class JaspiAuthenticator extends LoginAuthenticator
         catch (AuthException e)
         {
             throw new ServerAuthException(e);
+        }
+        finally
+        {
+            _callbackHandler.clear();
         }
     }
 

--- a/jetty-ee11/jetty-ee11-jaspi/src/main/java/org/eclipse/jetty/ee11/security/jaspi/JaspiAuthenticator.java
+++ b/jetty-ee11/jetty-ee11-jaspi/src/main/java/org/eclipse/jetty/ee11/security/jaspi/JaspiAuthenticator.java
@@ -159,7 +159,7 @@ public class JaspiAuthenticator extends LoginAuthenticator
         boolean isMandatory = !isDeferred || isAuthenticationRequest;
         JaspiMessageInfo messageInfo = new JaspiMessageInfo(request, response, callback);
         messageInfo.setMandatory(isMandatory);
-        messageInfo.setAuthenticationRequest(isMandatory);
+        messageInfo.setAuthenticationRequest(isAuthenticationRequest);
         return validateRequest(messageInfo);
     }
 

--- a/jetty-ee11/jetty-ee11-jaspi/src/main/java/org/eclipse/jetty/ee11/security/jaspi/JaspiAuthenticator.java
+++ b/jetty-ee11/jetty-ee11-jaspi/src/main/java/org/eclipse/jetty/ee11/security/jaspi/JaspiAuthenticator.java
@@ -174,9 +174,21 @@ public class JaspiAuthenticator extends LoginAuthenticator
             String authContextId = authConfig.getAuthContextID(messageInfo);
             ServerAuthContext authContext = authConfig.getAuthContext(authContextId, _serviceSubject, _authProperties);
             Subject clientSubject = new Subject();
+            AuthStatus authStatus;
+            CallerPrincipalCallback principalCallback;
+            GroupPrincipalCallback groupPrincipalCallback;
 
-            _callbackHandler.clear();
-            AuthStatus authStatus = authContext.validateRequest(messageInfo, clientSubject, _serviceSubject);
+            try
+            {
+                _callbackHandler.clear();
+                authStatus = authContext.validateRequest(messageInfo, clientSubject, _serviceSubject);
+                principalCallback = _callbackHandler.getThreadCallerPrincipalCallback();
+                groupPrincipalCallback = _callbackHandler.getThreadGroupPrincipalCallback();
+            }
+            finally
+            {
+                _callbackHandler.clear();
+            }
 
             if (authStatus == AuthStatus.SEND_CONTINUE)
                 return AuthenticationState.CHALLENGE;
@@ -187,13 +199,12 @@ public class JaspiAuthenticator extends LoginAuthenticator
             {
                 Set<UserIdentity> ids = clientSubject.getPrivateCredentials(UserIdentity.class);
                 UserIdentity userIdentity;
-                if (ids.size() > 0)
+                if (!ids.isEmpty())
                 {
                     userIdentity = ids.iterator().next();
                 }
                 else
                 {
-                    CallerPrincipalCallback principalCallback = _callbackHandler.getThreadCallerPrincipalCallback();
                     if (principalCallback == null)
                     {
                         return null;
@@ -218,7 +229,6 @@ public class JaspiAuthenticator extends LoginAuthenticator
                             principal = new UserPrincipal(principalName, null);
                         }
                     }
-                    GroupPrincipalCallback groupPrincipalCallback = _callbackHandler.getThreadGroupPrincipalCallback();
                     String[] groups = groupPrincipalCallback == null ? null : groupPrincipalCallback.getGroups();
                     userIdentity = _identityService.newUserIdentity(clientSubject, principal, groups);
                 }
@@ -248,10 +258,6 @@ public class JaspiAuthenticator extends LoginAuthenticator
         catch (AuthException e)
         {
             throw new ServerAuthException(e);
-        }
-        finally
-        {
-            _callbackHandler.clear();
         }
     }
 

--- a/jetty-ee11/jetty-ee11-jaspi/src/main/java/org/eclipse/jetty/ee11/security/jaspi/JaspiMessageInfo.java
+++ b/jetty-ee11/jetty-ee11-jaspi/src/main/java/org/eclipse/jetty/ee11/security/jaspi/JaspiMessageInfo.java
@@ -13,10 +13,8 @@
 
 package org.eclipse.jetty.ee11.security.jaspi;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 import jakarta.security.auth.message.MessageInfo;
 import jakarta.servlet.ServletRequest;
@@ -32,19 +30,19 @@ import org.eclipse.jetty.util.Callback;
  */
 public class JaspiMessageInfo implements MessageInfo
 {
+    public static final String AUTH_REQUEST_KEY = "jakarta.servlet.http.isAuthenticationRequest";
     public static final String AUTHENTICATION_TYPE_KEY = "jakarta.servlet.http.authType";
+    public static final String MANDATORY_KEY = "jakarta.security.auth.message.MessagePolicy.isMandatory";
     private final Callback _callback;
     private Request _request;
     private Response _response;
-    private final MIMap _map;
+    private final Map<String, Object> _map = new HashMap<>();
 
     public JaspiMessageInfo(Request request, Response response, Callback callback)
     {
         _request = request;
         _response = response;
         _callback = callback;
-        //JASPI 3.8.1
-        _map = new MIMap();
     }
     
     public Callback getCallback()
@@ -53,7 +51,7 @@ public class JaspiMessageInfo implements MessageInfo
     }
 
     @Override
-    public Map getMap()
+    public Map<String, Object> getMap()
     {
         return _map;
     }
@@ -66,6 +64,27 @@ public class JaspiMessageInfo implements MessageInfo
     public Response getBaseResponse()
     {
         return _response;
+    }
+
+    public String getAuthenticationType()
+    {
+        return (String)_map.get(AUTHENTICATION_TYPE_KEY);
+    }
+    
+    public void setMandatory(boolean isMandatory)
+    {
+        if (isMandatory)
+            _map.put(JaspiMessageInfo.MANDATORY_KEY, "true");
+        else
+            _map.remove(JaspiMessageInfo.MANDATORY_KEY);
+    }
+
+    public void setAuthenticationRequest(boolean isAuthenticationRequest)
+    {
+        if (isAuthenticationRequest)
+            _map.put(JaspiMessageInfo.AUTH_REQUEST_KEY, "true");
+        else
+            _map.remove(JaspiMessageInfo.AUTH_REQUEST_KEY);
     }
 
     @Override
@@ -96,141 +115,5 @@ public class JaspiMessageInfo implements MessageInfo
         if (!(response instanceof ServletResponse))
             throw new IllegalStateException("Not a ServletResponse");
         _response = ServletContextResponse.getServletContextResponse((ServletResponse)response);
-    }
-
-    //TODO this has bugs in the view implementations.  Changing them will not affect the hardcoded values.
-    private static class MIMap implements Map
-    {
-        private String authenticationType;
-        private Map delegate;
-
-        private MIMap()
-        {
-        }
-
-        @Override
-        public int size()
-        {
-            return delegate.size();
-        }
-
-        @Override
-        public boolean isEmpty()
-        {
-            return delegate == null || delegate.isEmpty();
-        }
-
-        @Override
-        public boolean containsKey(Object key)
-        {
-            if (AUTHENTICATION_TYPE_KEY.equals(key))
-                return authenticationType != null;
-            return delegate != null && delegate.containsKey(key);
-        }
-
-        @Override
-        public boolean containsValue(Object value)
-        {
-            if (authenticationType == value || (authenticationType != null && authenticationType.equals(value)))
-                return true;
-            return delegate != null && delegate.containsValue(value);
-        }
-
-        @Override
-        public Object get(Object key)
-        {
-            if (AUTHENTICATION_TYPE_KEY.equals(key))
-                return authenticationType;
-            if (delegate == null)
-                return null;
-            return delegate.get(key);
-        }
-
-        @Override
-        public Object put(Object key, Object value)
-        {
-            if (AUTHENTICATION_TYPE_KEY.equals(key))
-            {
-                String authenticationType = this.authenticationType;
-                this.authenticationType = (String)value;
-                if (delegate != null)
-                    delegate.put(AUTHENTICATION_TYPE_KEY, value);
-                return authenticationType;
-            }
-
-            return getDelegate(true).put(key, value);
-        }
-
-        @Override
-        public Object remove(Object key)
-        {
-            if (AUTHENTICATION_TYPE_KEY.equals(key))
-            {
-                String authenticationType = this.authenticationType;
-                this.authenticationType = null;
-                if (delegate != null)
-                    delegate.remove(AUTHENTICATION_TYPE_KEY);
-                return authenticationType;
-            }
-            if (delegate == null)
-                return null;
-            return delegate.remove(key);
-        }
-
-        @Override
-        public void putAll(Map map)
-        {
-            if (map != null)
-            {
-                for (Object o : map.entrySet())
-                {
-                    Map.Entry entry = (Entry)o;
-                    put(entry.getKey(), entry.getValue());
-                }
-            }
-        }
-
-        @Override
-        public void clear()
-        {
-            authenticationType = null;
-            delegate = null;
-        }
-
-        @Override
-        public Set keySet()
-        {
-            return getDelegate(true).keySet();
-        }
-
-        @Override
-        public Collection values()
-        {
-            return getDelegate(true).values();
-        }
-
-        @Override
-        public Set entrySet()
-        {
-            return getDelegate(true).entrySet();
-        }
-
-        private Map getDelegate(boolean create)
-        {
-            if (!create || delegate != null)
-                return delegate;
-            if (create)
-            {
-                delegate = new HashMap();
-                if (authenticationType != null)
-                    delegate.put(AUTHENTICATION_TYPE_KEY, authenticationType);
-            }
-            return delegate;
-        }
-
-        String getAuthenticationType()
-        {
-            return authenticationType;
-        }
     }
 }

--- a/jetty-ee11/jetty-ee11-jaspi/src/main/java/org/eclipse/jetty/ee11/security/jaspi/ServletCallbackHandler.java
+++ b/jetty-ee11/jetty-ee11-jaspi/src/main/java/org/eclipse/jetty/ee11/security/jaspi/ServletCallbackHandler.java
@@ -129,4 +129,10 @@ public class ServletCallbackHandler implements CallbackHandler
         _groupPrincipals.set(null);
         return groupPrincipalCallback;
     }
+
+    public void clear()
+    {
+        _callerPrincipals.remove();
+        _groupPrincipals.remove();
+    }
 }

--- a/jetty-ee9/jetty-ee9-jaspi/src/main/java/org/eclipse/jetty/ee9/security/jaspi/JaspiAuthenticator.java
+++ b/jetty-ee9/jetty-ee9-jaspi/src/main/java/org/eclipse/jetty/ee9/security/jaspi/JaspiAuthenticator.java
@@ -182,9 +182,21 @@ public class JaspiAuthenticator extends LoginAuthenticator
             String authContextId = authConfig.getAuthContextID(messageInfo);
             ServerAuthContext authContext = authConfig.getAuthContext(authContextId, _serviceSubject, _authProperties);
             Subject clientSubject = new Subject();
+            AuthStatus authStatus;
+            CallerPrincipalCallback principalCallback;
+            GroupPrincipalCallback groupPrincipalCallback;
 
-            _callbackHandler.clear();
-            AuthStatus authStatus = authContext.validateRequest(messageInfo, clientSubject, _serviceSubject);
+            try
+            {
+                _callbackHandler.clear();
+                authStatus = authContext.validateRequest(messageInfo, clientSubject, _serviceSubject);
+                principalCallback = _callbackHandler.getThreadCallerPrincipalCallback();
+                groupPrincipalCallback = _callbackHandler.getThreadGroupPrincipalCallback();
+            }
+            finally
+            {
+                _callbackHandler.clear();
+            }
 
             if (authStatus == AuthStatus.SEND_CONTINUE)
                 return Authentication.SEND_CONTINUE;
@@ -195,13 +207,12 @@ public class JaspiAuthenticator extends LoginAuthenticator
             {
                 Set<UserIdentity> ids = clientSubject.getPrivateCredentials(UserIdentity.class);
                 UserIdentity userIdentity;
-                if (ids.size() > 0)
+                if (!ids.isEmpty())
                 {
                     userIdentity = ids.iterator().next();
                 }
                 else
                 {
-                    CallerPrincipalCallback principalCallback = _callbackHandler.getThreadCallerPrincipalCallback();
                     if (principalCallback == null)
                     {
                         return Authentication.UNAUTHENTICATED;
@@ -226,7 +237,6 @@ public class JaspiAuthenticator extends LoginAuthenticator
                             return Authentication.UNAUTHENTICATED;
                         }
                     }
-                    GroupPrincipalCallback groupPrincipalCallback = _callbackHandler.getThreadGroupPrincipalCallback();
                     String[] groups = groupPrincipalCallback == null ? null : groupPrincipalCallback.getGroups();
                     userIdentity = _identityService.newUserIdentity(clientSubject, principal, groups);
                 }
@@ -255,10 +265,6 @@ public class JaspiAuthenticator extends LoginAuthenticator
         catch (IOException | AuthException e)
         {
             throw new ServerAuthException(e);
-        }
-        finally
-        {
-            _callbackHandler.clear();
         }
     }
 

--- a/jetty-ee9/jetty-ee9-jaspi/src/main/java/org/eclipse/jetty/ee9/security/jaspi/JaspiAuthenticator.java
+++ b/jetty-ee9/jetty-ee9-jaspi/src/main/java/org/eclipse/jetty/ee9/security/jaspi/JaspiAuthenticator.java
@@ -183,6 +183,7 @@ public class JaspiAuthenticator extends LoginAuthenticator
             ServerAuthContext authContext = authConfig.getAuthContext(authContextId, _serviceSubject, _authProperties);
             Subject clientSubject = new Subject();
 
+            _callbackHandler.clear();
             AuthStatus authStatus = authContext.validateRequest(messageInfo, clientSubject, _serviceSubject);
 
             if (authStatus == AuthStatus.SEND_CONTINUE)
@@ -254,6 +255,10 @@ public class JaspiAuthenticator extends LoginAuthenticator
         catch (IOException | AuthException e)
         {
             throw new ServerAuthException(e);
+        }
+        finally
+        {
+            _callbackHandler.clear();
         }
     }
 

--- a/jetty-ee9/jetty-ee9-jaspi/src/main/java/org/eclipse/jetty/ee9/security/jaspi/ServletCallbackHandler.java
+++ b/jetty-ee9/jetty-ee9-jaspi/src/main/java/org/eclipse/jetty/ee9/security/jaspi/ServletCallbackHandler.java
@@ -129,4 +129,10 @@ public class ServletCallbackHandler implements CallbackHandler
         _groupPrincipals.set(null);
         return groupPrincipalCallback;
     }
+
+    public void clear()
+    {
+        _callerPrincipals.remove();
+        _groupPrincipals.remove();
+    }
 }


### PR DESCRIPTION
### Issue #14165

- ensure `jakarta.security.auth.message.MessagePolicy.isMandatory` parameter is set in the `MessageInfo` map
- ensure the `jakarta.servlet.http.isAuthenticationRequest` parameter is set in the `MessageInfo` map
- cleanup for `ServletCallbackHandler`
- remove the `MIMap` which is just an optimization to lazily create the map