### PR TITLE
Disabled jetty-core tests that fail on Windows, on Windows.

### DIFF
--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/ConnectionPoolTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/ConnectionPoolTest.java
@@ -49,6 +49,8 @@ import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
@@ -344,6 +346,7 @@ public class ConnectionPoolTest
 
     @ParameterizedTest
     @MethodSource("pools")
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testConcurrentRequestsWithSlowAddressResolver(ConnectionPoolFactory factory) throws Exception
     {
         // ConnectionPools may open a few more connections than expected.

--- a/jetty-core/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/DeploymentScannerRuntimeUpdatesTest.java
+++ b/jetty-core/jetty-deploy/src/test/java/org/eclipse/jetty/deploy/DeploymentScannerRuntimeUpdatesTest.java
@@ -33,6 +33,8 @@ import org.eclipse.jetty.util.component.Environment;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -136,6 +138,7 @@ public class DeploymentScannerRuntimeUpdatesTest extends AbstractCleanEnvironmen
      * This addresses <a href="https://github.com/jetty/jetty.project/issues/12543">Issue 12543</a>
      */
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testRedeployIfAnyTrackedPathChanges(WorkDir workDir) throws Exception
     {
         Path baseDir = workDir.getEmptyPathDir();
@@ -279,6 +282,7 @@ public class DeploymentScannerRuntimeUpdatesTest extends AbstractCleanEnvironmen
      * @throws Exception on test failure
      */
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testAfterStartupThenUpdateContext(WorkDir workDir) throws Exception
     {
         Path baseDir = workDir.getEmptyPathDir();

--- a/jetty-core/jetty-fcgi/jetty-fcgi-proxy/src/test/java/org/eclipse/jetty/fcgi/proxy/FastCGIProxyHandlerTest.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-proxy/src/test/java/org/eclipse/jetty/fcgi/proxy/FastCGIProxyHandlerTest.java
@@ -44,6 +44,8 @@ import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -55,6 +57,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
 public class FastCGIProxyHandlerTest
 {
     private Server server;

--- a/jetty-core/jetty-fcgi/jetty-fcgi-server/src/test/java/org/eclipse/jetty/fcgi/server/ExternalFastCGIServerTest.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-server/src/test/java/org/eclipse/jetty/fcgi/server/ExternalFastCGIServerTest.java
@@ -24,9 +24,12 @@ import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.fcgi.client.transport.HttpClientTransportOverFCGI;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
 public class ExternalFastCGIServerTest
 {
     @Test

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/CancelWriteTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/CancelWriteTest.java
@@ -33,6 +33,8 @@ import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -41,6 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class CancelWriteTest extends AbstractTest
 {
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testCancelCongestedWrite() throws Exception
     {
         CountDownLatch serverFlusherPendingLatch = new CountDownLatch(1);

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/FlowControlStrategyTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/FlowControlStrategyTest.java
@@ -61,6 +61,8 @@ import org.eclipse.jetty.util.FuturePromise;
 import org.eclipse.jetty.util.Promise;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -301,6 +303,7 @@ public class FlowControlStrategyTest
 
     @ParameterizedTest
     @EnumSource(FlowControlStrategyType.class)
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testServerFlowControlOneBigWrite(FlowControlStrategyType type) throws Exception
     {
         int windowSize = 1536;

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/MaxConcurrentStreamsTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/MaxConcurrentStreamsTest.java
@@ -72,6 +72,8 @@ import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -362,6 +364,7 @@ public class MaxConcurrentStreamsTest extends AbstractTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testManyConcurrentRequestsWithSmallConcurrentStreams() throws Exception
     {
         byte[] data = new byte[64 * 1024];

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/SmallThreadPoolLoadTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/SmallThreadPoolLoadTest.java
@@ -43,6 +43,8 @@ import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.util.thread.Scheduler;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,6 +69,7 @@ public class SmallThreadPoolLoadTest extends AbstractTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testConcurrentWithSmallServerThreadPool() throws Exception
     {
         start(new LoadHandler());

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/test/java/org/eclipse/jetty/quic/quiche/foreign/LowLevelQuicheClientCertTest.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/test/java/org/eclipse/jetty/quic/quiche/foreign/LowLevelQuicheClientCertTest.java
@@ -35,6 +35,8 @@ import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.eclipse.jetty.quic.quiche.QuicheConstants.QUICHE_MIN_CLIENT_INITIAL_LEN;
@@ -47,6 +49,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 
 @ExtendWith(WorkDirExtension.class)
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
 public class LowLevelQuicheClientCertTest
 {
     public WorkDir workDir;

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/test/java/org/eclipse/jetty/quic/quiche/foreign/LowLevelQuicheTest.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/test/java/org/eclipse/jetty/quic/quiche/foreign/LowLevelQuicheTest.java
@@ -36,6 +36,8 @@ import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.eclipse.jetty.quic.quiche.QuicheConstants.QUICHE_MIN_CLIENT_INITIAL_LEN;
@@ -45,6 +47,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 
 @ExtendWith(WorkDirExtension.class)
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
 public class LowLevelQuicheTest
 {
     public WorkDir workDir;

--- a/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/CookiePatternRuleTest.java
+++ b/jetty-core/jetty-rewrite/src/test/java/org/eclipse/jetty/rewrite/handler/CookiePatternRuleTest.java
@@ -25,6 +25,8 @@ import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -32,6 +34,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
 public class CookiePatternRuleTest extends AbstractRuleTest
 {
     private void start(CookiePatternRule rule) throws Exception
@@ -179,7 +182,7 @@ public class CookiePatternRuleTest extends AbstractRuleTest
 
     private void assertResponseContentLine(String responseContent, String linePrefix, String expectedEquals)
     {
-        List<String> matches = Arrays.stream(responseContent.split("\n"))
+        List<String> matches = Arrays.stream(responseContent.split(System.lineSeparator()))
             .filter(line -> line.startsWith(linePrefix))
             .map(line -> line.substring(linePrefix.length()))
             .filter(line -> line.equals(expectedEquals))

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/CancelWriteTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/CancelWriteTest.java
@@ -33,6 +33,8 @@ import org.eclipse.jetty.util.component.LifeCycle;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -67,6 +69,7 @@ public class CancelWriteTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testCancelCongestedWrite() throws Exception
     {
         long idleTimeout = 1000;

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/CustomRequestLogTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/CustomRequestLogTest.java
@@ -51,6 +51,8 @@ import org.eclipse.jetty.util.component.LifeCycle;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -446,6 +448,7 @@ public class CustomRequestLogTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testLogEnvironmentVar() throws Exception
     {
         start("EnvironmentVar: %{JAVA_HOME}e");

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
@@ -81,6 +81,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -101,6 +103,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
 public class ContextHandlerTest
 {
     public static final File TEST_BAD = MavenTestingUtils.getTargetTestingPath("testBad").toFile();

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/PropertyPassingTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/PropertyPassingTest.java
@@ -224,7 +224,7 @@ public class PropertyPassingTest
             --module=empty
             # TESTING THIS (it should expand the ${jetty.base} portion
             test.config=${jetty.base}/etc/config.ini
-            """;
+            """.replace('/', File.separatorChar);
         Files.writeString(ini, iniBody, StandardCharsets.UTF_8);
 
         // Setup command line
@@ -242,7 +242,7 @@ public class PropertyPassingTest
         String output = collectRunOutput(commands);
 
         // Test for values
-        Path expectedPath = base.resolve("etc/config.ini");
+        Path expectedPath = base.resolve("etc/config.ini".replace('/', File.separatorChar));
         assertThat(output, containsString("test.config=" + expectedPath));
     }
 
@@ -269,7 +269,7 @@ public class PropertyPassingTest
             --module=env-config
             # TESTING THIS (it should expand the ${jetty.base} portion
             test.config=${jetty.base}/etc/config.ini
-            """;
+            """.replace('/', File.separatorChar);
         Files.writeString(ini, iniBody, StandardCharsets.UTF_8);
 
         // Setup command line
@@ -287,7 +287,7 @@ public class PropertyPassingTest
         String output = collectRunOutput(commands);
 
         // Test for values
-        Path expectedPath = base.resolve("etc/config.ini");
+        Path expectedPath = base.resolve("etc/config.ini".replace('/', File.separatorChar));
         assertThat(output, containsString("test.config=" + expectedPath));
     }
 

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/AgentPropertiesTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/AgentPropertiesTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.start.usecases;
 
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
@@ -63,18 +64,18 @@ public class AgentPropertiesTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml",
-            "${jetty.home}/etc/main.xml"
+            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
         List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar",
-            "${jetty.home}/lib/main.jar",
-            "${jetty.home}/lib/other.jar",
-            "${jetty.base}/lib/agent-jdk-1.7.jar"
+            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar),
+            "${jetty.base}/lib/agent-jdk-1.7.jar".replace('/', File.separatorChar)
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/AlternatesTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/AlternatesTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.start.usecases;
 
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
@@ -92,17 +93,17 @@ public class AlternatesTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml",
-            "${jetty.home}/etc/main.xml"
+            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
         List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar",
-            "${jetty.home}/lib/main.jar",
-            "${jetty.home}/lib/other.jar"
+            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));
@@ -176,19 +177,19 @@ public class AlternatesTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml",
-            "${jetty.home}/etc/main.xml",
-            "${jetty.base}/etc/d.xml",
-            "${jetty.base}/etc/ndb.xml"
+            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar),
+            "${jetty.base}/etc/d.xml".replace('/', File.separatorChar),
+            "${jetty.base}/etc/ndb.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
         List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar",
-            "${jetty.home}/lib/main.jar",
-            "${jetty.home}/lib/other.jar"
+            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));
@@ -263,18 +264,18 @@ public class AlternatesTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml",
-            "${jetty.home}/etc/main.xml",
-            "${jetty.base}/etc/ndb.xml"
+            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar),
+            "${jetty.base}/etc/ndb.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
         List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar",
-            "${jetty.home}/lib/main.jar",
-            "${jetty.home}/lib/other.jar"
+            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));
@@ -420,18 +421,18 @@ public class AlternatesTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml",
-            "${jetty.home}/etc/main.xml",
-            "${jetty.base}/etc/ndb.xml"
+            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar),
+            "${jetty.base}/etc/ndb.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
         List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar",
-            "${jetty.home}/lib/main.jar",
-            "${jetty.home}/lib/other.jar"
+            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/BarebonesAddToStartTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/BarebonesAddToStartTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.start.usecases;
 
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
@@ -54,19 +55,19 @@ public class BarebonesAddToStartTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/optional.xml",
-            "${jetty.home}/etc/base.xml",
-            "${jetty.home}/etc/main.xml"
+            "${jetty.home}/etc/optional.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
         List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar",
-            "${jetty.home}/lib/main.jar",
-            "${jetty.home}/lib/other.jar",
-            "${jetty.home}/lib/optional.jar"
+            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/optional.jar".replace('/', File.separatorChar)
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/BarebonesAddToStartdTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/BarebonesAddToStartdTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.start.usecases;
 
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
@@ -55,19 +56,19 @@ public class BarebonesAddToStartdTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/optional.xml",
-            "${jetty.home}/etc/base.xml",
-            "${jetty.home}/etc/main.xml"
+            "${jetty.home}/etc/optional.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
         List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar",
-            "${jetty.home}/lib/main.jar",
-            "${jetty.home}/lib/other.jar",
-            "${jetty.home}/lib/optional.jar"
+            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/optional.jar".replace('/', File.separatorChar)
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/BarebonesAlreadyEnabledTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/BarebonesAlreadyEnabledTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.start.usecases;
 
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
@@ -54,17 +55,17 @@ public class BarebonesAlreadyEnabledTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml",
-            "${jetty.home}/etc/main.xml"
+            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
         List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar",
-            "${jetty.home}/lib/main.jar",
-            "${jetty.home}/lib/other.jar"
+            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/BarebonesTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/BarebonesTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.start.usecases;
 
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
@@ -46,17 +47,17 @@ public class BarebonesTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml",
-            "${jetty.home}/etc/main.xml"
+            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
         List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar",
-            "${jetty.home}/lib/main.jar",
-            "${jetty.home}/lib/other.jar"
+            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/BasicPropertiesTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/BasicPropertiesTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.start.usecases;
 
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
@@ -64,17 +65,17 @@ public class BasicPropertiesTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml",
-            "${jetty.home}/etc/main.xml"
+            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
         List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar",
-            "${jetty.home}/lib/main.jar",
-            "${jetty.home}/lib/other.jar"
+            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/BasicTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/BasicTest.java
@@ -73,17 +73,17 @@ public class BasicTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml",
-            "${jetty.home}/etc/main.xml"
+            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
         List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar",
-            "${jetty.home}/lib/main.jar",
-            "${jetty.home}/lib/other.jar"
+            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));
@@ -184,7 +184,7 @@ public class BasicTest extends AbstractUseCase
         ExecResults results = exec(runArgs, true);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = List.of("${jetty.home}/etc/logging-a.xml");
+        List<String> expectedXmls = List.of("${jetty.home}/etc/logging-a.xml".replace('/', File.separatorChar));
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
@@ -219,7 +219,7 @@ public class BasicTest extends AbstractUseCase
         ExecResults results = exec(runArgs, true);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = List.of("${jetty.home}/etc/logging-b.xml");
+        List<String> expectedXmls = List.of("${jetty.home}/etc/logging-b.xml".replace('/', File.separatorChar));
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
@@ -274,11 +274,11 @@ public class BasicTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml",
-            "${jetty.home}/etc/main.xml",
-            "${jetty.home}/etc/config.xml",
-            "${jetty.home}/etc/config-foo.xml",
-            "${jetty.home}/etc/config-bar.xml"
+            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/config.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/config-foo.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/config-bar.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
@@ -287,9 +287,9 @@ public class BasicTest extends AbstractUseCase
         List<String> expectedLibs = Arrays.asList(
             extraJar.toString(),
             extraDir.toString(),
-            "${jetty.home}/lib/base.jar",
-            "${jetty.home}/lib/main.jar",
-            "${jetty.home}/lib/other.jar"
+            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));
@@ -335,22 +335,22 @@ public class BasicTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/optional.xml",
-            "${jetty.home}/etc/base.xml",
-            "${jetty.home}/etc/main.xml",
-            "${jetty.home}/etc/extra.xml"
+            "${jetty.home}/etc/optional.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/extra.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
         List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/optional.jar",
-            "${jetty.home}/lib/base.jar",
-            "${jetty.home}/lib/main.jar",
-            "${jetty.home}/lib/other.jar",
-            "${jetty.home}/lib/extra/extra0.jar",
-            "${jetty.home}/lib/extra/extra1.jar"
+            "${jetty.home}/lib/optional.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/extra/extra0.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/extra/extra1.jar".replace('/', File.separatorChar)
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));
@@ -382,17 +382,17 @@ public class BasicTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml",
-            "${jetty.home}/etc/main.xml"
+            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
         List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar",
-            "${jetty.home}/lib/main.jar",
-            "${jetty.home}/lib/other.jar"
+            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/DatabaseTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/DatabaseTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.start.usecases;
 
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
@@ -68,20 +69,20 @@ public class DatabaseTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml",
-            "${jetty.home}/etc/main.xml",
-            "${jetty.base}/etc/db.xml"
+            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar),
+            "${jetty.base}/etc/db.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
         List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar",
-            "${jetty.home}/lib/main.jar",
-            "${jetty.home}/lib/other.jar",
-            "${jetty.base}/lib/db/bonecp.jar",
-            "${jetty.base}/lib/db/mysql-driver.jar"
+            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar),
+            "${jetty.base}/lib/db/bonecp.jar".replace('/', File.separatorChar),
+            "${jetty.base}/lib/db/mysql-driver.jar".replace('/', File.separatorChar)
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/DynamicDependTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/DynamicDependTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.start.usecases;
 
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
@@ -71,17 +72,17 @@ public class DynamicDependTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml",
-            "${jetty.home}/etc/main.xml"
+            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
         List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar",
-            "${jetty.home}/lib/main.jar",
-            "${jetty.home}/lib/other.jar"
+            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));
@@ -135,17 +136,17 @@ public class DynamicDependTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml",
-            "${jetty.home}/etc/main.xml"
+            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
         List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar",
-            "${jetty.home}/lib/main.jar",
-            "${jetty.home}/lib/other.jar"
+            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/EmptyAddToStartCreateStartdTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/EmptyAddToStartCreateStartdTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.start.usecases;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -51,22 +52,22 @@ public class EmptyAddToStartCreateStartdTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/optional.xml",
-            "${jetty.home}/etc/base.xml",
-            "${jetty.home}/etc/main.xml",
-            "${jetty.home}/etc/extra.xml"
+            "${jetty.home}/etc/optional.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/extra.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
         List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/optional.jar",
-            "${jetty.home}/lib/base.jar",
-            "${jetty.home}/lib/main.jar",
-            "${jetty.home}/lib/other.jar",
-            "${jetty.home}/lib/extra/extra0.jar",
-            "${jetty.home}/lib/extra/extra1.jar"
+            "${jetty.home}/lib/optional.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/extra/extra0.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/extra/extra1.jar".replace('/', File.separatorChar)
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/EmptyAddToStartTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/EmptyAddToStartTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.start.usecases;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -49,22 +50,22 @@ public class EmptyAddToStartTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/optional.xml",
-            "${jetty.home}/etc/base.xml",
-            "${jetty.home}/etc/main.xml",
-            "${jetty.home}/etc/extra.xml"
+            "${jetty.home}/etc/optional.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/extra.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
         List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/optional.jar",
-            "${jetty.home}/lib/base.jar",
-            "${jetty.home}/lib/main.jar",
-            "${jetty.home}/lib/other.jar",
-            "${jetty.home}/lib/extra/extra0.jar",
-            "${jetty.home}/lib/extra/extra1.jar"
+            "${jetty.home}/lib/optional.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/extra/extra0.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/extra/extra1.jar".replace('/', File.separatorChar)
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/EmptyCreateStartdTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/EmptyCreateStartdTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.start.usecases;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -50,22 +51,22 @@ public class EmptyCreateStartdTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/optional.xml",
-            "${jetty.home}/etc/base.xml",
-            "${jetty.home}/etc/main.xml",
-            "${jetty.home}/etc/extra.xml"
+            "${jetty.home}/etc/optional.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/extra.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
         List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/optional.jar",
-            "${jetty.home}/lib/base.jar",
-            "${jetty.home}/lib/main.jar",
-            "${jetty.home}/lib/other.jar",
-            "${jetty.home}/lib/extra/extra0.jar",
-            "${jetty.home}/lib/extra/extra1.jar"
+            "${jetty.home}/lib/optional.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/extra/extra0.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/extra/extra1.jar".replace('/', File.separatorChar)
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/EnvironmentsTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/EnvironmentsTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.start.usecases;
 
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
@@ -89,17 +90,17 @@ public class EnvironmentsTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml",
-            "${jetty.home}/etc/main.xml"
+            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
         List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar",
-            "${jetty.home}/lib/main.jar",
-            "${jetty.home}/lib/other.jar"
+            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/OrderedTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/OrderedTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.start.usecases;
 
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
@@ -101,8 +102,8 @@ public class OrderedTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.base}/etc/alternateA.xml",
-            "${jetty.base}/etc/dependent.xml"
+            "${jetty.base}/etc/alternateA.xml".replace('/', File.separatorChar),
+            "${jetty.base}/etc/dependent.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
@@ -178,8 +179,8 @@ public class OrderedTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.base}/etc/alternateA.xml",
-            "${jetty.base}/etc/dependent.xml"
+            "${jetty.base}/etc/alternateA.xml".replace('/', File.separatorChar),
+            "${jetty.base}/etc/dependent.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
@@ -327,17 +328,17 @@ public class OrderedTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml",
-            "${jetty.home}/etc/main.xml"
+            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
         List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar",
-            "${jetty.home}/lib/main.jar",
-            "${jetty.home}/lib/other.jar"
+            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));
@@ -411,8 +412,8 @@ public class OrderedTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.base}/etc/implB.xml",
-            "${jetty.base}/etc/implA.xml"
+            "${jetty.base}/etc/implB.xml".replace('/', File.separatorChar),
+            "${jetty.base}/etc/implA.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/ParameterizedTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/ParameterizedTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.start.usecases;
 
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
@@ -90,17 +91,17 @@ public class ParameterizedTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml",
-            "${jetty.home}/etc/main.xml"
+            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
         List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar",
-            "${jetty.home}/lib/main.jar",
-            "${jetty.home}/lib/other.jar"
+            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));
@@ -178,17 +179,17 @@ public class ParameterizedTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml",
-            "${jetty.home}/etc/main.xml"
+            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
         List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar",
-            "${jetty.home}/lib/main.jar",
-            "${jetty.home}/lib/other.jar"
+            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));
@@ -272,17 +273,17 @@ public class ParameterizedTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml",
-            "${jetty.home}/etc/main.xml"
+            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
         List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar",
-            "${jetty.home}/lib/main.jar",
-            "${jetty.home}/lib/other.jar"
+            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/PropertyOverrideTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/PropertyOverrideTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.start.usecases;
 
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -21,6 +22,8 @@ import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.jetty.start.FS;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -77,17 +80,17 @@ public class PropertyOverrideTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml",
-            "${jetty.home}/etc/main.xml"
+            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, ordered(expectedXmls));
 
         // === Validate Resulting LIBs
         List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar",
-            "${jetty.home}/lib/main.jar",
-            "${jetty.home}/lib/other.jar"
+            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, ordered(expectedLibs));
@@ -151,17 +154,17 @@ public class PropertyOverrideTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml",
-            "${jetty.home}/etc/main.xml"
+            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, ordered(expectedXmls));
 
         // === Validate Resulting LIBs
         List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar",
-            "${jetty.home}/lib/main.jar",
-            "${jetty.home}/lib/other.jar"
+            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, ordered(expectedLibs));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/TransientIniTemplateTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/TransientIniTemplateTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.start.usecases;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -26,6 +27,8 @@ import java.util.stream.Stream;
 
 import org.eclipse.jetty.toolchain.test.FS;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -79,19 +82,19 @@ public class TransientIniTemplateTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml",
-            "${jetty.home}/etc/main.xml",
-            "${jetty.base}/etc/t.xml",
-            "${jetty.base}/etc/d.xml"
+            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar),
+            "${jetty.base}/etc/t.xml".replace('/', File.separatorChar),
+            "${jetty.base}/etc/d.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
         List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar",
-            "${jetty.home}/lib/main.jar",
-            "${jetty.home}/lib/other.jar"
+            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));
@@ -105,6 +108,7 @@ public class TransientIniTemplateTest extends AbstractUseCase
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testTransientWithIniTemplateTestStart() throws Exception
     {
         setupStandardHomeDir();
@@ -154,19 +158,19 @@ public class TransientIniTemplateTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml",
-            "${jetty.home}/etc/main.xml",
-            "${jetty.base}/etc/t.xml",
-            "${jetty.base}/etc/d.xml"
+            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar),
+            "${jetty.base}/etc/t.xml".replace('/', File.separatorChar),
+            "${jetty.base}/etc/d.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
         List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar",
-            "${jetty.home}/lib/main.jar",
-            "${jetty.home}/lib/other.jar"
+            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));
@@ -230,19 +234,19 @@ public class TransientIniTemplateTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml",
-            "${jetty.home}/etc/main.xml",
-            "${jetty.base}/etc/t.xml",
-            "${jetty.base}/etc/d.xml"
+            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar),
+            "${jetty.base}/etc/t.xml".replace('/', File.separatorChar),
+            "${jetty.base}/etc/d.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
         List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar",
-            "${jetty.home}/lib/main.jar",
-            "${jetty.home}/lib/other.jar"
+            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/VersionedModulesTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/VersionedModulesTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.start.usecases;
 
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
@@ -64,17 +65,17 @@ public class VersionedModulesTest extends AbstractUseCase
 
         // === Validate Resulting XMLs
         List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml",
-            "${jetty.home}/etc/main.xml"
+            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
+            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
         List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar",
-            "${jetty.home}/lib/main.jar",
-            "${jetty.home}/lib/other.jar"
+            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
+            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));

--- a/jetty-core/jetty-staticapp/src/test/java/org/eclipse/jetty/staticapp/StaticAppContextTest.java
+++ b/jetty-core/jetty-staticapp/src/test/java/org/eclipse/jetty/staticapp/StaticAppContextTest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.jetty.staticapp;
 
+import java.io.FileWriter;
+import java.io.Writer;
 import java.net.URI;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
@@ -21,6 +23,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 import java.util.function.Consumer;
 
 import org.eclipse.jetty.deploy.DeploymentScanner;
@@ -44,6 +47,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -342,6 +347,7 @@ public class StaticAppContextTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testDeployCustomResourceHandlerPropertiesBaseResourceAlt() throws Exception
     {
         Path root = workDir.getEmptyPathDir();
@@ -351,11 +357,14 @@ public class StaticAppContextTest
         // Intentionally not in webapps directory
         Path staticDir = root.resolve("static");
         FS.ensureEmpty(staticDir);
-        Files.writeString(webapps.resolve("static.properties"), """
-            environment=static
-            jetty.deploy.baseResource=%s
-            jetty.deploy.baseResource.dirAllowed=false
-            """.formatted(staticDir.toString()));
+        try (Writer out = Files.newBufferedWriter(webapps.resolve("static.properties")))
+        {
+            Properties props = new Properties();
+            props.put("environment", "static");
+            props.put("jetty.deploy.baseResource", staticDir.toString());
+            props.put("jetty.deploy.baseResource.dirAllowed", "false");
+            props.store(out, "");
+        }
         Files.writeString(staticDir.resolve("test.txt"), "TEST TEXT");
 
         startServerWithDeploy(ds -> ds.addWebappsDirectory(webapps));
@@ -386,6 +395,7 @@ public class StaticAppContextTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testDeployStaticWithDirectoryWithPropertyBaseResource() throws Exception
     {
         Path root = workDir.getEmptyPathDir();
@@ -400,10 +410,13 @@ public class StaticAppContextTest
         Path staticDir = webapps.resolve("static");
         FS.ensureEmpty(staticDir);
         Files.writeString(staticDir.resolve("test.txt"), "TEST TEXT");
-        Files.writeString(webapps.resolve("static.properties"), """
-            environment=static
-            jetty.deploy.baseResource=%s
-            """.formatted(alt.toString()));
+        try (Writer out = Files.newBufferedWriter(webapps.resolve("static.properties")))
+        {
+            Properties props = new Properties();
+            props.put("environment", "static");
+            props.put("jetty.deploy.baseResource", alt.toString());
+            props.store(out, "");
+        }
 
         startServerWithDeploy(ds -> ds.addWebappsDirectory(webapps));
 

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AbstractTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/AbstractTest.java
@@ -103,7 +103,10 @@ public class AbstractTest
 
     public static Collection<TransportType> transports()
     {
-        return EnumSet.allOf(TransportType.class);
+        EnumSet<TransportType> transportTypes = EnumSet.allOf(TransportType.class);
+        if (System.getProperty("os.name").startsWith("Windows"))
+            transportTypes.remove(TransportType.H3_QUICHE);
+        return transportTypes;
     }
 
     public static Collection<TransportType> transportsNoFCGI()

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HTTP1TransportTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HTTP1TransportTest.java
@@ -41,6 +41,8 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -123,6 +125,7 @@ public class HTTP1TransportTest extends AbstractTransportTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testUnixDomainTransport() throws Exception
     {
         UnixDomainServerConnector connector = new UnixDomainServerConnector(server, 1, 1, new HttpConnectionFactory());
@@ -140,6 +143,7 @@ public class HTTP1TransportTest extends AbstractTransportTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testQuicheTransport(WorkDir workDir) throws Exception
     {
         SslContextFactory.Server sslServer = new SslContextFactory.Server();

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HTTP2TransportTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HTTP2TransportTest.java
@@ -53,6 +53,8 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -138,6 +140,7 @@ public class HTTP2TransportTest extends AbstractTransportTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testUnixDomainTransport() throws Exception
     {
         UnixDomainServerConnector connector = new UnixDomainServerConnector(server, 1, 1, new HTTP2CServerConnectionFactory());
@@ -155,6 +158,7 @@ public class HTTP2TransportTest extends AbstractTransportTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testQuicheTransportWithH2C(WorkDir workDir) throws Exception
     {
         SslContextFactory.Server sslServer = new SslContextFactory.Server();
@@ -184,6 +188,7 @@ public class HTTP2TransportTest extends AbstractTransportTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testQuicheTransportWithH2(WorkDir workDir) throws Exception
     {
         SslContextFactory.Server sslServer = new SslContextFactory.Server();
@@ -268,6 +273,7 @@ public class HTTP2TransportTest extends AbstractTransportTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testLowLevelH2COverUnixDomain() throws Exception
     {
         UnixDomainServerConnector connector = new UnixDomainServerConnector(server, new HTTP2CServerConnectionFactory());
@@ -295,6 +301,7 @@ public class HTTP2TransportTest extends AbstractTransportTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testLowLevelH2COverQUIC(WorkDir workDir) throws Exception
     {
         SslContextFactory.Server sslServer = new SslContextFactory.Server();

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HTTPDynamicTransportTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HTTPDynamicTransportTest.java
@@ -73,6 +73,8 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.eclipse.jetty.test.client.transport.AbstractTest.freePort;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -369,6 +371,7 @@ public class HTTPDynamicTransportTest extends AbstractTransportTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testHighLevelH1OverUNIX() throws Exception
     {
         ConnectionFactory h1 = new HttpConnectionFactory();
@@ -398,6 +401,7 @@ public class HTTPDynamicTransportTest extends AbstractTransportTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testLowLevelH2OverUNIX() throws Exception
     {
         HttpConfiguration httpConfig = new HttpConfiguration();
@@ -461,6 +465,7 @@ public class HTTPDynamicTransportTest extends AbstractTransportTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testHighLevelH2COverQUIC(WorkDir workDir) throws Exception
     {
         SslContextFactory.Server sslServer = new SslContextFactory.Server();

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientDemandTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientDemandTest.java
@@ -68,7 +68,7 @@ public class HttpClientDemandTest extends AbstractTest
     public static Stream<Arguments> bufferingParams()
     {
         String content = "ABCDEF";
-        return Arrays.stream(TransportType.values()).flatMap(transportType ->
+        return transports().stream().flatMap(transportType ->
             Stream.of(
                 Arguments.of(transportType, content, /*consumeBuffer*/false, /*invokeSuper*/false, /*expectedContent*/""),
                 Arguments.of(transportType, content, true, false, ""),

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTimeoutTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/HttpClientTimeoutTest.java
@@ -49,6 +49,8 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opentest4j.TestAbortedException;
@@ -66,6 +68,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
 public class HttpClientTimeoutTest extends AbstractTest
 {
     @ParameterizedTest

--- a/jetty-core/jetty-unixdomain-server/src/test/java/org/eclipse/jetty/unixdomain/server/UnixDomainTest.java
+++ b/jetty-core/jetty-unixdomain-server/src/test/java/org/eclipse/jetty/unixdomain/server/UnixDomainTest.java
@@ -45,6 +45,8 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.eclipse.jetty.client.ProxyProtocolClientConnectionFactory.V1;
 import static org.eclipse.jetty.client.ProxyProtocolClientConnectionFactory.V2;
@@ -55,6 +57,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
 public class UnixDomainTest
 {
     private ConnectionFactory[] factories = new ConnectionFactory[]{new HttpConnectionFactory()};

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/ResourceTest.java
@@ -35,6 +35,7 @@ import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.IO;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -399,6 +400,7 @@ public class ResourceTest
 
     @Test
     @EnabledOnOs(OS.WINDOWS)
+    @Disabled("fails as PathResource now checks both Path and URI equivalence, and the latter fails")
     public void testEqualsWindowsCaseInsensitiveDrive() throws Exception
     {
         URI a = new URI("file:///c:/foo/bar");

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/thread/VirtualThreadPoolTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/thread/VirtualThreadPoolTest.java
@@ -21,7 +21,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.eclipse.jetty.util.StringUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledForJreRange;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.JRE;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -103,6 +105,7 @@ public class VirtualThreadPoolTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testTrackingDump() throws Exception
     {
         VirtualThreadPool vtp = new VirtualThreadPool();


### PR DESCRIPTION
This PR disables jetty-core tests on Windows, which fail on Windows. 
Where appropriate also uses OS-agnostic separators instead of hardcoded ones.
Use Properties format when writing Properties file to ensure proper encoding.
