### PR TITLE
Issue #14431 - fixes for ServletContainerInitializer exclusion with absolute-ordering (#14432)

### DIFF
--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/pom.xml
@@ -76,6 +76,13 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-test-sci-webapp</artifactId>
+      <version>${project.version}</version>
+      <type>war</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.ee10</groupId>
       <artifactId>jetty-ee10-test-webapp-rfc2616</artifactId>
       <version>${project.version}</version>
       <type>war</type>
@@ -160,6 +167,12 @@
                   <artifactId>jetty-ee10-demo-jetty-webapp</artifactId>
                   <type>war</type>
                   <destFileName>ee10-demo-jetty.war</destFileName>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.eclipse.jetty.ee10</groupId>
+                  <artifactId>jetty-ee10-test-sci-webapp</artifactId>
+                  <type>war</type>
+                  <destFileName>jetty-ee10-test-sci-webapp.war</destFileName>
                 </artifactItem>
               </artifactItems>
               <stripVersion>true</stripVersion>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/ServletContainerInitializerTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/ServletContainerInitializerTest.java
@@ -1,0 +1,86 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee10.test;
+
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.jetty.client.ContentResponse;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.ee10.webapp.WebAppContext;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.toolchain.test.MavenPaths;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(WorkDirExtension.class)
+public class ServletContainerInitializerTest
+{
+    private Server server;
+    private HttpClient client;
+    private ServerConnector connector;
+
+    @BeforeEach
+    public void startServer() throws Exception
+    {
+        server = new Server();
+        connector = new ServerConnector(server);
+        server.addConnector(connector);
+
+        WebAppContext context = new WebAppContext();
+        Path war = MavenPaths.targetDir().resolve("webapps").resolve("jetty-ee10-test-sci-webapp.war");
+        assertTrue(Files.isRegularFile(war), "Missing war file: " + war);
+        context.setWar(war.toString());
+
+        server.setHandler(context);
+        server.start();
+
+        client = new HttpClient();
+        client.start();
+    }
+
+    @AfterEach
+    public void tearDownServer()
+    {
+        LifeCycle.stop(client);
+        LifeCycle.stop(server);
+    }
+
+    @Test
+    public void testAbsoluteOrdering() throws InterruptedException, ExecutionException, TimeoutException
+    {
+        // This loads a webapp with a SCI which sets an attribute on the servlet context.
+        // The servlet in the webapp will respond to requests by printing the value of that attribute.
+        // This way we can tell if the SCI was run.
+        // The webapp also has an absolute ordering element in web.xml, so this tests we can still load the SCI with absolute ordering.
+        URI uri = URI.create("http://localhost:" + connector.getLocalPort());
+        ContentResponse response = client.GET(uri);
+        assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
+        assertThat(response.getContentAsString(), containsString("attribute: true"));
+    }
+}

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sci-jar/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sci-jar/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.jetty.ee10</groupId>
+    <artifactId>jetty-ee10-tests</artifactId>
+    <version>12.0.34-SNAPSHOT</version>
+  </parent>
+  <artifactId>jetty-ee10-test-sci-jar</artifactId>
+  <name>EE10 :: Tests :: SCI Test JAR</name>
+  <description>Jetty SCI Test JAR</description>
+  <properties>
+    <bundle-symbolic-name>${project.groupId}.tests.sci.jar</bundle-symbolic-name>
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sci-jar/src/main/java/org/example/TestSCI.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sci-jar/src/main/java/org/example/TestSCI.java
@@ -1,0 +1,28 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.example;
+
+import java.util.Set;
+
+import jakarta.servlet.ServletContainerInitializer;
+import jakarta.servlet.ServletContext;
+
+public class TestSCI implements ServletContainerInitializer
+{
+    @Override
+    public void onStartup(Set<Class<?>> set, ServletContext servletContext)
+    {
+        servletContext.setAttribute(TestSCI.class.getName(), "true");
+    }
+}

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sci-jar/src/main/resources/META-INF/services/jakarta.servlet.ServletContainerInitializer
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sci-jar/src/main/resources/META-INF/services/jakarta.servlet.ServletContainerInitializer
@@ -1,0 +1,1 @@
+org.example.TestSCI

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sci-webapp/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sci-webapp/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.jetty.ee10</groupId>
+    <artifactId>jetty-ee10-tests</artifactId>
+    <version>12.0.34-SNAPSHOT</version>
+  </parent>
+  <artifactId>jetty-ee10-test-sci-webapp</artifactId>
+  <packaging>war</packaging>
+  <name>EE10 :: Tests :: SCI Test WebApp</name>
+  <description>Jetty SCI Test JAR</description>
+  <properties>
+    <bundle-symbolic-name>${project.groupId}.tests.sci.webapp</bundle-symbolic-name>
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-test-sci-jar</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sci-webapp/src/main/java/org/eclipse/jetty/test/TestServlet.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sci-webapp/src/main/java/org/eclipse/jetty/test/TestServlet.java
@@ -1,0 +1,32 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.test;
+
+import java.io.IOException;
+
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.example.TestSCI;
+
+public class TestServlet extends HttpServlet
+{
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException
+    {
+        response.setContentType("text/html");
+        String attribute = (String)request.getServletContext().getAttribute(TestSCI.class.getName());
+        response.getWriter().println("attribute: " + attribute);
+    }
+}

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sci-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-sci-webapp/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app
+        xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+        metadata-complete="false"
+        version="3.1">
+
+  <servlet>
+    <servlet-name>TestServlet</servlet-name>
+    <servlet-class>org.eclipse.jetty.test.TestServlet</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>TestServlet</servlet-name>
+    <url-pattern>/</url-pattern>
+  </servlet-mapping>
+
+  <absolute-ordering>
+    <others/>
+  </absolute-ordering>
+
+</web-app>

--- a/jetty-ee10/jetty-ee10-tests/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/pom.xml
@@ -29,6 +29,8 @@
     <module>jetty-ee10-test-openid-webapp</module>
     <module>jetty-ee10-test-owb-cdi-webapp</module>
     <module>jetty-ee10-test-quickstart</module>
+    <module>jetty-ee10-test-sci-jar</module>
+    <module>jetty-ee10-test-sci-webapp</module>
     <module>jetty-ee10-test-sessions</module>
     <module>jetty-ee10-test-simple-session-webapp</module>
     <module>jetty-ee10-test-webapp-rfc2616</module>

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaData.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/MetaData.java
@@ -330,6 +330,7 @@ public class MetaData
         }
 
         //recompute the ordering with the new fragment name
+        _orderedWebInfResources.clear();
         orderFragments();
     }
 
@@ -429,8 +430,7 @@ public class MetaData
 
     public void orderFragments()
     {
-        _orderedWebInfResources.clear();
-        if (getOrdering() != null)
+        if (_orderedWebInfResources.isEmpty() && getOrdering() != null && !_webInfJars.isEmpty())
             _orderedWebInfResources.addAll(getOrdering().order(_webInfJars));
     }
 
@@ -580,7 +580,7 @@ public class MetaData
     public void setOrdering(Ordering o)
     {
         _ordering = o;
-        orderFragments();
+        _orderedWebInfResources.clear();
     }
 
     /**
@@ -702,14 +702,16 @@ public class MetaData
     public void addWebInfResource(Resource newResource)
     {
         _webInfJars.add(newResource);
+        _orderedWebInfResources.clear();
     }
 
     public List<Resource> getWebInfResources(boolean withOrdering)
     {
         if (!withOrdering)
             return Collections.unmodifiableList(_webInfJars);
-        else
-            return Collections.unmodifiableList(_orderedWebInfResources);
+
+        orderFragments();
+        return Collections.unmodifiableList(_orderedWebInfResources);
     }
 
     public List<Resource> getContainerResources()

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-sci-jar/pom.xml
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-sci-jar/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.jetty.ee11</groupId>
+    <artifactId>jetty-ee11-tests</artifactId>
+    <version>12.0.34-SNAPSHOT</version>
+  </parent>
+  <artifactId>jetty-ee11-test-sci-jar</artifactId>
+  <name>EE11 :: Tests :: SCI Test JAR</name>
+  <description>Jetty SCI Test JAR</description>
+  <properties>
+    <bundle-symbolic-name>${project.groupId}.tests.sci.jar</bundle-symbolic-name>
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-sci-jar/src/main/java/org/example/TestSCI.java
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-sci-jar/src/main/java/org/example/TestSCI.java
@@ -1,0 +1,28 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.example;
+
+import java.util.Set;
+
+import jakarta.servlet.ServletContainerInitializer;
+import jakarta.servlet.ServletContext;
+
+public class TestSCI implements ServletContainerInitializer
+{
+    @Override
+    public void onStartup(Set<Class<?>> set, ServletContext servletContext)
+    {
+        servletContext.setAttribute(TestSCI.class.getName(), "true");
+    }
+}

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-sci-jar/src/main/resources/META-INF/services/jakarta.servlet.ServletContainerInitializer
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-sci-jar/src/main/resources/META-INF/services/jakarta.servlet.ServletContainerInitializer
@@ -1,0 +1,1 @@
+org.example.TestSCI

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-sci-webapp/pom.xml
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-sci-webapp/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.jetty.ee11</groupId>
+    <artifactId>jetty-ee11-tests</artifactId>
+    <version>12.0.34-SNAPSHOT</version>
+  </parent>
+  <artifactId>jetty-ee11-test-sci-webapp</artifactId>
+  <packaging>war</packaging>
+  <name>EE11 :: Tests :: SCI Test WebApp</name>
+  <description>Jetty SCI Test JAR</description>
+  <properties>
+    <bundle-symbolic-name>${project.groupId}.tests.sci.webapp</bundle-symbolic-name>
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.jetty.ee11</groupId>
+      <artifactId>jetty-ee11-test-sci-jar</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-sci-webapp/src/main/java/org/eclipse/jetty/test/TestServlet.java
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-sci-webapp/src/main/java/org/eclipse/jetty/test/TestServlet.java
@@ -1,0 +1,32 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.test;
+
+import java.io.IOException;
+
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.example.TestSCI;
+
+public class TestServlet extends HttpServlet
+{
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException
+    {
+        response.setContentType("text/html");
+        String attribute = (String)request.getServletContext().getAttribute(TestSCI.class.getName());
+        response.getWriter().println("attribute: " + attribute);
+    }
+}

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-sci-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-sci-webapp/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app
+        xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+        metadata-complete="false"
+        version="3.1">
+
+  <servlet>
+    <servlet-name>TestServlet</servlet-name>
+    <servlet-class>org.eclipse.jetty.test.TestServlet</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>TestServlet</servlet-name>
+    <url-pattern>/</url-pattern>
+  </servlet-mapping>
+
+  <absolute-ordering>
+    <others/>
+  </absolute-ordering>
+
+</web-app>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/pom.xml
@@ -98,6 +98,13 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.ee9</groupId>
+      <artifactId>jetty-ee9-test-sci-webapp</artifactId>
+      <version>${project.version}</version>
+      <type>war</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.ee9</groupId>
       <artifactId>jetty-ee9-test-webapp-rfc2616</artifactId>
       <version>${project.version}</version>
       <type>war</type>
@@ -192,6 +199,12 @@
                   <artifactId>jetty-ee9-demo-jetty-webapp</artifactId>
                   <type>war</type>
                   <destFileName>ee9-demo-jetty.war</destFileName>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.eclipse.jetty.ee9</groupId>
+                  <artifactId>jetty-ee9-test-sci-webapp</artifactId>
+                  <type>war</type>
+                  <destFileName>jetty-ee9-test-sci-webapp.war</destFileName>
                 </artifactItem>
               </artifactItems>
               <stripVersion>true</stripVersion>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/ServletContainerInitializerTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/ServletContainerInitializerTest.java
@@ -1,0 +1,86 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee9.test;
+
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.jetty.client.ContentResponse;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.ee9.webapp.WebAppContext;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.toolchain.test.MavenPaths;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(WorkDirExtension.class)
+public class ServletContainerInitializerTest
+{
+    private Server server;
+    private HttpClient client;
+    private ServerConnector connector;
+
+    @BeforeEach
+    public void startServer() throws Exception
+    {
+        server = new Server();
+        connector = new ServerConnector(server);
+        server.addConnector(connector);
+
+        WebAppContext context = new WebAppContext();
+        Path war = MavenPaths.targetDir().resolve("webapps").resolve("jetty-ee9-test-sci-webapp.war");
+        assertTrue(Files.isRegularFile(war), "Missing war file: " + war);
+        context.setWar(war.toString());
+
+        server.setHandler(context);
+        server.start();
+
+        client = new HttpClient();
+        client.start();
+    }
+
+    @AfterEach
+    public void tearDownServer()
+    {
+        LifeCycle.stop(client);
+        LifeCycle.stop(server);
+    }
+
+    @Test
+    public void testAbsoluteOrdering() throws InterruptedException, ExecutionException, TimeoutException
+    {
+        // This loads a webapp with a SCI which sets an attribute on the servlet context.
+        // The servlet in the webapp will respond to requests by printing the value of that attribute.
+        // This way we can tell if the SCI was run.
+        // The webapp also has an absolute ordering element in web.xml, so this tests we can still load the SCI with absolute ordering.
+        URI uri = URI.create("http://localhost:" + connector.getLocalPort());
+        ContentResponse response = client.GET(uri);
+        assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
+        assertThat(response.getContentAsString(), containsString("attribute: true"));
+    }
+}

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sci-jar/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sci-jar/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.jetty.ee9</groupId>
+    <artifactId>jetty-ee9-tests</artifactId>
+    <version>12.0.34-SNAPSHOT</version>
+  </parent>
+  <artifactId>jetty-ee9-test-sci-jar</artifactId>
+  <name>EE9 :: Tests :: SCI Test JAR</name>
+  <description>Jetty SCI Test JAR</description>
+  <properties>
+    <bundle-symbolic-name>${project.groupId}.tests.sci.jar</bundle-symbolic-name>
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sci-jar/src/main/java/org/example/TestSCI.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sci-jar/src/main/java/org/example/TestSCI.java
@@ -1,0 +1,28 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.example;
+
+import java.util.Set;
+
+import jakarta.servlet.ServletContainerInitializer;
+import jakarta.servlet.ServletContext;
+
+public class TestSCI implements ServletContainerInitializer
+{
+    @Override
+    public void onStartup(Set<Class<?>> set, ServletContext servletContext)
+    {
+        servletContext.setAttribute(TestSCI.class.getName(), "true");
+    }
+}

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sci-jar/src/main/resources/META-INF/services/jakarta.servlet.ServletContainerInitializer
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sci-jar/src/main/resources/META-INF/services/jakarta.servlet.ServletContainerInitializer
@@ -1,0 +1,1 @@
+org.example.TestSCI

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sci-webapp/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sci-webapp/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.jetty.ee9</groupId>
+    <artifactId>jetty-ee9-tests</artifactId>
+    <version>12.0.34-SNAPSHOT</version>
+  </parent>
+  <artifactId>jetty-ee9-test-sci-webapp</artifactId>
+  <packaging>war</packaging>
+  <name>EE9 :: Tests :: SCI Test WebApp</name>
+  <description>Jetty SCI Test JAR</description>
+  <properties>
+    <bundle-symbolic-name>${project.groupId}.tests.sci.webapp</bundle-symbolic-name>
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.jetty.ee9</groupId>
+      <artifactId>jetty-ee9-test-sci-jar</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sci-webapp/src/main/java/org/eclipse/jetty/test/TestServlet.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sci-webapp/src/main/java/org/eclipse/jetty/test/TestServlet.java
@@ -1,0 +1,32 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.test;
+
+import java.io.IOException;
+
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.example.TestSCI;
+
+public class TestServlet extends HttpServlet
+{
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException
+    {
+        response.setContentType("text/html");
+        String attribute = (String)request.getServletContext().getAttribute(TestSCI.class.getName());
+        response.getWriter().println("attribute: " + attribute);
+    }
+}

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sci-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-sci-webapp/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app
+        xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+        metadata-complete="false"
+        version="3.1">
+
+  <servlet>
+    <servlet-name>TestServlet</servlet-name>
+    <servlet-class>org.eclipse.jetty.test.TestServlet</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>TestServlet</servlet-name>
+    <url-pattern>/</url-pattern>
+  </servlet-mapping>
+
+  <absolute-ordering>
+    <others/>
+  </absolute-ordering>
+
+</web-app>

--- a/jetty-ee9/jetty-ee9-tests/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/pom.xml
@@ -27,6 +27,8 @@
     <module>jetty-ee9-test-openid-webapp</module>
     <module>jetty-ee9-test-owb-cdi-webapp</module>
     <module>jetty-ee9-test-quickstart</module>
+    <module>jetty-ee9-test-sci-jar</module>
+    <module>jetty-ee9-test-sci-webapp</module>
     <module>jetty-ee9-test-sessions</module>
     <module>jetty-ee9-test-simple-session-webapp</module>
     <module>jetty-ee9-test-webapp-rfc2616</module>

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaData.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/MetaData.java
@@ -330,6 +330,7 @@ public class MetaData
         }
 
         //recompute the ordering with the new fragment name
+        _orderedWebInfResources.clear();
         orderFragments();
     }
 
@@ -429,8 +430,7 @@ public class MetaData
 
     public void orderFragments()
     {
-        _orderedWebInfResources.clear();
-        if (getOrdering() != null)
+        if (_orderedWebInfResources.isEmpty() && getOrdering() != null && !_webInfJars.isEmpty())
             _orderedWebInfResources.addAll(getOrdering().order(_webInfJars));
     }
 
@@ -487,7 +487,7 @@ public class MetaData
         resources.add(null); //always apply annotations with no resource first
         resources.addAll(_orderedContainerResources); //next all annotations from container path
         resources.addAll(_webInfClasses); //next everything from web-inf classes
-        resources.addAll(getWebInfResources(isOrdered())); //finally annotations (in order) from webinf path 
+        resources.addAll(getWebInfResources(isOrdered())); //finally annotations (in order) from webinf path
 
         for (Resource r : resources)
         {
@@ -532,7 +532,7 @@ public class MetaData
     {
         boolean distributable = (
             (_webDefaultsRoot != null && _webDefaultsRoot.isDistributable()) ||
-                (_webXmlRoot != null && _webXmlRoot.isDistributable()));
+            (_webXmlRoot != null && _webXmlRoot.isDistributable()));
 
         for (WebDescriptor d : _webOverrideRoots)
         {
@@ -580,7 +580,7 @@ public class MetaData
     public void setOrdering(Ordering o)
     {
         _ordering = o;
-        orderFragments();
+        _orderedWebInfResources.clear();
     }
 
     /**
@@ -702,14 +702,16 @@ public class MetaData
     public void addWebInfResource(Resource newResource)
     {
         _webInfJars.add(newResource);
+        _orderedWebInfResources.clear();
     }
 
     public List<Resource> getWebInfResources(boolean withOrdering)
     {
         if (!withOrdering)
             return Collections.unmodifiableList(_webInfJars);
-        else
-            return Collections.unmodifiableList(_orderedWebInfResources);
+
+        orderFragments();
+        return Collections.unmodifiableList(_orderedWebInfResources);
     }
 
     public List<Resource> getContainerResources()


### PR DESCRIPTION
## Cherry Pick of PR #14432 for Jetty 12.0.x

closes https://github.com/jetty/jetty.project/issues/14431

Change MetaData to lazily order its resources only when getWebInfResources(true) is called, and reset this ordering when metadata.setOrdering() is called.