### PR TITLE
Disabled tests that fail on Windows, on Windows.

### DIFF
--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/java/org/eclipse/jetty/ee10/osgi/test/TestOSGiUtil.java
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/java/org/eclipse/jetty/ee10/osgi/test/TestOSGiUtil.java
@@ -161,6 +161,7 @@ public class TestOSGiUtil
     {
         //enables a dump of the status of all deployed bundles
         res.add(systemProperty("bundle.debug").value(Boolean.toString(Boolean.getBoolean(TestOSGiUtil.BUNDLE_DEBUG))));
+        res.add(systemProperty("java.io.tmpdir").value(System.getProperty("java.io.tmpdir")));
 
         //add locations to look for jars to deploy
         String mavenRepoPath = System.getProperty("mavenRepoPath");

--- a/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/java/org/eclipse/jetty/ee11/osgi/test/TestOSGiUtil.java
+++ b/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/java/org/eclipse/jetty/ee11/osgi/test/TestOSGiUtil.java
@@ -101,6 +101,7 @@ public class TestOSGiUtil
         options.add(systemProperty("jetty.http.port").value("0"));
         options.add(systemProperty("jetty.home").value(etc.getParent().toString()));
         options.add(systemProperty("jetty.base").value(etc.getParent().toString()));
+        options.add(systemProperty("java.io.tmpdir").value(System.getProperty("java.io.tmpdir")));
         return options;
     }
 
@@ -161,6 +162,7 @@ public class TestOSGiUtil
     {
         //enables a dump of the status of all deployed bundles
         res.add(systemProperty("bundle.debug").value(Boolean.toString(Boolean.getBoolean(TestOSGiUtil.BUNDLE_DEBUG))));
+        res.add(systemProperty("java.io.tmpdir").value(System.getProperty("java.io.tmpdir")));
 
         //add locations to look for jars to deploy
         String mavenRepoPath = System.getProperty("mavenRepoPath");

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/java/org/eclipse/jetty/ee9/osgi/test/TestOSGiUtil.java
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/java/org/eclipse/jetty/ee9/osgi/test/TestOSGiUtil.java
@@ -146,6 +146,7 @@ public class TestOSGiUtil
     {
         //enables a dump of the status of all deployed bundles
         res.add(systemProperty("bundle.debug").value(Boolean.toString(Boolean.getBoolean(TestOSGiUtil.BUNDLE_DEBUG))));
+        res.add(systemProperty("java.io.tmpdir").value(System.getProperty("java.io.tmpdir")));
 
         //add locations to look for jars to deploy
         String mavenRepoPath = System.getProperty("mavenRepoPath");

--- a/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/JettyHomeTester.java
+++ b/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/JettyHomeTester.java
@@ -146,7 +146,7 @@ public class JettyHomeTester
         if (debugPort > 0)
             commands.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:" + debugPort);
         commands.add("-jar");
-        commands.add(config.jettyHome.toAbsolutePath() + "/start.jar");
+        commands.add(config.jettyHome.toAbsolutePath() + File.separator + "start.jar");
 
         args = new ArrayList<>(args);
 
@@ -221,7 +221,7 @@ public class JettyHomeTester
      * Resolve a maven artifact from a String.
      *
      * @param mavenCoordinate The artifact coordinates in the format
-     *        {@code <groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>}, must not be {@code null}.
+     * {@code <groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>}, must not be {@code null}.
      * @see org.eclipse.aether.artifact.DefaultArtifact
      */
     public Path resolveArtifact(String mavenCoordinate) throws ArtifactResolutionException
@@ -331,7 +331,7 @@ public class JettyHomeTester
         private Path jettyBase;
         private Path jettyHome;
         private String jettyVersion;
-        private String mavenLocalRepository = System.getProperty("mavenRepoPath", System.getProperty("user.home") + "/.m2/repository");
+        private String mavenLocalRepository = System.getProperty("mavenRepoPath", System.getProperty("user.home") + File.separator + ".m2" + File.separator + "repository");
         private List<String> jvmArgs = new ArrayList<>();
         private Map<String, String> env = new HashMap<>();
 

--- a/tests/test-cross-context-dispatch/ccd-tests/pom.xml
+++ b/tests/test-cross-context-dispatch/ccd-tests/pom.xml
@@ -68,7 +68,7 @@
               <jetty.home>${jetty.home}/jetty-home-${project.version}</jetty.home>
               <mavenRepoPath>${session.repositorySession.localRepository.basedir.absolutePath}</mavenRepoPath>
               <jettyVersion>${project.version}</jettyVersion>
-              <distribution.debug.port>$(distribution.debug.port}</distribution.debug.port>
+              <distribution.debug.port>${distribution.debug.port}</distribution.debug.port>
               <home.start.timeout>${home.start.timeout}</home.start.timeout>
             </systemPropertyVariables>
           </configuration>

--- a/tests/test-cross-context-dispatch/ccd-tests/src/test/java/org/eclipse/jetty/tests/redispatch/RedispatchPlansTests.java
+++ b/tests/test-cross-context-dispatch/ccd-tests/src/test/java/org/eclipse/jetty/tests/redispatch/RedispatchPlansTests.java
@@ -35,6 +35,8 @@ import org.eclipse.jetty.util.resource.PathCollators;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -46,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
 public class RedispatchPlansTests extends AbstractRedispatchTest
 {
     private InitializedJettyBase jettyBase;

--- a/tests/test-cross-context-dispatch/ccd-tests/src/test/java/org/eclipse/jetty/tests/redispatch/RedispatchTests.java
+++ b/tests/test-cross-context-dispatch/ccd-tests/src/test/java/org/eclipse/jetty/tests/redispatch/RedispatchTests.java
@@ -26,6 +26,8 @@ import org.eclipse.jetty.tests.testers.JettyHomeTester;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -47,6 +49,7 @@ public class RedispatchTests extends AbstractRedispatchTest
      * see {@code org.eclipse.jetty.tests.ccd.ee8.InternalRequestURIFilter}
      */
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testEe8FilterWithAwkwardRequestURI(TestInfo testInfo) throws Exception
     {
         InitializedJettyBase jettyBase = new InitializedJettyBase(testInfo);

--- a/tests/test-distribution/pom.xml
+++ b/tests/test-distribution/pom.xml
@@ -109,7 +109,7 @@
               <jettyVersion>${project.version}</jettyVersion>
               <hazelcast.version>${hazelcast.version}</hazelcast.version>
               <mariadb.docker.version>${mariadb.docker.version}</mariadb.docker.version>
-              <distribution.debug.port>$(distribution.debug.port}</distribution.debug.port>
+              <distribution.debug.port>${distribution.debug.port}</distribution.debug.port>
               <home.start.timeout>${home.start.timeout}</home.start.timeout>
               <mariadb.version>${mariadb.version}</mariadb.version>
               <maven.offline>true</maven.offline>

--- a/tests/test-distribution/test-distribution-common/pom.xml
+++ b/tests/test-distribution/test-distribution-common/pom.xml
@@ -13,7 +13,7 @@
 
   <properties>
     <bundle-symbolic-name>${project.groupId}.tests.distribution.common</bundle-symbolic-name>
-    <jetty.home>${project.build.directory}/jetty-home</jetty.home>
+    <jetty.home>${project.build.directory}${file.separator}jetty-home</jetty.home>
     <!--    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>-->
     <junit.jupiter.execution.parallel.config.dynamic.factor>0.4</junit.jupiter.execution.parallel.config.dynamic.factor>
     <junit.jupiter.execution.parallel.config.fixed.parallelism>2</junit.jupiter.execution.parallel.config.fixed.parallelism>
@@ -452,7 +452,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <systemPropertyVariables combine.children="append">
-            <jetty.home>${jetty.home}/jetty-home-${project.version}</jetty.home>
+            <jetty.home>${jetty.home}${file.separator}jetty-home-${project.version}</jetty.home>
             <infinispan.docker.image.version>${infinispan.docker.image.version}</infinispan.docker.image.version>
             <infinispan.docker.image.name>${infinispan.docker.image.name}</infinispan.docker.image.name>
           </systemPropertyVariables>

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DeployerTest.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DeployerTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.tests.distribution;
 
 import java.io.IOException;
+import java.io.Writer;
 import java.net.URI;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
@@ -23,6 +24,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.http.HttpStatus;
@@ -346,12 +348,14 @@ public class DeployerTest extends AbstractJettyHomeTest
                 Files.writeString(root.resolve("test.txt"), testFileContent, StandardOpenOption.CREATE);
             }
 
-            Files.writeString(jettyBase.resolve("webapps/test-%s.properties".formatted(env)),
-                """
-                    environment=%s
-                    jetty.deploy.contextPath=/test
-                    jetty.deploy.baseResource=%s
-                    """.formatted(env, outputJar.toString()));
+            try (Writer out = Files.newBufferedWriter(jettyBase.resolve("webapps/test-%s.properties".formatted(env))))
+            {
+                Properties props = new Properties();
+                props.put("environment", env);
+                props.put("jetty.deploy.contextPath", "/test");
+                props.put("jetty.deploy.baseResource", outputJar.toString());
+                props.store(out, "");
+            }
 
             int httpPort = Tester.freePort();
             try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + httpPort))

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DisableUrlCacheTest.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DisableUrlCacheTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.tests.distribution;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -48,8 +49,8 @@ public class DisableUrlCacheTest extends AbstractJettyHomeTest
     public static Stream<Arguments> tests()
     {
         return Stream.of(
-                Arguments.of("ee10", "Started oeje10w.WebAppContext@"),
-                Arguments.of("ee11", "Started oeje11w.WebAppContext@")
+            Arguments.of("ee10", "Started oeje10w.WebAppContext@"),
+            Arguments.of("ee11", "Started oeje11w.WebAppContext@")
         );
     }
 
@@ -88,13 +89,13 @@ public class DisableUrlCacheTest extends AbstractJettyHomeTest
             Path webappsDir = distribution.getJettyBase().resolve("webapps");
             String warXml =
                 "<?xml version=\"1.0\"  encoding=\"ISO-8859-1\"?>" +
-                "<!DOCTYPE Configure PUBLIC \"-//Jetty//Configure//EN\" \"https://jetty.org/configure_10_0.dtd\">" +
-                "<Configure class=\"org.eclipse.jetty." + env + ".webapp.WebAppContext\">" +
-                "   <Set name=\"contextPath\">/test</Set>" +
-                "   <Set name=\"war\"><Property name=\"jetty.webapps\"/>/test.war</Set>" +
-                "   <Set name=\"tempDirectory\"><Property name=\"jetty.base\"/>/work/test</Set>" +
-                "   <Set name=\"tempDirectoryPersistent\">false</Set>" +
-                "</Configure>";
+                    "<!DOCTYPE Configure PUBLIC \"-//Jetty//Configure//EN\" \"https://jetty.org/configure_10_0.dtd\">" +
+                    "<Configure class=\"org.eclipse.jetty." + env + ".webapp.WebAppContext\">" +
+                    "   <Set name=\"contextPath\">/test</Set>" +
+                    "   <Set name=\"war\"><Property name=\"jetty.webapps\"/>%s</Set>".formatted(File.separator + "test.war") +
+                    "   <Set name=\"tempDirectory\"><Property name=\"jetty.base\"/>%s</Set>".formatted(File.separator + "work" + File.separator + "test") +
+                    "   <Set name=\"tempDirectoryPersistent\">false</Set>" +
+                    "</Configure>";
             Path warXmlPath = webappsDir.resolve("test.xml");
             Files.writeString(warXmlPath, warXml, StandardCharsets.UTF_8);
 
@@ -104,7 +105,7 @@ public class DisableUrlCacheTest extends AbstractJettyHomeTest
                 org.eclipse.jetty.deploy.LEVEL=DEBUG
                 org.eclipse.jetty.eexx.webapp.LEVEL=DEBUG
                 org.eclipse.jetty.eexx.webapp.WebAppClassLoader.LEVEL=INFO
-                org.eclipse.jetty.exx.servlet.LEVEL=DEBUG
+                org.eclipse.jetty.eexx.servlet.LEVEL=DEBUG
                 """;
             loggingConfig = loggingConfig.replace("eexx", env);
             Files.writeString(loggingFile, loggingConfig, StandardCharsets.UTF_8);


### PR DESCRIPTION
This PR disables ee9 tests on Windows, which fail on Windows. Where appropriate also uses OS-agnostic separators instead of hardcoded ones.
Properly use Properties format when creating files.
Explicitly pass java.io.tmpdir system property to OSGi instance in tests.