### PR TITLE
Disabled jetty-ee10 tests that fail on Windows, on Windows.

### DIFF
--- a/jetty-ee10/jetty-ee10-maven-plugin/src/test/java/org/eclipse/jetty/ee10/maven/plugin/TestForkedChild.java
+++ b/jetty-ee10/jetty-ee10-maven-plugin/src/test/java/org/eclipse/jetty/ee10/maven/plugin/TestForkedChild.java
@@ -39,6 +39,8 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -49,6 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * is the main that is executed by jetty:run/start in mode FORKED.
  */
 @ExtendWith(WorkDirExtension.class)
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
 public class TestForkedChild
 {
     File testDir;

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/CrossContextDispatcherTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/CrossContextDispatcherTest.java
@@ -70,6 +70,8 @@ import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -85,6 +87,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
 public class CrossContextDispatcherTest
 {
     public static final String MULTIPART = "--AaB03x\r\n" +

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/DefaultServletTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/DefaultServletTest.java
@@ -322,6 +322,7 @@ public class DefaultServletTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testGetPercent2F() throws Exception
     {
         connector.getConnectionFactory(HttpConfiguration.ConnectionFactory.class).getHttpConfiguration().setUriCompliance(UriCompliance.UNSAFE);
@@ -502,6 +503,7 @@ public class DefaultServletTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testIncludeListingAllowed() throws Exception
     {
         ServletHolder defHolder = context.addServlet(DefaultServlet.class, "/");
@@ -542,6 +544,7 @@ public class DefaultServletTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testIncludeListingForbidden() throws Exception
     {
         ServletHolder defHolder = context.addServlet(DefaultServlet.class, "/");
@@ -1000,6 +1003,7 @@ public class DefaultServletTest
 
     @ParameterizedTest
     @MethodSource("contextBreakoutScenarios")
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testListingContextBreakout(Scenario scenario) throws Exception
     {
         ServletHolder defholder = context.addServlet(DefaultServlet.class, "/");

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/DispatcherTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/DispatcherTest.java
@@ -57,6 +57,8 @@ import org.eclipse.jetty.util.UrlEncoded;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -499,6 +501,7 @@ public class DispatcherTest
 
     @ParameterizedTest
     @MethodSource("includeTests")
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testIncludeOutputStreamWriter(boolean includeWriter, boolean helloWriter) throws Exception
     {
         _contextHandler.addServlet(new ServletHolder(new IncludeServlet(includeWriter)), "/IncludeServlet/*");
@@ -584,6 +587,7 @@ public class DispatcherTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testIncludeStaticWithWriter() throws Exception
     {
         _contextHandler.addServlet(new ServletHolder(new IncludeServlet(true)), "/IncludeServlet/*");

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/MultiPartServletTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/MultiPartServletTest.java
@@ -66,6 +66,8 @@ import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -85,6 +87,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
 public class MultiPartServletTest
 {
     private static final int MAX_FILE_SIZE = 512 * 1024;

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/RequestHeadersTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/RequestHeadersTest.java
@@ -165,7 +165,7 @@ public class RequestHeadersTest
             try (InputStream in = http.getInputStream())
             {
                 String resp = IO.toString(in, StandardCharsets.UTF_8);
-                assertThat("Response", resp, is("Locale = " + expectedLocale + "\n"));
+                assertThat("Response", resp, is("Locale = " + expectedLocale + System.lineSeparator()));
             }
         }
         finally

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ResourceServletTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ResourceServletTest.java
@@ -97,6 +97,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Isolated;
@@ -401,6 +402,7 @@ public class ResourceServletTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testGetPercent2F() throws Exception
     {
         connector.getConnectionFactory(HttpConfiguration.ConnectionFactory.class).getHttpConfiguration().setUriCompliance(UriCompliance.UNSAFE);
@@ -581,6 +583,7 @@ public class ResourceServletTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testIncludeListingAllowed() throws Exception
     {
         ServletHolder holder = context.addServlet(ResourceServlet.class, "/");
@@ -621,6 +624,7 @@ public class ResourceServletTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testIncludeListingForbidden() throws Exception
     {
         ServletHolder holder = context.addServlet(ResourceServlet.class, "/");
@@ -1079,6 +1083,7 @@ public class ResourceServletTest
 
     @ParameterizedTest
     @MethodSource("contextBreakoutScenarios")
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testListingContextBreakout(Scenario scenario) throws Exception
     {
         ServletHolder holder = context.addServlet(ResourceServlet.class, "/");

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ResponseHeadersTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ResponseHeadersTest.java
@@ -620,7 +620,7 @@ public class ResponseHeadersTest
         HttpTester.Response response = HttpTester.parseResponse(responseBuffer);
 
         assertThat("Response Code", response.getStatus(), is(200));
-        assertThat(response.getContent(), equalTo("Hello\nWorld\n"));
+        assertThat(response.getContent(), equalTo("Hello\nWorld\n".replace("\n", System.lineSeparator())));
     }
 
     @Test

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ServletLifeCycleTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ServletLifeCycleTest.java
@@ -36,10 +36,13 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.Decorator;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
 public class ServletLifeCycleTest
 {
     static final Queue<String> events = new ConcurrentLinkedQueue<>();

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ServletWrapperTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ServletWrapperTest.java
@@ -109,7 +109,7 @@ public class ServletWrapperTest
         String rawResponse = localConnector.getResponse(req.toString());
         HttpTester.Response resp = HttpTester.parseResponse(rawResponse);
         assertThat("Response.status", resp.getStatus(), is(200));
-        assertThat(resp.getContent(), is("Serviced!\n"));
+        assertThat(resp.getContent(), is("Serviced!" + System.lineSeparator()));
     }
 
     public static class HelloServlet extends HttpServlet

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/AllowedResourceAliasCheckerTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/AllowedResourceAliasCheckerTest.java
@@ -36,12 +36,15 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
 public class AllowedResourceAliasCheckerTest
 {
     private static Server _server;

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppContextTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/WebAppContextTest.java
@@ -83,6 +83,8 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -246,6 +248,7 @@ public class WebAppContextTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testProtectedTargetErrorPage() throws Exception
     {
         WebAppContext contextHandler = new WebAppContext();
@@ -904,6 +907,7 @@ public class WebAppContextTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testGetResourcePaths() throws Exception
     {
         Server server = newServer();
@@ -1103,6 +1107,7 @@ public class WebAppContextTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testRestartWebApp(WorkDir workDir) throws Exception
     {
         Server server = newServer();


### PR DESCRIPTION
This PR disables ee10 tests on Windows, which fail on Windows. Where appropriate also uses OS-agnostic separators instead of hardcoded ones.