### PR TITLE
Issue #14824 - Deprecate FileSystemPool

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/FileSystemPool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/FileSystemPool.java
@@ -44,9 +44,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * TODO figure out if this should be a LifeCycle or not, how many instances of this class can reside in a JVM, who can call sweep and when.
+ * @deprecated FileSystemPool is no longer used.
  */
 @ManagedObject("Pool of FileSystems used to mount Resources")
+@Deprecated(since = "12.1.9", forRemoval = true)
 public class FileSystemPool implements Dumpable
 {
     private static final Logger LOG = LoggerFactory.getLogger(FileSystemPool.class);

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/MountedPathResource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/MountedPathResource.java
@@ -26,17 +26,27 @@ import org.eclipse.jetty.util.URIUtil;
  */
 public class MountedPathResource extends PathResource
 {
+    private final FileSystem fileSystem;
     private final URI containerUri;
 
     MountedPathResource(URI uri) throws IOException
     {
         super(uri, true);
+        fileSystem = null;
         containerUri = URIUtil.unwrapContainer(getURI());
     }
 
     MountedPathResource(Path path, URI uri)
     {
         super(path, uri, true);
+        fileSystem = null;
+        containerUri = URIUtil.unwrapContainer(getURI());
+    }
+
+    MountedPathResource(FileSystem fs, Path path, URI uri)
+    {
+        super(path, uri, true);
+        fileSystem = fs;
         containerUri = URIUtil.unwrapContainer(getURI());
     }
 
@@ -50,6 +60,11 @@ public class MountedPathResource extends PathResource
     public boolean isContainedIn(Resource container)
     {
         return URIUtil.unwrapContainer(container.getURI()).equals(containerUri);
+    }
+
+    public FileSystem getFileSystem()
+    {
+        return fileSystem;
     }
 
     public Path getContainerPath()

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/MountedPathResourceFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/MountedPathResourceFactory.java
@@ -70,14 +70,14 @@ public class MountedPathResourceFactory implements ResourceFactory
     @Override
     public Resource newResource(URI uri)
     {
-        // ZipFileSystemProvider only supports absolute URIs with scheme "jar"
+        // Most FileSystemProviders only supports absolute URIs
         if (!uri.isAbsolute())
             throw new IllegalArgumentException("not an absolute uri: " + uri);
 
         // Unwrap any containers found.
         // Examples:
         //    "jar:file:/path/to/foo.jar!/deep/reference.txt" becomes "file:/path/to/foo.jar"
-        //    ""jimfs://testNavigateResource/" becomes ""jimfs://testNavigateResource/"
+        //    "jimfs://testNavigateResource/" becomes ""jimfs://testNavigateResource/"
         URI containerURI = URIUtil.unwrapContainer(uri);
         Path containerPath = Path.of(containerURI.normalize());
         if (!Files.exists(containerPath))
@@ -85,19 +85,16 @@ public class MountedPathResourceFactory implements ResourceFactory
 
         FileSystem fs = forcedFileSystem != null ? forcedFileSystem : newFileSystem(containerPath);
 
-        // Obtain the deep reference inside the URI.
+        // Get a Path that is the deep reference specified in the URI.
         // Examples:
-        //   "jar:file:/path/to/foo.jar!/deep/ref.txt" would be "/deep/ref.txt"
-        //   "jar:file:/path/to/bar.jar!/" would be "/"
+        //   "jar:file:/path/to/foo.jar!/deep/ref.txt"
+        //   "jar:file:/path/to/bar.jar!/"
+        //   "jimfs://a3cc0bda-1238-4847-864f-22fae7614146/path/inside/"
         Path ref = getDeepPathReference(fs, uri);
 
-        // Check for existence of deep reference, we don't want to create (top level)
-        // Resource objects that don't have an associated file.
-        if (Files.exists(ref))
-        {
-            return new MountedPathResource(forcedFileSystem == null ? fs : null, ref, uri);
-        }
-        else
+        // Check for existence of the URI deep reference, we don't want to create
+        // Resource objects that don't have an associated file/dir.
+        if (!Files.exists(ref))
         {
             if (forcedFileSystem == null)
             {
@@ -113,6 +110,8 @@ public class MountedPathResourceFactory implements ResourceFactory
             }
             return null;
         }
+
+        return new MountedPathResource(forcedFileSystem == null ? fs : null, ref, uri);
     }
 
     private Path getDeepPathReference(FileSystem fs, URI uri)

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/MountedPathResourceFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/MountedPathResourceFactory.java
@@ -13,19 +13,128 @@
 
 package org.eclipse.jetty.util.resource;
 
+import java.io.IOException;
 import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
 
+import org.eclipse.jetty.util.URIUtil;
+
+/**
+ * A ResourceFactory for mounted FileSystems.
+ * <p>
+ * Example, for the "jar" scheme, this would use the JDK built-in ZipFileSystemProvider to load JAR files
+ * as a {@link FileSystem} suitable for {@link PathResource}.
+ * </p>
+ */
 public class MountedPathResourceFactory implements ResourceFactory
 {
+    private static final Map<String, String> ENV_MULTIRELEASE_RUNTIME;
+
+    static
+    {
+        Map<String, String> env = new HashMap<>();
+        // Key and Value documented at https://docs.oracle.com/en/java/javase/17/docs/api/jdk.zipfs/module-summary.html
+        env.put("releaseVersion", "runtime");
+        ENV_MULTIRELEASE_RUNTIME = env;
+    }
+
+    /**
+     * In some FileSystem types, there is no FileSystemProvider that can
+     * properly create that FileSystem.  In those cases, a FileSystem is created
+     * using other FileSystem specific APIs and that FileSystem is just referenced
+     * here and used.  This forced FileSystem is never closed by the Jetty implementation.
+     */
+    private final FileSystem forcedFileSystem;
+
+    public MountedPathResourceFactory()
+    {
+        this(null);
+    }
+
+    /**
+     * Pre-initialize a {@link MountedPathResourceFactory} with a known FileSystem that must always be used.
+     *
+     * @param fileSystem if not null, use the provided {@link FileSystem} when calls to {@link #newResource(URI)} is used.
+     * if null, then the JDK {@link FileSystems#newFileSystem} API is used for all {@link #newResource(URI)} calls.
+     */
+    public MountedPathResourceFactory(FileSystem fileSystem)
+    {
+        this.forcedFileSystem = fileSystem;
+    }
+
     @Override
     public Resource newResource(URI uri)
     {
-        Path path = Paths.get(uri.normalize());
-        if (!Files.exists(path))
+        // ZipFileSystemProvider only supports absolute URIs with scheme "jar"
+        if (!uri.isAbsolute())
+            throw new IllegalArgumentException("not an absolute uri: " + uri);
+
+        // Unwrap any containers found.
+        // Examples:
+        //    "jar:file:/path/to/foo.jar!/deep/reference.txt" becomes "file:/path/to/foo.jar"
+        //    ""jimfs://testNavigateResource/" becomes ""jimfs://testNavigateResource/"
+        URI containerURI = URIUtil.unwrapContainer(uri);
+        Path containerPath = Path.of(containerURI.normalize());
+        if (!Files.exists(containerPath))
             return null;
-        return new MountedPathResource(path, uri);
+
+        FileSystem fs = forcedFileSystem != null ? forcedFileSystem : newFileSystem(containerPath);
+
+        // Obtain the deep reference inside the URI.
+        // Examples:
+        //   "jar:file:/path/to/foo.jar!/deep/ref.txt" would be "/deep/ref.txt"
+        //   "jar:file:/path/to/bar.jar!/" would be "/"
+        Path ref = getDeepPathReference(fs, uri);
+
+        // Check for existence of deep reference, we don't want to create (top level)
+        // Resource objects that don't have an associated file.
+        if (Files.exists(ref))
+        {
+            return new MountedPathResource(forcedFileSystem == null ? fs : null, ref, uri);
+        }
+        else
+        {
+            if (forcedFileSystem == null)
+            {
+                try
+                {
+                    fs.close();
+                }
+                catch (IOException e)
+                {
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("Unable to close non-existent FileSystem: {}", uri, e);
+                }
+            }
+            return null;
+        }
+    }
+
+    private Path getDeepPathReference(FileSystem fs, URI uri)
+    {
+        String ssp = uri.getSchemeSpecificPart();
+        int idx = ssp.indexOf("!/");
+        if (idx >= 0)
+            return fs.getPath(ssp.substring(idx + 1));
+        else
+            return Path.of(uri);
+    }
+
+    private FileSystem newFileSystem(Path containerPath)
+    {
+        try
+        {
+            //noinspection resource (handled by MountedPathResource)
+            return FileSystems.newFileSystem(containerPath, ENV_MULTIRELEASE_RUNTIME);
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException("Unable to create FileSystem for " + containerPath, e);
+        }
     }
 }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
@@ -293,8 +293,26 @@ public class PathResource extends Resource
 
         URI uri = getURI();
         URI resolvedUri = URIUtil.addPath(uri, subUriPath);
-        Path path = Paths.get(resolvedUri);
-        return newResource(path, resolvedUri);
+        Path newPath = resolveSchemeSpecificPath(resolvedUri);
+        return newResource(newPath, resolvedUri);
+    }
+
+    private Path resolveSchemeSpecificPath(URI uri)
+    {
+        // Resolve from this PathResource to maintain FileSystem tracking.
+        // Do NOT use Path.of() or Paths.of() as that requires the JDK to track FileSystem objects.
+        // (Not all FileSystemProvider's track the FileSystems they create. Currently only ZipFileSystemProvider does)
+
+        String scheme = Objects.requireNonNull(uri.getScheme(), "scheme cannot be null");
+        if (scheme.equals("jar"))
+        {
+            String ssp = uri.getSchemeSpecificPart();
+            int idx = ssp.indexOf("!/");
+            if (idx == -1)
+                throw new IllegalArgumentException("Unable to find jar !/ deep reference in " + uri);
+            return path.resolve(ssp.substring(idx + 1));
+        }
+        return path.resolve(uri.getPath());
     }
 
     /**

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
@@ -547,7 +547,7 @@ public interface ResourceFactory
                     URI uri = URIUtil.toURI(rawDir);
                     // Load rawDir as a Resource
                     Resource dir = newResource(uri);
-                    if (dir.isDirectory())
+                    if (Resources.isDirectory(dir))
                     {
                         // Loop through resource entries for content that will match glob.
                         List<Resource> expanded = dir.list();
@@ -561,12 +561,12 @@ public interface ResourceFactory
                     URI uri = URIUtil.toURI(reference);
                     if ("jar".equals(uri.getScheme()) && unwrap)
                     {
-                        list.add(newResource(URIUtil.unwrapContainer(uri)));
+                        uri = URIUtil.unwrapContainer(uri);
                     }
-                    else
-                    {
-                        list.add(newResource(uri));
-                    }
+
+                    Resource resource = newResource(uri);
+                    if (resource != null)
+                        list.add(resource);
                 }
             }
             catch (Exception e)

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactoryInternals.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactoryInternals.java
@@ -17,24 +17,21 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.FileSystem;
 import java.nio.file.Path;
 import java.nio.file.ProviderNotFoundException;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.Index;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
 import org.eclipse.jetty.util.component.Dumpable;
 import org.eclipse.jetty.util.component.DumpableCollection;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 class ResourceFactoryInternals
 {
-    private static final Logger LOG = LoggerFactory.getLogger(ResourceFactoryInternals.class);
     private static final Path CURRENT_WORKING_DIR;
 
     /**
@@ -83,14 +80,14 @@ class ResourceFactoryInternals
     static ResourceFactory ROOT = new CompositeResourceFactory()
     {
         @Override
-        protected void onMounted(FileSystemPool.Mount mount, URI uri)
+        public void onNewFileSystem(FileSystem fs, Path path, URI uri)
         {
             // Since this ROOT ResourceFactory and has no lifecycle that can clean up
-            // the mount, we shall report this mount as a leak
+            // Close the FileSystem, we shall report this mount as a leak
             if (LOG.isDebugEnabled())
-                LOG.warn("Leaked {} for {}", mount, uri, new Throwable());
+                LOG.warn("Leaked {} for {}", fs, uri, new Throwable());
             else
-                LOG.warn("Leaked {} for {}", mount, uri);
+                LOG.warn("Leaked {} for {}", fs, uri);
         }
     };
 
@@ -149,14 +146,12 @@ class ResourceFactoryInternals
         public void close()
         {
             closed = true;
-            for (FileSystemPool.Mount mount : _compositeResourceFactory.getMounts())
-                IO.close(mount);
-            _compositeResourceFactory.clearMounts();
+            _compositeResourceFactory.closeFileSystems();
         }
 
         public int getTrackingCount()
         {
-            return _compositeResourceFactory.getMounts().size();
+            return _compositeResourceFactory.mounted.size();
         }
     }
 
@@ -174,17 +169,15 @@ class ResourceFactoryInternals
         @Override
         protected void doStop() throws Exception
         {
-            for (FileSystemPool.Mount mount : _compositeResourceFactory.getMounts())
-                IO.close(mount);
-            _compositeResourceFactory.clearMounts();
+            _compositeResourceFactory.closeFileSystems();
             super.doStop();
         }
 
         @Override
         public void dump(Appendable out, String indent) throws IOException
         {
-            List<URI> referencedUris = _compositeResourceFactory.getMounts().stream()
-                .map(mount -> mount.root().getURI())
+            List<URI> referencedUris = _compositeResourceFactory.mounted.stream()
+                .map(PathResource::getURI)
                 .toList();
             Dumpable.dumpObjects(out, indent, this, new DumpableCollection("newResourceReferences", referencedUris));
         }
@@ -192,7 +185,7 @@ class ResourceFactoryInternals
 
     static class CompositeResourceFactory implements ResourceFactory
     {
-        private final List<FileSystemPool.Mount> _mounts = new CopyOnWriteArrayList<>();
+        private final List<MountedPathResource> mounted = new CopyOnWriteArrayList<>();
 
         @Override
         public Resource newResource(URI uri)
@@ -220,16 +213,16 @@ class ResourceFactoryInternals
                 ResourceFactory resourceFactory = RESOURCE_FACTORIES.get(uri.getScheme());
                 if (resourceFactory == null)
                     throw new IllegalArgumentException("URI scheme not registered: " + uri.getScheme());
-                if (resourceFactory instanceof MountedPathResourceFactory)
+                Resource resource = resourceFactory.newResource(uri);
+                if (resource instanceof MountedPathResource mountedPathResource)
                 {
-                    FileSystemPool.Mount mount = mountIfNeeded(uri);
-                    if (mount != null)
+                    if (mountedPathResource.getFileSystem() != null)
                     {
-                        _mounts.add(mount);
-                        onMounted(mount, uri);
+                        mounted.add(mountedPathResource);
+                        onNewFileSystem(mountedPathResource.getFileSystem(), mountedPathResource.getPath(), uri);
                     }
                 }
-                return resourceFactory.newResource(uri);
+                return resource;
             }
             catch (URISyntaxException | ProviderNotFoundException ex)
             {
@@ -240,52 +233,55 @@ class ResourceFactoryInternals
         }
 
         /**
-         * <p>Mount a URI if it is needed.</p>
-         *
-         * @param uri The URI to mount that may require a FileSystem (e.g. "jar:file://tmp/some.jar!/directory/file.txt")
-         * @return A reference counted {@link FileSystemPool.Mount} for that file system or null. Callers should call
-         * {@link FileSystemPool.Mount#close()} once they no longer require this specific Mount.
-         * @throws IllegalArgumentException If the uri could not be mounted.
+         * @deprecated FileSystemPool is no longer used.
          */
-        private FileSystemPool.Mount mountIfNeeded(URI uri)
-        {
-            // do not mount if it is not a jar URI
-            String scheme = uri.getScheme();
-            if (!"jar".equalsIgnoreCase(scheme))
-                return null;
-
-            // Do not mount if we have already mounted
-            // TODO there is probably a better way of doing this other than string comparisons
-            String uriString = uri.toASCIIString();
-            for (FileSystemPool.Mount mount : _mounts)
-            {
-                if (uriString.startsWith(mount.root().toString()))
-                    return null;
-            }
-
-            try
-            {
-                return FileSystemPool.INSTANCE.mount(uri);
-            }
-            catch (IOException ioe)
-            {
-                throw new IllegalArgumentException("Unable to mount: " + uri, ioe);
-            }
-        }
-
+        @Deprecated(since = "12.1.9", forRemoval = true)
         protected void onMounted(FileSystemPool.Mount mount, URI uri)
         {
-            // override to specify behavior
+            // does nothing
         }
 
+        /**
+         * @deprecated FileSystemPool is no longer used.
+         */
+        @Deprecated(since = "12.1.9", forRemoval = true)
         public List<FileSystemPool.Mount> getMounts()
         {
-            return _mounts;
+            return List.of();
         }
 
+        /**
+         * @deprecated FileSystemPool is no longer used.
+         */
+        @Deprecated(since = "12.1.9", forRemoval = true)
         public void clearMounts()
         {
-            _mounts.clear();
+            // does nothing
+        }
+
+        public void onNewFileSystem(FileSystem fs, Path path, URI uri)
+        {
+
+        }
+
+        protected void closeFileSystems()
+        {
+            for (MountedPathResource mounted : mounted)
+            {
+                // Skip MountedPathResource that doesn't have a mounted newly FileSystem
+                if (mounted.getFileSystem() == null)
+                    continue;
+                try
+                {
+                    mounted.getFileSystem().close();
+                }
+                catch (IOException e)
+                {
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("Failed to close FileSystem: {}", mounted.getFileSystem(), e);
+                }
+            }
+            mounted.clear();
         }
     }
 }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/AlternateFileSystemResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/AlternateFileSystemResourceTest.java
@@ -69,7 +69,7 @@ public class AlternateFileSystemResourceTest
         }
         fsBaseURI = jimfs.getPath("/").toUri();
 
-        ResourceFactory.registerResourceFactory(fsBaseURI.getScheme(), new MountedPathResourceFactory());
+        ResourceFactory.registerResourceFactory(fsBaseURI.getScheme(), new MountedPathResourceFactory(jimfs));
     }
 
     @AfterEach
@@ -84,16 +84,19 @@ public class AlternateFileSystemResourceTest
         // Create some content to reference
         Files.writeString(jimfs.getPath("/foo.txt"), "Hello Foo", StandardCharsets.UTF_8);
 
-        // Reference it via Resource object
-        Resource resource = ResourceFactory.root().newResource(fsBaseURI.resolve("/foo.txt"));
-        assertTrue(Resources.isReadable(resource));
-
-        LOG.info("resource = {}", resource);
-
-        try (InputStream in = resource.newInputStream())
+        try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {
-            String contents = IO.toString(in, StandardCharsets.UTF_8);
-            assertThat(contents, is("Hello Foo"));
+            // Reference it via Resource object
+            Resource resource = resourceFactory.newResource(fsBaseURI.resolve("/foo.txt"));
+            assertTrue(Resources.isReadable(resource));
+
+            LOG.info("resource = {}", resource);
+
+            try (InputStream in = resource.newInputStream())
+            {
+                String contents = IO.toString(in, StandardCharsets.UTF_8);
+                assertThat(contents, is("Hello Foo"));
+            }
         }
     }
 
@@ -104,20 +107,23 @@ public class AlternateFileSystemResourceTest
         Files.createDirectories(jimfs.getPath("/zed"));
         Files.writeString(jimfs.getPath("/zed/bar.txt"), "Hello Bar", StandardCharsets.UTF_8);
 
-        // Reference it via Resource object
-        Resource resourceRoot = ResourceFactory.root().newResource(fsBaseURI.resolve("/"));
-        assertTrue(Resources.isDirectory(resourceRoot));
-
-        Resource resourceZedDir = resourceRoot.resolve("zed");
-        assertTrue(Resources.isDirectory(resourceZedDir));
-
-        Resource resourceBarText = resourceZedDir.resolve("bar.txt");
-        LOG.info("resource = {}", resourceBarText);
-
-        try (InputStream in = resourceBarText.newInputStream())
+        try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {
-            String contents = IO.toString(in, StandardCharsets.UTF_8);
-            assertThat(contents, is("Hello Bar"));
+            // Reference it via Resource object
+            Resource resourceRoot = resourceFactory.newResource(fsBaseURI.resolve("/"));
+            assertTrue(Resources.isDirectory(resourceRoot));
+
+            Resource resourceZedDir = resourceRoot.resolve("zed");
+            assertTrue(Resources.isDirectory(resourceZedDir));
+
+            Resource resourceBarText = resourceZedDir.resolve("bar.txt");
+            LOG.info("resource = {}", resourceBarText);
+
+            try (InputStream in = resourceBarText.newInputStream())
+            {
+                String contents = IO.toString(in, StandardCharsets.UTF_8);
+                assertThat(contents, is("Hello Bar"));
+            }
         }
     }
 }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/MountedPathResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/MountedPathResourceTest.java
@@ -17,7 +17,6 @@ import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.ClosedFileSystemException;
-import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -39,7 +38,6 @@ import org.junit.jupiter.api.parallel.Isolated;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -202,38 +200,10 @@ public class MountedPathResourceTest
             resource = resourceFactory.newResource(uri);
             assertTrue(resource.exists());
             Files.delete(testZip);
-            assertThrows(FileSystemNotFoundException.class, () -> resource.resolve("alphabet"));
+            Resource alpha = resource.resolve("alphabet");
+            assertTrue(Resources.exists(alpha));
         }
         assertThrows(ClosedFileSystemException.class, resource::exists);
-    }
-
-    @Test
-    public void testDumpAndSweep(WorkDir workDir) throws Exception
-    {
-        Path originalTestZip = MavenTestingUtils.getTestResourcePathFile("TestData/test.zip");
-        Path testZip = Files.copy(originalTestZip, workDir.getEmptyPathDir().resolve("test.zip"));
-        String s = "jar:" + testZip.toUri().toASCIIString() + "!/subdir/";
-        URI uri = URI.create(s);
-        try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
-        {
-            Resource resource = resourceFactory.newResource(uri);
-            assertTrue(resource.exists());
-
-            String dump = FileSystemPool.INSTANCE.dump();
-            // System.out.println(dump);
-            assertThat(dump, containsString("FileSystemPool"));
-            assertThat(dump, containsString("buckets size=1"));
-            assertThat(dump, containsString(testZip + "#1"));
-
-            Files.delete(testZip);
-            FileSystemPool.INSTANCE.sweep();
-
-            dump = FileSystemPool.INSTANCE.dump();
-            assertThat(dump, containsString("FileSystemPool"));
-            assertThat(dump, containsString("buckets size=0"));
-
-            assertThrows(ClosedFileSystemException.class, resource::exists);
-        }
     }
 
     @Test
@@ -405,82 +375,6 @@ public class MountedPathResourceTest
                 "..\\a different file.txt",
                 };
             assertThat("Dir contents", actual, containsInAnyOrder(expected));
-        }
-    }
-
-    /**
-     * When mounting multiple points within the same JAR, only
-     * 1 mount should be created, but have reference counts
-     * tracked separately.  Done via {@link ResourceFactory.Closeable}
-     * essentially a duplicate of {@link #testMountByJarNameLifeCycle()}
-     * to ensure parity in the two implementations.
-     */
-    @Test
-    public void testMountByJarNameClosable()
-    {
-        Path jarPath = MavenPaths.findTestResourceFile("jar-file-resource.jar");
-        URI uriRoot = URI.create("jar:" + jarPath.toUri().toASCIIString() + "!/"); // root
-        URI uriRez = URI.create("jar:" + jarPath.toUri().toASCIIString() + "!/rez/"); // dir
-        URI uriDeep = URI.create("jar:" + jarPath.toUri().toASCIIString() + "!/rez/deep/"); // dir
-        URI uriZzz = URI.create("jar:" + jarPath.toUri().toASCIIString() + "!/rez/deep/zzz"); // file
-
-        try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
-        {
-            Resource resRoot = resourceFactory.newResource(uriRoot);
-            Resource resRez = resourceFactory.newResource(uriRez);
-            Resource resDeep = resourceFactory.newResource(uriDeep);
-            Resource resZzz = resourceFactory.newResource(uriZzz);
-
-            assertThat(FileSystemPool.INSTANCE.mounts().size(), is(1));
-            int mountCount = FileSystemPool.INSTANCE.getReferenceCount(uriRoot);
-            assertThat(mountCount, is(1));
-        }
-
-        assertThat(FileSystemPool.INSTANCE.mounts().size(), is(0));
-        int mountCount = FileSystemPool.INSTANCE.getReferenceCount(uriRoot);
-        assertThat(mountCount, is(0));
-    }
-
-    /**
-     * When mounting multiple points within the same JAR, only
-     * 1 mount should be created, but have reference counts
-     * tracked separately.  Done via {@link ResourceFactory.LifeCycle}
-     * essentially a duplicate of {@link #testMountByJarNameClosable()}
-     * to ensure parity in the two implementations.
-     */
-    @Test
-    public void testMountByJarNameLifeCycle() throws Exception
-    {
-        Path jarPath = MavenPaths.findTestResourceFile("jar-file-resource.jar");
-        URI uriRoot = URI.create("jar:" + jarPath.toUri().toASCIIString() + "!/"); // root
-        URI uriRez = URI.create("jar:" + jarPath.toUri().toASCIIString() + "!/rez/"); // dir
-        URI uriDeep = URI.create("jar:" + jarPath.toUri().toASCIIString() + "!/rez/deep/"); // dir
-        URI uriZzz = URI.create("jar:" + jarPath.toUri().toASCIIString() + "!/rez/deep/zzz"); // file
-
-        ResourceFactory.LifeCycle resourceFactory = ResourceFactory.lifecycle();
-
-        try
-        {
-            resourceFactory.start();
-            Resource resRoot = resourceFactory.newResource(uriRoot);
-            Resource resRez = resourceFactory.newResource(uriRez);
-            Resource resDeep = resourceFactory.newResource(uriDeep);
-            Resource resZzz = resourceFactory.newResource(uriZzz);
-
-            assertThat(FileSystemPool.INSTANCE.mounts().size(), is(1));
-            int mountCount = FileSystemPool.INSTANCE.getReferenceCount(uriRoot);
-            assertThat(mountCount, is(1));
-            String dump = resourceFactory.dump();
-            assertThat(dump, containsString("newResourceReferences size=1"));
-            assertThat(dump, containsString(uriRoot.toASCIIString()));
-        }
-        finally
-        {
-            resourceFactory.stop();
-
-            assertThat(FileSystemPool.INSTANCE.mounts().size(), is(0));
-            int mountCount = FileSystemPool.INSTANCE.getReferenceCount(uriRoot);
-            assertThat(mountCount, is(0));
         }
     }
 }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
@@ -34,8 +34,6 @@ import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.URIUtil;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,7 +43,6 @@ import org.slf4j.LoggerFactory;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -64,18 +61,6 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 public class PathResourceTest
 {
     private static final Logger LOG = LoggerFactory.getLogger(PathResourceTest.class);
-
-    @BeforeEach
-    public void beforeEach()
-    {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
-    }
-
-    @AfterEach
-    public void afterEach()
-    {
-        assertThat(FileSystemPool.INSTANCE.mounts(), empty());
-    }
 
     @Test
     public void testNonDefaultFileSystemGetInputStream() throws IOException
@@ -242,7 +227,7 @@ public class PathResourceTest
 
             if (resourceFactory instanceof ResourceFactoryInternals.Tracking tracking)
             {
-                assertThat(tracking.getTrackingCount(), is(1));
+                assertThat(tracking.getTrackingCount(), is(0));
             }
         }
     }
@@ -276,7 +261,7 @@ public class PathResourceTest
 
             if (resourceFactory instanceof ResourceFactoryInternals.Tracking tracking)
             {
-                assertThat(tracking.getTrackingCount(), is(1));
+                assertThat(tracking.getTrackingCount(), is(2));
             }
         }
     }
@@ -301,8 +286,6 @@ public class PathResourceTest
             Files.writeString(dir.resolve("two.txt"), "Contents of two.txt", StandardCharsets.UTF_8);
         }
 
-        assertThat(FileSystemPool.INSTANCE.mounts(), is(empty()));
-
         try (ResourceFactory.Closeable resourceFactory1 = ResourceFactory.closeable();
              ResourceFactory.Closeable resourceFactory2 = ResourceFactory.closeable())
         {
@@ -315,11 +298,9 @@ public class PathResourceTest
             Resource twoTxt = resourceFactory2.newResource(jarUri.toASCIIString() + "datainf/two.txt");
             assertTrue(Resources.isReadableFile(twoTxt));
 
-            assertThat("Should see only 1 FS Mount", FileSystemPool.INSTANCE.mounts().size(), is(1));
-
             if (resourceFactory1 instanceof ResourceFactoryInternals.Tracking tracking)
             {
-                assertThat(tracking.getTrackingCount(), is(1));
+                assertThat(tracking.getTrackingCount(), is(2));
             }
 
             if (resourceFactory2 instanceof ResourceFactoryInternals.Tracking tracking)
@@ -335,13 +316,8 @@ public class PathResourceTest
                 assertThat(tracking.getTrackingCount(), is(0));
             }
 
-            // Resource one still works because factory 2 is holding filesystem open
-            assertThat(IO.toString(oneTxt.newInputStream()), is("Contents of one.txt"));
-
             // should not be able to use closed ResourceFactory.Closable
             assertThrows(IllegalStateException.class, () -> resourceFactory1.newResource(jarUri.toASCIIString() + "one.txt"));
-
-            assertThat("Should see only 1 FS Mount", FileSystemPool.INSTANCE.mounts().size(), is(1));
 
             Resource oneAlt = resourceFactory2.newResource(jarUri.toASCIIString() + "one.txt");
             assertTrue(Resources.isReadableFile(oneAlt));
@@ -352,12 +328,6 @@ public class PathResourceTest
             // Neither Resource one nor two  works because filesystem is now closed
             assertThrows(ClosedFileSystemException.class, oneTxt::newInputStream);
             assertThrows(ClosedFileSystemException.class, oneTxt2::newInputStream);
-
-            assertThat("Should see only 0 FS Mount", FileSystemPool.INSTANCE.mounts().size(), is(0));
-        }
-        finally
-        {
-            assertThat(FileSystemPool.INSTANCE.mounts(), is(empty()));
         }
     }
 


### PR DESCRIPTION
Deprecate the `FileSystemPool` in favor of a `newFileSystem` per `ResourceFactory.newResource`.
The existing `MountedPathResourceFactory` is responsible for creating the `newFileSystem`.
The existing `MountedPathResource` tracks any new `FileSystem` created by Jetty.
The existing `ResourceFactory.Closable` and `ResourceFactory.LifeCycle` will close new `FileSystem` created by Jetty during their lifecycle stop/close.