### PR TITLE
 Issue #14846 - Fix NPE in processing of Web Fragments that attempt to redefine a mime-type from another Web Fragment.

### DIFF
--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/MimeTypesTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/MimeTypesTest.java
@@ -47,7 +47,12 @@ public class MimeTypesTest
             // Make sure that a deep path doesn't interfere
             Arguments.of("org/eclipse/jetty/Logo.png", "image/png"),
             // Make sure that path that looks like a filename doesn't interfere
-            Arguments.of("org/eclipse.jpg/jetty/Logo.png", "image/png")
+            Arguments.of("org/eclipse.jpg/jetty/Logo.png", "image/png"),
+            // Test of an undefined mime-type extensions (the extension ".bogus" shouldn't exist in mime.properties)
+            Arguments.of("foo.bogus", null),
+            // Test of dotfiles (that start with ".")
+            Arguments.of(".gitconfig", null),
+            Arguments.of(".bashrc", null)
         );
     }
 

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/StandardDescriptorProcessor.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/StandardDescriptorProcessor.java
@@ -859,8 +859,8 @@ public class StandardDescriptorProcessor extends IterativeDescriptorProcessor
                 }
                 case WebFragment:
                 {
-                    //a web-fragment set the value, all web-fragments must have the same value
-                    if (!context.getMimeTypes().getMimeByExtension("." + extension).equals(mimeType))
+                    // a web-fragment set the value, all web-fragments must have the same value
+                    if (!mimeType.equals(context.getMimeTypes().getMimeByExtension("." + extension)))
                         throw new IllegalStateException("Conflicting mime-type " + mimeType + " for extension " + extension + " in " + descriptor.getURI());
                     break;
                 }

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/StandardDescriptorProcessor.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/StandardDescriptorProcessor.java
@@ -860,7 +860,7 @@ public class StandardDescriptorProcessor extends IterativeDescriptorProcessor
                 case WebFragment:
                 {
                     // a web-fragment set the value, all web-fragments must have the same value
-                    if (!mimeType.equals(context.getMimeTypes().getMimeByExtension("." + extension)))
+                    if (!mimeType.equals(context.getMimeTypes().getMimeForExtension(extension)))
                         throw new IllegalStateException("Conflicting mime-type " + mimeType + " for extension " + extension + " in " + descriptor.getURI());
                     break;
                 }

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/StandardDescriptorProcessorTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/StandardDescriptorProcessorTest.java
@@ -33,6 +33,7 @@ import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
+import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.resource.Resources;
@@ -280,6 +281,10 @@ public class StandardDescriptorProcessorTest
             IllegalStateException ise = (IllegalStateException)ite.getCause();
             assertThat(ise.getMessage(), containsString("Conflicting mime-type application/vnd.ms-fontobject for extension eot in " +
                 "jar:" + fragResource.getURI().toASCIIString() + "!/META-INF/web-fragment.xml"));
+        }
+        finally
+        {
+            LifeCycle.stop(wac);
         }
     }
 

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/StandardDescriptorProcessorTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/StandardDescriptorProcessorTest.java
@@ -216,7 +216,7 @@ public class StandardDescriptorProcessorTest
             """);
         wac.setDescriptor(descriptorXml.toUri().toASCIIString());
 
-        Map<String, String> CREATE_JAR_ENV = new HashMap<>();
+        final Map<String, String> CREATE_JAR_ENV = new HashMap<>();
         CREATE_JAR_ENV.put("create", "true");
 
         // Fragment one: sets the eot mime-type

--- a/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/StandardDescriptorProcessorTest.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/test/java/org/eclipse/jetty/ee10/webapp/StandardDescriptorProcessorTest.java
@@ -13,10 +13,14 @@
 
 package org.eclipse.jetty.ee10.webapp;
 
-import java.io.File;
 import java.lang.reflect.InvocationTargetException;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -25,9 +29,13 @@ import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.eclipse.jetty.ee10.servlet.ServletMapping;
 import org.eclipse.jetty.logging.StacklessLogging;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.toolchain.test.FS;
+import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
+import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.util.resource.ResourceFactory;
+import org.eclipse.jetty.util.resource.Resources;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,13 +43,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalToIgnoringCase;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(WorkDirExtension.class)
 public class StandardDescriptorProcessorTest
@@ -144,11 +156,11 @@ public class StandardDescriptorProcessorTest
     {
         //Test that the DefaultServlet mapping from webdefault-ee10.xml can be overridden in web.xml
         Path docroot = workDir.getEmptyPathDir();
-        File webXml = MavenTestingUtils.getTestResourceFile("web-redefine-mapping.xml");
+        Path webXml = MavenPaths.findTestResourceFile("web-redefine-mapping.xml");
         WebAppContext wac = new WebAppContext();
         wac.setServer(_server);
         wac.setBaseResourceAsPath(docroot);
-        wac.setDescriptor(webXml.toURI().toURL().toString());
+        wac.setDescriptor(webXml.toUri().toASCIIString());
         wac.start();
         ServletMapping[] mappings = wac.getServletHandler().getServletMappings();
         ServletMapping mapping = null;
@@ -166,15 +178,15 @@ public class StandardDescriptorProcessorTest
     }
 
     @Test
-    public void testBadDuplicateServletMappingsFromDescriptors(WorkDir workDir) throws Exception
+    public void testBadDuplicateServletMappingsFromDescriptors(WorkDir workDir)
     {
         //Test that the same mapping cannot be redefined to a different servlet in the same (non-default) descriptor
         Path docroot = workDir.getEmptyPathDir();
-        File webXml = MavenTestingUtils.getTestResourceFile("web-redefine-mapping-fail.xml");
+        Path webXml = MavenPaths.findTestResourceFile("web-redefine-mapping-fail.xml");
         WebAppContext wac = new WebAppContext();
         wac.setServer(_server);
         wac.setBaseResourceAsPath(docroot);
-        wac.setDescriptor(webXml.toURI().toURL().toString());
+        wac.setDescriptor(webXml.toUri().toASCIIString());
         wac.setThrowUnavailableOnStartupException(true);
         try (StacklessLogging ignored = new StacklessLogging(WebAppContext.class))
         {
@@ -183,14 +195,103 @@ public class StandardDescriptorProcessorTest
     }
 
     @Test
-    public void testVisitSessionConfig(WorkDir workDir) throws Exception
+    public void testDuplicateMimeTypes(WorkDir workDir) throws Exception
     {
+        // Ensure that behavior of duplicate mime-type works as intended.
         Path docroot = workDir.getEmptyPathDir();
-        File webXml = MavenTestingUtils.getTestResourceFile("web-session-config.xml");
         WebAppContext wac = new WebAppContext();
         wac.setServer(_server);
         wac.setBaseResourceAsPath(docroot);
-        wac.setDescriptor(webXml.toURI().toURL().toString());
+
+        Path descriptorXml = docroot.resolve("WEB-INF/web.xml");
+        FS.ensureDirExists(descriptorXml.getParent());
+        Files.writeString(descriptorXml, """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+              version="6.0">
+              <name>Test WebApp</name>
+            </web-app>
+            """);
+        wac.setDescriptor(descriptorXml.toUri().toASCIIString());
+
+        Map<String, String> CREATE_JAR_ENV = new HashMap<>();
+        CREATE_JAR_ENV.put("create", "true");
+
+        // Fragment one: sets the eot mime-type
+        Path fragmentOneJar = docroot.resolve("WEB-INF/lib/frag1.jar");
+        FS.ensureDirExists(fragmentOneJar.getParent());
+        URI uriOne = URI.create("jar:" + fragmentOneJar.toUri().toASCIIString());
+        try (FileSystem zipfs = FileSystems.newFileSystem(uriOne, CREATE_JAR_ENV))
+        {
+            String fragmentXml = """
+                <?xml version="1.0" encoding="ISO-8859-1"?>
+                <web-fragment
+                   xmlns="http://java.sun.com/xml/ns/javaee"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-fragment_4_0.xsd"
+                   version="4.0">
+                  <name>Frag1Test</name>
+                  <mime-mapping>
+                    <extension>eot</extension>
+                    <mime-type>application/octet-stream</mime-type>
+                  </mime-mapping>
+                </web-fragment>
+                """;
+            Path path = zipfs.getPath("/META-INF/web-fragment.xml");
+            FS.ensureDirExists(path.getParent());
+            Files.writeString(path, fragmentXml);
+        }
+
+        // Fragment two: tries to set the eot mime-type to something difference (it should fail)
+        Path fragmentTwoJar = docroot.resolve("WEB-INF/lib/frag2.jar");
+        FS.ensureDirExists(fragmentTwoJar.getParent());
+        URI uriTwo = URI.create("jar:" + fragmentTwoJar.toUri().toASCIIString());
+        try (FileSystem zipfs = FileSystems.newFileSystem(uriTwo, CREATE_JAR_ENV))
+        {
+            String fragmentXml = """
+                <?xml version="1.0" encoding="ISO-8859-1"?>
+                <web-fragment
+                   xmlns="http://java.sun.com/xml/ns/javaee"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-fragment_4_0.xsd"
+                   version="4.0">
+                  <name>Frag2Test</name>
+                  <mime-mapping>
+                    <extension>eot</extension>
+                    <mime-type>application/vnd.ms-fontobject</mime-type>
+                  </mime-mapping>
+                </web-fragment>
+                """;
+            Path path = zipfs.getPath("/META-INF/web-fragment.xml");
+            FS.ensureDirExists(path.getParent());
+            Files.writeString(path, fragmentXml);
+        }
+
+        ResourceFactory resourceFactory = wac.getResourceFactory();
+        Resource fragResource = resourceFactory.newResource(fragmentTwoJar);
+        assertTrue(Resources.exists(fragResource));
+        wac.setThrowUnavailableOnStartupException(true);
+        try (StacklessLogging ignored = new StacklessLogging(WebAppContext.class))
+        {
+            InvocationTargetException ite = assertThrows(InvocationTargetException.class, wac::start);
+            assertThat(ite.getCause(), is(instanceOf(IllegalStateException.class)));
+            IllegalStateException ise = (IllegalStateException)ite.getCause();
+            assertThat(ise.getMessage(), containsString("Conflicting mime-type application/vnd.ms-fontobject for extension eot in " +
+                "jar:" + fragResource.getURI().toASCIIString() + "!/META-INF/web-fragment.xml"));
+        }
+    }
+
+    @Test
+    public void testVisitSessionConfig(WorkDir workDir) throws Exception
+    {
+        Path docroot = workDir.getEmptyPathDir();
+        Path webXml = MavenPaths.findTestResourceFile("web-session-config.xml");
+        WebAppContext wac = new WebAppContext();
+        wac.setServer(_server);
+        wac.setBaseResourceAsPath(docroot);
+        wac.setDescriptor(webXml.toUri().toASCIIString());
         wac.start();
         assertEquals(54, TimeUnit.SECONDS.toMinutes(wac.getSessionHandler().getMaxInactiveInterval()));
         
@@ -201,6 +302,7 @@ public class StandardDescriptorProcessorTest
         assertEquals("SPECIALSESSIONID", wac.getSessionHandler().getSessionCookie());
         
         //comment
+        //noinspection removal
         assertEquals("nocomment", wac.getSessionHandler().getSessionCookieConfig().getComment());
         assertEquals("nocomment", wac.getSessionHandler().getSessionCookieConfig().getAttribute("Comment"));
         assertEquals("nocomment", wac.getSessionHandler().getSessionComment());

--- a/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/StandardDescriptorProcessor.java
+++ b/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/StandardDescriptorProcessor.java
@@ -860,7 +860,7 @@ public class StandardDescriptorProcessor extends IterativeDescriptorProcessor
                 case WebFragment:
                 {
                     //a web-fragment set the value, all web-fragments must have the same value
-                    if (!mimeType.equals(context.getMimeTypes().getMimeByExtension("." + extension)))
+                    if (!mimeType.equals(context.getMimeTypes().getMimeForExtension(extension)))
                         throw new IllegalStateException("Conflicting mime-type " + mimeType + " for extension " + extension + " in " + descriptor.getURI());
                     break;
                 }

--- a/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/StandardDescriptorProcessor.java
+++ b/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/StandardDescriptorProcessor.java
@@ -860,7 +860,7 @@ public class StandardDescriptorProcessor extends IterativeDescriptorProcessor
                 case WebFragment:
                 {
                     //a web-fragment set the value, all web-fragments must have the same value
-                    if (!context.getMimeTypes().getMimeByExtension("." + extension).equals(mimeType))
+                    if (!mimeType.equals(context.getMimeTypes().getMimeByExtension("." + extension)))
                         throw new IllegalStateException("Conflicting mime-type " + mimeType + " for extension " + extension + " in " + descriptor.getURI());
                     break;
                 }

--- a/jetty-ee11/jetty-ee11-webapp/src/test/java/org/eclipse/jetty/ee11/webapp/StandardDescriptorProcessorTest.java
+++ b/jetty-ee11/jetty-ee11-webapp/src/test/java/org/eclipse/jetty/ee11/webapp/StandardDescriptorProcessorTest.java
@@ -33,6 +33,7 @@ import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
+import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.resource.Resources;
@@ -280,6 +281,10 @@ public class StandardDescriptorProcessorTest
             IllegalStateException ise = (IllegalStateException)ite.getCause();
             assertThat(ise.getMessage(), containsString("Conflicting mime-type application/vnd.ms-fontobject for extension eot in " +
                 "jar:" + fragResource.getURI().toASCIIString() + "!/META-INF/web-fragment.xml"));
+        }
+        finally
+        {
+            LifeCycle.stop(wac);
         }
     }
 

--- a/jetty-ee11/jetty-ee11-webapp/src/test/java/org/eclipse/jetty/ee11/webapp/StandardDescriptorProcessorTest.java
+++ b/jetty-ee11/jetty-ee11-webapp/src/test/java/org/eclipse/jetty/ee11/webapp/StandardDescriptorProcessorTest.java
@@ -13,10 +13,14 @@
 
 package org.eclipse.jetty.ee11.webapp;
 
-import java.io.File;
 import java.lang.reflect.InvocationTargetException;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -25,9 +29,13 @@ import org.eclipse.jetty.ee11.servlet.ServletHolder;
 import org.eclipse.jetty.ee11.servlet.ServletMapping;
 import org.eclipse.jetty.logging.StacklessLogging;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.toolchain.test.FS;
+import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
+import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.util.resource.ResourceFactory;
+import org.eclipse.jetty.util.resource.Resources;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,13 +43,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalToIgnoringCase;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(WorkDirExtension.class)
 public class StandardDescriptorProcessorTest
@@ -144,11 +156,11 @@ public class StandardDescriptorProcessorTest
     {
         //Test that the DefaultServlet mapping from webdefault-ee11.xml can be overridden in web.xml
         Path docroot = workDir.getEmptyPathDir();
-        File webXml = MavenTestingUtils.getTestResourceFile("web-redefine-mapping.xml");
+        Path webXml = MavenPaths.findTestResourceFile("web-redefine-mapping.xml");
         WebAppContext wac = new WebAppContext();
         wac.setServer(_server);
         wac.setBaseResourceAsPath(docroot);
-        wac.setDescriptor(webXml.toURI().toURL().toString());
+        wac.setDescriptor(webXml.toUri().toASCIIString());
         wac.start();
         ServletMapping[] mappings = wac.getServletHandler().getServletMappings();
         ServletMapping mapping = null;
@@ -166,15 +178,15 @@ public class StandardDescriptorProcessorTest
     }
 
     @Test
-    public void testBadDuplicateServletMappingsFromDescriptors(WorkDir workDir) throws Exception
+    public void testBadDuplicateServletMappingsFromDescriptors(WorkDir workDir)
     {
         //Test that the same mapping cannot be redefined to a different servlet in the same (non-default) descriptor
         Path docroot = workDir.getEmptyPathDir();
-        File webXml = MavenTestingUtils.getTestResourceFile("web-redefine-mapping-fail.xml");
+        Path webXml = MavenPaths.findTestResourceFile("web-redefine-mapping-fail.xml");
         WebAppContext wac = new WebAppContext();
         wac.setServer(_server);
         wac.setBaseResourceAsPath(docroot);
-        wac.setDescriptor(webXml.toURI().toURL().toString());
+        wac.setDescriptor(webXml.toUri().toASCIIString());
         wac.setThrowUnavailableOnStartupException(true);
         try (StacklessLogging ignored = new StacklessLogging(WebAppContext.class))
         {
@@ -183,14 +195,103 @@ public class StandardDescriptorProcessorTest
     }
 
     @Test
-    public void testVisitSessionConfig(WorkDir workDir) throws Exception
+    public void testDuplicateMimeTypes(WorkDir workDir) throws Exception
     {
+        // Ensure that behavior of duplicate mime-type works as intended.
         Path docroot = workDir.getEmptyPathDir();
-        File webXml = MavenTestingUtils.getTestResourceFile("web-session-config.xml");
         WebAppContext wac = new WebAppContext();
         wac.setServer(_server);
         wac.setBaseResourceAsPath(docroot);
-        wac.setDescriptor(webXml.toURI().toURL().toString());
+
+        Path descriptorXml = docroot.resolve("WEB-INF/web.xml");
+        FS.ensureDirExists(descriptorXml.getParent());
+        Files.writeString(descriptorXml, """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+              version="6.0">
+              <name>Test WebApp</name>
+            </web-app>
+            """);
+        wac.setDescriptor(descriptorXml.toUri().toASCIIString());
+
+        Map<String, String> CREATE_JAR_ENV = new HashMap<>();
+        CREATE_JAR_ENV.put("create", "true");
+
+        // Fragment one: sets the eot mime-type
+        Path fragmentOneJar = docroot.resolve("WEB-INF/lib/frag1.jar");
+        FS.ensureDirExists(fragmentOneJar.getParent());
+        URI uriOne = URI.create("jar:" + fragmentOneJar.toUri().toASCIIString());
+        try (FileSystem zipfs = FileSystems.newFileSystem(uriOne, CREATE_JAR_ENV))
+        {
+            String fragmentXml = """
+                <?xml version="1.0" encoding="ISO-8859-1"?>
+                <web-fragment
+                   xmlns="http://java.sun.com/xml/ns/javaee"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-fragment_4_0.xsd"
+                   version="4.0">
+                  <name>Frag1Test</name>
+                  <mime-mapping>
+                    <extension>eot</extension>
+                    <mime-type>application/octet-stream</mime-type>
+                  </mime-mapping>
+                </web-fragment>
+                """;
+            Path path = zipfs.getPath("/META-INF/web-fragment.xml");
+            FS.ensureDirExists(path.getParent());
+            Files.writeString(path, fragmentXml);
+        }
+
+        // Fragment two: tries to set the eot mime-type to something difference (it should fail)
+        Path fragmentTwoJar = docroot.resolve("WEB-INF/lib/frag2.jar");
+        FS.ensureDirExists(fragmentTwoJar.getParent());
+        URI uriTwo = URI.create("jar:" + fragmentTwoJar.toUri().toASCIIString());
+        try (FileSystem zipfs = FileSystems.newFileSystem(uriTwo, CREATE_JAR_ENV))
+        {
+            String fragmentXml = """
+                <?xml version="1.0" encoding="ISO-8859-1"?>
+                <web-fragment
+                   xmlns="http://java.sun.com/xml/ns/javaee"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-fragment_4_0.xsd"
+                   version="4.0">
+                  <name>Frag2Test</name>
+                  <mime-mapping>
+                    <extension>eot</extension>
+                    <mime-type>application/vnd.ms-fontobject</mime-type>
+                  </mime-mapping>
+                </web-fragment>
+                """;
+            Path path = zipfs.getPath("/META-INF/web-fragment.xml");
+            FS.ensureDirExists(path.getParent());
+            Files.writeString(path, fragmentXml);
+        }
+
+        ResourceFactory resourceFactory = wac.getResourceFactory();
+        Resource fragResource = resourceFactory.newResource(fragmentTwoJar);
+        assertTrue(Resources.exists(fragResource));
+        wac.setThrowUnavailableOnStartupException(true);
+        try (StacklessLogging ignored = new StacklessLogging(WebAppContext.class))
+        {
+            InvocationTargetException ite = assertThrows(InvocationTargetException.class, wac::start);
+            assertThat(ite.getCause(), is(instanceOf(IllegalStateException.class)));
+            IllegalStateException ise = (IllegalStateException)ite.getCause();
+            assertThat(ise.getMessage(), containsString("Conflicting mime-type application/vnd.ms-fontobject for extension eot in " +
+                "jar:" + fragResource.getURI().toASCIIString() + "!/META-INF/web-fragment.xml"));
+        }
+    }
+
+    @Test
+    public void testVisitSessionConfig(WorkDir workDir) throws Exception
+    {
+        Path docroot = workDir.getEmptyPathDir();
+        Path webXml = MavenPaths.findTestResourceFile("web-session-config.xml");
+        WebAppContext wac = new WebAppContext();
+        wac.setServer(_server);
+        wac.setBaseResourceAsPath(docroot);
+        wac.setDescriptor(webXml.toUri().toASCIIString());
         wac.start();
         assertEquals(54, TimeUnit.SECONDS.toMinutes(wac.getSessionHandler().getMaxInactiveInterval()));
         
@@ -201,6 +302,7 @@ public class StandardDescriptorProcessorTest
         assertEquals("SPECIALSESSIONID", wac.getSessionHandler().getSessionCookie());
         
         //comment
+        //noinspection removal
         assertEquals("nocomment", wac.getSessionHandler().getSessionCookieConfig().getComment());
         assertEquals("nocomment", wac.getSessionHandler().getSessionCookieConfig().getAttribute("Comment"));
         assertEquals("nocomment", wac.getSessionHandler().getSessionComment());

--- a/jetty-ee11/jetty-ee11-webapp/src/test/java/org/eclipse/jetty/ee11/webapp/StandardDescriptorProcessorTest.java
+++ b/jetty-ee11/jetty-ee11-webapp/src/test/java/org/eclipse/jetty/ee11/webapp/StandardDescriptorProcessorTest.java
@@ -216,7 +216,7 @@ public class StandardDescriptorProcessorTest
             """);
         wac.setDescriptor(descriptorXml.toUri().toASCIIString());
 
-        Map<String, String> CREATE_JAR_ENV = new HashMap<>();
+        final Map<String, String> CREATE_JAR_ENV = new HashMap<>();
         CREATE_JAR_ENV.put("create", "true");
 
         // Fragment one: sets the eot mime-type

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/StandardDescriptorProcessor.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/StandardDescriptorProcessor.java
@@ -1026,7 +1026,7 @@ public class StandardDescriptorProcessor extends IterativeDescriptorProcessor
                 case WebFragment:
                 {
                     //a web-fragment set the value, all web-fragments must have the same value
-                    if (!context.getMimeTypes().getMimeByExtension("." + extension).equals(mimeType))
+                    if (!mimeType.equals(context.getMimeTypes().getMimeByExtension("." + extension)))
                         throw new IllegalStateException("Conflicting mime-type " + mimeType + " for extension " + extension + " in " + descriptor.getURI());
                     break;
                 }

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/StandardDescriptorProcessor.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/StandardDescriptorProcessor.java
@@ -1026,7 +1026,7 @@ public class StandardDescriptorProcessor extends IterativeDescriptorProcessor
                 case WebFragment:
                 {
                     //a web-fragment set the value, all web-fragments must have the same value
-                    if (!mimeType.equals(context.getMimeTypes().getMimeByExtension("." + extension)))
+                    if (!mimeType.equals(context.getMimeTypes().getMimeForExtension(extension)))
                         throw new IllegalStateException("Conflicting mime-type " + mimeType + " for extension " + extension + " in " + descriptor.getURI());
                     break;
                 }

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/StandardDescriptorProcessorTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/StandardDescriptorProcessorTest.java
@@ -14,7 +14,13 @@
 package org.eclipse.jetty.ee9.webapp;
 
 import java.lang.reflect.InvocationTargetException;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jetty.ee9.servlet.DefaultServlet;
@@ -22,20 +28,28 @@ import org.eclipse.jetty.ee9.servlet.ServletHolder;
 import org.eclipse.jetty.ee9.servlet.ServletMapping;
 import org.eclipse.jetty.logging.StacklessLogging;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
+import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.util.resource.ResourceFactory;
+import org.eclipse.jetty.util.resource.Resources;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(WorkDirExtension.class)
 public class StandardDescriptorProcessorTest
@@ -143,7 +157,7 @@ public class StandardDescriptorProcessorTest
         WebAppContext wac = new WebAppContext();
         wac.setServer(_server);
         wac.setBaseResourceAsPath(docroot);
-        wac.setDescriptor(webXml.toUri().toURL().toString());
+        wac.setDescriptor(webXml.toUri().toASCIIString());
         wac.start();
         ServletMapping[] mappings = wac.getServletHandler().getServletMappings();
         ServletMapping mapping = null;
@@ -169,11 +183,102 @@ public class StandardDescriptorProcessorTest
         WebAppContext wac = new WebAppContext();
         wac.setServer(_server);
         wac.setBaseResourceAsPath(docroot);
-        wac.setDescriptor(webXml.toUri().toURL().toString());
+        wac.setDescriptor(webXml.toUri().toASCIIString());
         wac.setThrowUnavailableOnStartupException(true);
         try (StacklessLogging ignored = new StacklessLogging(WebAppContext.class))
         {
             assertThrows(RuntimeException.class, () -> wac.start());
+        }
+    }
+
+    @Test
+    public void testDuplicateMimeTypes(WorkDir workDir) throws Exception
+    {
+        // Ensure that behavior of duplicate mime-type works as intended.
+        Path docroot = workDir.getEmptyPathDir();
+        WebAppContext wac = new WebAppContext();
+        wac.setServer(_server);
+        wac.setBaseResourceAsPath(docroot);
+
+        Path descriptorXml = docroot.resolve("WEB-INF/web.xml");
+        FS.ensureDirExists(descriptorXml.getParent());
+        Files.writeString(descriptorXml, """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
+              version="4.0">
+              <name>Test WebApp</name>
+            </web-app>
+            """);
+        wac.setDescriptor(descriptorXml.toUri().toASCIIString());
+
+        Map<String, String> CREATE_JAR_ENV = new HashMap<>();
+        CREATE_JAR_ENV.put("create", "true");
+
+        // Fragment one: sets the eot mime-type
+        Path fragmentOneJar = docroot.resolve("WEB-INF/lib/frag1.jar");
+        FS.ensureDirExists(fragmentOneJar.getParent());
+        URI uriOne = URI.create("jar:" + fragmentOneJar.toUri().toASCIIString());
+        try (FileSystem zipfs = FileSystems.newFileSystem(uriOne, CREATE_JAR_ENV))
+        {
+            String fragmentXml = """
+                <?xml version="1.0" encoding="ISO-8859-1"?>
+                <web-fragment
+                   xmlns="http://java.sun.com/xml/ns/javaee"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-fragment_4_0.xsd"
+                   version="4.0">
+                  <name>Frag1Test</name>
+                  <mime-mapping>
+                    <extension>eot</extension>
+                    <mime-type>application/octet-stream</mime-type>
+                  </mime-mapping>
+                </web-fragment>
+                """;
+            Path path = zipfs.getPath("/META-INF/web-fragment.xml");
+            FS.ensureDirExists(path.getParent());
+            Files.writeString(path, fragmentXml);
+        }
+
+        // Fragment two: tries to set the eot mime-type to something difference (it should fail)
+        Path fragmentTwoJar = docroot.resolve("WEB-INF/lib/frag2.jar");
+        FS.ensureDirExists(fragmentTwoJar.getParent());
+        URI uriTwo = URI.create("jar:" + fragmentTwoJar.toUri().toASCIIString());
+        try (FileSystem zipfs = FileSystems.newFileSystem(uriTwo, CREATE_JAR_ENV))
+        {
+            String fragmentXml = """
+                <?xml version="1.0" encoding="ISO-8859-1"?>
+                <web-fragment
+                   xmlns="http://java.sun.com/xml/ns/javaee"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-fragment_4_0.xsd"
+                   version="4.0">
+                  <name>Frag2Test</name>
+                  <mime-mapping>
+                    <extension>eot</extension>
+                    <mime-type>application/vnd.ms-fontobject</mime-type>
+                  </mime-mapping>
+                </web-fragment>
+                """;
+            Path path = zipfs.getPath("/META-INF/web-fragment.xml");
+            FS.ensureDirExists(path.getParent());
+            Files.writeString(path, fragmentXml);
+        }
+
+        ResourceFactory resourceFactory = wac.getResourceFactory();
+        Resource fragResource = resourceFactory.newResource(fragmentTwoJar);
+        assertTrue(Resources.exists(fragResource));
+        wac.setThrowUnavailableOnStartupException(true);
+        try (StacklessLogging ignored = new StacklessLogging(WebAppContext.class))
+        {
+            RuntimeException re = assertThrows(RuntimeException.class, wac::start);
+            assertThat(re.getCause(), is(instanceOf(InvocationTargetException.class)));
+            InvocationTargetException ite = (InvocationTargetException)re.getCause();
+            assertThat(ite.getCause(), is(instanceOf(IllegalStateException.class)));
+            IllegalStateException ise = (IllegalStateException)ite.getCause();
+            assertThat(ise.getMessage(), containsString("Conflicting mime-type application/vnd.ms-fontobject for extension eot in " +
+                "jar:" + fragResource.getURI().toASCIIString() + "!/META-INF/web-fragment.xml"));
         }
     }
 
@@ -185,7 +290,7 @@ public class StandardDescriptorProcessorTest
         WebAppContext wac = new WebAppContext();
         wac.setServer(_server);
         wac.setBaseResourceAsPath(docroot);
-        wac.setDescriptor(webXml.toUri().toURL().toString());
+        wac.setDescriptor(webXml.toUri().toASCIIString());
         wac.start();
         assertEquals(54, TimeUnit.SECONDS.toMinutes(wac.getSessionHandler().getMaxInactiveInterval()));
         

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/StandardDescriptorProcessorTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/StandardDescriptorProcessorTest.java
@@ -32,6 +32,7 @@ import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
+import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.resource.Resources;
@@ -279,6 +280,10 @@ public class StandardDescriptorProcessorTest
             IllegalStateException ise = (IllegalStateException)ite.getCause();
             assertThat(ise.getMessage(), containsString("Conflicting mime-type application/vnd.ms-fontobject for extension eot in " +
                 "jar:" + fragResource.getURI().toASCIIString() + "!/META-INF/web-fragment.xml"));
+        }
+        finally
+        {
+            LifeCycle.stop(wac);
         }
     }
 

--- a/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/StandardDescriptorProcessorTest.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/test/java/org/eclipse/jetty/ee9/webapp/StandardDescriptorProcessorTest.java
@@ -213,7 +213,7 @@ public class StandardDescriptorProcessorTest
             """);
         wac.setDescriptor(descriptorXml.toUri().toASCIIString());
 
-        Map<String, String> CREATE_JAR_ENV = new HashMap<>();
+        final Map<String, String> CREATE_JAR_ENV = new HashMap<>();
         CREATE_JAR_ENV.put("create", "true");
 
         // Fragment one: sets the eot mime-type


### PR DESCRIPTION
Add testcase.

Use the more appropriate `MimeTypes.getMimeForExtension(String ext)` to skip the `FileID.getExtension(String filename)` step that the original code was doing.

Fixes: #14846 
